### PR TITLE
Mirror: Juggluco protocol test button in connection card and edit dialog, minor ui changes

### DIFF
--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1646,7 +1646,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="mirror_delete_connection_message">%1$s wordt definitief verwijderd.</string>
     <string name="mirror_connection_type">Verbindingstype</string>
     <string name="mirror_type_local">Lokaal</string>
-    <string name="mirror_type_direct_ip">Direct IP</string>
+    <string name="mirror_type_direct_ip">Direct</string>
     <string name="mirror_type_local_hint">Zelfde wifi. IP automatisch gedetecteerd.</string>
     <string name="mirror_type_ice_hint">Tussen netwerken via STUN/TURN.</string>
     <string name="mirror_type_direct_hint">Specifieke IP/hostnaam.</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1822,7 +1822,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="mirror_delete_connection_message">%1$s will be removed permanently.</string>
     <string name="mirror_connection_type">Connection Type</string>
     <string name="mirror_type_local">Local</string>
-    <string name="mirror_type_direct_ip">Direct IP</string>
+    <string name="mirror_type_direct_ip">Direct</string>
     <string name="mirror_type_local_hint">Same Wi-Fi. IP auto-detected.</string>
     <string name="mirror_type_ice_hint">Across networks via STUN/TURN.</string>
     <string name="mirror_type_direct_hint">Specific IP/hostname.</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
@@ -53,10 +53,27 @@ import tk.glucodata.ui.components.*
 import tk.glucodata.ui.util.ConnectedButtonGroup
 import tk.glucodata.util.DiscoveredMirror
 import tk.glucodata.util.MDnsManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.net.InetSocketAddress
+import java.net.Socket
 
 private const val UNIFIED_EXTRA_SCAN_TEXT = "tk.glucodata.extra.scan_text"
 private const val UNIFIED_EXTRA_SCAN_CONTEXT = "tk.glucodata.extra.scan_context"
 private const val UNIFIED_SCAN_CONTEXT_MIRROR = 1
+
+private enum class TestState { IDLE, TESTING, SUCCESS, FAILURE }
+
+private suspend fun testTcpConnection(host: String, port: Int): Boolean =
+    withContext(Dispatchers.IO) {
+        try {
+            Socket().use { it.connect(InetSocketAddress(host, port), 5000) }
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
 
 // ── QR Code ──────────────────────────────────────────────────────────────────
 
@@ -577,6 +594,8 @@ enum class ConnectionDirection { PASSIVE, ACTIVE, BOTH }
 fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
     val context = LocalContext.current
     val isNew = pos == -1
+    val scope = rememberCoroutineScope()
+    var testState by remember { mutableStateOf(TestState.IDLE) }
     fun connectionTypeLabel(option: ConnectionType): String = when (option) {
         ConnectionType.LOCAL -> context.getString(R.string.mirror_type_local)
         ConnectionType.ICE -> context.getString(R.string.ice)
@@ -645,6 +664,8 @@ fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
             else -> ConnectionDirection.BOTH
         }
     )}
+
+    LaunchedEffect(hostname, port, connectionType) { testState = TestState.IDLE }
 
     fun save(): Boolean {
         val isICE = connectionType == ConnectionType.ICE
@@ -879,6 +900,60 @@ fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
                     }
                 }
             )
+
+            // Test connectivity (only for connections with a specific hostname/IP)
+            val canTest = (connectionType == ConnectionType.DIRECT ||
+                    (connectionType == ConnectionType.LOCAL && !autoDetect)) &&
+                    hostname.isNotBlank()
+            if (canTest) {
+                Spacer(Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = {
+                            testState = TestState.TESTING
+                            scope.launch {
+                                val portInt = port.toIntOrNull() ?: 8795
+                                testState = if (testTcpConnection(hostname.trim(), portInt))
+                                    TestState.SUCCESS else TestState.FAILURE
+                            }
+                        },
+                        enabled = testState != TestState.TESTING,
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        if (testState == TestState.TESTING) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(Modifier.width(8.dp))
+                        }
+                        Text(if (testState == TestState.TESTING)
+                            stringResource(R.string.connecting) else stringResource(R.string.test))
+                    }
+                    when (testState) {
+                        TestState.SUCCESS -> {
+                            Icon(Icons.Filled.CheckCircle, contentDescription = null,
+                                tint = Color(0xFF4CAF50), modifier = Modifier.size(24.dp))
+                            Text(stringResource(R.string.status_connected),
+                                color = Color(0xFF4CAF50),
+                                style = MaterialTheme.typography.bodyMedium)
+                        }
+                        TestState.FAILURE -> {
+                            Icon(Icons.Filled.Error, contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(24.dp))
+                            Text(stringResource(R.string.status_connection_failed),
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyMedium)
+                        }
+                        else -> {}
+                    }
+                }
+            }
 
             // Save
             Spacer(Modifier.height(24.dp))

--- a/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
@@ -65,11 +65,28 @@ private const val UNIFIED_SCAN_CONTEXT_MIRROR = 1
 
 private enum class ConnTestState { IDLE, TESTING, SUCCESS, FAILURE }
 
-private suspend fun testTcpConnection(host: String, port: Int): Boolean =
+// Juggluco mirror protocol handshake (sendmagicinit / receivemagic)
+private val JUGGLUCO_SEND_MAGIC = byteArrayOf(
+    218.toByte(), 173.toByte(), 190.toByte(), 237.toByte(),
+    222.toByte(), 237.toByte(), 190.toByte(), 239.toByte(),
+    209.toByte(), 239.toByte(), 0, 0, 0, 1          // last byte must be non-zero
+)
+private val JUGGLUCO_RECV_MAGIC_PREFIX = byteArrayOf(
+    103, 249.toByte(), 45, 66, 52, 128.toByte(), 40,
+    222.toByte(), 186.toByte(), 129.toByte(), 63    // first 11 bytes of receivemagic
+)
+
+private suspend fun testJugglucoConnection(host: String, port: Int): Boolean =
     withContext(Dispatchers.IO) {
         try {
-            Socket().use { it.connect(InetSocketAddress(host, port), 5000) }
-            true
+            Socket().use { socket ->
+                socket.connect(InetSocketAddress(host, port), 5000)
+                socket.soTimeout = 5000
+                socket.getOutputStream().apply { write(JUGGLUCO_SEND_MAGIC); flush() }
+                val buf = ByteArray(15)
+                val read = socket.getInputStream().read(buf)
+                read >= 11 && buf.copyOf(11).contentEquals(JUGGLUCO_RECV_MAGIC_PREFIX)
+            }
         } catch (_: Exception) {
             false
         }
@@ -494,10 +511,13 @@ fun MirrorConnectionCard(
     onDelete: () -> Unit
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var expanded by remember { mutableStateOf(false) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
     var qrContent by remember { mutableStateOf<String?>(null) }
+    var cardTestState by remember { mutableStateOf(ConnTestState.IDLE) }
     val chevronRotation by animateFloatAsState(if (expanded) 180f else 0f, label = "chevron")
+    LaunchedEffect(expanded) { if (!expanded) cardTestState = ConnTestState.IDLE }
 
     if (qrContent != null) {
         AlertDialog(
@@ -574,6 +594,37 @@ fun MirrorConnectionCard(
                         }
                         TextButton(onClick = { qrContent = Natives.getbackJson(mirror.index) }) {
                             Text(stringResource(R.string.qr))
+                        }
+                        val testHost = mirror.names?.firstOrNull()?.takeIf { it.isNotBlank() }
+                        if (testHost != null) {
+                            TextButton(
+                                onClick = {
+                                    cardTestState = ConnTestState.TESTING
+                                    scope.launch {
+                                        val portInt = mirror.port?.toIntOrNull() ?: 8795
+                                        cardTestState = if (testJugglucoConnection(testHost, portInt))
+                                            ConnTestState.SUCCESS else ConnTestState.FAILURE
+                                    }
+                                },
+                                enabled = cardTestState != ConnTestState.TESTING,
+                                colors = ButtonDefaults.textButtonColors(
+                                    contentColor = when (cardTestState) {
+                                        ConnTestState.SUCCESS -> Color(0xFF4CAF50)
+                                        ConnTestState.FAILURE -> MaterialTheme.colorScheme.error
+                                        else -> MaterialTheme.colorScheme.primary
+                                    }
+                                )
+                            ) {
+                                if (cardTestState == ConnTestState.TESTING) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(12.dp),
+                                        strokeWidth = 1.5.dp,
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                    Spacer(Modifier.width(4.dp))
+                                }
+                                Text(stringResource(R.string.test))
+                            }
                         }
                         TextButton(onClick = onEdit) {
                             Text(stringResource(R.string.edit))
@@ -917,7 +968,7 @@ fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
                             testState = ConnTestState.TESTING
                             scope.launch {
                                 val portInt = port.toIntOrNull() ?: 8795
-                                testState = if (testTcpConnection(hostname.trim(), portInt))
+                                testState = if (testJugglucoConnection(hostname.trim(), portInt))
                                     ConnTestState.SUCCESS else ConnTestState.FAILURE
                             }
                         },

--- a/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
@@ -63,7 +63,7 @@ private const val UNIFIED_EXTRA_SCAN_TEXT = "tk.glucodata.extra.scan_text"
 private const val UNIFIED_EXTRA_SCAN_CONTEXT = "tk.glucodata.extra.scan_context"
 private const val UNIFIED_SCAN_CONTEXT_MIRROR = 1
 
-private enum class TestState { IDLE, TESTING, SUCCESS, FAILURE }
+private enum class ConnTestState { IDLE, TESTING, SUCCESS, FAILURE }
 
 private suspend fun testTcpConnection(host: String, port: Int): Boolean =
     withContext(Dispatchers.IO) {
@@ -595,7 +595,7 @@ fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
     val context = LocalContext.current
     val isNew = pos == -1
     val scope = rememberCoroutineScope()
-    var testState by remember { mutableStateOf(TestState.IDLE) }
+    var testState by remember { mutableStateOf(ConnTestState.IDLE) }
     fun connectionTypeLabel(option: ConnectionType): String = when (option) {
         ConnectionType.LOCAL -> context.getString(R.string.mirror_type_local)
         ConnectionType.ICE -> context.getString(R.string.ice)
@@ -665,7 +665,7 @@ fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
         }
     )}
 
-    LaunchedEffect(hostname, port, connectionType) { testState = TestState.IDLE }
+    LaunchedEffect(hostname, port, connectionType) { testState = ConnTestState.IDLE }
 
     fun save(): Boolean {
         val isICE = connectionType == ConnectionType.ICE
@@ -914,17 +914,17 @@ fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
                 ) {
                     OutlinedButton(
                         onClick = {
-                            testState = TestState.TESTING
+                            testState = ConnTestState.TESTING
                             scope.launch {
                                 val portInt = port.toIntOrNull() ?: 8795
                                 testState = if (testTcpConnection(hostname.trim(), portInt))
-                                    TestState.SUCCESS else TestState.FAILURE
+                                    ConnTestState.SUCCESS else ConnTestState.FAILURE
                             }
                         },
-                        enabled = testState != TestState.TESTING,
+                        enabled = testState != ConnTestState.TESTING,
                         modifier = Modifier.weight(1f)
                     ) {
-                        if (testState == TestState.TESTING) {
+                        if (testState == ConnTestState.TESTING) {
                             CircularProgressIndicator(
                                 modifier = Modifier.size(16.dp),
                                 strokeWidth = 2.dp,
@@ -932,18 +932,18 @@ fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
                             )
                             Spacer(Modifier.width(8.dp))
                         }
-                        Text(if (testState == TestState.TESTING)
+                        Text(if (testState == ConnTestState.TESTING)
                             stringResource(R.string.connecting) else stringResource(R.string.test))
                     }
                     when (testState) {
-                        TestState.SUCCESS -> {
+                        ConnTestState.SUCCESS -> {
                             Icon(Icons.Filled.CheckCircle, contentDescription = null,
                                 tint = Color(0xFF4CAF50), modifier = Modifier.size(24.dp))
                             Text(stringResource(R.string.status_connected),
                                 color = Color(0xFF4CAF50),
                                 style = MaterialTheme.typography.bodyMedium)
                         }
-                        TestState.FAILURE -> {
+                        ConnTestState.FAILURE -> {
                             Icon(Icons.Filled.Error, contentDescription = null,
                                 tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(24.dp))
                             Text(stringResource(R.string.status_connection_failed),


### PR DESCRIPTION
Used this code for a week now.

Rob

---

## Mirror: Juggluco protocol test button in connection card and edit dialog

Adds a "Test" button to both the connection list card and the add/edit
connection dialog that verifies a real Juggluco server is listening — not
just that TCP port is open.

### Protocol handshake

`testJugglucoConnection()` performs the actual Juggluco mirror handshake:
1. Opens a TCP socket with a 5-second connect + read timeout
2. Sends the 14-byte `sendmagicinit` header
3. Reads the response and checks that the first 11 bytes match `receivemagic`

A plain TCP check passes for any open port (nginx, SSH, etc.). The handshake
confirms an actual Juggluco instance is listening and responding correctly.

### Connection card (list view)

A "Test" button appears in the expanded card footer when the connection has
a known hostname. Shows a `CircularProgressIndicator` while testing; button
color reflects the result (green / error / primary). State resets when the
card is collapsed.

### Edit dialog

A "Test" button appears below the hostname/port fields for DIRECT connections
and LOCAL connections with a manual address (i.e. where a hostname is actually
configured). Full result row shows a checkmark/error icon plus a status string.
State resets automatically via `LaunchedEffect` whenever hostname, port, or
connection type changes, so stale results don't persist across edits.

### Rename "Direct IP" → "Direct"

The connection type label is updated in `strings.xml` (en + nl) to reflect
that this mode now accepts hostnames as well as IP addresses.
