### PR TITLE
Audio & TTS improvements

### DIFF
--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -520,8 +520,7 @@ public class Notify {
         var ring = setring(uristr, defaults[kind]);
         if (android.os.Build.VERSION.SDK_INT >= 21) {
             try {
-                // Use ALARM stream only if disturb=true AND USEALARM is enabled
-                boolean useAlarmStream = (!AlertType.Companion.isLegacyOnlyId(kind) && getUSEALARM() && disturb);
+                boolean useAlarmStream = (!AlertType.Companion.isLegacyOnlyId(kind) && disturb);
                 ring.setAudioAttributes(useAlarmStream ? ScanNfcV.audioattributes : notification_audio);
             } catch (Throwable e) {
                 Log.stack(LOG_ID, "mkring", e);
@@ -1725,10 +1724,7 @@ public class Notify {
                 final CurrentDisplaySource.Snapshot current = resolveNotificationCurrentSnapshot();
                 if (current != null) {
                     SuperGattCallback.talker.speak(current.getPrimaryStr(),
-                            getUSEALARM() ? ScanNfcV.audioattributes : notification_audio);
-                    // Applic.scheduler.schedule( () -> SuperGattCallback.talker.speak(glu.value,
-                    // getUSEALARM()?ScanNfcV.audioattributes:notification_audio), 50,
-                    // TimeUnit.MILLISECONDS);
+                            disturb ? ScanNfcV.audioattributes : notification_audio);
                 }
             }
         }
@@ -1812,7 +1808,7 @@ public class Notify {
                         if (current != null) {
                             Applic.scheduler.schedule(
                                     () -> SuperGattCallback.talker.speak(current.getPrimaryStr(),
-                                            getUSEALARM() ? ScanNfcV.audioattributes : notification_audio),
+                                            disturb ? ScanNfcV.audioattributes : notification_audio),
                                     300, TimeUnit.MILLISECONDS);
                         } else
                             doTurnFocusoff();
@@ -1970,8 +1966,7 @@ public class Notify {
         final boolean sound = p.getBoolean("alert_" + kind + "_sound", defSound);
         final boolean vibration = p.getBoolean("alert_" + kind + "_vibration", defVibrate);
 
-        final boolean dist = isWearable || getalarmdisturb(kind); // DND might need Prefs too, but keeping Natives for
-                                                                  // now
+        final boolean dist = isWearable || p.getBoolean("alert_" + kind + "_dnd", getalarmdisturb(kind));
         final boolean useAlarmStream = shouldUseAlarmAudioStream(kind, dist);
         final AlertSoundHandle soundHandle = sound ? buildAlertSoundHandle(ringUri, kind, useAlarmStream) : null;
 

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -157,12 +157,15 @@ public class Notify {
         private static final long SOUND_FADE_IN_MS = 1_200L;
         private static final int SOUND_FADE_STEPS = 8;
         private static final float SOUND_START_VOLUME = 0.12f;
+        // Hard floor: sound must never accidentally go silent even if profile logic has a bug
+        private static final float MIN_PLAY_VOLUME = 0.3f;
 
         private final Ringtone ringtone;
         private final MediaPlayer mediaPlayer;
         private final String title;
         private boolean released = false;
         private int playGeneration = 0;
+        private float maxVolume = 1.0f;
 
         AlertSoundHandle(Ringtone ringtone, MediaPlayer mediaPlayer, String title) {
             this.ringtone = ringtone;
@@ -176,6 +179,10 @@ public class Notify {
 
         String getTitle() {
             return (title != null && !title.isEmpty()) ? title : "alert sound";
+        }
+
+        synchronized void setMaxVolume(float vol) {
+            maxVolume = Math.max(MIN_PLAY_VOLUME, Math.min(1.0f, vol));
         }
 
         private synchronized void setVolume(float volume) {
@@ -206,7 +213,7 @@ public class Notify {
                         }
                     }
                     final float progress = (float) finalStep / (float) SOUND_FADE_STEPS;
-                    setVolume(SOUND_START_VOLUME + ((1.0f - SOUND_START_VOLUME) * progress));
+                    setVolume(SOUND_START_VOLUME + ((maxVolume - SOUND_START_VOLUME) * progress));
                 }, delayMs, TimeUnit.MILLISECONDS);
             }
         }
@@ -1854,6 +1861,7 @@ public class Notify {
         if (sound) {
             if (doplaysound[0] && hasSoundHandle) {
                 if (soundHandle != null) {
+                    soundHandle.setMaxVolume(soundVolumeForProfile(resolvedHapticProfile));
                     soundHandle.play();
                 } else if (doLog) {
                     Log.w(LOG_ID, "playringhier: sound handle is null");
@@ -1931,6 +1939,17 @@ public class Notify {
             }
         } catch (Exception e) {
             return "STRONG";
+        }
+    }
+
+    // SOFT=0.4, STEADY=0.7, STRONG/ESCALATING=1.0 — matches the old dead getVolumeFromProfile() intent.
+    // Never returns below AlertSoundHandle.MIN_PLAY_VOLUME (enforced again in setMaxVolume as a safety net).
+    private static float soundVolumeForProfile(String profile) {
+        if (profile == null) return 1.0f;
+        switch (profile.toUpperCase()) {
+            case "SOFT":      case "LOW":      return 0.4f;
+            case "STEADY":    case "MEDIUM":   return 0.7f;
+            default:                           return 1.0f;
         }
     }
 

--- a/Common/src/main/java/tk/glucodata/SpeakSchedule.kt
+++ b/Common/src/main/java/tk/glucodata/SpeakSchedule.kt
@@ -1,0 +1,55 @@
+package tk.glucodata
+
+import android.content.Context
+import java.util.Calendar
+
+object SpeakSchedule {
+    private const val PREFS = "tk.glucodata_preferences"
+    private const val KEY_ENABLED = "voice_schedule_enabled"
+    private const val KEY_START = "voice_schedule_start_minutes"
+    private const val KEY_END = "voice_schedule_end_minutes"
+
+    private const val DEFAULT_START = 0        // 00:00
+    private const val DEFAULT_END = 22 * 60    // 22:00
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    fun isEnabled(context: Context): Boolean =
+        prefs(context).getBoolean(KEY_ENABLED, false)
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+        prefs(context).edit().putBoolean(KEY_ENABLED, enabled).apply()
+    }
+
+    fun getStartMinutes(context: Context): Int =
+        prefs(context).getInt(KEY_START, DEFAULT_START)
+
+    fun getEndMinutes(context: Context): Int =
+        prefs(context).getInt(KEY_END, DEFAULT_END)
+
+    fun setStartMinutes(context: Context, minutes: Int) {
+        prefs(context).edit().putInt(KEY_START, minutes.coerceIn(0, 1439)).apply()
+    }
+
+    fun setEndMinutes(context: Context, minutes: Int) {
+        prefs(context).edit().putInt(KEY_END, minutes.coerceIn(0, 1440)).apply()
+    }
+
+    fun isWithinSchedule(context: Context): Boolean {
+        if (!isEnabled(context)) return true
+        val cal = Calendar.getInstance()
+        val nowMinutes = cal.get(Calendar.HOUR_OF_DAY) * 60 + cal.get(Calendar.MINUTE)
+        val start = getStartMinutes(context)
+        val end = getEndMinutes(context)
+        if (start == end) return true // equal = all day, no restriction
+        return if (start < end) nowMinutes in start until end
+        else nowMinutes >= start || nowMinutes < end // spans midnight
+    }
+
+    fun formatMinutes(minutes: Int): String {
+        val h = (minutes / 60).coerceIn(0, 23)
+        val m = (minutes % 60).coerceIn(0, 59)
+        return String.format("%02d:%02d", h, m)
+    }
+}

--- a/Common/src/main/java/tk/glucodata/Talker.java
+++ b/Common/src/main/java/tk/glucodata/Talker.java
@@ -181,7 +181,7 @@ public static void ensureComposeTalker(Context context) {
         SuperGattCallback.newtalker(context);
     }
 
-public static void applyComposeSettings(Context context, boolean speakGlucose, boolean touchTalk, boolean speakMessages, boolean speakAlarms, boolean mediaSound, float speed, float pitch, int separationSeconds, int selectedVoice) {
+public static void applyComposeSettings(Context context, boolean speakGlucose, boolean touchTalk, boolean speakMessages, boolean speakAlarms, boolean mediaSound, boolean overrideSilent, float speed, float pitch, int separationSeconds, int selectedVoice) {
     if(DontTalk)
         return;
     curspeed=speed;
@@ -191,7 +191,10 @@ public static void applyComposeSettings(Context context, boolean speakGlucose, b
     if(selectedVoice>=0)
         voicepos=selectedVoice;
 
-    if(mediaSound) {
+    if(overrideSilent) {
+        Natives.setSoundType(AudioAttributes.USAGE_ALARM);
+        }
+    else if(mediaSound) {
         Natives.setSoundType(AudioAttributes.USAGE_MEDIA);
         }
     else {

--- a/Common/src/main/java/tk/glucodata/Talker.java
+++ b/Common/src/main/java/tk/glucodata/Talker.java
@@ -148,11 +148,76 @@ public static void removeVoiceOptionsListener(Runnable listener) {
         }
     }
 
+static String getFriendlyVoiceName(Voice voice) {
+    String systemName = voice.getName();
+    if (systemName.contains("-x-")) {
+        String id = systemName.split("-x-")[1].split("-")[0];
+        if (id.startsWith("msm")) return "Device Voice";
+        switch (id) {
+            case "iob": return "Voice A";
+            case "iog": return "Voice B";
+            case "iol": return "Voice C";
+            case "iom": return "Voice D";
+            case "sfg": return "Voice E";
+            case "tpc": return "Voice F";
+            case "tpd": return "Voice G";
+            case "tpf": return "Voice H";
+            default:    return "Voice (" + id.toUpperCase() + ")";
+        }
+    }
+    return systemName;
+}
+
+private static volatile Runnable previewDoneCallback;
+
+public static void setPreviewDoneListener(Runnable r) {
+    previewDoneCallback = r;
+}
+
+public static void previewVoice(int index) {
+    if (DontTalk) return;
+    var talk = SuperGattCallback.talker;
+    if (talk == null || !talk.engineReady) return;
+    Voice voice;
+    synchronized (voiceChoice) {
+        if (index < 0 || index >= voiceChoice.size()) return;
+        voice = voiceChoice.get(index);
+    }
+    talk.setvalues();
+    talk.engine.setVoice(voice);
+    talk.speakPreview();
+}
+
+private void speakPreview() {
+    if (DontTalk) return;
+    try {
+        if (android.os.Build.VERSION.SDK_INT >= minandroid) {
+            engine.setAudioAttributes(mediaAudio);
+            engine.speak("This is a voice preview.", TextToSpeech.QUEUE_FLUSH, null, "voice_preview");
+            engine.setAudioAttributes(notification_audio);
+        } else {
+            engine.speak("This is a voice preview.", TextToSpeech.QUEUE_FLUSH, null);
+        }
+    } catch (Throwable th) {
+        Log.stack(LOG_ID, "speakPreview failed", th);
+    }
+}
+
+public static void stopPreview() {
+    var talk = SuperGattCallback.talker;
+    if (talk != null && talk.engine != null) {
+        talk.engine.stop();
+        talk.setvoice();
+    }
+    var cb = previewDoneCallback;
+    if (cb != null) Applic.RunOnUiThread(cb);
+}
+
 public static ArrayList<String> getVoiceNames() {
     ArrayList<String> names=new ArrayList<>();
     synchronized(voiceChoice) {
         for(var voice:voiceChoice) {
-            names.add(voice.getName());
+            names.add(getFriendlyVoiceName(voice));
             }
         }
     return names;
@@ -337,6 +402,8 @@ if(!DontTalk) {
                         if(voice.isNetworkConnectionRequired()) continue;
                         // Skip voices that are listed but not actually installed
                         if(voice.getFeatures().contains(android.speech.tts.TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)) continue;
+                        // Skip base locale placeholder — not a selectable voice
+                        if(voice.getName().endsWith("-language")) continue;
                         filtered.add(voice);
                         }
                     filtered.sort(Comparator.comparing(Voice::getName));
@@ -349,8 +416,8 @@ if(!DontTalk) {
                         {if(doLog) {Log.i(LOG_ID,"Talker spinner!=null");};};
                           Applic.RunOnUiThread(() -> {
                             spin.setAdapter(new RangeAdapter<Voice>(voiceChoice, Applic.app, voice -> {
-                                    return voice.getName();
-                                    })); 
+                                    return getFriendlyVoiceName(voice);
+                                    }));
                             if(voicepos>=0&&voicepos<voiceChoice.size())
                                 spin.setSelection(voicepos);
                             });
@@ -382,6 +449,10 @@ if(!DontTalk) {
             if(doLog) {Log.i(LOG_ID,"onDone "+utteranceId);};
             if(!notifyfocus)
                 doTurnFocusoff();
+            if ("voice_preview".equals(utteranceId)) {
+                var cb = previewDoneCallback;
+                if (cb != null) Applic.RunOnUiThread(cb);
+            }
         }
 
         @Override
@@ -389,7 +460,10 @@ if(!DontTalk) {
             if(doLog) {Log.i(LOG_ID,"onError "+utteranceId);};
             if(!notifyfocus)
                 doTurnFocusoff();
-
+            if ("voice_preview".equals(utteranceId)) {
+                var cb = previewDoneCallback;
+                if (cb != null) Applic.RunOnUiThread(cb);
+            }
             }
         @Override
         public void onStart(String utteranceId) {
@@ -704,7 +778,7 @@ private static View makeConfigView(MainActivity context, boolean overlayMode, Ru
 
             } });
         spin.setAdapter(new RangeAdapter<Voice>(voiceChoice, context, voice -> {
-                return voice.getName();
+                return getFriendlyVoiceName(voice);
                 }));
         {if(doLog) {Log.i(LOG_ID,"voicepos="+voicepos);};};
         if(voicepos>=0&&voicepos<voiceChoice.size())

--- a/Common/src/main/java/tk/glucodata/Talker.java
+++ b/Common/src/main/java/tk/glucodata/Talker.java
@@ -78,12 +78,14 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Locale;
 import java.util.Set;
 
 public class Talker {
 static public final String LOG_ID="Talker";
     private TextToSpeech engine;
+    volatile boolean engineReady = false;
 
 static    private float curpitch=1.0f;
 static  private float curspeed=1.0f;
@@ -234,22 +236,31 @@ public static void selectProfile(Context context,int profile) {
     notifyVoiceListeners();
     }
 
+static final AudioAttributes mediaAudio = new AudioAttributes.Builder()
+        .setUsage(AudioAttributes.USAGE_MEDIA)
+        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+        .build();
+
 public static void testCurrentValue(Context context) {
     if(DontTalk)
         return;
     var current = CurrentDisplaySource.resolveCurrent(Notify.glucosetimeout);
     var say=(current!=null&&current.getPrimaryStr()!=null)?current.getPrimaryStr():"8.7";
-    if(istalking()) {
-        var talk=SuperGattCallback.talker;
-        if(talk!=null) {
-            talk.setvalues();
-            talk.setvoice();
+    var talk=SuperGattCallback.talker;
+    if(talk!=null && talk.engineReady) {
+        talk.setvalues();
+        talk.setvoice();
+        // Use media stream so test is audible regardless of notification mute
+        if(android.os.Build.VERSION.SDK_INT >= minandroid)
+            talk.speak(say, mediaAudio);
+        else
             talk.speak(say);
-            return;
-            }
+        return;
         }
+    // Engine not ready yet — queue for after init
     playstring=say;
-    SuperGattCallback.newtalker(context);
+    if(talk==null)
+        SuperGattCallback.newtalker(context);
     }
 
 void setvalues() {
@@ -280,6 +291,7 @@ if(!DontTalk) {
     }
 void destruct() {
 if(!DontTalk) {
+    engineReady = false;
     if(engine!=null) {
         engine.shutdown();
         engine=null;
@@ -306,6 +318,7 @@ if(!DontTalk) {
             return;
             }
          if(status ==TextToSpeech.SUCCESS) {
+            engineReady = true;
             setvalues();
             if (android.os.Build.VERSION.SDK_INT >= minandroid) {
                 Set<Voice> voices=gine.getVoices();
@@ -314,17 +327,22 @@ if(!DontTalk) {
                     }
                 else {
                     var loc=getlocale();
-   //                    var lang=(context!=null)?context.getString(R.string.language):loc.getLanguage();
                     var lang=loc.getLanguage();
                     {if(doLog) {Log.i(LOG_ID,"lang="+lang);};};
 
+                    var filtered=new ArrayList<Voice>();
+                    for(var voice:voices) {
+                        if(!lang.equals(voice.getLocale().getLanguage())) continue;
+                        // Skip network-only voices — not reliably available offline
+                        if(voice.isNetworkConnectionRequired()) continue;
+                        // Skip voices that are listed but not actually installed
+                        if(voice.getFeatures().contains(android.speech.tts.TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)) continue;
+                        filtered.add(voice);
+                        }
+                    filtered.sort(Comparator.comparing(Voice::getName));
                     synchronized(voiceChoice) {
                         voiceChoice.clear();
-                        for(var voice:voices) {
-                            if(lang.equals(voice.getLocale().getLanguage())) {
-                                voiceChoice.add(voice);
-                                }
-                            }
+                        voiceChoice.addAll(filtered);
                         }
                     var spin=spinner;
                     if(spin!=null) {
@@ -459,8 +477,8 @@ if(!DontTalk) {
 static long nexttime=0L;
 void selspeak(String message) {
     if(!DontTalk) {
-        var now=System.currentTimeMillis();    
-        if(now>nexttime) {
+        var now=System.currentTimeMillis();
+        if(now>nexttime && SpeakSchedule.INSTANCE.isWithinSchedule(Applic.app)) {
             nexttime=now+cursep;
             speak(message);
             }

--- a/Common/src/main/java/tk/glucodata/Talker.java
+++ b/Common/src/main/java/tk/glucodata/Talker.java
@@ -310,7 +310,7 @@ public static void testCurrentValue(Context context) {
     if(DontTalk)
         return;
     var current = CurrentDisplaySource.resolveCurrent(Notify.glucosetimeout);
-    var say=(current!=null&&current.getPrimaryStr()!=null)?current.getPrimaryStr():"8.7";
+    var say=(current!=null&&current.getPrimaryStr()!=null)?current.getPrimaryStr():context.getString(R.string.tts_missed_readings);
     var talk=SuperGattCallback.talker;
     if(talk!=null && talk.engineReady) {
         talk.setvalues();
@@ -888,7 +888,7 @@ private static View makeConfigView(MainActivity context, boolean overlayMode, Ru
         });
     test.setOnClickListener(v->  {
         var current = CurrentDisplaySource.resolveCurrent(Notify.glucosetimeout);
-        var say=(current!=null&&current.getPrimaryStr()!=null)?current.getPrimaryStr():"8.7";
+        var say=(current!=null&&current.getPrimaryStr()!=null)?current.getPrimaryStr():context.getString(R.string.tts_missed_readings);
         getvalues.run();
         if(istalking()) {
             var talk=SuperGattCallback.talker;

--- a/Common/src/main/java/tk/glucodata/Talker.java
+++ b/Common/src/main/java/tk/glucodata/Talker.java
@@ -387,9 +387,37 @@ if(!DontTalk) {
         }
    }
 
+// Fraction of the stream's max volume that is the minimum allowed for TTS output.
+// Prevents silence when the user (or system) drives the stream to zero.
+private static final float MIN_TTS_VOLUME_FRACTION = 0.25f;
+
+private static int usageToStreamType(int usage) {
+    switch (usage) {
+        case AudioAttributes.USAGE_ALARM:  return AudioManager.STREAM_ALARM;
+        case AudioAttributes.USAGE_MEDIA:  return AudioManager.STREAM_MUSIC;
+        default:                           return AudioManager.STREAM_NOTIFICATION;
+    }
+}
+
+private static void ensureMinStreamVolume() {
+    try {
+        AudioManager am = (AudioManager) Applic.app.getSystemService(Context.AUDIO_SERVICE);
+        if (am == null) return;
+        final int stream = usageToStreamType(Natives.getSoundType());
+        final int maxVol = am.getStreamMaxVolume(stream);
+        final int minVol = Math.max(1, Math.round(maxVol * MIN_TTS_VOLUME_FRACTION));
+        if (am.getStreamVolume(stream) < minVol) {
+            am.setStreamVolume(stream, minVol, 0);
+        }
+    } catch (Throwable th) {
+        Log.stack(LOG_ID, "ensureMinStreamVolume", th);
+    }
+}
+
 public void speak(String message) {
     if(!DontTalk) {
         try {
+            ensureMinStreamVolume();
             if(
                     ((android.os.Build.VERSION.SDK_INT >= 21)?
                     engine.speak(message, TextToSpeech.QUEUE_FLUSH, null,message):

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1964,4 +1964,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="api_source_telegram_token">Telegram bot token</string>
     <string name="api_source_telegram_chat_ids">Allowed chat IDs</string>
     <string name="api_source_telegram_note">Telegram keeps bot updates for up to 24 hours. Enter one or more chat IDs/usernames whose bot messages may be imported.</string>
+    <string name="voice_schedule_title">Speak Schedule</string>
+    <string name="voice_schedule_desc">Only speak readings during this time window</string>
+    <string name="voice_schedule_from">From</string>
+    <string name="voice_schedule_until">Until</string>
 </resources>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -288,6 +288,7 @@
  <string name="streamhistory">Bluetooth History</string>
  <string name="libreisviewed">Spy views</string>
  <string name="novalue">No value</string>
+ <string name="tts_missed_readings">Missed readings</string>
  <string name="talk">Talk</string>
  <string name="watches">Watch</string>
  <string name="menus">Menus</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/CommonAlertSettings.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/CommonAlertSettings.kt
@@ -135,10 +135,10 @@ fun CommonAlertSettings(
                 unselectedContentColor = MaterialTheme.colorScheme.onPrimaryContainer
             )
 
-            AnimatedVisibility(visible = config.vibrationEnabled) {
+            AnimatedVisibility(visible = config.soundEnabled || config.vibrationEnabled) {
                 Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                     Text(
-                        text = stringResource(R.string.haptics),
+                        text = stringResource(R.string.intensity),
                         style = MaterialTheme.typography.labelLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/TalkerSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/TalkerSettingsScreen.kt
@@ -96,6 +96,7 @@ private data class TalkerUiState(
     val speakMessages: Boolean,
     val speakAlarms: Boolean,
     val mediaSound: Boolean,
+    val overrideSilent: Boolean,
     val separationSeconds: Int,
     val speed: Float,
     val pitch: Float,
@@ -151,6 +152,7 @@ fun TalkerSettingsScreen(navController: NavController) {
             updated.speakMessages,
             updated.speakAlarms,
             updated.mediaSound,
+            updated.overrideSilent,
             updated.speed,
             updated.pitch,
             updated.separationSeconds,
@@ -292,9 +294,18 @@ fun TalkerSettingsScreen(navController: NavController) {
                 SettingsSwitchItem(
                     title = "Media",
                     checked = uiState.mediaSound,
-                    onCheckedChange = { persist(uiState.copy(mediaSound = it)) },
+                    onCheckedChange = { persist(uiState.copy(mediaSound = it, overrideSilent = false)) },
                     icon = Icons.Default.MusicNote,
                     iconTint = MaterialTheme.colorScheme.tertiary,
+                    position = CardPosition.MIDDLE
+                )
+                SettingsSwitchItem(
+                    title = stringResource(R.string.override_silent_mode),
+                    subtitle = stringResource(R.string.override_silent_mode_desc),
+                    checked = uiState.overrideSilent,
+                    onCheckedChange = { persist(uiState.copy(overrideSilent = it, mediaSound = false)) },
+                    icon = Icons.Default.NotificationsActive,
+                    iconTint = MaterialTheme.colorScheme.error,
                     position = CardPosition.BOTTOM
                 )
             }
@@ -611,12 +622,14 @@ private fun SliderCard(
 
 private fun loadTalkerUiState(context: Context): TalkerUiState {
     Talker.ensureComposeTalker(context)
+    val soundType = Natives.getSoundType()
     return TalkerUiState(
         speakGlucose = Natives.getVoiceActive(),
         talkTouch = Natives.gettouchtalk(),
         speakMessages = Natives.speakmessages(),
         speakAlarms = Natives.speakalarms(),
-        mediaSound = Natives.getSoundType() == AudioAttributes.USAGE_MEDIA,
+        mediaSound = soundType == AudioAttributes.USAGE_MEDIA,
+        overrideSilent = soundType == AudioAttributes.USAGE_ALARM,
         separationSeconds = Talker.getSeparationSeconds().coerceAtLeast(1),
         speed = Talker.getSelectedSpeed().coerceAtLeast(0.18f),
         pitch = Talker.getSelectedPitch().coerceAtLeast(0.18f),

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/TalkerSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/TalkerSettingsScreen.kt
@@ -50,8 +50,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -79,6 +83,7 @@ import kotlin.math.round
 import tk.glucodata.MainActivity
 import tk.glucodata.Natives
 import tk.glucodata.R
+import tk.glucodata.SpeakSchedule
 import tk.glucodata.Talker
 import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.SettingsItem
@@ -117,6 +122,11 @@ fun TalkerSettingsScreen(navController: NavController) {
     var voiceNames by remember(activity) { mutableStateOf(Talker.getVoiceNames().toList()) }
     var profileMenuExpanded by remember { mutableStateOf(false) }
     var voiceMenuExpanded by remember { mutableStateOf(false) }
+    var scheduleEnabled by remember { mutableStateOf(SpeakSchedule.isEnabled(activity)) }
+    var scheduleStart by remember { mutableStateOf(SpeakSchedule.getStartMinutes(activity)) }
+    var scheduleEnd by remember { mutableStateOf(SpeakSchedule.getEndMinutes(activity)) }
+    var showStartPicker by remember { mutableStateOf(false) }
+    var showEndPicker by remember { mutableStateOf(false) }
 
     LaunchedEffect(uiState.separationSeconds) {
         separationText = uiState.separationSeconds.toString()
@@ -178,6 +188,33 @@ fun TalkerSettingsScreen(navController: NavController) {
     }
     val headlineSummary = enabledSpeechLabels.joinToString(" • ").ifEmpty { selectedVoiceLabel }
     val profileLabel = profiles.getOrElse(uiState.profile) { profiles.first() }
+
+    if (showStartPicker) {
+        ScheduleTimePickerDialog(
+            initialHour = scheduleStart / 60,
+            initialMinute = scheduleStart % 60,
+            onDismiss = { showStartPicker = false },
+            onConfirm = { h, m ->
+                val mins = h * 60 + m
+                scheduleStart = mins
+                SpeakSchedule.setStartMinutes(activity, mins)
+                showStartPicker = false
+            }
+        )
+    }
+    if (showEndPicker) {
+        ScheduleTimePickerDialog(
+            initialHour = scheduleEnd / 60,
+            initialMinute = scheduleEnd % 60,
+            onDismiss = { showEndPicker = false },
+            onConfirm = { h, m ->
+                val mins = h * 60 + m
+                scheduleEnd = mins
+                SpeakSchedule.setEndMinutes(activity, mins)
+                showEndPicker = false
+            }
+        )
+    }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
@@ -381,8 +418,46 @@ fun TalkerSettingsScreen(navController: NavController) {
 //                }
 //            }
 
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                SettingsSwitchItem(
+                    title = stringResource(R.string.voice_schedule_title),
+                    subtitle = stringResource(R.string.voice_schedule_desc),
+                    checked = scheduleEnabled,
+                    onCheckedChange = {
+                        scheduleEnabled = it
+                        SpeakSchedule.setEnabled(activity, it)
+                    },
+                    icon = Icons.Default.Schedule,
+                    iconTint = MaterialTheme.colorScheme.primary,
+                    position = if (scheduleEnabled) CardPosition.TOP else CardPosition.SINGLE
+                )
+                if (scheduleEnabled) {
+                    SettingsItem(
+                        title = stringResource(R.string.voice_schedule_from),
+                        subtitle = SpeakSchedule.formatMinutes(scheduleStart),
+                        showArrow = true,
+                        icon = Icons.Default.Schedule,
+                        iconTint = MaterialTheme.colorScheme.secondary,
+                        position = CardPosition.MIDDLE,
+                        onClick = { showStartPicker = true }
+                    )
+                    SettingsItem(
+                        title = stringResource(R.string.voice_schedule_until),
+                        subtitle = SpeakSchedule.formatMinutes(scheduleEnd),
+                        showArrow = true,
+                        icon = Icons.Default.Schedule,
+                        iconTint = MaterialTheme.colorScheme.tertiary,
+                        position = CardPosition.BOTTOM,
+                        onClick = { showEndPicker = true }
+                    )
+                }
+            }
+
             FilledTonalButton(
-                onClick = { Talker.testCurrentValue(activity) },
+                onClick = {
+                    persist(uiState)
+                    Talker.testCurrentValue(activity)
+                },
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(horizontal = 20.dp, vertical = 14.dp)
             ) {
@@ -663,4 +738,28 @@ private fun talkerSliderProgressToRatio(progress: Float): Float {
 
 private fun formatTalkerRatio(value: Float): String {
     return String.format(Locale.US, "%.2f", value)
+}
+
+@Composable
+private fun ScheduleTimePickerDialog(
+    initialHour: Int,
+    initialMinute: Int,
+    onDismiss: () -> Unit,
+    onConfirm: (hour: Int, minute: Int) -> Unit
+) {
+    val state = rememberTimePickerState(initialHour = initialHour, initialMinute = initialMinute)
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = { onConfirm(state.hour, state.minute) }) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+        text = { TimePicker(state = state) }
+    )
 }

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/TalkerSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/TalkerSettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.HelpOutline
 import androidx.compose.material.icons.filled.Message
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.NotificationsActive
+import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.RecordVoiceOver
 import androidx.compose.material.icons.filled.Schedule
@@ -120,6 +121,7 @@ fun TalkerSettingsScreen(navController: NavController) {
     var uiState by remember(activity) { mutableStateOf(loadTalkerUiState(activity)) }
     var separationText by remember { mutableStateOf(uiState.separationSeconds.toString()) }
     var voiceNames by remember(activity) { mutableStateOf(Talker.getVoiceNames().toList()) }
+    var previewingVoiceIndex by remember { mutableStateOf(-1) }
     var profileMenuExpanded by remember { mutableStateOf(false) }
     var voiceMenuExpanded by remember { mutableStateOf(false) }
     var scheduleEnabled by remember { mutableStateOf(SpeakSchedule.isEnabled(activity)) }
@@ -147,8 +149,11 @@ fun TalkerSettingsScreen(navController: NavController) {
         }
         Talker.addVoiceOptionsListener(listener)
         listener.run()
+        Talker.setPreviewDoneListener { previewingVoiceIndex = -1 }
         onDispose {
             Talker.removeVoiceOptionsListener(listener)
+            Talker.setPreviewDoneListener(null)
+            Talker.stopPreview()
             Talker.finishComposeSession()
         }
     }
@@ -318,8 +323,25 @@ fun TalkerSettingsScreen(navController: NavController) {
                     onExpandedChange = { voiceMenuExpanded = it }
                 ) {
                     voiceNames.forEachIndexed { index, label ->
+                        val isPreviewing = previewingVoiceIndex == index
                         DropdownMenuItem(
                             text = { Text(label) },
+                            trailingIcon = {
+                                IconButton(onClick = {
+                                    if (isPreviewing) {
+                                        Talker.stopPreview()
+                                        previewingVoiceIndex = -1
+                                    } else {
+                                        previewingVoiceIndex = index
+                                        Talker.previewVoice(index)
+                                    }
+                                }) {
+                                    Icon(
+                                        if (isPreviewing) Icons.Default.Pause else Icons.Default.PlayArrow,
+                                        contentDescription = null
+                                    )
+                                }
+                            },
                             onClick = {
                                 voiceMenuExpanded = false
                                 persist(uiState.copy(selectedVoiceIndex = index))


### PR DESCRIPTION
I've been running with this code 4-5 days now.

Rob

---

## Audio & TTS improvements: silent-mode override, volume floor, voice picker, speak schedule

Six related improvements to the alert sound and spoken-reading subsystems. Each is
independently useful but they build on each other, so they're combined into one PR
for coherence.

---

### 1. Alarm sound respects "Override DND" without needing USEALARM flag (`Notify.java`)

**Bug:** `mkring()` gated alarm-stream audio on both `disturb` AND `getUSEALARM()`.
For alert types 9–11 (missed reading, persistent high, sensor expiry), the DND
override pref was never read — falling back to `getalarmdisturb()` which always
returned false for those types. Result: those alerts played on the notification
stream even with DND override enabled, so they were silenced in Do Not Disturb.

**Fix:**
- `mkring()`: remove the `getUSEALARM()` gate — the `disturb` flag alone controls
  stream selection. Using `USAGE_ALARM` is the correct semantic for anything that
  should break through DND.
- `mksound()`: read `alert_N_dnd` from SharedPrefs (falling back to
  `getalarmdisturb()`) so each alert type can be independently configured.
- TTS spoken readings: use `disturb` flag (not `getUSEALARM()`) to select alarm vs
  notification audio attributes, consistent with the ringtone path.

**Behaviour change:** Previously, non-legacy alerts only used the alarm stream if
both `getUSEALARM()` and `disturb` were true. Now `disturb` alone controls it.
Users who had USEALARM=false will see alarm-stream audio when DND override is
enabled for an alert — which is the intended behaviour.

---

### 2. Haptic intensity profile drives alarm volume (`Notify.java`)

The `getVolumeFromProfile()` intent existed in the codebase but was never connected
to the actual sound handle. Now `playringhier()` calls
`soundHandle.setMaxVolume(soundVolumeForProfile(resolvedHapticProfile))` before
play, with:

- SOFT / LOW → 0.4 × max
- STEADY / MEDIUM → 0.7 × max
- STRONG / ESCALATING / default → 1.0 × max

A hard floor of `MIN_PLAY_VOLUME = 0.3f` is enforced in `setMaxVolume()` so a
misconfigured profile can never accidentally silence an alarm. The fade-in animation
uses the profile volume as its ceiling instead of always fading to 1.0.

---

### 3. TTS reliability fixes (`Talker.java`)

**Minimum volume floor:** `ensureMinStreamVolume()` is called before every
`engine.speak()`. It reads the active stream (ALARM / MEDIA / NOTIFICATION
depending on `getSoundType()`) and raises it to 25% of the stream maximum if below
that threshold. Wrapped in `catch (Throwable)` so it cannot crash speech on any
device.

**Engine readiness flag:** `engineReady` volatile boolean is set in `onInit()` and
cleared in `destruct()`. `testCurrentValue()` and `previewVoice()` guard on this
flag, preventing calls into an uninitialised engine on fast re-entry.

**Test button improvements:**
- Uses the MEDIA stream regardless of settings, so the test is audible even when the
  notification stream is muted.
- Falls back to the localised string `"Missed readings"` rather than a hardcoded
  number when no current glucose reading is available.
- No longer creates a new `Talker` instance if one already exists but is not yet
  initialised; instead queues `playstring` and waits.

---

### 4. Voice picker: filtering, friendly names, preview (`Talker.java`, `TalkerSettingsScreen.kt`)

**Filtering:** Voices are now filtered to those that are:
- Matching the current UI locale language
- Not network-only (`isNetworkConnectionRequired() == false`)
- Actually installed (no `KEY_FEATURE_NOT_INSTALLED` feature)
- Not a base-locale placeholder (name does not end with `-language`)

Result is sorted by name for a stable order.

**Friendly names:** Google TTS encodes voice variants in IDs like
`en-us-x-iob-local`. These are mapped to readable labels (Voice A–H); OEM `msm*`
voices become "Device Voice"; unknowns fall back to `Voice (ID)`. Gender labels
removed — they are inaccurate on many devices.

**Preview:** Each voice in the dropdown gets a play/pause button. Tapping it calls
`previewVoice(index)` which sets that voice temporarily and speaks a sample on the
MEDIA stream (audible even if notification stream is muted). `stopPreview()` fires a
`previewDoneCallback` on the UI thread to reset the button state. The preview is
stopped and the callback cleared in `DisposableEffect.onDispose`.

---

### 5. Speak Schedule — quiet-hours window for spoken readings (`SpeakSchedule.kt`, `TalkerSettingsScreen.kt`)

New `SpeakSchedule` object gates `selspeak()` to a configurable time window. Off by
default. When enabled, spoken glucose readings are suppressed outside the window.
Midnight-spanning ranges (e.g. 22:00–07:00) are handled correctly:

```kotlin
return if (start < end) nowMinutes in start until end
else nowMinutes >= start || nowMinutes < end
start == end is treated as "all day, no restriction" — avoids accidentally
silencing everything if the picker is misconfigured.
```

UI: toggle in TalkerSettingsScreen; when enabled, From/Until rows appear using
Material3 TimePicker in a dialog. Settings are persisted to SharedPreferences
immediately on confirmation.

---

### 6. Minor: intensity profile visible for sound-only alerts (CommonAlertSettings.kt)
The haptic intensity selector was AnimatedVisibility(visible = vibrationEnabled).
Changed to soundEnabled || vibrationEnabled — the profile now also appears when
only sound is enabled, since it controls alarm volume (change 2 above). Label
updated from "Haptics" to "Intensity".