### PR TITLE
feat(outbound): Telegram bubble refresh with stale/missed detection

### DIFF
--- a/Common/src/main/java/tk/glucodata/OutboundApi.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApi.kt
@@ -491,7 +491,12 @@ object OutboundApi {
         val json: JSONObject? = null
     )
 
-    internal fun renderMessage(template: String, reading: Reading): String {
+    internal fun renderMessage(
+        template: String,
+        reading: Reading,
+        destination: OutboundApiSettings.Destination? = null,
+        status: String? = null
+    ): String {
         val time = DateFormat.getDateTimeInstance(
             DateFormat.SHORT,
             DateFormat.SHORT,
@@ -508,6 +513,10 @@ object OutboundApi {
         }
         val effectiveIob = journal.iob.takeIf { it.isFinite() } ?: reading.iob
         val journalEvents = journalEventsJsonArray(journal)
+        val effectiveStatus = status
+            ?: destination?.rangeStatus(reading.mgdl)
+            ?: OutboundApiSettings.TUNNEL_STATUS_IN_RANGE
+        val statusEmojiValue = statusEmoji(effectiveStatus)
         return template
             .replace("{event_id}", reading.eventId)
             .replace("{recipient}", reading.recipient)
@@ -546,6 +555,16 @@ object OutboundApi {
             .replace("{journal_events}", journalEvents?.toString().orEmpty())
             .replace("{journal}", journal.json?.toString().orEmpty())
             .replace("{test}", reading.test.toString())
+            .replace("{status}", effectiveStatus)
+            .replace("{status_emoji}", statusEmojiValue)
+    }
+
+    internal fun statusEmoji(status: String): String = when (status) {
+        OutboundApiSettings.TUNNEL_STATUS_HIGH -> "\uD83D\uDFE1"      // 🟡
+        OutboundApiSettings.TUNNEL_STATUS_LOW -> "\uD83D\uDD34"       // 🔴
+        OutboundApiSettings.TUNNEL_STATUS_STALE -> "\u26A0\uFE0F"     // ⚠️
+        OutboundApiSettings.TUNNEL_STATUS_MISSED -> "\u26AA"          // ⚪
+        else -> "\uD83D\uDFE2"                                        // 🟢
     }
 
     internal fun formatNumber(value: Float, decimals: Int): String {
@@ -635,9 +654,25 @@ class OutboundApiWorker(
             val reading = OutboundApi.inputToReading(inputData) ?: return Result.success()
 
             return try {
-                val response = send(destination, reading)
+                val response = send(context, destination, reading)
                 if (response.ok) {
                     OutboundApiSettings.recordSuccess(context, destination.id, response.code)
+                    if (!response.suppressed) {
+                        OutboundApiSettings.recordBubbleSent(
+                            context = context.applicationContext,
+                            destinationId = destination.id,
+                            recipient = reading.recipient,
+                            messageId = response.messageId,
+                            sentAtMs = System.currentTimeMillis(),
+                            mgdl = reading.mgdl
+                        )
+                        TelegramStaleCheckWork.schedule(
+                            context = context.applicationContext,
+                            destinationId = destination.id,
+                            delayMs = (destination.staleThresholdMinutes.coerceIn(1, 120) * 60_000L) +
+                                OutboundApiSettings.STALE_CHECK_SLACK_MS
+                        )
+                    }
                     Result.success()
                 } else {
                     OutboundApiSettings.recordAttempt(context, destination.id, response.code, response.error)
@@ -658,7 +693,9 @@ class OutboundApiWorker(
             val code: Int,
             val ok: Boolean,
             val retryable: Boolean,
-            val error: String?
+            val error: String?,
+            val messageId: Long? = null,
+            val suppressed: Boolean = false
         )
 
         private data class ApiError(
@@ -668,12 +705,17 @@ class OutboundApiWorker(
         )
 
         private fun send(
+            context: Context,
             destination: OutboundApiSettings.Destination,
             reading: OutboundApi.Reading
         ): SendResponse {
-            val message = OutboundApi.renderMessage(destination.resolvedTemplate(), reading)
+            val message = OutboundApi.renderMessage(
+                template = destination.resolvedTemplate(),
+                reading = reading,
+                destination = destination
+            )
             return when (destination.normalizedPreset()) {
-                OutboundApiSettings.PRESET_TELEGRAM_BOT -> sendTelegram(destination, reading, message)
+                OutboundApiSettings.PRESET_TELEGRAM_BOT -> sendTelegram(context, destination, reading, message)
                 OutboundApiSettings.PRESET_GLUCO_WATCH_VK,
                 OutboundApiSettings.PRESET_VK_MESSAGES -> sendVk(destination, reading, message)
                 else -> sendJson(destination, reading, message)
@@ -681,6 +723,52 @@ class OutboundApiWorker(
         }
 
         private fun sendTelegram(
+            context: Context,
+            destination: OutboundApiSettings.Destination,
+            reading: OutboundApi.Reading,
+            message: String
+        ): SendResponse {
+            val now = System.currentTimeMillis()
+            val lastMsgId = destination.lastMessageIdByRecipient[reading.recipient] ?: 0L
+            val lastSentMs = destination.lastSentAtMsByRecipient[reading.recipient] ?: 0L
+            val lastMgdl = destination.lastSentMgdlByRecipient[reading.recipient] ?: 0
+            val windowMs = destination.refreshWindowMinutes.coerceIn(1, 60) * 60_000L
+            val withinWindow = destination.refreshInPlaceEnabled &&
+                lastMsgId > 0L && lastSentMs > 0L &&
+                (now - lastSentMs) <= windowMs
+            val suppressThreshold = destination.suppressDeltaBelowMgdl.coerceIn(0, 100)
+            val shouldSuppress = withinWindow && suppressThreshold > 0 &&
+                kotlin.math.abs(reading.mgdl - lastMgdl) < suppressThreshold
+
+            if (shouldSuppress) {
+                return SendResponse(
+                    code = 200,
+                    ok = true,
+                    retryable = false,
+                    error = null,
+                    messageId = lastMsgId,
+                    suppressed = true
+                )
+            }
+            if (withinWindow) {
+                val editResponse = sendTelegramEdit(
+                    destination = destination,
+                    reading = reading,
+                    message = message,
+                    messageId = lastMsgId
+                )
+                if (editResponse.ok) return editResponse
+                // Edit failed (message deleted, etc.) — fall through to a fresh send.
+                OutboundApiSettings.clearRecipientState(
+                    context = context.applicationContext,
+                    destinationId = destination.id,
+                    recipient = reading.recipient
+                )
+            }
+            return sendTelegramSend(destination, reading, message)
+        }
+
+        private fun sendTelegramSend(
             destination: OutboundApiSettings.Destination,
             reading: OutboundApi.Reading,
             message: String
@@ -697,7 +785,34 @@ class OutboundApiWorker(
                 body = body,
                 parseApiError = ::parseTelegramError,
                 connectTimeoutMs = 20_000,
-                readTimeoutMs = 30_000
+                readTimeoutMs = 30_000,
+                parseMessageId = ::parseTelegramMessageId
+            )
+        }
+
+        private fun sendTelegramEdit(
+            destination: OutboundApiSettings.Destination,
+            reading: OutboundApi.Reading,
+            message: String,
+            messageId: Long
+        ): SendResponse {
+            val editUrl = destination.resolvedUrl()
+                .replace(Regex("/sendMessage$"), "/editMessageText")
+            val body = JSONObject()
+                .put("chat_id", reading.recipient)
+                .put("message_id", messageId)
+                .put("text", message)
+                .toString()
+                .toByteArray(Charsets.UTF_8)
+            return executePost(
+                urlString = editUrl,
+                contentType = "application/json; charset=UTF-8",
+                headers = destination.headers,
+                body = body,
+                parseApiError = ::parseTelegramError,
+                connectTimeoutMs = 20_000,
+                readTimeoutMs = 30_000,
+                parseMessageId = ::parseTelegramMessageId
             )
         }
 
@@ -743,7 +858,8 @@ class OutboundApiWorker(
             parseApiError: (String) -> ApiError?,
             connectTimeoutMs: Int = 15_000,
             readTimeoutMs: Int = 30_000,
-            preResponseRetries: Int = 0
+            preResponseRetries: Int = 0,
+            parseMessageId: (String) -> Long? = { null }
         ): SendResponse {
             var lastFailure: Throwable? = null
             repeat(preResponseRetries + 1) { attempt ->
@@ -755,7 +871,8 @@ class OutboundApiWorker(
                         body = body,
                         parseApiError = parseApiError,
                         connectTimeoutMs = connectTimeoutMs,
-                        readTimeoutMs = readTimeoutMs
+                        readTimeoutMs = readTimeoutMs,
+                        parseMessageId = parseMessageId
                     )
                 } catch (th: Throwable) {
                     lastFailure = th
@@ -773,7 +890,8 @@ class OutboundApiWorker(
             body: ByteArray,
             parseApiError: (String) -> ApiError?,
             connectTimeoutMs: Int,
-            readTimeoutMs: Int
+            readTimeoutMs: Int,
+            parseMessageId: (String) -> Long?
         ): SendResponse {
             val connection = (URL(urlString).openConnection() as HttpURLConnection).apply {
                 requestMethod = "POST"
@@ -803,11 +921,13 @@ class OutboundApiWorker(
                     )
                 }
                 val ok = code in 200..299
+                val messageId = if (ok) parseMessageId(responseText) else null
                 return SendResponse(
                     code = code,
                     ok = ok,
                     retryable = code == 429 || code >= 500,
-                    error = if (ok) null else responseText.take(500).ifBlank { "HTTP $code" }
+                    error = if (ok) null else responseText.take(500).ifBlank { "HTTP $code" },
+                    messageId = messageId
                 )
             } finally {
                 connection.disconnect()
@@ -946,6 +1066,19 @@ class OutboundApiWorker(
                     code = code,
                     retryable = code == 429 || code == 500 || code == 502 || code == 503
                 )
+            } catch (_: Throwable) {
+                null
+            }
+        }
+
+        private fun parseTelegramMessageId(responseText: String): Long? {
+            if (responseText.isBlank()) return null
+            return try {
+                val root = JSONObject(responseText)
+                if (!root.optBoolean("ok", true)) return null
+                val result = root.optJSONObject("result") ?: return null
+                val id = result.optLong("message_id", 0L)
+                if (id > 0L) id else null
             } catch (_: Throwable) {
                 null
             }

--- a/Common/src/main/java/tk/glucodata/OutboundApi.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApi.kt
@@ -739,7 +739,9 @@ class OutboundApiWorker(
                 lastMsgId > 0L && lastSentMs > 0L &&
                 (now - lastSentMs) <= windowMs
             val suppressThreshold = destination.suppressDeltaBelowMgdl.coerceIn(0, 100)
-            val shouldSuppress = withinWindow && suppressThreshold > 0 &&
+            // Test sends use the same reading data every time, so never suppress them —
+            // the user needs to be able to verify edit-in-place via the test button.
+            val shouldSuppress = withinWindow && !reading.test && suppressThreshold > 0 &&
                 kotlin.math.abs(reading.mgdl - lastMgdl) < suppressThreshold
 
             if (shouldSuppress) {
@@ -760,7 +762,20 @@ class OutboundApiWorker(
                     messageId = lastMsgId
                 )
                 if (editResponse.ok) return editResponse
-                // Edit failed (message deleted, etc.) — fall through to a fresh send.
+                // Telegram rejects edits where the content hasn't changed (400 "not modified").
+                // This is a success — the bubble is already correct — so preserve state and
+                // return without posting a new message.
+                if (editResponse.error?.contains("not modified") == true) {
+                    return SendResponse(
+                        code = 200,
+                        ok = true,
+                        retryable = false,
+                        error = null,
+                        messageId = lastMsgId
+                    )
+                }
+                // Any other edit failure (message deleted, chat not found, etc.):
+                // clear stale state so the next reading starts a fresh bubble.
                 OutboundApiSettings.clearRecipientState(
                     context = context.applicationContext,
                     destinationId = destination.id,

--- a/Common/src/main/java/tk/glucodata/OutboundApi.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApi.kt
@@ -666,12 +666,14 @@ class OutboundApiWorker(
                             sentAtMs = System.currentTimeMillis(),
                             mgdl = reading.mgdl
                         )
-                        TelegramStaleCheckWork.schedule(
-                            context = context.applicationContext,
-                            destinationId = destination.id,
-                            delayMs = (destination.staleThresholdMinutes.coerceIn(1, 120) * 60_000L) +
-                                OutboundApiSettings.STALE_CHECK_SLACK_MS
-                        )
+                        if (destination.normalizedPreset() == OutboundApiSettings.PRESET_TELEGRAM_BOT) {
+                            TelegramStaleCheckWork.schedule(
+                                context = context.applicationContext,
+                                destinationId = destination.id,
+                                delayMs = (destination.staleThresholdMinutes.coerceIn(1, 120) * 60_000L) +
+                                    OutboundApiSettings.STALE_CHECK_SLACK_MS
+                            )
+                        }
                     }
                     Result.success()
                 } else {

--- a/Common/src/main/java/tk/glucodata/OutboundApi.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApi.kt
@@ -774,7 +774,11 @@ class OutboundApiWorker(
                         messageId = lastMsgId
                     )
                 }
-                // Any other edit failure (message deleted, chat not found, etc.):
+                // Transient failure (rate limit, server error): preserve the message ID so
+                // the next reading retries the edit. Don't attempt a fresh send that will
+                // likely also fail.
+                if (editResponse.retryable) return editResponse
+                // Definitive rejection (message deleted, chat not found, etc.):
                 // clear stale state so the next reading starts a fresh bubble.
                 OutboundApiSettings.clearRecipientState(
                     context = context.applicationContext,

--- a/Common/src/main/java/tk/glucodata/OutboundApi.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApi.kt
@@ -657,23 +657,34 @@ class OutboundApiWorker(
                 val response = send(context, destination, reading)
                 if (response.ok) {
                     OutboundApiSettings.recordSuccess(context, destination.id, response.code)
+                    val nowMs = System.currentTimeMillis()
                     if (!response.suppressed) {
                         OutboundApiSettings.recordBubbleSent(
                             context = context.applicationContext,
                             destinationId = destination.id,
                             recipient = reading.recipient,
                             messageId = response.messageId,
-                            sentAtMs = System.currentTimeMillis(),
+                            sentAtMs = nowMs,
                             mgdl = reading.mgdl
                         )
-                        if (destination.normalizedPreset() == OutboundApiSettings.PRESET_TELEGRAM_BOT) {
-                            TelegramStaleCheckWork.schedule(
-                                context = context.applicationContext,
-                                destinationId = destination.id,
-                                delayMs = (destination.staleThresholdMinutes.coerceIn(1, 120) * 60_000L) +
-                                    OutboundApiSettings.STALE_CHECK_SLACK_MS
-                            )
-                        }
+                    } else {
+                        // Reading arrived but bubble text was unchanged — still update the
+                        // "last received" timestamp so the stale timer doesn't fire during
+                        // a flat-glucose stretch where every reading is suppressed.
+                        OutboundApiSettings.recordReadingArrived(
+                            context = context.applicationContext,
+                            destinationId = destination.id,
+                            recipient = reading.recipient,
+                            arrivedAtMs = nowMs
+                        )
+                    }
+                    if (destination.normalizedPreset() == OutboundApiSettings.PRESET_TELEGRAM_BOT) {
+                        TelegramStaleCheckWork.schedule(
+                            context = context.applicationContext,
+                            destinationId = destination.id,
+                            delayMs = (destination.staleThresholdMinutes.coerceIn(1, 120) * 60_000L) +
+                                OutboundApiSettings.STALE_CHECK_SLACK_MS
+                        )
                     }
                     Result.success()
                 } else {

--- a/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
@@ -48,10 +48,22 @@ object OutboundApiSettings {
     const val TRIGGER_OUTSIDE_RANGE = "outside_range"
     const val DEFAULT_TRIGGER_LOW_MGDL = 70
     const val DEFAULT_TRIGGER_HIGH_MGDL = 180
+    const val DEFAULT_REFRESH_IN_PLACE_ENABLED = true
+    const val DEFAULT_REFRESH_WINDOW_MINUTES = 5
+    const val DEFAULT_SUPPRESS_DELTA_BELOW_MGDL = 1
+    const val DEFAULT_STALE_ENABLED = true
+    const val DEFAULT_STALE_THRESHOLD_MINUTES = 10
+    const val DEFAULT_MISSED_THRESHOLD_MINUTES = 15
+    const val STALE_CHECK_SLACK_MS = 10_000L
+    const val TUNNEL_STATUS_IN_RANGE = "in_range"
+    const val TUNNEL_STATUS_HIGH = "high"
+    const val TUNNEL_STATUS_LOW = "low"
+    const val TUNNEL_STATUS_STALE = "stale"
+    const val TUNNEL_STATUS_MISSED = "missed"
     const val DEFAULT_CUSTOM_TEMPLATE =
         "{value} {unit} {trend_arrow} RAW:{raw} ({rate_mgdl} mg/dL/min) IOB:{iob} COB:{cob} {time}"
     const val DEFAULT_CHAT_TEMPLATE =
-        "{value} {unit} {trend_arrow} {time}"
+        "{status_emoji} {value} {unit} {trend_arrow} {time}"
     const val DEFAULT_GLUCO_WATCH_TEMPLATE =
         "GV:{mmol}|RAW:{raw}|TR:{trend_arrow}|AL:{alarm}|RT:{rate_mmol}|IOB:{iob}|COB:{cob}|TS:{timestamp}"
 
@@ -89,7 +101,17 @@ object OutboundApiSettings {
         val lastAttemptAtMs: Long,
         val lastSuccessAtMs: Long,
         val lastResponseCode: Int,
-        val lastError: String?
+        val lastError: String?,
+        val refreshInPlaceEnabled: Boolean = DEFAULT_REFRESH_IN_PLACE_ENABLED,
+        val refreshWindowMinutes: Int = DEFAULT_REFRESH_WINDOW_MINUTES,
+        val suppressDeltaBelowMgdl: Int = DEFAULT_SUPPRESS_DELTA_BELOW_MGDL,
+        val staleEnabled: Boolean = DEFAULT_STALE_ENABLED,
+        val staleThresholdMinutes: Int = DEFAULT_STALE_THRESHOLD_MINUTES,
+        val missedThresholdMinutes: Int = DEFAULT_MISSED_THRESHOLD_MINUTES,
+        val lastMessageIdByRecipient: Map<String, Long> = emptyMap(),
+        val lastSentAtMsByRecipient: Map<String, Long> = emptyMap(),
+        val lastSentMgdlByRecipient: Map<String, Int> = emptyMap(),
+        val lastStaleAtMsByRecipient: Map<String, Long> = emptyMap()
     ) {
         fun normalizedPreset(): String = normalizePreset(preset)
 
@@ -151,6 +173,17 @@ object OutboundApiSettings {
                 TRIGGER_AT_OR_ABOVE -> mgdl >= high
                 TRIGGER_OUTSIDE_RANGE -> mgdl <= low || mgdl >= high
                 else -> true
+            }
+        }
+
+        fun rangeStatus(mgdl: Int): String {
+            if (mgdl <= 0) return TUNNEL_STATUS_IN_RANGE
+            val low = triggerLowMgdl.coerceIn(1, 600)
+            val high = triggerHighMgdl.coerceIn(1, 600)
+            return when {
+                mgdl < low -> TUNNEL_STATUS_LOW
+                mgdl > high -> TUNNEL_STATUS_HIGH
+                else -> TUNNEL_STATUS_IN_RANGE
             }
         }
 
@@ -242,7 +275,17 @@ object OutboundApiSettings {
             lastAttemptAtMs = 0L,
             lastSuccessAtMs = 0L,
             lastResponseCode = 0,
-            lastError = null
+            lastError = null,
+            refreshInPlaceEnabled = DEFAULT_REFRESH_IN_PLACE_ENABLED,
+            refreshWindowMinutes = DEFAULT_REFRESH_WINDOW_MINUTES,
+            suppressDeltaBelowMgdl = DEFAULT_SUPPRESS_DELTA_BELOW_MGDL,
+            staleEnabled = DEFAULT_STALE_ENABLED,
+            staleThresholdMinutes = DEFAULT_STALE_THRESHOLD_MINUTES,
+            missedThresholdMinutes = DEFAULT_MISSED_THRESHOLD_MINUTES,
+            lastMessageIdByRecipient = emptyMap(),
+            lastSentAtMsByRecipient = emptyMap(),
+            lastSentMgdlByRecipient = emptyMap(),
+            lastStaleAtMsByRecipient = emptyMap()
         )
     }
 
@@ -306,6 +349,57 @@ object OutboundApiSettings {
                 lastSuccessAtMs = now,
                 lastResponseCode = responseCode,
                 lastError = null
+            )
+        }
+    }
+
+    fun recordBubbleSent(
+        context: Context,
+        destinationId: String,
+        recipient: String,
+        messageId: Long?,
+        sentAtMs: Long,
+        mgdl: Int
+    ) {
+        if (messageId == null || messageId <= 0L) return
+        updateDestination(context, destinationId) { dest ->
+            dest.copy(
+                lastMessageIdByRecipient = dest.lastMessageIdByRecipient +
+                    (recipient to messageId),
+                lastSentAtMsByRecipient = dest.lastSentAtMsByRecipient +
+                    (recipient to sentAtMs),
+                lastSentMgdlByRecipient = dest.lastSentMgdlByRecipient +
+                    (recipient to mgdl),
+                lastStaleAtMsByRecipient = dest.lastStaleAtMsByRecipient - recipient
+            )
+        }
+    }
+
+    fun recordStaleAt(
+        context: Context,
+        destinationId: String,
+        recipient: String,
+        staleAtMs: Long
+    ) {
+        updateDestination(context, destinationId) { dest ->
+            dest.copy(
+                lastStaleAtMsByRecipient = dest.lastStaleAtMsByRecipient +
+                    (recipient to staleAtMs)
+            )
+        }
+    }
+
+    fun clearRecipientState(
+        context: Context,
+        destinationId: String,
+        recipient: String
+    ) {
+        updateDestination(context, destinationId) { dest ->
+            dest.copy(
+                lastMessageIdByRecipient = dest.lastMessageIdByRecipient - recipient,
+                lastSentAtMsByRecipient = dest.lastSentAtMsByRecipient - recipient,
+                lastSentMgdlByRecipient = dest.lastSentMgdlByRecipient - recipient,
+                lastStaleAtMsByRecipient = dest.lastStaleAtMsByRecipient - recipient
             )
         }
     }
@@ -425,6 +519,28 @@ object OutboundApiSettings {
                         .put("lastSuccessAtMs", destination.lastSuccessAtMs)
                         .put("lastResponseCode", destination.lastResponseCode)
                         .put("lastError", destination.lastError)
+                        .put("refreshInPlaceEnabled", destination.refreshInPlaceEnabled)
+                        .put("refreshWindowMinutes", destination.refreshWindowMinutes)
+                        .put("suppressDeltaBelowMgdl", destination.suppressDeltaBelowMgdl)
+                        .put("staleEnabled", destination.staleEnabled)
+                        .put("staleThresholdMinutes", destination.staleThresholdMinutes)
+                        .put("missedThresholdMinutes", destination.missedThresholdMinutes)
+                        .put(
+                            "lastMessageIdByRecipient",
+                            encodeLongMap(destination.lastMessageIdByRecipient)
+                        )
+                        .put(
+                            "lastSentAtMsByRecipient",
+                            encodeLongMap(destination.lastSentAtMsByRecipient)
+                        )
+                        .put(
+                            "lastSentMgdlByRecipient",
+                            encodeIntMap(destination.lastSentMgdlByRecipient)
+                        )
+                        .put(
+                            "lastStaleAtMsByRecipient",
+                            encodeLongMap(destination.lastStaleAtMsByRecipient)
+                        )
                 )
             }
         }
@@ -459,10 +575,71 @@ object OutboundApiSettings {
                 lastAttemptAtMs = item.optLong("lastAttemptAtMs", 0L),
                 lastSuccessAtMs = item.optLong("lastSuccessAtMs", 0L),
                 lastResponseCode = item.optInt("lastResponseCode", 0),
-                lastError = item.optString("lastError", "").ifBlank { null }
+                lastError = item.optString("lastError", "").ifBlank { null },
+                refreshInPlaceEnabled = item.optBoolean(
+                    "refreshInPlaceEnabled",
+                    DEFAULT_REFRESH_IN_PLACE_ENABLED
+                ),
+                refreshWindowMinutes = item.optInt(
+                    "refreshWindowMinutes",
+                    DEFAULT_REFRESH_WINDOW_MINUTES
+                ).coerceIn(1, 60),
+                suppressDeltaBelowMgdl = item.optInt(
+                    "suppressDeltaBelowMgdl",
+                    DEFAULT_SUPPRESS_DELTA_BELOW_MGDL
+                ).coerceIn(0, 100),
+                staleEnabled = item.optBoolean("staleEnabled", DEFAULT_STALE_ENABLED),
+                staleThresholdMinutes = item.optInt(
+                    "staleThresholdMinutes",
+                    DEFAULT_STALE_THRESHOLD_MINUTES
+                ).coerceIn(1, 120),
+                missedThresholdMinutes = item.optInt(
+                    "missedThresholdMinutes",
+                    DEFAULT_MISSED_THRESHOLD_MINUTES
+                ).coerceIn(
+                    item.optInt("staleThresholdMinutes", DEFAULT_STALE_THRESHOLD_MINUTES)
+                        .coerceIn(1, 120) + 1,
+                    240
+                ),
+                lastMessageIdByRecipient = decodeLongMap(item.optJSONObject("lastMessageIdByRecipient")),
+                lastSentAtMsByRecipient = decodeLongMap(item.optJSONObject("lastSentAtMsByRecipient")),
+                lastSentMgdlByRecipient = decodeIntMap(item.optJSONObject("lastSentMgdlByRecipient")),
+                lastStaleAtMsByRecipient = decodeLongMap(item.optJSONObject("lastStaleAtMsByRecipient"))
             )
         }
         return destinations.distinctBy { it.id.lowercase(Locale.US) }
+    }
+
+    private fun encodeLongMap(values: Map<String, Long>): JSONObject =
+        JSONObject().also { obj ->
+            values.forEach { (key, value) -> obj.put(key, value) }
+        }
+
+    private fun encodeIntMap(values: Map<String, Int>): JSONObject =
+        JSONObject().also { obj ->
+            values.forEach { (key, value) -> obj.put(key, value) }
+        }
+
+    private fun decodeLongMap(obj: JSONObject?): Map<String, Long> {
+        if (obj == null) return emptyMap()
+        val out = LinkedHashMap<String, Long>(obj.length())
+        val keys = obj.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            out[key] = obj.optLong(key, 0L)
+        }
+        return out
+    }
+
+    private fun decodeIntMap(obj: JSONObject?): Map<String, Int> {
+        if (obj == null) return emptyMap()
+        val out = LinkedHashMap<String, Int>(obj.length())
+        val keys = obj.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            out[key] = obj.optInt(key, 0)
+        }
+        return out
     }
 
     private fun prefs(context: Context) =

--- a/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
@@ -64,6 +64,8 @@ object OutboundApiSettings {
         "{value} {unit} {trend_arrow} RAW:{raw} ({rate_mgdl} mg/dL/min) IOB:{iob} COB:{cob} {time}"
     const val DEFAULT_CHAT_TEMPLATE =
         "{status_emoji} {value} {unit} {trend_arrow} {time}"
+    // Old default before status tokens were added — used to migrate stored templates on load.
+    private const val LEGACY_CHAT_TEMPLATE = "{value} {unit} {trend_arrow} {time}"
     const val DEFAULT_GLUCO_WATCH_TEMPLATE =
         "GV:{mmol}|RAW:{raw}|TR:{trend_arrow}|AL:{alarm}|RT:{rate_mmol}|IOB:{iob}|COB:{cob}|TS:{timestamp}"
 
@@ -562,7 +564,13 @@ object OutboundApiSettings {
                 apiVersion = item.optString("apiVersion", DEFAULT_VK_API_VERSION)
                     .ifBlank { DEFAULT_VK_API_VERSION },
                 headers = item.optString("headers", ""),
-                messageTemplate = item.optString("messageTemplate", defaultTemplate(preset)),
+                messageTemplate = run {
+                    val stored = item.optString("messageTemplate", defaultTemplate(preset))
+                    // Migrate the old default (pre-status-emoji) to the current default.
+                    if (stored == LEGACY_CHAT_TEMPLATE &&
+                        (preset == PRESET_TELEGRAM_BOT || preset == PRESET_VK_MESSAGES)
+                    ) DEFAULT_CHAT_TEMPLATE else stored
+                },
                 minIntervalMinutes = item.optInt(
                     "minIntervalMinutes",
                     DEFAULT_MIN_INTERVAL_MINUTES

--- a/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
@@ -566,9 +566,9 @@ object OutboundApiSettings {
                 headers = item.optString("headers", ""),
                 messageTemplate = run {
                     val stored = item.optString("messageTemplate", defaultTemplate(preset))
-                    // Migrate the old default (pre-status-emoji) to the current default.
+                    // Migrate the old Telegram default (pre-status-emoji) to the current default.
                     if (stored == LEGACY_CHAT_TEMPLATE &&
-                        (preset == PRESET_TELEGRAM_BOT || preset == PRESET_VK_MESSAGES)
+                        preset == PRESET_TELEGRAM_BOT
                     ) DEFAULT_CHAT_TEMPLATE else stored
                 },
                 minIntervalMinutes = item.optInt(

--- a/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
@@ -355,6 +355,21 @@ object OutboundApiSettings {
         }
     }
 
+    fun recordReadingArrived(
+        context: Context,
+        destinationId: String,
+        recipient: String,
+        arrivedAtMs: Long
+    ) {
+        updateDestination(context, destinationId) { dest ->
+            // Only update the timestamp; leave messageId and lastSentMgdl unchanged
+            // so suppression delta is still computed from the last-sent value.
+            dest.copy(
+                lastSentAtMsByRecipient = dest.lastSentAtMsByRecipient + (recipient to arrivedAtMs)
+            )
+        }
+    }
+
     fun recordBubbleSent(
         context: Context,
         destinationId: String,

--- a/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApiSettings.kt
@@ -49,7 +49,7 @@ object OutboundApiSettings {
     const val DEFAULT_TRIGGER_LOW_MGDL = 70
     const val DEFAULT_TRIGGER_HIGH_MGDL = 180
     const val DEFAULT_REFRESH_IN_PLACE_ENABLED = true
-    const val DEFAULT_REFRESH_WINDOW_MINUTES = 5
+    const val DEFAULT_REFRESH_WINDOW_MINUTES = 15
     const val DEFAULT_SUPPRESS_DELTA_BELOW_MGDL = 1
     const val DEFAULT_STALE_ENABLED = true
     const val DEFAULT_STALE_THRESHOLD_MINUTES = 10
@@ -591,7 +591,10 @@ object OutboundApiSettings {
                 refreshWindowMinutes = item.optInt(
                     "refreshWindowMinutes",
                     DEFAULT_REFRESH_WINDOW_MINUTES
-                ).coerceIn(1, 60),
+                ).let { stored ->
+                    // Migrate the old 5-minute default: too tight for a 5-min CGM interval.
+                    if (stored == 5) DEFAULT_REFRESH_WINDOW_MINUTES else stored
+                }.coerceIn(1, 60),
                 suppressDeltaBelowMgdl = item.optInt(
                     "suppressDeltaBelowMgdl",
                     DEFAULT_SUPPRESS_DELTA_BELOW_MGDL

--- a/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
+++ b/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
@@ -35,6 +35,10 @@ object TelegramStaleCheckWork {
 
     private const val STALE_PREFIX = "telegram_stale_check:"
     private const val TRANSIENT_RETRY_DELAY_MS = 60_000L
+    // Must exceed TRANSIENT_RETRY_DELAY_MS: a recipient that just posted STALE is
+    // throttled on the 60 s retry cycle but re-evaluated when the missed-threshold
+    // timer fires (which can be minutes later).
+    private const val STALE_THROTTLE_MS = 70_000L
 
     fun schedule(context: Context, destinationId: String, delayMs: Long) {
         val key = STALE_PREFIX + destinationId
@@ -78,7 +82,10 @@ object TelegramStaleCheckWork {
                 else -> continue
             }
             val lastStaleMs = destination.lastStaleAtMsByRecipient[recipient] ?: 0L
-            if (lastStaleMs > 0L && now - lastStaleMs < 30_000L) continue  // throttle
+            // STALE_THROTTLE_MS > TRANSIENT_RETRY_DELAY_MS: a recipient that just
+            // succeeded is skipped on the 60 s retry cycle but re-evaluated when
+            // the missed-threshold timer fires later.
+            if (lastStaleMs > 0L && now - lastStaleMs < STALE_THROTTLE_MS) continue
             val messageId = destination.lastMessageIdByRecipient[recipient] ?: 0L
             if (messageId <= 0L) continue
 

--- a/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
+++ b/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
@@ -34,6 +34,7 @@ object TelegramStaleCheckWork {
     private val pending = ConcurrentHashMap<String, Runnable>()
 
     private const val STALE_PREFIX = "telegram_stale_check:"
+    private const val TRANSIENT_RETRY_DELAY_MS = 60_000L
 
     fun schedule(context: Context, destinationId: String, delayMs: Long) {
         val key = STALE_PREFIX + destinationId
@@ -65,7 +66,7 @@ object TelegramStaleCheckWork {
             240
         ) * 60_000L
 
-        var earliestMissedRemainingMs = Long.MAX_VALUE
+        var earliestNextDelayMs = Long.MAX_VALUE
         val recipients = destination.recipients()
         for (recipient in recipients) {
             val lastSentMs = destination.lastSentAtMsByRecipient[recipient] ?: 0L
@@ -88,7 +89,10 @@ object TelegramStaleCheckWork {
                     OutboundApiSettings.recordStaleAt(context, destinationId, recipient, now)
                     if (status == OutboundApiSettings.TUNNEL_STATUS_STALE) {
                         val remaining = (lastSentMs + missedThresholdMs) - now
-                        if (remaining > 0) earliestMissedRemainingMs = minOf(earliestMissedRemainingMs, remaining)
+                        if (remaining > 0) earliestNextDelayMs = minOf(
+                            earliestNextDelayMs,
+                            remaining + OutboundApiSettings.STALE_CHECK_SLACK_MS
+                        )
                     }
                 }
                 false -> {
@@ -100,11 +104,15 @@ object TelegramStaleCheckWork {
                         recipient = recipient
                     )
                 }
-                null -> { /* transient network error — leave state intact to retry next cycle */ }
+                null -> {
+                    // Transient network error — reschedule so the notification is
+                    // retried rather than silently dropped.
+                    earliestNextDelayMs = minOf(earliestNextDelayMs, TRANSIENT_RETRY_DELAY_MS)
+                }
             }
         }
-        if (earliestMissedRemainingMs < Long.MAX_VALUE) {
-            schedule(context, destinationId, earliestMissedRemainingMs + OutboundApiSettings.STALE_CHECK_SLACK_MS)
+        if (earliestNextDelayMs < Long.MAX_VALUE) {
+            schedule(context, destinationId, earliestNextDelayMs)
         }
     }
 

--- a/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
+++ b/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
@@ -36,10 +36,10 @@ object TelegramStaleCheckWork {
 
     private const val STALE_PREFIX = "telegram_stale_check:"
     private const val TRANSIENT_RETRY_DELAY_MS = 60_000L
-    // Must exceed TRANSIENT_RETRY_DELAY_MS: a recipient that just posted STALE is
-    // throttled on the 60 s retry cycle but re-evaluated when the missed-threshold
-    // timer fires (which can be minutes later).
-    private const val STALE_THROTTLE_MS = 70_000L
+    // Derived from TRANSIENT_RETRY_DELAY_MS to keep the invariant self-enforcing:
+    // a recipient that just posted STALE is skipped on the 60 s retry cycle but
+    // re-evaluated when the missed-threshold timer fires later.
+    private const val STALE_THROTTLE_MS = TRANSIENT_RETRY_DELAY_MS + 10_000L
 
     fun schedule(context: Context, destinationId: String, delayMs: Long) {
         val key = STALE_PREFIX + destinationId
@@ -83,9 +83,6 @@ object TelegramStaleCheckWork {
                 else -> continue
             }
             val lastStaleMs = destination.lastStaleAtMsByRecipient[recipient] ?: 0L
-            // STALE_THROTTLE_MS > TRANSIENT_RETRY_DELAY_MS: a recipient that just
-            // succeeded is skipped on the 60 s retry cycle but re-evaluated when
-            // the missed-threshold timer fires later.
             if (lastStaleMs > 0L && now - lastStaleMs < STALE_THROTTLE_MS) continue
             val hasActiveBubble = (destination.lastMessageIdByRecipient[recipient] ?: 0L) > 0L
             if (!hasActiveBubble) continue

--- a/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
+++ b/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
@@ -1,0 +1,151 @@
+package tk.glucodata
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import androidx.work.Data
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-process scheduler for the Telegram "stale" / "missed reading" edit.
+ *
+ * The producer ([OutboundApi.sendTelegram]) calls [schedule] right after a
+ * successful send. We queue a single [Runnable] per destination in a static
+ * [Handler]; when it fires, we call the Telegram editMessageText endpoint to
+ * rewrite the existing bubble to "⚠️ Stale." (at the stale threshold) or
+ * "⚪ Missed reading." (at the missed threshold). The edit is best-effort:
+ * if the bubble was deleted, the API returns an error and we give up.
+ *
+ * Limitation: this is in-process only. If the app process is killed between
+ * sends, the stale check is lost until the next CGM reading arrives and
+ * re-schedules. That's acceptable for a personal 1:1 CGM bubble — the worst
+ * case is one missed stale period after a phone restart, with no
+ * notification cost.
+ */
+object TelegramStaleCheckWork {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val pending = ConcurrentHashMap<String, Runnable>()
+
+    private const val STALE_PREFIX = "telegram_stale_check:"
+
+    fun schedule(context: Context, destinationId: String, delayMs: Long) {
+        val key = STALE_PREFIX + destinationId
+        pending.remove(key)?.let { handler.removeCallbacks(it) }
+        val appContext = context.applicationContext
+        val runnable = Runnable {
+            pending.remove(key)
+            run(appContext, destinationId)
+        }
+        pending[key] = runnable
+        handler.postDelayed(runnable, delayMs)
+    }
+
+    fun cancel(destinationId: String) {
+        val key = STALE_PREFIX + destinationId
+        pending.remove(key)?.let { handler.removeCallbacks(it) }
+    }
+
+    private fun run(context: Context, destinationId: String) {
+        val config = OutboundApiSettings.load(context)
+        val destination = config.findDestination(destinationId) ?: return
+        if (!destination.enabled || !destination.staleEnabled) return
+        if (destination.normalizedPreset() != OutboundApiSettings.PRESET_TELEGRAM_BOT) return
+
+        val now = System.currentTimeMillis()
+        val staleThresholdMs = destination.staleThresholdMinutes.coerceIn(1, 120) * 60_000L
+        val missedThresholdMs = destination.missedThresholdMinutes.coerceIn(
+            destination.staleThresholdMinutes.coerceIn(1, 120) + 1,
+            240
+        ) * 60_000L
+
+        val recipients = destination.recipients()
+        for (recipient in recipients) {
+            val lastSentMs = destination.lastSentAtMsByRecipient[recipient] ?: 0L
+            if (lastSentMs <= 0L) continue
+            val elapsedMs = now - lastSentMs
+            val status = when {
+                elapsedMs >= missedThresholdMs -> OutboundApiSettings.TUNNEL_STATUS_MISSED
+                elapsedMs >= staleThresholdMs -> OutboundApiSettings.TUNNEL_STATUS_STALE
+                else -> continue
+            }
+            val lastStaleMs = destination.lastStaleAtMsByRecipient[recipient] ?: 0L
+            if (lastStaleMs > 0L && now - lastStaleMs < 30_000L) continue  // throttle
+            val messageId = destination.lastMessageIdByRecipient[recipient] ?: 0L
+            if (messageId <= 0L) continue
+
+            val text = renderStaleText(status, now)
+            val ok = postEdit(destination, recipient, messageId, text)
+            if (ok) {
+                OutboundApiSettings.recordStaleAt(context, destinationId, recipient, now)
+            } else {
+                // Bubble gone (deleted by user) — clear state so next reading
+                // starts a fresh bubble.
+                OutboundApiSettings.clearRecipientState(
+                    context = context,
+                    destinationId = destinationId,
+                    recipient = recipient
+                )
+            }
+        }
+    }
+
+    private fun renderStaleText(status: String, nowMs: Long): String {
+        val time = DateFormat.getDateTimeInstance(
+            DateFormat.SHORT, DateFormat.SHORT, Locale.getDefault()
+        ).format(Date(nowMs))
+        val emoji = OutboundApi.statusEmoji(status)
+        val label = when (status) {
+            OutboundApiSettings.TUNNEL_STATUS_MISSED -> "Missed reading."
+            OutboundApiSettings.TUNNEL_STATUS_STALE -> "Stale — waiting for next reading."
+            else -> "Stale."
+        }
+        return "$emoji $label ($time)"
+    }
+
+    private fun postEdit(
+        destination: OutboundApiSettings.Destination,
+        recipient: String,
+        messageId: Long,
+        text: String
+    ): Boolean {
+        val editUrl = destination.resolvedUrl()
+            .replace(Regex("/sendMessage$"), "/editMessageText")
+        val body = JSONObject()
+            .put("chat_id", recipient)
+            .put("message_id", messageId)
+            .put("text", text)
+            .toString()
+            .toByteArray(Charsets.UTF_8)
+        return try {
+            val connection = (URL(editUrl).openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                connectTimeout = 20_000
+                readTimeout = 30_000
+                doOutput = true
+                setRequestProperty("Content-Type", "application/json; charset=UTF-8")
+                destination.headers.split('\n')
+                    .filter { it.contains(':') }
+                    .forEach { line ->
+                        val (k, v) = line.split(':', limit = 2).let { it[0].trim() to it[1].trim() }
+                        if (k.equals("Content-Type", ignoreCase = true)) return@forEach
+                        setRequestProperty(k, v)
+                    }
+            }
+            connection.outputStream.use { it.write(body) }
+            val code = connection.responseCode
+            connection.disconnect()
+            code in 200..299
+        } catch (_: Throwable) {
+            false
+        }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
+++ b/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
@@ -2,10 +2,7 @@ package tk.glucodata
 
 import android.content.Context
 import android.os.Handler
-import android.os.Looper
-import androidx.work.Data
-import androidx.work.Worker
-import androidx.work.WorkerParameters
+import android.os.HandlerThread
 import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
@@ -32,7 +29,8 @@ import java.util.concurrent.ConcurrentHashMap
  */
 object TelegramStaleCheckWork {
 
-    private val handler = Handler(Looper.getMainLooper())
+    private val workerThread = HandlerThread("telegram-stale-check").also { it.start() }
+    private val handler = Handler(workerThread.looper)
     private val pending = ConcurrentHashMap<String, Runnable>()
 
     private const val STALE_PREFIX = "telegram_stale_check:"
@@ -67,6 +65,7 @@ object TelegramStaleCheckWork {
             240
         ) * 60_000L
 
+        var earliestMissedRemainingMs = Long.MAX_VALUE
         val recipients = destination.recipients()
         for (recipient in recipients) {
             val lastSentMs = destination.lastSentAtMsByRecipient[recipient] ?: 0L
@@ -86,6 +85,10 @@ object TelegramStaleCheckWork {
             val ok = postEdit(destination, recipient, messageId, text)
             if (ok) {
                 OutboundApiSettings.recordStaleAt(context, destinationId, recipient, now)
+                if (status == OutboundApiSettings.TUNNEL_STATUS_STALE) {
+                    val remaining = (lastSentMs + missedThresholdMs) - now
+                    if (remaining > 0) earliestMissedRemainingMs = minOf(earliestMissedRemainingMs, remaining)
+                }
             } else {
                 // Bubble gone (deleted by user) — clear state so next reading
                 // starts a fresh bubble.
@@ -95,6 +98,9 @@ object TelegramStaleCheckWork {
                     recipient = recipient
                 )
             }
+        }
+        if (earliestMissedRemainingMs < Long.MAX_VALUE) {
+            schedule(context, destinationId, earliestMissedRemainingMs + OutboundApiSettings.STALE_CHECK_SLACK_MS)
         }
     }
 

--- a/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
+++ b/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
@@ -16,10 +16,11 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * The producer ([OutboundApi.sendTelegram]) calls [schedule] right after a
  * successful send. We queue a single [Runnable] per destination in a static
- * [Handler]; when it fires, we call the Telegram editMessageText endpoint to
- * rewrite the existing bubble to "⚠️ Stale." (at the stale threshold) or
- * "⚪ Missed reading." (at the missed threshold). The edit is best-effort:
- * if the bubble was deleted, the API returns an error and we give up.
+ * [Handler]; when it fires, we post a **new** Telegram message ("⚠️ Stale" at
+ * the stale threshold, "⚪ Missed reading" at the missed threshold) rather than
+ * editing the bubble. This preserves the last valid reading in the bubble and
+ * leaves stale/missed events as distinct, timestamped messages in the chat
+ * history for easy retrospective review.
  *
  * Limitation: this is in-process only. If the app process is killed between
  * sends, the stale check is lost until the next CGM reading arrives and
@@ -86,11 +87,11 @@ object TelegramStaleCheckWork {
             // succeeded is skipped on the 60 s retry cycle but re-evaluated when
             // the missed-threshold timer fires later.
             if (lastStaleMs > 0L && now - lastStaleMs < STALE_THROTTLE_MS) continue
-            val messageId = destination.lastMessageIdByRecipient[recipient] ?: 0L
-            if (messageId <= 0L) continue
+            val hasActiveBubble = (destination.lastMessageIdByRecipient[recipient] ?: 0L) > 0L
+            if (!hasActiveBubble) continue
 
             val text = renderStaleText(status, now)
-            val result = postEdit(destination, recipient, messageId, text)
+            val result = postSend(destination, recipient, text)
             when (result) {
                 true -> {
                     OutboundApiSettings.recordStaleAt(context, destinationId, recipient, now)
@@ -103,8 +104,8 @@ object TelegramStaleCheckWork {
                     }
                 }
                 false -> {
-                    // Definitive Telegram rejection (bubble deleted) — clear state
-                    // so next reading starts a fresh bubble.
+                    // Definitive Telegram rejection (bot blocked, wrong chat_id, etc.) —
+                    // clear state so next reading starts a fresh bubble.
                     OutboundApiSettings.clearRecipientState(
                         context = context,
                         destinationId = destinationId,
@@ -137,25 +138,23 @@ object TelegramStaleCheckWork {
     }
 
     /**
+     * Posts a new stale/missed message to the chat (does not edit the existing bubble).
      * Returns true on 2xx, false on a definitive API rejection (4xx),
      * null on transient network failure (caller should leave state intact).
      */
-    private fun postEdit(
+    private fun postSend(
         destination: OutboundApiSettings.Destination,
         recipient: String,
-        messageId: Long,
         text: String
     ): Boolean? {
-        val editUrl = destination.resolvedUrl()
-            .replace(Regex("/sendMessage$"), "/editMessageText")
+        val sendUrl = destination.resolvedUrl()
         val body = JSONObject()
             .put("chat_id", recipient)
-            .put("message_id", messageId)
             .put("text", text)
             .toString()
             .toByteArray(Charsets.UTF_8)
         return try {
-            val connection = (URL(editUrl).openConnection() as HttpURLConnection).apply {
+            val connection = (URL(sendUrl).openConnection() as HttpURLConnection).apply {
                 requestMethod = "POST"
                 connectTimeout = 20_000
                 readTimeout = 30_000

--- a/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
+++ b/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
@@ -82,21 +82,25 @@ object TelegramStaleCheckWork {
             if (messageId <= 0L) continue
 
             val text = renderStaleText(status, now)
-            val ok = postEdit(destination, recipient, messageId, text)
-            if (ok) {
-                OutboundApiSettings.recordStaleAt(context, destinationId, recipient, now)
-                if (status == OutboundApiSettings.TUNNEL_STATUS_STALE) {
-                    val remaining = (lastSentMs + missedThresholdMs) - now
-                    if (remaining > 0) earliestMissedRemainingMs = minOf(earliestMissedRemainingMs, remaining)
+            val result = postEdit(destination, recipient, messageId, text)
+            when (result) {
+                true -> {
+                    OutboundApiSettings.recordStaleAt(context, destinationId, recipient, now)
+                    if (status == OutboundApiSettings.TUNNEL_STATUS_STALE) {
+                        val remaining = (lastSentMs + missedThresholdMs) - now
+                        if (remaining > 0) earliestMissedRemainingMs = minOf(earliestMissedRemainingMs, remaining)
+                    }
                 }
-            } else {
-                // Bubble gone (deleted by user) — clear state so next reading
-                // starts a fresh bubble.
-                OutboundApiSettings.clearRecipientState(
-                    context = context,
-                    destinationId = destinationId,
-                    recipient = recipient
-                )
+                false -> {
+                    // Definitive Telegram rejection (bubble deleted) — clear state
+                    // so next reading starts a fresh bubble.
+                    OutboundApiSettings.clearRecipientState(
+                        context = context,
+                        destinationId = destinationId,
+                        recipient = recipient
+                    )
+                }
+                null -> { /* transient network error — leave state intact to retry next cycle */ }
             }
         }
         if (earliestMissedRemainingMs < Long.MAX_VALUE) {
@@ -117,12 +121,16 @@ object TelegramStaleCheckWork {
         return "$emoji $label ($time)"
     }
 
+    /**
+     * Returns true on 2xx, false on a definitive API rejection (4xx),
+     * null on transient network failure (caller should leave state intact).
+     */
     private fun postEdit(
         destination: OutboundApiSettings.Destination,
         recipient: String,
         messageId: Long,
         text: String
-    ): Boolean {
+    ): Boolean? {
         val editUrl = destination.resolvedUrl()
             .replace(Regex("/sendMessage$"), "/editMessageText")
         val body = JSONObject()
@@ -149,9 +157,9 @@ object TelegramStaleCheckWork {
             connection.outputStream.use { it.write(body) }
             val code = connection.responseCode
             connection.disconnect()
-            code in 200..299
+            if (code in 200..299) true else false
         } catch (_: Throwable) {
-            false
+            null
         }
     }
 }

--- a/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
+++ b/Common/src/main/java/tk/glucodata/TelegramStaleCheckWork.kt
@@ -154,10 +154,18 @@ object TelegramStaleCheckWork {
                         setRequestProperty(k, v)
                     }
             }
-            connection.outputStream.use { it.write(body) }
-            val code = connection.responseCode
-            connection.disconnect()
-            if (code in 200..299) true else false
+            try {
+                connection.outputStream.use { it.write(body) }
+                val code = connection.responseCode
+                // 429 (rate limit) and 5xx (server error) are transient — leave state intact.
+                when {
+                    code in 200..299 -> true
+                    code == 429 || code >= 500 -> null
+                    else -> false
+                }
+            } finally {
+                connection.disconnect()
+            }
         } catch (_: Throwable) {
             null
         }

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1989,6 +1989,16 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_trigger_summary_low">At or below %1$s %2$s</string>
     <string name="outbound_api_trigger_summary_high">At or above %1$s %2$s</string>
     <string name="outbound_api_trigger_summary_range">At or below %1$s or at or above %2$s %3$s</string>
+    <string name="outbound_api_bubble_title">Telegram bubble</string>
+    <string name="outbound_api_bubble_refresh_title">Refresh in place</string>
+    <string name="outbound_api_bubble_refresh_desc">Within the refresh window, edit the same bubble instead of posting a new one.</string>
+    <string name="outbound_api_bubble_refresh_window">Refresh window (minutes)</string>
+    <string name="outbound_api_bubble_suppress_title">Skip if value unchanged</string>
+    <string name="outbound_api_bubble_suppress_desc">Don\'t edit the bubble if the new reading is within 1 mg/dL of the last.</string>
+    <string name="outbound_api_bubble_stale_title">Show "Missed reading." when silent</string>
+    <string name="outbound_api_bubble_stale_desc">Edit the bubble to a stale or missed state if no new reading arrives in time.</string>
+    <string name="outbound_api_bubble_stale_threshold">Stale threshold (minutes)</string>
+    <string name="outbound_api_bubble_missed_threshold">Missed threshold (minutes)</string>
     <string name="outbound_api_send_test">Send test message</string>
     <string name="outbound_api_test_queued">Test message queued</string>
     <string name="outbound_api_no_current_reading">No current reading available</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
@@ -568,6 +568,9 @@ private fun DestinationEditor(
         )
     )
     TriggerPicker(destination = destination, onChange = onChange)
+    if (isTelegram) {
+        BubbleRefreshSection(destination = destination, onChange = onChange)
+    }
     TemplateEditor(destination = destination, onChange = onChange)
 }
 
@@ -725,6 +728,140 @@ private fun TriggerEditorSheet(
                 )
             )
         }
+    }
+}
+
+@Composable
+private fun BubbleRefreshSection(
+    destination: OutboundApiSettings.Destination,
+    onChange: (OutboundApiSettings.Destination) -> Unit
+) {
+    SettingsSubsectionTitle(stringResource(R.string.outbound_api_bubble_title))
+    ToggleRow(
+        title = stringResource(R.string.outbound_api_bubble_refresh_title),
+        subtitle = stringResource(R.string.outbound_api_bubble_refresh_desc),
+        checked = destination.refreshInPlaceEnabled,
+        onCheckedChange = { checked ->
+            onChange(destination.copy(refreshInPlaceEnabled = checked))
+        }
+    )
+    if (destination.refreshInPlaceEnabled) {
+        NumberStepper(
+            label = stringResource(R.string.outbound_api_bubble_refresh_window),
+            value = destination.refreshWindowMinutes,
+            range = 1..60,
+            onChange = { onChange(destination.copy(refreshWindowMinutes = it)) }
+        )
+    }
+    ToggleRow(
+        title = stringResource(R.string.outbound_api_bubble_suppress_title),
+        subtitle = stringResource(R.string.outbound_api_bubble_suppress_desc),
+        checked = destination.suppressDeltaBelowMgdl > 0,
+        onCheckedChange = { checked ->
+            onChange(
+                destination.copy(
+                    suppressDeltaBelowMgdl = if (checked) {
+                        OutboundApiSettings.DEFAULT_SUPPRESS_DELTA_BELOW_MGDL
+                    } else 0
+                )
+            )
+        }
+    )
+    ToggleRow(
+        title = stringResource(R.string.outbound_api_bubble_stale_title),
+        subtitle = stringResource(R.string.outbound_api_bubble_stale_desc),
+        checked = destination.staleEnabled,
+        onCheckedChange = { checked ->
+            onChange(destination.copy(staleEnabled = checked))
+        }
+    )
+    if (destination.staleEnabled) {
+        NumberStepper(
+            label = stringResource(R.string.outbound_api_bubble_stale_threshold),
+            value = destination.staleThresholdMinutes,
+            range = 1..120,
+            onChange = { stale ->
+                val missed = if (destination.missedThresholdMinutes <= stale) stale + 1
+                else destination.missedThresholdMinutes
+                onChange(
+                    destination.copy(
+                        staleThresholdMinutes = stale,
+                        missedThresholdMinutes = missed
+                    )
+                )
+            }
+        )
+        NumberStepper(
+            label = stringResource(R.string.outbound_api_bubble_missed_threshold),
+            value = destination.missedThresholdMinutes,
+            range = (destination.staleThresholdMinutes + 1)..240,
+            onChange = { onChange(destination.copy(missedThresholdMinutes = it)) }
+        )
+    }
+}
+
+@Composable
+private fun ToggleRow(
+    title: String,
+    subtitle: String?,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (!subtitle.isNullOrBlank()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+        StyledSwitch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Composable
+private fun NumberStepper(
+    label: String,
+    value: Int,
+    range: IntRange,
+    onChange: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = value.toString(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        TextButton(
+            onClick = { onChange((value - 1).coerceAtLeast(range.first)) },
+            enabled = value > range.first
+        ) { Text("−") }
+        TextButton(
+            onClick = { onChange((value + 1).coerceAtMost(range.last)) },
+            enabled = value < range.last
+        ) { Text("+") }
     }
 }
 
@@ -1091,5 +1228,7 @@ private val templateTokens = listOf(
     "{cob}",
     "{journal_cob}",
     "{journal_events}",
-    "{journal}"
+    "{journal}",
+    "{status}",
+    "{status_emoji}"
 )

--- a/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -238,20 +237,6 @@ fun OutboundApiSettingsScreen(navController: NavController) {
                             )
                         }
                     }
-                }
-            }
-
-            item("outbound_add") {
-                FilledTonalButton(
-                    onClick = { showAddSheet = true },
-                    modifier = Modifier.fillMaxWidth(),
-                    contentPadding = PaddingValues(horizontal = 18.dp, vertical = 14.dp)
-                ) {
-                    Icon(Icons.Filled.Add, contentDescription = null)
-                    Text(
-                        text = stringResource(R.string.outbound_api_add_destination),
-                        modifier = Modifier.padding(start = 10.dp)
-                    )
                 }
             }
 

--- a/docs/outbound-api.md
+++ b/docs/outbound-api.md
@@ -1,0 +1,473 @@
+# Outbound API — Architecture & Extension Guide
+
+> Outbound-only HTTP / chat delivery of CGM readings to user-configured
+> destinations. GlucoDroid does not currently receive from any of these
+> channels; the inbound direction is reserved for future work.
+
+---
+
+## 1. Scope
+
+`OutboundApi` is the single framework that ships glucose readings from
+GlucoDroid to user-configured third-party destinations. The supported
+presets are:
+
+| Preset constant          | Display name        | Protocol                                   |
+|--------------------------|---------------------|--------------------------------------------|
+| `custom_json`            | Custom JSON webhook | User-supplied HTTP POST with full JSON body |
+| `telegram_bot`           | Telegram bot        | `POST https://api.telegram.org/bot{token}/sendMessage` |
+| `glucowatch_vk`          | VK direct message   | `POST https://api.vk.com/method/messages.send` (DM) |
+| `vk_messages`            | VK text message     | `POST https://api.vk.com/method/messages.send` (text) |
+| `delta_chat_relay` *(v2)*| Delta Chat relay    | `POST <user relay URL>/glucose` (chatmail) |
+
+The framework is intentionally generic: a destination is `preset + url +
+token + chatId/recipients + template + headers + trigger thresholds + min
+interval`. New presets plug in via three extension points (see §7).
+
+---
+
+## 2. Files
+
+| File | Role |
+|---|---|
+| `Common/src/main/java/tk/glucodata/SuperGattCallback.java` (line 577) | **Producer** — calls `OutboundApi.enqueueGlucose(...)` on every new CGM reading. |
+| `Common/src/main/java/tk/glucodata/OutboundApi.kt` | **Orchestrator + worker.** Object `OutboundApi` (queue, trigger gating, rate limit, network guard), data class `Reading` (post-render fields), data class `JournalSnapshot`, and `class OutboundApiWorker` (`runOnce`, `sendTelegram`, `sendVk`, `sendJson`, HTTP plumbing). |
+| `Common/src/main/java/tk/glucodata/OutboundApiSettings.kt` | **Persistence + destination model.** `Config`, `Destination`, presets, defaults, encode/decode to JSON, legacy migration. |
+| `Common/src/mobile/java/tk/glucodata/OutboundApiJournalSnapshot.kt` | **Journal data source.** Builds a JSON snapshot of recent insulin / carb entries for `{journal}`, `{iob}`, `{cob}` substitution. `mobile` flavour only. |
+| `Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt` | **UI.** Compose screen, preset picker, per-destination editor, status row, test button. |
+| `Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt` | **Wiring** — registers the route into the settings nav graph. |
+
+---
+
+## 3. Data flow
+
+```
+   CGM sensor
+       │
+       ▼
+ SuperGattCallback                ◀── producer (Bluetooth LE notify)
+       │
+       │  outboundApiEnabled && shouldEmitExchangeUpdate
+       ▼
+ OutboundApi.enqueueGlucose(…)    ◀── public API; 4 overloads (varying
+       │                              rawValue / autoValue inclusion)
+       │
+       │  enqueueGlucoseInternal()
+       ▼
+ OutboundApiSettings.Config       ◀── cached in-memory; reread from
+                                    SharedPreferences("outbound_api")
+                                    on first call. JSON-encoded array
+                                    of Destination objects.
+
+   For each active, ready destination:
+       │
+       ├── shouldSendForGlucose(mgdl)  ◀── trigger thresholds
+       │
+       ├── shouldQueue(...)            ◀── min interval + duplicate event-id guard
+       │
+       ├── recordQueued(...)
+       │
+       ├── build androidx.work.Data with reading fields
+       │
+       └── sendInProcess(...)
+              │
+              ├── hasUsableNetwork()   ◀── ConnectivityManager gate
+              │
+              ├── pendingSends < MAX_PENDING_SENDS (=12)
+              │
+              └── sendExecutor.execute { OutboundApiWorker.runOnce(...) }
+                                         │
+                                         ▼
+                                  send()  ◀── dispatches on preset
+                                         │
+                            ┌────────────┼────────────┬────────────┐
+                            ▼            ▼            ▼            ▼
+                       sendTelegram   sendVk       sendJson   sendDeltaChatRelay
+                                                                 (v2, not yet)
+```
+
+`OutboundApiWorker` is invoked directly from the in-process executor; the
+`allowRetry=false` argument is hardcoded at the call site, so the
+`Result.retry()` branch is currently dead code.
+
+---
+
+## 4. Destination model
+
+```kotlin
+data class Destination(
+    val id: String,                    // UUID; primary key in the JSON array
+    val enabled: Boolean,
+    val name: String,                  // user-facing label
+    val preset: String,                // one of PRESET_*; normalisePreset() maps legacy values
+    val url: String,                   // resolved via resolvedUrl() → defaultUrl(preset) if blank
+    val token: String,                 // bot token / VK access_token / relay auth
+    val chatId: String,                // comma/semicolon/newline-split recipient list
+    val apiVersion: String,            // VK only; defaults to "5.199"
+    val headers: String,               // newline-separated `Name: value`, applied via applyHeaders()
+    val messageTemplate: String,       // see §6 tokens
+    val minIntervalMinutes: Int,       // dedup window; 0 = always
+    val triggerMode: String,           // always | at_or_below | at_or_above | outside_range
+    val triggerLowMgdl: Int,           // default 70
+    val triggerHighMgdl: Int,          // default 180
+    val lastQueuedEventId: String,     // dedup guard
+    val lastQueuedAtMs: Long,
+    val lastAttemptAtMs: Long,
+    val lastSuccessAtMs: Long,
+    val lastResponseCode: Int,
+    val lastError: String?
+)
+```
+
+`isReady()` gates dispatch:
+
+- Telegram: `token.isNotBlank() && recipients().isNotEmpty() && all valid (numeric or @username)`
+- VK: `token.isNotBlank() && recipients().isNotEmpty() && all numeric`
+- Custom JSON / Delta Chat relay: just `resolvedUrl().isNotBlank()`
+
+`withPreset(nextPreset)` swaps defaults smartly: if the user hasn't
+overridden the URL, template, or name, they're replaced with the new
+preset's defaults.
+
+---
+
+## 5. Message template tokens
+
+`OutboundApi.renderMessage(template, reading)` substitutes the
+following placeholders. `reading` is a flat view of the glucose + journal
+state at the moment of send.
+
+| Token              | Source                                                |
+|--------------------|-------------------------------------------------------|
+| `{event_id}`       | `{sensorId}:{timeMillis}:{mgdl}` (or `test-<ts>`)     |
+| `{recipient}`      | The chat_id / VK peer_id / email the message is going to |
+| `{value}`          | `displayText` — primary value formatted per `Applic.unit` |
+| `{unit}`           | `mg/dL` or `mmol/L`                                   |
+| `{mgdl}`           | Raw mg/dL integer                                     |
+| `{mmol}`           | mmol/L, 2 decimals                                    |
+| `{auto}` / `{auto_value}` | Raw auto-mode reading formatted per unit         |
+| `{auto_mgdl}` / `{auto_mmol}` | Numeric auto reading in the named unit        |
+| `{raw}`            | Raw sensor value, unconverted                         |
+| `{raw_mgdl}` / `{raw_mmol}` | Raw value converted to mg/dL or mmol/L        |
+| `{trend}`          | Trend name (e.g. `SingleUp`, `Flat`)                  |
+| `{trend_arrow}`    | Unicode arrow (↑↗→↘↓ etc.)                            |
+| `{rate_mgdl}` / `{rate_mmol}` | Rate of change in the named unit             |
+| `{timestamp}`      | `timeMillis` as integer                               |
+| `{time}`           | Locale-formatted short date+time                      |
+| `{sensor}`         | Sensor ID                                             |
+| `{sensor_gen}`     | Sensor generation                                     |
+| `{alarm}`          | Alarm code                                            |
+| `{iob}` / `{journal_iob}` | Active insulin (units)                         |
+| `{cob}` / `{journal_cob}` | Active carbs (grams)                           |
+| `{journal_events}` | JSON array of recent treatments (last 12h, capped 64) |
+| `{journal}`        | Full journal JSON snapshot (`tk.glucodata.journal.snapshot.v2`) |
+| `{test}`           | `true` for test sends, `false` for live readings      |
+
+The full list is also exposed at runtime in
+`templateTokens` (private val in `OutboundApiSettingsScreen.kt`).
+
+Default templates:
+
+- `DEFAULT_CHAT_TEMPLATE = "{value} {unit} {trend_arrow} {time}"`
+  (Telegram, VK messages)
+- `DEFAULT_GLUCO_WATCH_TEMPLATE = "GV:{mmol}|RAW:{raw}|TR:{trend_arrow}|AL:{alarm}|RT:{rate_mmol}|IOB:{iob}|COB:{cob}|TS:{timestamp}"`
+  (GlucoWatch VK)
+- `DEFAULT_CUSTOM_TEMPLATE = "{value} {unit} {trend_arrow} RAW:{raw} ({rate_mgdl} mg/dL/min) IOB:{iob} COB:{cob} {time}"`
+  (Custom JSON webhook)
+
+---
+
+## 6. HTTP plumbing
+
+`OutboundApiWorker.executePost(...)` is shared by all senders. It:
+
+- `HttpURLConnection` with 15 s connect / 30 s read timeout (20 s / 30 s
+  for Telegram because the bot API can be slow).
+- `User-Agent: JugglucoNG API destinations`.
+- Sends body as UTF-8 bytes; content-type differs by preset (JSON or
+  form-urlencoded).
+- Applies extra headers from `Destination.headers` (newline-separated
+  `Name: value`); `Content-Type` cannot be overridden.
+- Pre-response retry loop (off by default, `preResponseRetries=0`).
+- Parses the response into `SendResponse(code, ok, retryable, error)`.
+  Retryable: HTTP 429, 5xx, plus preset-specific API error codes
+  (Telegram: 429/500/502/503; VK: 6/9/10).
+- Records outcome: `recordSuccess()` on 2xx, `recordAttempt()` on failure
+  (writes `lastResponseCode`, `lastError`, `lastAttemptAtMs`).
+
+`friendlyError()` rewrites raw `HttpURLConnection` exceptions for
+Telegram failures so the user sees
+`"Telegram Bot API connection failed before a JSON response: <cause>"`
+instead of the underlying `SocketTimeoutException` text.
+
+---
+
+## 7. Adding a new preset (e.g. `delta_chat_relay`)
+
+Three extension points; for the Delta Chat relay all three are needed.
+
+### 7.1 Constant in `OutboundApiSettings.kt`
+
+```kotlin
+const val PRESET_DELTA_CHAT_RELAY = "delta_chat_relay"
+```
+
+Add to `normalizePreset(...)` whitelist so the value round-trips through
+JSON. Decide on validation rules for `Destination.isReady()` — the
+relay needs `url.isNotBlank() && token.isNotBlank()` (token is the relay
+auth bearer). Recipients are required; add an `isDeltaChatRecipient()`
+helper accepting either a chatmail address (`@<server>`) or a numeric
+chat-id-equivalent (delta-chat doesn't use numeric ids, so the helper
+just validates that the address contains an `@`).
+
+### 7.2 Default URL + template + name in `OutboundApiSettings.kt`
+
+```kotlin
+fun defaultUrl(preset: String, token: String = ""): String = when (normalizePreset(preset)) {
+    …
+    PRESET_DELTA_CHAT_RELAY -> ""  // user must configure
+    else -> DEFAULT_CUSTOM_URL
+}
+
+fun defaultTemplate(preset: String): String = when (normalizePreset(preset)) {
+    …
+    PRESET_DELTA_CHAT_RELAY -> DEFAULT_CHAT_TEMPLATE  // same concise format as Telegram
+    else -> DEFAULT_CUSTOM_TEMPLATE
+}
+
+fun defaultName(preset: String): String = when (normalizePreset(preset)) {
+    …
+    PRESET_DELTA_CHAT_RELAY -> "Delta Chat relay"
+    else -> "Custom JSON webhook"
+}
+```
+
+### 7.3 Send branch in `OutboundApiWorker.send(...)` and the `OutboundApiSettingsScreen` preset list
+
+```kotlin
+// OutboundApi.kt
+private fun send(
+    destination: OutboundApiSettings.Destination,
+    reading: OutboundApi.Reading
+): SendResponse {
+    val message = OutboundApi.renderMessage(destination.resolvedTemplate(), reading)
+    return when (destination.normalizedPreset()) {
+        OutboundApiSettings.PRESET_TELEGRAM_BOT -> sendTelegram(destination, reading, message)
+        OutboundApiSettings.PRESET_GLUCO_WATCH_VK,
+        OutboundApiSettings.PRESET_VK_MESSAGES -> sendVk(destination, reading, message)
+        OutboundApiSettings.PRESET_DELTA_CHAT_RELAY -> sendDeltaChatRelay(destination, reading, message)
+        else -> sendJson(destination, reading, message)
+    }
+}
+
+private fun sendDeltaChatRelay(
+    destination: OutboundApiSettings.Destination,
+    reading: OutboundApi.Reading,
+    message: String
+): SendResponse {
+    val body = JSONObject()
+        .put("preset", "delta_chat_relay")
+        .put("event_id", reading.eventId)
+        .put("recipient", reading.recipient)
+        .put("message", message)
+        .put("test", reading.test)
+        .toString()
+        .toByteArray(Charsets.UTF_8)
+    val headers = "Authorization: Bearer ${destination.token.trim()}"
+    return executePost(
+        urlString = destination.resolvedUrl(),
+        contentType = "application/json; charset=UTF-8",
+        headers = headers,
+        body = body,
+        parseApiError = ::parseDeltaChatRelayError,
+        connectTimeoutMs = 20_000,
+        readTimeoutMs = 30_000
+    )
+}
+```
+
+```kotlin
+// OutboundApiSettingsScreen.kt
+private fun destinationPresetSpecs(): List<PresetSpec> = listOf(
+    …,
+    PresetSpec(
+        id = OutboundApiSettings.PRESET_DELTA_CHAT_RELAY,
+        titleRes = R.string.outbound_api_preset_delta_chat_relay,
+        descriptionRes = R.string.outbound_api_preset_delta_chat_relay_desc,
+        icon = Icons.Filled.MailOutline  // or similar; pick from filled icons
+    )
+)
+```
+
+For v1 (outbound only, no commands) this is the entire change set:
+~50 lines in `OutboundApiSettings.kt`, ~30 lines in `OutboundApi.kt`, one
+`PresetSpec` entry, and corresponding string resources. No changes to
+`SuperGattCallback` — the producer is preset-agnostic.
+
+### 7.4 String resources
+
+Add to `Common/src/mobile/res/values/strings.xml`:
+
+- `outbound_api_preset_delta_chat_relay` = "Delta Chat relay"
+- `outbound_api_preset_delta_chat_relay_desc` = "Send readings to a Delta Chat relay (chatmail)."
+- `outbound_api_delta_chat_relay_url_label` = "Relay URL"
+- `outbound_api_delta_chat_relay_url_help` = "URL of your Delta Chat relay, e.g. https://glucodroid-relay.example.com"
+- `outbound_api_delta_chat_relay_token_label` = "Relay auth token"
+- `outbound_api_delta_chat_relay_recipient_help` = "One chatmail address per line (e.g. you@chatmail.example)."
+
+---
+
+## 8. Persistence and migration
+
+Destinations are stored as a JSON array under the key
+`destinations_json` in `SharedPreferences("outbound_api")`. Top-level
+boolean `enabled` is kept for backward compatibility with the
+pre-destinations migration.
+
+`migrateLegacy(context)` (in `OutboundApiSettings.kt`) runs once if no
+JSON array is present: reads the flat `provider/url/token/chat_id/...`
+keys (where `provider` is `webhook_json` or `vk`) and synthesises a
+single `Destination` of the matching preset. The result is
+immediately `save()`d back so the legacy keys become inert.
+
+JSON encoding is symmetric via `encodeDestinations(...)` /
+`decodeDestinations(...)`. The `id` field is deduped
+case-insensitively on load.
+
+---
+
+## 9. Known limitations and v2 ideas
+
+- **No inbound.** GlucoDroid never listens for messages on any of these
+  channels. Adding inbound means a foreground service, a server
+  endpoint (or long-poll), and a command grammar.
+- **No retry on transient failure.** The `allowRetry=false` hardcode
+  means a failed POST is logged but not re-queued. A simple fix is to
+  persist `(destinationId, eventId, payload)` and have a periodic
+  alarm retry pending failures.
+- **No media (images, charts).** All senders are text-only.
+- **No auth refresh.** VK tokens and Telegram tokens are user-supplied
+  strings; rotation is manual. A future preset could integrate
+  service-account OAuth.
+- **Single-process executor.** A single thread
+  (`OutboundApiSend`) handles all sends. Throughput is fine for a
+  single user but is a bottleneck if multiple destinations are
+  configured and one is slow.
+- **No "send only on change" beyond min-interval.** Two identical
+  readings 6 minutes apart are sent. ~~Adding a
+  "only on delta ≥ N mg/dL" trigger would help noisy sensors.~~
+  **Resolved by `suppressDeltaBelowMgdl` — see §9.**
+
+These are tracked in the audit document
+(`docs/chatbots-branch-audit.md`).
+
+---
+
+## 9. Telegram bubble refresh (v0.2.4.4+)
+
+To stop the chat from filling with one-bubble-per-reading noise, the
+Telegram destination supports an "edit in place" model. Each destination
+gets a small bag of per-recipient state (last message id, last sent
+time, last sent mg/dL, last stale time) keyed by recipient chat id, so
+multi-recipient configs don't collide.
+
+### 9.1 Per-destination fields
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `refreshInPlaceEnabled` | `Boolean` | `true` | Master switch. When off, every reading posts a new message (legacy behaviour). |
+| `refreshWindowMinutes` | `Int` | `5` | After this many minutes since the last send, the next reading posts a fresh message instead of editing. 1–60. |
+| `suppressDeltaBelowMgdl` | `Int` | `1` | 0 = never suppress; >0 = skip the edit if `|new_mgdl − last_mgdl| < threshold`. Default 1 ignores sensor noise within 1 mg/dL. |
+| `staleEnabled` | `Boolean` | `true` | Show "Stale" / "Missed reading." in the bubble when no new reading arrives in time. |
+| `staleThresholdMinutes` | `Int` | `10` | After this many minutes of silence, edit the bubble to "⚠️ Stale — waiting for next reading. (HH:mm)". |
+| `missedThresholdMinutes` | `Int` | `15` | After this many minutes of silence, edit the bubble to "⚪ Missed reading. (HH:mm)". Must be > `staleThresholdMinutes`. |
+| `lastMessageIdByRecipient` | `Map<String, Long>` | `{}` | Per-recipient last Telegram `message_id`, used as the `message_id` for `editMessageText`. |
+| `lastSentAtMsByRecipient` | `Map<String, Long>` | `{}` | Per-recipient timestamp of the last successful send. |
+| `lastSentMgdlByRecipient` | `Map<String, Int>` | `{}` | Per-recipient last sent mg/dL (for delta suppression). |
+| `lastStaleAtMsByRecipient` | `Map<String, Long>` | `{}` | Per-recipient timestamp of the last stale edit; used to throttle stale edits to 30 s. |
+
+### 9.2 Send path
+
+`OutboundApiWorker.runOnce()` → `send()` → `sendTelegram()`:
+
+```
+1. Compute windowMs = refreshWindowMinutes * 60_000
+2. withinWindow = enabled && lastMsgId > 0 && lastSentAt > 0 &&
+                  (now - lastSentAt) <= windowMs
+3. if withinWindow && |newMgdl - lastMgdl| < suppressDeltaBelowMgdl:
+       return synthetic 200 response, no API call (suppressed)
+4. if withinWindow:
+       response = editMessageText(chat_id, message_id, text)
+       if response.ok: return response
+       else: clearRecipientState()  // bubble gone; next send will be fresh
+5. response = sendMessage(chat_id, text)  // fresh bubble
+6. on success: recordBubbleSent(msgId, now, mgdl)
+              schedule stale-check Handler(delay = staleThresholdMinutes*60s + 10s)
+```
+
+### 9.3 Stale-check scheduler
+
+`TelegramStaleCheckWork` is a thin in-process Handler-based scheduler.
+After every successful `sendMessage` or `editMessageText`, the producer
+schedules a single Handler post-delayed by `staleThresholdMinutes*60_000
++ 10_000` (the 10 s slack avoids firing on slightly-late deliveries).
+
+When the post fires:
+
+```
+for each recipient in destination.recipients():
+    elapsed = now - lastSentAtMsByRecipient[recipient]
+    status = missed if elapsed >= missedThresholdMs
+           else stale if elapsed >= staleThresholdMs
+           else continue
+    if lastStaleAt within last 30s: continue  // throttle
+    if lastMessageIdByRecipient[recipient] <= 0: continue
+    text = "⚠️ Stale — waiting for next reading. (HH:mm)"   # if stale
+         or "⚪ Missed reading. (HH:mm)"                    # if missed
+    if editMessageText(chat_id, message_id, text) returns 2xx:
+        recordStaleAt(recipient, now)
+    else:
+        clearRecipientState(recipient)  // bubble deleted by user
+```
+
+**Limitation:** in-process only. If Android kills the app between sends,
+the stale check is lost until the next CGM reading arrives and
+re-schedules. Acceptable for a 1:1 CGM bubble — worst case is one missed
+stale period after a phone restart. A future revision could persist the
+pending `WorkRequest` via WorkManager for stricter guarantees.
+
+### 9.4 Template tokens for status
+
+| Token | Renders | Example |
+|---|---|---|
+| `{status}` | Status key | `in_range`, `high`, `low`, `stale`, `missed` |
+| `{status_emoji}` | Status emoji | 🟢 / 🟡 / 🔴 / ⚠️ / ⚪ |
+
+`Destination.rangeStatus(mgdl)` returns one of the five status keys
+based on the per-destination `triggerLowMgdl` / `triggerHighMgdl`
+thresholds. The default Telegram template
+(`DEFAULT_CHAT_TEMPLATE`) now includes `{status_emoji}` at the start:
+
+```
+{status_emoji} {value} {unit} {trend_arrow} {time}
+```
+
+Existing destinations with a non-empty `messageTemplate` are not
+touched; only the default for new destinations changes.
+
+### 9.5 Wire-level details
+
+- **Edit URL:** `sendMessage` → `editMessageText` (last segment swap).
+  Bot token stays the same. No additional endpoint or scope needed.
+- **`SendResponse` extended** with `messageId: Long?` (parsed from
+  `result.message_id` in the Telegram 2xx response) and `suppressed:
+  Boolean` (true for the synthetic "no API call" path).
+- **Edit failures fall through to fresh send.** Common cases:
+  400 "message is not modified" (we re-send identical text — handled by
+  the suppression path), 400 "message to edit not found" (user deleted
+  the bubble), 429 (rate limit). In all of these we clear the cached
+  `lastMessageId` and post fresh on the next reading.
+- **Headers on the edit path:** any custom `headers` field on the
+  destination is also applied to `editMessageText` so e.g.
+  `Authorization: Bearer …` relays keep working.
+


### PR DESCRIPTION
## Summary

Adds a Telegram "bubble" mode to the outbound API: subsequent CGM readings within a configurable window **edit the same Telegram message in-place** rather than posting a new one, keeping chats clean. When readings stop arriving, separate ⚠️ Stale and ⚪ Missed messages are posted so gaps are visible in chat history.

**Example output:** `🟢 7.3 mmol/L ↗ 08/06/2026 15:25`

### What changed

- **Edit-in-place** (`OutboundApiWorker.sendTelegram`): within a configurable refresh window (default 15 min) calls `editMessageText` on the existing bubble instead of `sendMessage`. Falls through to a fresh send only on definitive rejection (message deleted, chat not found). Rate-limit and server errors preserve the message ID so the next reading retries the edit.
- **Noise suppression**: skip the edit if |new − last| < N mg/dL (default 1) to avoid flicker on noisy sensors. Suppressed readings still reset the stale clock so flat glucose doesn't trigger false stale alerts.
- **Status tokens**: `{status}` and `{status_emoji}` added to the template engine. Default Telegram template updated to `{status_emoji} {value} {unit} {trend_arrow} {time}`. Emoji: 🟢 in-range / 🟡 high / 🔴 low / ⚠️ stale / ⚪ missed.
- **Stale/missed detection** (`TelegramStaleCheckWork`): in-process `HandlerThread` scheduler fires at the stale threshold (default 10 min + 10 s slack) and posts a **new** message — leaving the bubble intact with the last valid reading. Reschedules itself for the missed threshold (default 15 min) and posts another new message then. This makes gaps visible as timestamped events in chat history.
- **Per-recipient state** in `OutboundApiSettings.Destination`: last message ID, last sent time, last mg/dL, last stale time — persisted as JSON maps so multi-recipient configs don't collide.
- **UI**: new "Telegram bubble" settings section with toggles and ± steppers for all thresholds (refresh window, noise suppression, stale, missed). Only shown for the Telegram preset.

### Fixes included

| Commit | Fix |
|--------|-----|
| `34ad698d` | `HandlerThread` replaces `Looper.getMainLooper()` (NetworkOnMainThreadException); stale→missed re-schedule; gate stale timer on Telegram preset |
| `a5a83fd7` | `postEdit()` returns `Boolean?` — `null` on transient network error preserves message ID; `false` only on definitive 4xx rejection |
| `b05a511c` | Remove redundant "Add destination" button from settings screen |
| `c8612dc1` | Handle Telegram "message is not modified" 400 as success; bypass noise suppression for test sends |
| `14ac3170` | Auto-migrate legacy default template to include `{status_emoji}` on first load (Telegram only) |
| `8b51bc03` | Treat 429/5xx edit failures as transient (preserve message ID); fix `HttpURLConnection` leak in stale checker when `write()` throws |
| `e9aedf02` | Increase default refresh window from 5 → 15 min; migrate existing stored value of 5 on load |
| `968851a8` | Update stale clock on suppressed readings so flat glucose doesn't trigger false stale/missed alerts |
| `80c380ea` | Retry stale/missed notification after 60 s on transient network error (previously silently dropped) |
| `83103480` | Raise stale throttle to 70 s so a recipient that just posted STALE is skipped on the 60 s retry cycle but re-evaluated at the missed-threshold deadline |
| `2ff4e73d` | Switch stale/missed from `editMessageText` to `sendMessage`: prevents the glucose bubble being overwritten with stale text, which combined with noise suppression caused the bubble to get stuck at "⚠️ Stale" indefinitely |
| `4dfbe2c1` | Derive `STALE_THROTTLE_MS` from `TRANSIENT_RETRY_DELAY_MS + 10_000L` to make the throttle > retry-delay invariant self-enforcing |

## Test plan

- [ ] Add a Telegram bot destination; trigger a reading — verify a new message appears with a status emoji
- [ ] Trigger a second reading within the refresh window — verify the **same** message is edited in-place (no new message)
- [ ] Trigger a reading outside the window — verify a new message is posted
- [ ] Wait past the stale threshold — verify a **new** "⚠️ Stale" message appears and the original bubble is unchanged
- [ ] Wait past the missed threshold — verify a **new** "⚪ Missed reading" message appears
- [ ] When readings resume after missed — verify a fresh bubble is started
- [ ] Flat glucose for 15+ min (all readings suppressed) — verify no false stale alert fires
- [ ] Simulate a network outage while the stale timer is pending — verify a retry fires ~60 s after connectivity returns and does not duplicate the stale post for recipients that already succeeded
- [ ] Delete the Telegram message mid-session — verify the next reading posts a fresh bubble
- [ ] Disable "Refresh in place" — verify each reading posts a new message
- [ ] Verify VK and custom JSON destinations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)