### PR TITLE
fix(nsf): survive BT-off events + 59s self-healing probe

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
@@ -130,7 +130,16 @@ class NightscoutFollowerManager(
 
     override fun close() {
         handler.removeCallbacksAndMessages(null)
-        runCatching { handlerThread.quitSafely() }
+        if (stop) {
+            // Permanent shutdown: free() sets stop=true before calling close().
+            // Quit the HandlerThread so it doesn't outlive the sensor object.
+            runCatching { handlerThread.quitSafely() }
+        } else {
+            // Transient disconnect (e.g. Bluetooth off, network drop).
+            // Keep the HandlerThread alive and reset to IDLE so reconnect() can
+            // restart polling without needing a full sensor teardown/reinit.
+            setStatus(Phase.IDLE, localizedString(R.string.nightscout_follow_status_idle, "Nightscout follower idle"))
+        }
         super.close()
     }
 

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
@@ -3,6 +3,7 @@ package tk.glucodata.drivers.nightscout
 import android.content.Context
 import android.os.Handler
 import android.os.HandlerThread
+import android.os.Looper
 import java.net.HttpURLConnection
 import java.net.URL
 import java.security.MessageDigest
@@ -33,6 +34,7 @@ class NightscoutFollowerManager(
         private const val SENSOR_GEN = 0
         private const val POLL_INTERVAL_MS = 60_000L
         private const val RETRY_INTERVAL_MS = 30_000L
+        private const val PROBE_INTERVAL_MS = 59_000L
         private const val HISTORY_COUNT = 288
         private const val MMOL_TO_MGDL = 18.0182f
     }
@@ -46,6 +48,8 @@ class NightscoutFollowerManager(
     private val handlerThread = HandlerThread("NightscoutFollower-$serial").also { it.start() }
     private val handler = Handler(handlerThread.looper)
     private val pollRunnable = Runnable { refresh("poll") }
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val probeRunnable = Runnable { reconnect(System.currentTimeMillis()) }
 
     @Volatile private var phase: Phase = Phase.IDLE
     @Volatile private var status: String = localizedString(R.string.nightscout_follow_status_idle, "Nightscout follower idle")
@@ -125,6 +129,8 @@ class NightscoutFollowerManager(
     override fun connectDevice(delayMillis: Long): Boolean {
         stop = false
         scheduleRefresh(delayMillis.coerceAtLeast(0L))
+        mainHandler.removeCallbacks(probeRunnable)
+        mainHandler.postDelayed(probeRunnable, PROBE_INTERVAL_MS)
         return true
     }
 
@@ -133,6 +139,7 @@ class NightscoutFollowerManager(
         if (stop) {
             // Permanent shutdown: free() sets stop=true before calling close().
             // Quit the HandlerThread so it doesn't outlive the sensor object.
+            mainHandler.removeCallbacks(probeRunnable)
             runCatching { handlerThread.quitSafely() }
         } else {
             // Transient disconnect (e.g. Bluetooth off, network drop).
@@ -146,6 +153,7 @@ class NightscoutFollowerManager(
     override fun softDisconnect() {
         stop = true
         handler.removeCallbacksAndMessages(null)
+        mainHandler.removeCallbacks(probeRunnable)
         setStatus(Phase.IDLE, localizedString(R.string.nightscout_follow_status_paused, "Nightscout follower paused"))
     }
 
@@ -155,13 +163,18 @@ class NightscoutFollowerManager(
     }
 
     override fun reconnect(now: Long): Boolean {
-        if (!stop && phase == Phase.IDLE) connectDevice(0)
+        if (!stop) {
+            if (phase == Phase.IDLE) connectDevice(0)
+            mainHandler.removeCallbacks(probeRunnable)
+            mainHandler.postDelayed(probeRunnable, PROBE_INTERVAL_MS)
+        }
         return true
     }
 
     override fun terminateManagedSensor(wipeData: Boolean) {
         stop = true
         handler.removeCallbacksAndMessages(null)
+        mainHandler.removeCallbacks(probeRunnable)
         if (wipeData) {
             Applic.app?.let { NightscoutFollowerRegistry.disableFollowerSensor(it) }
         }


### PR DESCRIPTION
## What

Two reliability fixes for `NightscoutFollowerManager`, both isolated to that single file and building directly on the NSF work from #34.

Tested this for half a day myself, didn't want to wait too long as this is a sneaky bug that needed fixing asap.

---

### Fix 1 — NSF goes silent after Bluetooth off / airplane mode

**Root cause:** `SensorBluetooth`'s `BluetoothAdapter.STATE_OFF` handler calls `close()` on every registered GATT callback, including virtual sensors like the Nightscout follower that don't use Bluetooth at all. The old `close()` unconditionally called `handlerThread.quitSafely()`, permanently killing the poll loop's Looper. Additionally it left `phase == FOLLOWING`, so the `!stop && phase == IDLE` guard in `reconnect()` never fired on subsequent `LossOfSensorAlarm` cycles.

Confirmed trigger: 4-hour reading gap, same PID throughout, no crash. Logcat shows `BLUETOOTH switched OFF` → `SuperGattCallback close NSF-*` at 14:21, then `LossOfSensorAlarm` firing every ~350 s calling `reconnectall()` with no effect until manual restart at 17:29.

**Fix:** `close()` checks `stop` to distinguish permanent from transient shutdown. `free()` already sets `stop = true` before calling `close()`, so that path (permanent sensor destroy) quits the HandlerThread as before. When `stop` is false — which covers the BT-off broadcast and any other transient close — the HandlerThread is kept alive and `phase` is reset to `IDLE`. The next `reconnect()` call then sees `phase == IDLE` and calls `connectDevice()` to restart polling.

---

### Fix 2 — 59-second self-healing watchdog

**Motivation:** The `LossOfSensorAlarm` recovery cycle is ~350 s. With fix 1 in place the HandlerThread survives transient events, but if the poll loop stops for any other reason (unknown future trigger, logic edge case) the gap before recovery is up to 350 s.

**Fix:** `reconnect()` now schedules a recurring probe on the main looper every 59 s (staggered from the alarm cycle). The probe calls `reconnect()` again, which re-arms the next probe and restarts `connectDevice()` if `phase == IDLE`. `connectDevice()` also arms the probe on startup so it's live from the first poll. The probe is cancelled on intentional stop: `softDisconnect()`, `terminateManagedSensor()`, and the permanent-shutdown branch of `close()`.

No new threads or timers — `mainHandler` is just `Handler(Looper.getMainLooper())`, reusing the same infrastructure already present for the HandlerThread.

---

## Diff summary

Single file changed: `NightscoutFollowerManager.kt`

- `+import android.os.Looper`
- `+PROBE_INTERVAL_MS = 59_000L` constant
- `+mainHandler`, `+probeRunnable` fields
- `close()`: branch on `stop` — quit thread only on permanent shutdown, reset to IDLE on transient
- `connectDevice()`: arm probe after scheduling refresh
- `softDisconnect()`: cancel probe
- `reconnect()`: re-arm probe on every call while `!stop`
- `terminateManagedSensor()`: cancel probe