### PR TITLE
fix(nsf): replace regex with isSha1Hex to eliminate ICU JNI crash

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
@@ -146,8 +146,17 @@ object NightscoutFollowerRegistry {
         }
         connection.setRequestProperty(
             "api-secret",
-            if (trimmed.matches(Regex("^[0-9a-fA-F]{40}$"))) trimmed else sha1(trimmed)
+            if (isSha1Hex(trimmed)) trimmed else sha1(trimmed)
         )
+    }
+
+    // Replaces Regex("^[0-9a-fA-F]{40}$") to avoid repeated ICU JNI allocation on
+    // the NightscoutFollower HandlerThread.  On Samsung Android 15 with Scudo+MTE the
+    // ReleaseIntArrayElements call inside MatcherNative_matchesImpl corrupts the chunk
+    // header after many poll cycles, resulting in a fatal SIGABRT.
+    private fun isSha1Hex(s: String): Boolean {
+        if (s.length != 40) return false
+        return s.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }
     }
 
     private fun sha1(value: String): String =

--- a/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistryTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistryTests.kt
@@ -49,12 +49,43 @@ class NightscoutFollowerRegistryTests {
     }
 
     @Test
-    fun applyAuth_rawSha1Hex_sentAsApiSecret() {
-        // 40-char hex = raw SHA1 (Nightscout stores api-secret this way)
-        val sha1hex = "a".repeat(40)
+    fun applyAuth_rawSha1Hex_lowercase_sentAsApiSecret() {
+        val sha1hex = "a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1"
         val headers = applyAuthToMock(sha1hex)
         assertEquals(sha1hex, headers["api-secret"])
         assertNull(headers["Authorization"])
+    }
+
+    @Test
+    fun applyAuth_rawSha1Hex_uppercase_sentAsApiSecret() {
+        val sha1hex = "A0B1C2D3E4F5A0B1C2D3E4F5A0B1C2D3E4F5A0B1"
+        val headers = applyAuthToMock(sha1hex)
+        assertEquals(sha1hex, headers["api-secret"])
+        assertNull(headers["Authorization"])
+    }
+
+    @Test
+    fun applyAuth_rawSha1Hex_mixedCase_sentAsApiSecret() {
+        val sha1hex = "a0B1C2d3E4f5A0b1C2D3e4F5a0B1C2d3E4f5A0b1"
+        val headers = applyAuthToMock(sha1hex)
+        assertEquals(sha1hex, headers["api-secret"])
+        assertNull(headers["Authorization"])
+    }
+
+    @Test
+    fun applyAuth_39charHex_hashed() {
+        val notSha1 = "a".repeat(39)
+        val headers = applyAuthToMock(notSha1)
+        assertNotEquals(notSha1, headers["api-secret"])
+        assertNotNull(headers["api-secret"])
+    }
+
+    @Test
+    fun applyAuth_40charNonHex_hashed() {
+        val notHex = "a".repeat(39) + "g"
+        val headers = applyAuthToMock(notHex)
+        assertNotEquals(notHex, headers["api-secret"])
+        assertNotNull(headers["api-secret"])
     }
 
     @Test


### PR DESCRIPTION
## Summary

`applyAuth()` in `NightscoutFollowerRegistry` creates a new `Regex("^[0-9a-fA-F]{40}$")` object on every call. The `NightscoutFollowerManager` calls `applyAuth()` twice per 60-second poll cycle (once for readings, once for treatments), meaning ~120 ICU `MatcherNative_matchesImpl` JNI invocations per hour run on the `NightscoutFollower` HandlerThread.

On Samsung Galaxy S24 FE (SM-S721B) / Android 15 (AP3A.240905.015.A2) with Scudo+MTE enabled, this causes the process to crash after ~73 minutes of polling with:

```
Scudo ERROR: corrupted chunk header at address 0x200007666b2b010
#05 scudo::Allocator::deallocate
#06 JNI<true>::ReleasePrimitiveArray<_jintArray*, int>  +412  (libart.so)
#07 CheckJNI::ReleasePrimitiveArrayElements             +260  (libart.so)
#08 MatcherNative_matchesImpl                           +64   (libicu_jni.so)
     ← java.util.regex.Matcher.matches()
     ← NightscoutFollowerRegistry.applyAuth()
```

The `jintArray` offsets buffer allocated by ICU when `ReleaseIntArrayElements` is called is what Scudo detects as corrupted after many short-lived JNI cycles with Scudo+MTE tags active.

## Fix

Replace the inline `Regex(...).matches()` call with `isSha1Hex()`, a pure Kotlin char scan that is semantically identical (exact 40-character [0-9a-fA-F] string) but makes **no ICU JNI calls**:

```kotlin
private fun isSha1Hex(s: String): Boolean {
    if (s.length != 40) return false
    return s.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }
}
```

## Test plan

- [ ] `applyAuth_rawSha1Hex_lowercase_sentAsApiSecret` — 40-char lowercase hex → sent raw
- [ ] `applyAuth_rawSha1Hex_uppercase_sentAsApiSecret` — 40-char uppercase hex → sent raw
- [ ] `applyAuth_rawSha1Hex_mixedCase_sentAsApiSecret` — 40-char mixed-case hex → sent raw
- [ ] `applyAuth_39charHex_hashed` — 39-char hex → SHA-1 hashed
- [ ] `applyAuth_40charNonHex_hashed` — 40-char string with 'g' → SHA-1 hashed
- [ ] `applyAuth_plainText_hashed` — plain text → SHA-1 hashed (existing)
- [ ] Verified against tombstone from Samsung Galaxy S24 FE device

🤖 Generated with [Claude Code](https://claude.com/claude-code)