### PR TITLE
Nightscout Follower robustness

### DIFF
--- a/Common/src/main/java/tk/glucodata/SensorBluetooth.java
+++ b/Common/src/main/java/tk/glucodata/SensorBluetooth.java
@@ -1058,7 +1058,7 @@ public class SensorBluetooth {
         Natives.setmaxsensors(gattcallbacks.size());
     }
 
-    private void addPersistedManagedCallbacks() {
+    void addPersistedManagedCallbacks() {
         final Context context = Applic.app;
         if (context == null) {
             return;
@@ -1773,12 +1773,20 @@ public class SensorBluetooth {
         if (usebluetooth) {
             if (SensorBluetooth.blueone == null) {
                 blueone = new tk.glucodata.SensorBluetooth();
-                if (blueone != null && hasSensors) {
-                    blueone.startDevices(sensors);
+                if (blueone != null) {
+                    if (hasSensors) {
+                        blueone.startDevices(sensors);
+                    } else {
+                        // No native BT sensors, but managed sensors (e.g. NightscoutFollower) still need initialization.
+                        blueone.addPersistedManagedCallbacks();
+                    }
                 }
             } else {
-                if (hasSensors)
+                if (hasSensors) {
                     blueone.connectDevices(0);
+                } else {
+                    blueone.addPersistedManagedCallbacks();
+                }
             }
         }
     }

--- a/Common/src/main/java/tk/glucodata/SensorBluetooth.java
+++ b/Common/src/main/java/tk/glucodata/SensorBluetooth.java
@@ -1083,6 +1083,9 @@ public class SensorBluetooth {
             if (dataptr != 0L || canRunWithoutNativeData) {
                 adoptCurrentSensorIfBlank(sensorId);
             }
+            if (canRunWithoutNativeData) {
+                cb.connectDevice(0);
+            }
         }
     }
 

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
@@ -145,6 +145,11 @@ class NightscoutFollowerManager(
         scheduleRefresh(0L)
     }
 
+    override fun reconnect(now: Long): Boolean {
+        if (!stop && phase == Phase.IDLE) connectDevice(0)
+        return true
+    }
+
     override fun terminateManagedSensor(wipeData: Boolean) {
         stop = true
         handler.removeCallbacksAndMessages(null)

--- a/Common/src/mobile/java/tk/glucodata/GlucoseAlarms.java
+++ b/Common/src/mobile/java/tk/glucodata/GlucoseAlarms.java
@@ -34,6 +34,7 @@ public GlucoseAlarms(Application context) {
 
 public    void handlealarm() {
     SensorBluetooth.reconnectall();
+    SensorBluetooth.ensureCurrentSensorSelection();
     final var view=Floating.floatview;
     if(view!=null) {
         view.postInvalidate();


### PR DESCRIPTION
## Fix NightscoutFollower silently stopping after process kill/restart

After Android kills the app process and restarts it, NightscoutFollower
(a "managed" sensor) stopped receiving glucose readings silently — no
error, no log, just no data.

**Root cause:** `SensorBluetooth.start()` only called `addPersistedCallbacks()`
for native Bluetooth sensors. `NightscoutFollower` uses
`isManagedOutsideNativeActiveSet()` so it is excluded from
`Natives.activeSensors()` — meaning `addPersistedManagedCallbacks()` was
never invoked on restart when no BT hardware was active.

**Fixes:**

1. **`SensorBluetooth.start()`** — when there are no native BT sensors,
   explicitly call `addPersistedManagedCallbacks()` so managed sensors
   (including NightscoutFollower) are initialised. Covers both the fresh
   `blueone` allocation path and the existing-instance path.

2. **`addPersistedManagedCallbacks()`** — call `connectDevice(0)` for
   sensors that can run without native data (`canRunWithoutNativeData`),
   so polling starts immediately rather than waiting for the first alarm.

3. **`NightscoutFollowerManager.reconnect()`** — override added so that
   `reconnectall()` → `reconnect()` actually kicks off a fetch when the
   manager is in IDLE state, rather than just returning `true` doing nothing.

4. **`GlucoseAlarms.handlealarm()`** — call `ensureCurrentSensorSelection()`
   after `reconnectall()` as a belt-and-suspenders recovery path when
   a `LossOfSensorAlarm` fires after a crash-restart loop.

Note: these are vibe-coded attempts to improve JugglucoNG as I really like the initiative, but I am not a developer - I have limited coding skills but I can make sense of code quite ok. Hope these fixes help.

Cheers,
Rob