### PR TITLE
Journal IOB/eIOB/COB for external consumers (GlucoDataHandler)

### DIFF
--- a/Common/proguard-rules.my
+++ b/Common/proguard-rules.my
@@ -93,16 +93,19 @@
 }
 
 # Keep OutboundApiJournalSnapshot name and reflected members stable.
-# OutboundApi and ApiGlucoseSourceManager (src/main) resolve this mobile-only
-# object by name: snapshotJson() backs the {iob}/{cob}/{journal}/{journal_events}
-# message-template tokens, and importFromJson*() ingests API journal payloads.
-# Without this, R8 renames/strips the class and the reflection silently yields an
-# empty snapshot (tokens render as "0 - 0 - 0 - 0 -  -").
+# OutboundApi, ApiGlucoseSourceManager and JugglucoSend (src/main) resolve this
+# mobile-only object by name: snapshotJson() backs the {iob}/{cob}/{journal}/
+# {journal_events} message-template tokens, importFromJson*() ingests API
+# journal payloads, and broadcastIobSnapshot() feeds the glucodata.Minute
+# IOB/eIOB/COB extras. Without this, R8 renames/strips the class and the
+# reflection silently yields an empty snapshot (tokens render as
+# "0 - 0 - 0 - 0 -  -") / a broadcast without IOB.
 -keepnames class tk.glucodata.OutboundApiJournalSnapshot
 -keepclassmembers class tk.glucodata.OutboundApiJournalSnapshot {
     public static java.lang.String snapshotJson(long);
     public static int importFromJson(java.lang.String);
     public static int importFromJsonForSource(java.lang.String,java.lang.String);
+    public static float[] broadcastIobSnapshot(long);
 }
 
 #-keep class tk.glucodata.watchface.WatchFaceService

--- a/Common/src/main/java/tk/glucodata/JournalIobAccess.java
+++ b/Common/src/main/java/tk/glucodata/JournalIobAccess.java
@@ -1,0 +1,44 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+// Bridge to the journal-based insulin/carb snapshot. The journal only exists
+// in the mobile source set, so callers in src/main (JugglucoSend, Notify)
+// resolve it by name — same pattern as OutboundApi. Returns null on variants
+// without the journal (wear/small) and when the journal is unused/disabled.
+public class JournalIobAccess {
+    private static java.lang.reflect.Method snapshotMethod;
+    private static boolean snapshotResolved;
+
+    // [classicIob, eiob, cob] in units/grams, NaN marking "no data of that
+    // kind"; null when unavailable.
+    static float[] snapshot(long atMillis) {
+        try {
+            if (!snapshotResolved) {
+                snapshotResolved = true;
+                snapshotMethod = Class.forName("tk.glucodata.OutboundApiJournalSnapshot")
+                        .getMethod("broadcastIobSnapshot", long.class);
+            }
+            if (snapshotMethod == null)
+                return null;
+            return (float[]) snapshotMethod.invoke(null, atMillis);
+        } catch (Throwable e) {
+            snapshotMethod = null;
+            return null;
+        }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/JugglucoSend.java
+++ b/Common/src/main/java/tk/glucodata/JugglucoSend.java
@@ -37,9 +37,16 @@ public class JugglucoSend   {
 	private static final String TREND_NAME = "glucodata.Minute.TrendName";
     private static final String ALARM = "glucodata.Minute.Alarm";
     private static final String TIME = "glucodata.Minute.Time";
+    // GDH-standard extras: classic remaining-action IOB and COB, plus the
+    // computation timestamp GDH uses for its obsolescence check.
+    private static final String IOB = "glucodata.Minute.IOB";
+    private static final String COB = "glucodata.Minute.COB";
+    private static final String IOBCOBTIME = "gdh.IOB_COB_time";
+    // NG extension: activity-based "effective" IOB (ignored by current GDH).
+    private static final String EIOB = "glucodata.Minute.eIOB";
 private static final String LOG_ID="JugglucoSend";
 
-private static Bundle mkGlucosebundle(String SerialNumber, ExchangeGlucosePayload payload, int alarm) {
+private static Bundle mkGlucosebundle(String SerialNumber, ExchangeGlucosePayload payload, int alarm, float[] iobcob, long iobComputedAt) {
       Bundle extras = new Bundle();
         extras.putString(SERIAL,SerialNumber);
 	extras.putInt(MGDL,payload.primaryMgdl);
@@ -49,6 +56,13 @@ private static Bundle mkGlucosebundle(String SerialNumber, ExchangeGlucosePayloa
         extras.putString(TREND_NAME,payload.trendName);
         extras.putInt(ALARM,alarm);
         extras.putLong(TIME,payload.timeMillis);
+	if(iobcob!=null&&iobcob.length>=3) {
+		boolean any=false;
+		if(!Float.isNaN(iobcob[0])) { extras.putFloat(IOB,iobcob[0]); any=true; }
+		if(!Float.isNaN(iobcob[1])) { extras.putFloat(EIOB,iobcob[1]); any=true; }
+		if(!Float.isNaN(iobcob[2])) { extras.putFloat(COB,iobcob[2]); any=true; }
+		if(any) extras.putLong(IOBCOBTIME,iobComputedAt);
+		}
 	return extras;
 	  }
 
@@ -62,7 +76,8 @@ static void broadcastglucose(String SerialNumber, ExchangeGlucosePayload payload
 	{if(doLog) {Log.i(LOG_ID,"broadcastglucose "+payload.primaryDisplayValue+" rate="+payload.rate);};};
         final Context context=Applic.app;
         Intent intent = new Intent(ACTION);
-	intent.putExtras(mkGlucosebundle(SerialNumber, payload, alarm));
+	final long iobComputedAt=System.currentTimeMillis();
+	intent.putExtras(mkGlucosebundle(SerialNumber, payload, alarm, JournalIobAccess.snapshot(iobComputedAt), iobComputedAt));
 	intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
 	for(var name:names) {
 		if(name!=null) {

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1569,6 +1569,12 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="journal_metric_activity_today">Aktivität heute</string>
     <string name="journal_no_active_insulin">Kein aktives Insulin</string>
     <string name="journal_active_now_percent">%1$d%% aktiv</string>
+    <string name="journal_metric_iob">IOB</string>
+    <string name="journal_metric_eiob">eIOB %1$s E</string>
+    <string name="journal_eiob_display_title">Effektives IOB (eIOB) anzeigen</string>
+    <string name="journal_eiob_display_desc">Aktivitätsbasiertes Insulin an Bord zusätzlich zum klassischen IOB anzeigen</string>
+    <string name="journal_iob_expanded">IOB %1$s E verbleibend</string>
+    <string name="journal_eiob_expanded">eIOB %1$s E wirksam</string>
     <string name="journal_visible_events">Sichtbare Ereignisse</string>
     <string name="journal_empty">Noch keine Journalereignisse in diesem Fenster</string>
     <string name="journal_type_insulin">Insulin</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1825,6 +1825,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_metric_activity_today">Activity today</string>
     <string name="journal_no_active_insulin">No active insulin</string>
     <string name="journal_active_now_percent">%1$d%% active</string>
+    <string name="journal_metric_iob">IOB</string>
+    <string name="journal_metric_eiob">eIOB %1$s U</string>
+    <string name="journal_eiob_display_title">Show effective IOB (eIOB)</string>
+    <string name="journal_eiob_display_desc">Also display activity-based insulin on board next to classic IOB</string>
+    <string name="journal_iob_expanded">IOB %1$sU remaining</string>
+    <string name="journal_eiob_expanded">eIOB %1$sU acting</string>
     <string name="journal_visible_events">Visible events</string>
     <string name="journal_empty">No journal events in this window yet</string>
     <string name="journal_type_insulin">Insulin</string>

--- a/Common/src/mobile/java/tk/glucodata/OutboundApiJournalSnapshot.kt
+++ b/Common/src/mobile/java/tk/glucodata/OutboundApiJournalSnapshot.kt
@@ -1,5 +1,6 @@
 package tk.glucodata
 
+import android.os.Looper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -11,6 +12,7 @@ import tk.glucodata.data.journal.JournalEntrySource
 import tk.glucodata.data.journal.JournalEntryType
 import tk.glucodata.data.journal.JournalFoodEntity
 import tk.glucodata.data.journal.JournalInsulinPreset
+import tk.glucodata.data.journal.JournalIobCalculator
 import tk.glucodata.data.journal.JournalInsulinPresetEntity
 import tk.glucodata.data.journal.JournalRepository
 import tk.glucodata.data.journal.JournalTreatmentTransfer
@@ -22,12 +24,72 @@ object OutboundApiJournalSnapshot {
     private const val SNAPSHOT_EVENT_WINDOW_MS = 12L * 60L * 60L * 1000L
     private const val DEFAULT_ACTIVE_WINDOW_MS = 24L * 60L * 60L * 1000L
     private const val API_SOURCE_PREFIX = "api"
+    private const val JOURNAL_ENABLED_KEY = "dashboard_journal_enabled"
 
     @JvmStatic
     fun snapshotJson(timeMillis: Long): String = runBlocking {
         withContext(Dispatchers.IO) {
             buildSnapshot(timeMillis.takeIf { it > 0L } ?: System.currentTimeMillis()).toString()
         }
+    }
+
+    private class BroadcastIobCache(val atMillis: Long, val values: FloatArray?)
+
+    @Volatile
+    private var broadcastIobCache: BroadcastIobCache? = null
+    private const val BROADCAST_IOB_CACHE_MS = 30_000L
+
+    /**
+     * Compact insulin/carb snapshot for the glucodata.Minute broadcast and the
+     * persistent notification, resolved from src/main (JugglucoSend, Notify)
+     * via reflection because the journal only exists in the mobile source set.
+     * Returns [classicIob, eiob, cob] with NaN marking "no data of that kind",
+     * or null when the journal feature is disabled or has never seen
+     * insulin/carb entries — users of the legacy native amounts must not have
+     * their /pebble-polled IOB clobbered with journal zeros.
+     *
+     * Results are cached briefly; on the main thread the cache (possibly
+     * stale) is returned instead of blocking on Room.
+     */
+    @JvmStatic
+    fun broadcastIobSnapshot(timeMillis: Long): FloatArray? {
+        val atMillis = timeMillis.takeIf { it > 0L } ?: System.currentTimeMillis()
+        val cached = broadcastIobCache
+        if (cached != null && atMillis - cached.atMillis < BROADCAST_IOB_CACHE_MS) return cached.values
+        if (Looper.myLooper() == Looper.getMainLooper()) return cached?.values
+        val fresh = runBlocking {
+            withContext(Dispatchers.IO) {
+                runCatching { buildBroadcastIob(atMillis) }.getOrNull()
+            }
+        }
+        broadcastIobCache = BroadcastIobCache(atMillis, fresh)
+        return fresh
+    }
+
+    private suspend fun buildBroadcastIob(atMillis: Long): FloatArray? {
+        val app = Applic.app ?: return null
+        val prefs = app.getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE)
+        if (!prefs.getBoolean(JOURNAL_ENABLED_KEY, true)) return null
+        val dao = HistoryDatabase.getInstance(app).journalDao()
+        val hasInsulin = dao.countEntriesByType(JournalEntryType.INSULIN.storageValue) > 0
+        val hasCarbs = dao.countEntriesByType(JournalEntryType.CARBS.storageValue) > 0
+        if (!hasInsulin && !hasCarbs) return null
+        val presetsById = dao.getInsulinPresets().map { toPresetModel(it) }.associateBy { it.id }
+        val maxPresetDurationMs = presetsById.values.maxOfOrNull { it.durationMinutes.coerceAtLeast(0) }
+            ?.times(60_000L)
+            ?: DEFAULT_ACTIVE_WINDOW_MS
+        val startMillis = (atMillis - maxOf(DEFAULT_ACTIVE_WINDOW_MS, maxPresetDurationMs) - 60_000L)
+            .coerceAtLeast(0L)
+        val entries = dao.getEntriesBetween(startMillis, atMillis)
+        val insulin = JournalIobCalculator.compute(
+            JournalIobCalculator.dosesFromEntities(entries, presetsById),
+            atMillis
+        )
+        return floatArrayOf(
+            if (hasInsulin) insulin.iobUnits else Float.NaN,
+            if (hasInsulin) insulin.eiobUnits else Float.NaN,
+            if (hasCarbs) activeCarbsGrams(entries, atMillis) else Float.NaN
+        )
     }
 
     @JvmStatic
@@ -57,7 +119,10 @@ object OutboundApiJournalSnapshot {
         val startMillis = (atMillis - maxOf(DEFAULT_ACTIVE_WINDOW_MS, maxPresetDurationMs) - 60_000L)
             .coerceAtLeast(0L)
         val entries = dao.getEntriesBetween(startMillis, atMillis)
-        val iob = activeInsulinUnits(entries, presetsById, atMillis)
+        val insulin = JournalIobCalculator.compute(
+            JournalIobCalculator.dosesFromEntities(entries, presetsById),
+            atMillis
+        )
         val cob = activeCarbsGrams(entries, atMillis)
         val eventWindowStart = atMillis - SNAPSHOT_EVENT_WINDOW_MS
         val events = JSONArray()
@@ -68,8 +133,10 @@ object OutboundApiJournalSnapshot {
         return JSONObject()
             .put("schema", "tk.glucodata.journal.snapshot.v2")
             .put("timestamp", atMillis)
-            .put("iob", finiteOrNull(iob))
-            .put("journal_iob", finiteOrNull(iob))
+            .put("iob", finiteOrNull(insulin.iobUnits))
+            .put("journal_iob", finiteOrNull(insulin.iobUnits))
+            .put("eiob", finiteOrNull(insulin.eiobUnits))
+            .put("journal_eiob", finiteOrNull(insulin.eiobUnits))
             .put("cob", finiteOrNull(cob))
             .put("journal_cob", finiteOrNull(cob))
             .put("events", events)
@@ -213,20 +280,6 @@ object OutboundApiJournalSnapshot {
             .put("nsRemoteId", nsRemoteId)
     }
 
-    private fun activeInsulinUnits(
-        entries: List<JournalEntryEntity>,
-        presetsById: Map<Long, JournalInsulinPreset>,
-        atMillis: Long
-    ): Float {
-        return entries.sumOf { entry ->
-            if (JournalEntryType.fromStorage(entry.entryType) != JournalEntryType.INSULIN) return@sumOf 0.0
-            val preset = entry.insulinPresetId?.let(presetsById::get) ?: return@sumOf 0.0
-            if (!preset.countsTowardIob) return@sumOf 0.0
-            val amount = entry.amount?.takeIf { it.isFinite() && it > 0f } ?: return@sumOf 0.0
-            (amount * remainingCurveFraction(preset.curvePoints, entry.timestamp, atMillis)).toDouble()
-        }.toFloat()
-    }
-
     private fun activeCarbsGrams(entries: List<JournalEntryEntity>, atMillis: Long): Float {
         val prefs = Applic.app.getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE)
         val absorptionGramsPerHour = prefs
@@ -240,41 +293,6 @@ object OutboundApiJournalSnapshot {
             val progress = linearProgress(entry.timestamp, absorptionMinutes, atMillis)
             (grams * (1f - progress)).coerceAtLeast(0f).toDouble()
         }.toFloat()
-    }
-
-    private fun remainingCurveFraction(
-        points: List<tk.glucodata.data.journal.JournalCurvePoint>,
-        doseTimestamp: Long,
-        atMillis: Long
-    ): Float {
-        if (points.size < 2 || atMillis < doseTimestamp) return 0f
-        val elapsedMinutes = ((atMillis - doseTimestamp) / 60_000f).coerceAtLeast(0f)
-        val total = integrateCurve(points, points.last().minute.toFloat())
-        if (total <= 0.0001f) return 0f
-        val delivered = (integrateCurve(points, elapsedMinutes) / total).coerceIn(0f, 1f)
-        return (1f - delivered).coerceIn(0f, 1f)
-    }
-
-    private fun integrateCurve(
-        points: List<tk.glucodata.data.journal.JournalCurvePoint>,
-        upToMinute: Float
-    ): Float {
-        if (points.size < 2 || upToMinute <= points.first().minute) return 0f
-        var area = 0f
-        for (index in 0 until points.lastIndex) {
-            val start = points[index]
-            val end = points[index + 1]
-            if (upToMinute <= start.minute) break
-            val segmentEndMinute = minOf(upToMinute, end.minute.toFloat())
-            val segmentWidth = segmentEndMinute - start.minute
-            if (segmentWidth <= 0f) continue
-            val fullWidth = (end.minute - start.minute).coerceAtLeast(1).toFloat()
-            val endFraction = ((segmentEndMinute - start.minute) / fullWidth).coerceIn(0f, 1f)
-            val segmentEndActivity = start.activity + ((end.activity - start.activity) * endFraction)
-            area += ((start.activity + segmentEndActivity) * 0.5f) * segmentWidth
-            if (upToMinute <= end.minute) break
-        }
-        return area
     }
 
     private fun linearProgress(startMillis: Long, durationMinutes: Float, atMillis: Long): Float {

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
@@ -24,6 +24,9 @@ interface JournalDao {
     @Query("SELECT * FROM journal_entries WHERE timestamp BETWEEN :startMillis AND :endMillis ORDER BY timestamp ASC, id ASC")
     suspend fun getEntriesBetween(startMillis: Long, endMillis: Long): List<JournalEntryEntity>
 
+    @Query("SELECT COUNT(*) FROM journal_entries WHERE entryType = :entryType")
+    suspend fun countEntriesByType(entryType: String): Int
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertEntry(entry: JournalEntryEntity): Long
 

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalIobCalculator.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalIobCalculator.kt
@@ -1,0 +1,138 @@
+package tk.glucodata.data.journal
+
+import kotlin.math.roundToInt
+
+/**
+ * Single source of truth for insulin-on-board math, shared by the journal UI,
+ * the outbound API snapshot and the glucodata.Minute broadcast.
+ *
+ * Two distinct quantities are computed from the same dose list:
+ *  - [Result.iobUnits]: classic IOB — remaining future action,
+ *    `sum(amount * (1 - deliveredCurveArea/totalCurveArea))`. Counts the full
+ *    amount from injection time (t=0 -> 100%), monotonically falling. This is
+ *    the semantic external consumers (GDH/AAPS-style) expect.
+ *  - [Result.eiobUnits]: activity-based "effective" IOB —
+ *    `sum(amount * remainingFraction(t) * activityLevel(t))`, i.e. how much of
+ *    the remaining insulin is actively working right now. Zero until the
+ *    action curve's onset, equals IOB at the activity peak, never exceeds IOB.
+ */
+object JournalIobCalculator {
+
+    data class Dose(
+        val timestampMillis: Long,
+        val amountUnits: Float,
+        val preset: JournalInsulinPreset
+    )
+
+    data class Result(
+        val iobUnits: Float,
+        val eiobUnits: Float
+    )
+
+    fun dosesFromEntities(
+        entries: List<JournalEntryEntity>,
+        presetsById: Map<Long, JournalInsulinPreset>
+    ): List<Dose> = entries.mapNotNull { entry ->
+        if (JournalEntryType.fromStorage(entry.entryType) != JournalEntryType.INSULIN) return@mapNotNull null
+        toDose(entry.timestamp, entry.amount, entry.insulinPresetId, presetsById)
+    }
+
+    fun dosesFromModels(
+        entries: List<JournalEntry>,
+        presetsById: Map<Long, JournalInsulinPreset>
+    ): List<Dose> = entries.mapNotNull { entry ->
+        if (entry.type != JournalEntryType.INSULIN) return@mapNotNull null
+        toDose(entry.timestamp, entry.amount, entry.insulinPresetId, presetsById)
+    }
+
+    private fun toDose(
+        timestamp: Long,
+        amount: Float?,
+        presetId: Long?,
+        presetsById: Map<Long, JournalInsulinPreset>
+    ): Dose? {
+        // Archived presets intentionally still count: insulin injected with a
+        // since-disabled preset keeps acting.
+        val preset = presetId?.let(presetsById::get) ?: return null
+        if (!preset.countsTowardIob) return null
+        val units = amount?.takeIf { it.isFinite() && it > 0f } ?: return null
+        return Dose(timestamp, units, preset)
+    }
+
+    fun compute(doses: List<Dose>, atMillis: Long): Result {
+        var iob = 0.0
+        var eiob = 0.0
+        doses.forEach { dose ->
+            val remaining = remainingCurveFraction(dose.preset.curvePoints, dose.timestampMillis, atMillis)
+            val activity = dose.preset.activityFractionAt(dose.timestampMillis, atMillis)
+            iob += (dose.amountUnits * remaining).toDouble()
+            eiob += (dose.amountUnits * remaining * activity).toDouble()
+        }
+        return Result(iob.toFloat(), eiob.toFloat())
+    }
+
+    fun remainingCurveFraction(
+        points: List<JournalCurvePoint>,
+        doseTimestampMillis: Long,
+        atMillis: Long
+    ): Float {
+        if (points.size < 2 || atMillis < doseTimestampMillis) return 0f
+        val elapsedMinutes = ((atMillis - doseTimestampMillis) / 60_000f).coerceAtLeast(0f)
+        val total = integrateCurve(points, points.last().minute.toFloat())
+        if (total <= 0.0001f) return 0f
+        val delivered = (integrateCurve(points, elapsedMinutes) / total).coerceIn(0f, 1f)
+        return (1f - delivered).coerceIn(0f, 1f)
+    }
+
+    private fun integrateCurve(
+        points: List<JournalCurvePoint>,
+        upToMinute: Float
+    ): Float {
+        if (points.size < 2 || upToMinute <= points.first().minute) return 0f
+        var area = 0f
+        for (index in 0 until points.lastIndex) {
+            val start = points[index]
+            val end = points[index + 1]
+            if (upToMinute <= start.minute) break
+            val segmentEndMinute = minOf(upToMinute, end.minute.toFloat())
+            val segmentWidth = segmentEndMinute - start.minute
+            if (segmentWidth <= 0f) continue
+            val fullWidth = (end.minute - start.minute).coerceAtLeast(1).toFloat()
+            val endFraction = ((segmentEndMinute - start.minute) / fullWidth).coerceIn(0f, 1f)
+            val segmentEndActivity = start.activity + ((end.activity - start.activity) * endFraction)
+            area += ((start.activity + segmentEndActivity) * 0.5f) * segmentWidth
+            if (upToMinute <= end.minute) break
+        }
+        return area
+    }
+
+    fun buildActiveInsulinSummary(
+        entries: List<JournalEntry>,
+        presetsById: Map<Long, JournalInsulinPreset>,
+        atMillis: Long
+    ): JournalActiveInsulinSummary? {
+        val active = entries.mapNotNull { entry ->
+            if (entry.type != JournalEntryType.INSULIN) return@mapNotNull null
+            val dose = toDose(entry.timestamp, entry.amount, entry.insulinPresetId, presetsById)
+                ?: return@mapNotNull null
+            val activity = dose.preset.activityFractionAt(dose.timestampMillis, atMillis)
+            val remaining = remainingCurveFraction(dose.preset.curvePoints, dose.timestampMillis, atMillis)
+            // A dose is on board from injection until its curve is fully spent —
+            // include the pre-onset window where activity is still ~0.
+            if (activity <= 0.01f && remaining <= 0.001f) return@mapNotNull null
+            Triple(dose, activity, remaining)
+        }
+        if (active.isEmpty()) return null
+
+        val totalUnits = active.sumOf { it.first.amountUnits.toDouble() }.toFloat()
+        val weightedActivity = active.sumOf { (it.first.amountUnits * it.second).toDouble() }.toFloat()
+        return JournalActiveInsulinSummary(
+            activeEntryCount = active.size,
+            totalUnits = totalUnits,
+            weightedActivityPercent = ((weightedActivity / totalUnits) * 100f).roundToInt().coerceIn(0, 100),
+            nextEndingAt = active.minOfOrNull { it.first.preset.activeEndAt(it.first.timestampMillis) },
+            iobUnits = active.sumOf { (it.first.amountUnits * it.third).toDouble() }.toFloat(),
+            eiobUnits = active.sumOf { (it.first.amountUnits * it.third * it.second).toDouble() }.toFloat()
+        )
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalModels.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalModels.kt
@@ -179,7 +179,9 @@ data class JournalActiveInsulinSummary(
     val activeEntryCount: Int,
     val totalUnits: Float,
     val weightedActivityPercent: Int,
-    val nextEndingAt: Long?
+    val nextEndingAt: Long?,
+    val iobUnits: Float = 0f,
+    val eiobUnits: Float = 0f
 )
 
 enum class JournalBuiltInCurveProfile {

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
@@ -644,6 +644,7 @@ fun DashboardChartSection(
     peerPredictionSeries: Map<String, List<GlucosePredictionSeries>> = emptyMap(),
     journalMarkers: List<JournalChartMarker> = emptyList(),
     activeInsulinSummary: JournalActiveInsulinSummary? = null,
+    showEiob: Boolean = true,
     predictionPoints: List<GlucosePredictionPoint> = emptyList(),
     predictionSeries: List<GlucosePredictionSeries> = emptyList(),
     graphSmoothingMinutes: Int = 0,
@@ -684,6 +685,7 @@ fun DashboardChartSection(
                         peerPredictionSeries = peerPredictionSeries,
                         journalMarkers = journalMarkers,
                         activeInsulinSummary = activeInsulinSummary,
+                        showEiob = showEiob,
                         predictionPoints = predictionPoints,
                         predictionSeries = predictionSeries,
                         graphSmoothingMinutes = graphSmoothingMinutes,
@@ -747,6 +749,7 @@ fun InteractiveGlucoseChart(
     peerPredictionSeries: Map<String, List<GlucosePredictionSeries>> = emptyMap(),
     journalMarkers: List<JournalChartMarker> = emptyList(),
     activeInsulinSummary: JournalActiveInsulinSummary? = null,
+    showEiob: Boolean = true,
     predictionPoints: List<GlucosePredictionPoint> = emptyList(),
     predictionSeries: List<GlucosePredictionSeries> = emptyList(),
     graphSmoothingMinutes: Int = 0,
@@ -3393,11 +3396,14 @@ fun InteractiveGlucoseChart(
                 }
 
             activeInsulinSummary?.let { summary ->
-                val totalUnitsLabel = if (summary.totalUnits % 1f < 0.05f) {
-                    summary.totalUnits.roundToInt().toString()
-                } else {
-                    String.format(java.util.Locale.getDefault(), "%.1f", summary.totalUnits)
+                val unitsLabel = { units: Float ->
+                    if (units % 1f < 0.05f) {
+                        units.roundToInt().toString()
+                    } else {
+                        String.format(java.util.Locale.getDefault(), "%.1f", units)
+                    }
                 }
+                val totalUnitsLabel = unitsLabel(summary.totalUnits)
                 val remainingLabel = summary.nextEndingAt
                     ?.let { formatRemainingDuration(it - System.currentTimeMillis()) }
                     ?.takeIf { it.isNotBlank() }
@@ -3418,16 +3424,18 @@ fun InteractiveGlucoseChart(
                     ) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(
-                                text = "${totalUnitsLabel}U",
+                                text = "IOB ${unitsLabel(summary.iobUnits)}U",
                                 style = MaterialTheme.typography.labelLarge,
                                 fontWeight = FontWeight.SemiBold
                             )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(
-                                text = "${summary.weightedActivityPercent}%",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                            if (showEiob) {
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Text(
+                                    text = "eIOB ${unitsLabel(summary.eiobUnits)}U",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                             remainingLabel?.let { label ->
                                 Spacer(modifier = Modifier.width(10.dp))
                                 Icon(
@@ -3451,6 +3459,16 @@ fun InteractiveGlucoseChart(
                                     style = MaterialTheme.typography.labelLarge,
                                     fontWeight = FontWeight.SemiBold,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Text(
+                                    text = buildString {
+                                        append(stringResource(R.string.journal_iob_expanded, unitsLabel(summary.iobUnits)))
+                                        if (showEiob) {
+                                            append(" · ")
+                                            append(stringResource(R.string.journal_eiob_expanded, unitsLabel(summary.eiobUnits)))
+                                        }
+                                    },
+                                    style = MaterialTheme.typography.titleSmall
                                 )
                                 Text(
                                     text = stringResource(

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -161,7 +161,7 @@ import tk.glucodata.ui.journal.JournalEntrySheet
 import tk.glucodata.ui.journal.JournalFloatingActionMenu
 import tk.glucodata.ui.journal.JournalInlineChip
 import tk.glucodata.ui.journal.JournalSettingsScreen
-import tk.glucodata.ui.journal.buildActiveInsulinSummary
+import tk.glucodata.data.journal.JournalIobCalculator
 import tk.glucodata.ui.journal.buildJournalChartMarkers
 import tk.glucodata.ui.viewmodel.DashboardViewModel
 import tk.glucodata.ui.theme.displayLargeExpressive
@@ -309,6 +309,7 @@ fun DashboardScreen(
     val visualSmoothingMinutes = if (dataSmoothingExchangeOnly) 0 else chartSmoothingMinutes
     val previewWindowMode by viewModel.previewWindowMode.collectAsState()
     val journalEnabled by viewModel.journalEnabled.collectAsState()
+    val journalEiobDisplayEnabled by viewModel.journalEiobDisplayEnabled.collectAsState()
     val journalDoseCalculatorEnabled by viewModel.journalDoseCalculatorEnabled.collectAsState()
     val journalFoodMacrosEnabled by viewModel.journalFoodMacrosEnabled.collectAsState()
     val journalFoodLibraryEnabled by viewModel.journalFoodLibraryEnabled.collectAsState()
@@ -376,7 +377,7 @@ fun DashboardScreen(
         if (!journalEnabled || scopedJournalEntries.isEmpty()) {
             null
         } else {
-            buildActiveInsulinSummary(scopedJournalEntries, journalPresetsById, journalNow)
+            JournalIobCalculator.buildActiveInsulinSummary(scopedJournalEntries, journalPresetsById, journalNow)
         }
     }
     val predictionSettings = remember(
@@ -1296,6 +1297,7 @@ fun DashboardScreen(
                                     peerPredictionSeries = peerPredictionSeries,
                                     journalMarkers = journalChartMarkers,
                                     activeInsulinSummary = activeInsulinSummary,
+                                    showEiob = journalEiobDisplayEnabled,
                                     predictionSeries = predictionSeries,
                                     graphSmoothingMinutes = visualSmoothingMinutes,
                                     collapseSmoothedData = dataSmoothingCollapseChunks,
@@ -1475,6 +1477,7 @@ fun DashboardScreen(
                                     peerPredictionSeries = peerPredictionSeries,
                                     journalMarkers = journalChartMarkers,
                                     activeInsulinSummary = activeInsulinSummary,
+                                    showEiob = journalEiobDisplayEnabled,
                                     predictionSeries = predictionSeries,
                                     graphSmoothingMinutes = visualSmoothingMinutes,
                                     collapseSmoothedData = dataSmoothingCollapseChunks,

--- a/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
@@ -293,6 +293,7 @@ private fun JournalRoute(
     val journalEntries by dashboardViewModel.journalEntries.collectAsStateWithLifecycle()
     val journalInsulinPresets by dashboardViewModel.journalInsulinPresets.collectAsStateWithLifecycle()
     val journalFoods by dashboardViewModel.journalFoods.collectAsStateWithLifecycle()
+    val journalEiobDisplayEnabled by dashboardViewModel.journalEiobDisplayEnabled.collectAsStateWithLifecycle()
     val predictionCarbRatioGramsPerUnit by dashboardViewModel.predictionCarbRatioGramsPerUnit.collectAsStateWithLifecycle()
     val predictionInsulinSensitivityMgDlPerUnit by dashboardViewModel.predictionInsulinSensitivityMgDlPerUnit.collectAsStateWithLifecycle()
     val calibrations by tk.glucodata.data.calibration.CalibrationManager.calibrations.collectAsStateWithLifecycle()
@@ -362,7 +363,8 @@ private fun JournalRoute(
         modifier = modifier,
         showTitle = showTitle,
         useStatusBarsPadding = useStatusBarsPadding,
-        bottomContentPadding = bottomContentPadding
+        bottomContentPadding = bottomContentPadding,
+        showEiob = journalEiobDisplayEnabled
     )
 
     journalEditorRequest?.let { request ->

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -160,7 +160,6 @@ import tk.glucodata.ui.journal.JournalDoseProfile
 import tk.glucodata.ui.journal.JournalEntrySheet
 import tk.glucodata.ui.journal.JournalInlineChip
 import tk.glucodata.ui.journal.JournalSettingsScreen
-import tk.glucodata.ui.journal.buildActiveInsulinSummary
 import tk.glucodata.ui.journal.buildJournalChartMarkers
 import tk.glucodata.ui.journal.journalTypeColor
 import tk.glucodata.ui.journal.journalTypeSelectedContainerColor

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorScreen.kt
@@ -158,7 +158,6 @@ import tk.glucodata.ui.journal.JournalDoseProfile
 import tk.glucodata.ui.journal.JournalEntrySheet
 import tk.glucodata.ui.journal.JournalInlineChip
 import tk.glucodata.ui.journal.JournalSettingsScreen
-import tk.glucodata.ui.journal.buildActiveInsulinSummary
 import tk.glucodata.ui.journal.buildJournalChartMarkers
 import tk.glucodata.ui.journal.journalTypeColor
 import tk.glucodata.ui.journal.journalTypeSelectedContainerColor

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
@@ -102,7 +102,6 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 import tk.glucodata.Applic
 import tk.glucodata.R
-import tk.glucodata.data.journal.JournalActiveInsulinSummary
 import tk.glucodata.data.journal.JournalChartMarker
 import tk.glucodata.data.journal.JournalCurvePoint
 import tk.glucodata.data.journal.JournalEntry
@@ -234,32 +233,6 @@ fun buildJournalChartMarkers(
             }
         )
     }
-}
-
-fun buildActiveInsulinSummary(
-    entries: List<JournalEntry>,
-    presetsById: Map<Long, JournalInsulinPreset>,
-    atMillis: Long
-): JournalActiveInsulinSummary? {
-    val activeEntries = entries.mapNotNull { entry ->
-        val preset = entry.insulinPresetId?.let(presetsById::get) ?: return@mapNotNull null
-        if (entry.type != JournalEntryType.INSULIN) return@mapNotNull null
-        if (!preset.countsTowardIob) return@mapNotNull null
-        val amount = entry.amount ?: return@mapNotNull null
-        val activity = preset.activityFractionAt(entry.timestamp, atMillis)
-        if (activity <= 0.01f) return@mapNotNull null
-        Triple(entry, preset, amount to activity)
-    }
-    if (activeEntries.isEmpty()) return null
-
-    val totalUnits = activeEntries.sumOf { it.third.first.toDouble() }.toFloat()
-    val weightedActivity = activeEntries.sumOf { (it.third.first * it.third.second).toDouble() }.toFloat()
-    return JournalActiveInsulinSummary(
-        activeEntryCount = activeEntries.size,
-        totalUnits = totalUnits,
-        weightedActivityPercent = ((weightedActivity / totalUnits) * 100f).roundToInt().coerceIn(0, 100),
-        nextEndingAt = activeEntries.minOfOrNull { it.second.activeEndAt(it.first.timestamp) }
-    )
 }
 
 @Composable

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
@@ -3,6 +3,7 @@
 package tk.glucodata.ui.journal
 
 import android.view.HapticFeedbackConstants
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -31,7 +32,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -46,10 +49,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import tk.glucodata.R
+import kotlinx.coroutines.delay
 import tk.glucodata.data.journal.JournalEntry
 import tk.glucodata.data.journal.JournalEntryType
 import tk.glucodata.data.journal.JournalFood
 import tk.glucodata.data.journal.JournalInsulinPreset
+import tk.glucodata.data.journal.JournalIobCalculator
 import tk.glucodata.ui.ChartViewportSnapshot
 import tk.glucodata.ui.DashboardChartSection
 import tk.glucodata.ui.GlucosePoint
@@ -101,7 +106,8 @@ fun JournalScreen(
     modifier: Modifier = Modifier,
     showTitle: Boolean = true,
     useStatusBarsPadding: Boolean = true,
-    bottomContentPadding: Dp = 104.dp
+    bottomContentPadding: Dp = 104.dp,
+    showEiob: Boolean = true
 ) {
     val view = LocalView.current
     val sortedHistory = remember(glucoseHistory) { glucoseHistory.sortedBy { it.timestamp } }
@@ -169,7 +175,8 @@ fun JournalScreen(
             item(key = "journal-metrics") {
                 JournalMetricsPanel(
                     entries = journalEntries,
-                    presetsById = presetsById
+                    presetsById = presetsById,
+                    showEiob = showEiob
                 )
             }
 
@@ -423,9 +430,19 @@ private fun JournalHeader(
 @Composable
 private fun JournalMetricsPanel(
     entries: List<JournalEntry>,
-    presetsById: Map<Long, JournalInsulinPreset>
+    presetsById: Map<Long, JournalInsulinPreset>,
+    showEiob: Boolean
 ) {
-    val nowMillis = remember(entries) { System.currentTimeMillis() }
+    // Tick the clock so IOB/eIOB keep decaying while the screen stays open
+    // (mirrors the dashboard's journalNow ticker).
+    var nowMillis by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(entries) {
+        nowMillis = System.currentTimeMillis()
+        while (true) {
+            delay(30_000L)
+            nowMillis = System.currentTimeMillis()
+        }
+    }
     val zone = remember { ZoneId.systemDefault() }
     val startOfDayMillis = remember(nowMillis, zone) {
         LocalDate.now(zone).atStartOfDay(zone).toInstant().toEpochMilli()
@@ -434,18 +451,25 @@ private fun JournalMetricsPanel(
         entries.filter { it.timestamp in startOfDayMillis..nowMillis }
     }
     val activeInsulin = remember(entries, presetsById, nowMillis) {
-        buildActiveInsulinSummary(entries, presetsById, nowMillis)
+        JournalIobCalculator.buildActiveInsulinSummary(entries, presetsById, nowMillis)
     }
-    val activeInsulinUnits = activeInsulin
-        ?.let { it.totalUnits * (it.weightedActivityPercent / 100f) }
-        ?.coerceAtLeast(0f)
-        ?: 0f
+    val iobUnits = activeInsulin?.iobUnits?.coerceAtLeast(0f) ?: 0f
+    val eiobUnits = activeInsulin?.eiobUnits?.coerceAtLeast(0f) ?: 0f
     val activeUntilFormatter = remember { SimpleDateFormat("HH:mm", Locale.getDefault()) }
-    val activeInsulinDetail = activeInsulin?.nextEndingAt?.let { endingAt ->
+    val eiobText = if (showEiob) {
+        stringResource(R.string.journal_metric_eiob, formatJournalMetric(eiobUnits))
+    } else {
+        null
+    }
+    val untilText = activeInsulin?.nextEndingAt?.let { endingAt ->
         stringResource(R.string.journal_active_insulin_until, activeUntilFormatter.format(Date(endingAt)))
-    } ?: activeInsulin?.let {
-        stringResource(R.string.journal_active_now_percent, it.weightedActivityPercent)
-    } ?: stringResource(R.string.journal_no_active_insulin)
+    }
+    val activeInsulinDetail = if (activeInsulin == null) {
+        stringResource(R.string.journal_no_active_insulin)
+    } else {
+        listOfNotNull(eiobText, untilText).joinToString(" · ")
+            .ifEmpty { stringResource(R.string.journal_active_now_percent, activeInsulin.weightedActivityPercent) }
+    }
     val foodToday = todaysEntries
         .filter { it.type == JournalEntryType.CARBS }
         .sumOf { (it.amount ?: 0f).toDouble() }
@@ -458,15 +482,21 @@ private fun JournalMetricsPanel(
         .filter { it.type == JournalEntryType.ACTIVITY }
         .sumOf { (it.durationMinutes ?: 0).toInt() }
 
+    var iobDetailsExpanded by rememberSaveable { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             JournalMetricCard(
-                title = stringResource(R.string.journal_active_insulin),
-                value = "${formatJournalMetric(activeInsulinUnits)} U",
+                title = stringResource(R.string.journal_metric_iob),
+                value = "${formatJournalMetric(iobUnits)} U",
                 detail = activeInsulinDetail,
                 icon = Icons.Default.Vaccines,
                 type = JournalEntryType.INSULIN,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
+                onClick = if (activeInsulin != null) {
+                    { iobDetailsExpanded = !iobDetailsExpanded }
+                } else {
+                    null
+                }
             )
             JournalMetricCard(
                 title = stringResource(R.string.journal_type_food),
@@ -479,6 +509,63 @@ private fun JournalMetricsPanel(
                 type = JournalEntryType.CARBS,
                 modifier = Modifier.weight(1f)
             )
+        }
+        AnimatedVisibility(visible = iobDetailsExpanded && activeInsulin != null) {
+            activeInsulin?.let { summary ->
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(18.dp),
+                    color = journalTypeSelectedContainerColor(
+                        JournalEntryType.INSULIN,
+                        MaterialTheme.colorScheme.surfaceContainerHighest
+                    ).copy(alpha = 0.68f)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        Text(
+                            text = buildString {
+                                append(
+                                    stringResource(
+                                        R.string.journal_iob_expanded,
+                                        formatJournalMetric(summary.iobUnits.coerceAtLeast(0f))
+                                    )
+                                )
+                                if (showEiob) {
+                                    append(" · ")
+                                    append(
+                                        stringResource(
+                                            R.string.journal_eiob_expanded,
+                                            formatJournalMetric(summary.eiobUnits.coerceAtLeast(0f))
+                                        )
+                                    )
+                                }
+                            },
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.journal_active_insulin_summary,
+                                summary.activeEntryCount,
+                                formatJournalMetric(summary.totalUnits),
+                                summary.weightedActivityPercent
+                            ),
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        summary.nextEndingAt?.let { endingAt ->
+                            Text(
+                                text = stringResource(
+                                    R.string.journal_active_insulin_until,
+                                    activeUntilFormatter.format(Date(endingAt))
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
         }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             JournalMetricCard(
@@ -508,10 +595,13 @@ private fun JournalMetricCard(
     detail: String,
     icon: ImageVector,
     type: JournalEntryType,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null
 ) {
     val tint = journalTypeColor(type)
     Surface(
+        onClick = onClick ?: {},
+        enabled = onClick != null,
         modifier = modifier.heightIn(min = 74.dp),
         shape = RoundedCornerShape(18.dp),
         color = journalTypeSelectedContainerColor(

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
@@ -173,6 +173,7 @@ fun JournalSettingsScreen(
     val journalDoseCalculatorEnabled by viewModel.journalDoseCalculatorEnabled.collectAsState()
     val journalFoodMacrosEnabled by viewModel.journalFoodMacrosEnabled.collectAsState()
     val journalFoodLibraryEnabled by viewModel.journalFoodLibraryEnabled.collectAsState()
+    val journalEiobDisplayEnabled by viewModel.journalEiobDisplayEnabled.collectAsState()
     val journalHealthConnectActivityEnabled by viewModel.journalHealthConnectActivityEnabled.collectAsState()
     val aapsJournalImportEnabled by viewModel.aapsJournalImportEnabled.collectAsState()
     val allPresets by viewModel.journalInsulinPresets.collectAsState()
@@ -254,6 +255,16 @@ fun JournalSettingsScreen(
                         onCheckedChange = { viewModel.setJournalFoodMacrosEnabled(it) },
                         icon = Icons.Default.Restaurant,
                         iconTint = MaterialTheme.colorScheme.secondary,
+                        position = CardPosition.MIDDLE,
+                        enabled = journalEnabled
+                    )
+                    SettingsSwitchItem(
+                        title = stringResource(R.string.journal_eiob_display_title),
+                        subtitle = stringResource(R.string.journal_eiob_display_desc),
+                        checked = journalEiobDisplayEnabled,
+                        onCheckedChange = { viewModel.setJournalEiobDisplayEnabled(it) },
+                        icon = Icons.Default.Vaccines,
+                        iconTint = MaterialTheme.colorScheme.tertiary,
                         position = CardPosition.MIDDLE,
                         enabled = journalEnabled
                     )

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
@@ -111,6 +111,7 @@ class DashboardViewModel(
         const val JOURNAL_NAVIGATION_TAB_KEY = "dashboard_journal_navigation_tab_enabled"
         const val JOURNAL_FOOD_MACROS_KEY = "dashboard_journal_food_macros_enabled"
         const val JOURNAL_FOOD_LIBRARY_KEY = "dashboard_journal_food_library_enabled"
+        const val JOURNAL_EIOB_DISPLAY_KEY = "dashboard_journal_eiob_display_enabled"
         const val JOURNAL_HEALTH_CONNECT_ACTIVITY_KEY = "dashboard_journal_health_connect_activity_enabled"
         const val PREDICTION_CARB_RATIO_KEY = "dashboard_prediction_carb_ratio_g_per_u"
         const val PREDICTION_INSULIN_SENSITIVITY_KEY = "dashboard_prediction_insulin_sensitivity_mgdl_per_u"
@@ -291,6 +292,9 @@ class DashboardViewModel(
 
     private val _journalFoodLibraryEnabled = MutableStateFlow(true)
     val journalFoodLibraryEnabled = _journalFoodLibraryEnabled.asStateFlow()
+
+    private val _journalEiobDisplayEnabled = MutableStateFlow(true)
+    val journalEiobDisplayEnabled = _journalEiobDisplayEnabled.asStateFlow()
 
     private val _journalHealthConnectActivityEnabled = MutableStateFlow(false)
     val journalHealthConnectActivityEnabled = _journalHealthConnectActivityEnabled.asStateFlow()
@@ -543,6 +547,7 @@ class DashboardViewModel(
         _journalDoseCalculatorEnabled.value = prefs.getBoolean(JOURNAL_DOSE_CALCULATOR_KEY, false)
         _journalFoodMacrosEnabled.value = prefs.getBoolean(JOURNAL_FOOD_MACROS_KEY, false)
         _journalFoodLibraryEnabled.value = prefs.getBoolean(JOURNAL_FOOD_LIBRARY_KEY, true)
+        _journalEiobDisplayEnabled.value = prefs.getBoolean(JOURNAL_EIOB_DISPLAY_KEY, true)
         _journalHealthConnectActivityEnabled.value = prefs.getBoolean(JOURNAL_HEALTH_CONNECT_ACTIVITY_KEY, false)
         _aapsJournalImportEnabled.value = AapsJournalImport.isEnabled(context)
         _predictiveSimulationEnabled.value = prefs.getBoolean("dashboard_predictive_simulation_enabled", true)
@@ -1270,6 +1275,13 @@ class DashboardViewModel(
         val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
         prefs.edit().putBoolean(JOURNAL_FOOD_LIBRARY_KEY, enabled).apply()
         _journalFoodLibraryEnabled.value = enabled
+    }
+
+    fun setJournalEiobDisplayEnabled(enabled: Boolean) {
+        val context = tk.glucodata.Applic.app
+        val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(JOURNAL_EIOB_DISPLAY_KEY, enabled).apply()
+        _journalEiobDisplayEnabled.value = enabled
     }
 
     fun setJournalHealthConnectActivityEnabled(enabled: Boolean) {

--- a/Common/src/test/java/tk/glucodata/data/journal/JournalIobCalculatorTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/JournalIobCalculatorTests.kt
@@ -1,0 +1,273 @@
+package tk.glucodata.data.journal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JournalIobCalculatorTests {
+
+    private val doseTime = 1_700_000_000_000L
+
+    // Triangle curve: activity ramps 0 -> 1 over 30 min, back to 0 at 60 min.
+    // Trapezoidal integral: 0..30 = 15, total = 30.
+    private fun trianglePreset(
+        id: Long = 1L,
+        countsTowardIob: Boolean = true,
+        isArchived: Boolean = false
+    ) = JournalInsulinPreset(
+        id = id,
+        displayName = "Triangle",
+        onsetMinutes = 0,
+        durationMinutes = 60,
+        accentColor = 0,
+        curveJson = "0:0;30:1;60:0",
+        isBuiltIn = false,
+        isArchived = isArchived,
+        countsTowardIob = countsTowardIob,
+        sortOrder = 0
+    )
+
+    // Fiasp-like curve with a flat zero-activity onset segment until minute 19.
+    private fun onsetPreset(id: Long = 2L) = JournalInsulinPreset(
+        id = id,
+        displayName = "Onset",
+        onsetMinutes = 19,
+        durationMinutes = 360,
+        accentColor = 0,
+        curveJson = "0:0;19:0;55:1;360:0",
+        isBuiltIn = false,
+        isArchived = false,
+        countsTowardIob = true,
+        sortOrder = 0
+    )
+
+    private fun entity(
+        amount: Float?,
+        presetId: Long? = 1L,
+        entryType: String = "insulin",
+        timestamp: Long = doseTime
+    ) = JournalEntryEntity(
+        id = 0,
+        timestamp = timestamp,
+        sensorSerial = null,
+        entryType = entryType,
+        title = "",
+        note = null,
+        amount = amount,
+        glucoseValueMgDl = null,
+        durationMinutes = null,
+        intensity = null,
+        insulinPresetId = presetId,
+        source = "manual",
+        sourceRecordId = null,
+        createdAt = timestamp,
+        updatedAt = timestamp
+    )
+
+    private fun model(
+        amount: Float?,
+        presetId: Long? = 1L,
+        type: JournalEntryType = JournalEntryType.INSULIN,
+        timestamp: Long = doseTime
+    ) = JournalEntry(
+        id = 0,
+        timestamp = timestamp,
+        sensorSerial = null,
+        type = type,
+        title = "",
+        note = null,
+        amount = amount,
+        glucoseValueMgDl = null,
+        durationMinutes = null,
+        intensity = null,
+        insulinPresetId = presetId,
+        foodId = null,
+        proteinGrams = null,
+        fatGrams = null,
+        source = JournalEntrySource.MANUAL,
+        sourceRecordId = null,
+        createdAt = timestamp,
+        updatedAt = timestamp
+    )
+
+    private fun minutes(min: Long) = min * 60_000L
+
+    @Test
+    fun classicIobCountsFullAmountAtInjectionTime() {
+        val presets = mapOf(1L to trianglePreset())
+        val doses = JournalIobCalculator.dosesFromEntities(listOf(entity(10f)), presets)
+        val result = JournalIobCalculator.compute(doses, doseTime)
+        assertEquals(10f, result.iobUnits, 0.01f)
+        assertEquals(0f, result.eiobUnits, 0.01f)
+    }
+
+    @Test
+    fun iobDecaysWhileEiobFollowsActivityPeak() {
+        val presets = mapOf(1L to trianglePreset())
+        val doses = JournalIobCalculator.dosesFromEntities(listOf(entity(10f)), presets)
+        val result = JournalIobCalculator.compute(doses, doseTime + minutes(30))
+        // Half of the curve area delivered at the peak.
+        assertEquals(5f, result.iobUnits, 0.05f)
+        // At the 1.0 activity peak the whole remaining insulin is acting:
+        // eIOB = amount * remaining(0.5) * activity(1.0) = IOB.
+        assertEquals(5f, result.eiobUnits, 0.05f)
+    }
+
+    @Test
+    fun windowedDeliveryIsIobDecayAcrossTheWindow() {
+        // The notification risk warning projects with iob(t) - iob(t+30min):
+        // triangle curve delivers exactly half its 10U in the first 30 minutes.
+        val presets = mapOf(1L to trianglePreset())
+        val doses = JournalIobCalculator.dosesFromEntities(listOf(entity(10f)), presets)
+        val now = JournalIobCalculator.compute(doses, doseTime).iobUnits
+        val afterWindow = JournalIobCalculator.compute(doses, doseTime + minutes(30)).iobUnits
+        assertEquals(5f, now - afterWindow, 0.05f)
+        // Decay is monotonic: the window quantity can never be negative.
+        for (elapsed in 0..90 step 10) {
+            val a = JournalIobCalculator.compute(doses, doseTime + minutes(elapsed.toLong())).iobUnits
+            val b = JournalIobCalculator.compute(doses, doseTime + minutes(elapsed.toLong() + 30)).iobUnits
+            assertTrue("delivery negative at +${elapsed}min", a - b >= -0.0001f)
+        }
+    }
+
+    @Test
+    fun eiobNeverExceedsIob() {
+        val presets = mapOf(1L to trianglePreset(), 2L to onsetPreset())
+        val entries = listOf(
+            entity(10f),
+            entity(4f, presetId = 2L, timestamp = doseTime + minutes(20))
+        )
+        val doses = JournalIobCalculator.dosesFromEntities(entries, presets)
+        for (elapsed in 0..400 step 5) {
+            val result = JournalIobCalculator.compute(doses, doseTime + minutes(elapsed.toLong()))
+            assertTrue(
+                "eIOB ${result.eiobUnits} > IOB ${result.iobUnits} at +${elapsed}min",
+                result.eiobUnits <= result.iobUnits + 0.0001f
+            )
+        }
+    }
+
+    @Test
+    fun bothZeroAfterCurveEnd() {
+        val presets = mapOf(1L to trianglePreset())
+        val doses = JournalIobCalculator.dosesFromEntities(listOf(entity(10f)), presets)
+        val result = JournalIobCalculator.compute(doses, doseTime + minutes(90))
+        assertEquals(0f, result.iobUnits, 0.001f)
+        assertEquals(0f, result.eiobUnits, 0.001f)
+    }
+
+    @Test
+    fun futureDosesContributeNothing() {
+        val presets = mapOf(1L to trianglePreset())
+        val doses = JournalIobCalculator.dosesFromEntities(listOf(entity(10f)), presets)
+        val result = JournalIobCalculator.compute(doses, doseTime - minutes(5))
+        assertEquals(0f, result.iobUnits, 0.001f)
+        assertEquals(0f, result.eiobUnits, 0.001f)
+    }
+
+    @Test
+    fun presetNotCountingTowardIobIsExcluded() {
+        val presets = mapOf(1L to trianglePreset(countsTowardIob = false))
+        val doses = JournalIobCalculator.dosesFromEntities(listOf(entity(10f)), presets)
+        assertTrue(doses.isEmpty())
+    }
+
+    @Test
+    fun nonInsulinUnknownPresetAndInvalidAmountsAreExcluded() {
+        val presets = mapOf(1L to trianglePreset())
+        val entries = listOf(
+            entity(40f, entryType = "carbs"),
+            entity(10f, presetId = null),
+            entity(10f, presetId = 99L),
+            entity(null),
+            entity(0f),
+            entity(-2f)
+        )
+        val doses = JournalIobCalculator.dosesFromEntities(entries, presets)
+        assertTrue(doses.isEmpty())
+    }
+
+    @Test
+    fun archivedPresetStillCounts() {
+        // Archiving hides a preset from the picker; insulin already injected with
+        // it keeps acting, so it must keep counting toward IOB (underreporting
+        // IOB invites insulin stacking).
+        val presets = mapOf(1L to trianglePreset(isArchived = true))
+        val doses = JournalIobCalculator.dosesFromEntities(listOf(entity(10f)), presets)
+        val result = JournalIobCalculator.compute(doses, doseTime)
+        assertEquals(10f, result.iobUnits, 0.01f)
+    }
+
+    @Test
+    fun entityAndModelPathsAgree() {
+        val presets = mapOf(1L to trianglePreset())
+        val at = doseTime + minutes(20)
+        val fromEntities = JournalIobCalculator.compute(
+            JournalIobCalculator.dosesFromEntities(listOf(entity(7.5f)), presets), at
+        )
+        val fromModels = JournalIobCalculator.compute(
+            JournalIobCalculator.dosesFromModels(listOf(model(7.5f)), presets), at
+        )
+        assertEquals(fromEntities.iobUnits, fromModels.iobUnits, 0.0001f)
+        assertEquals(fromEntities.eiobUnits, fromModels.eiobUnits, 0.0001f)
+    }
+
+    @Test
+    fun multipleDosesAreSummed() {
+        val presets = mapOf(1L to trianglePreset())
+        val entries = listOf(
+            entity(10f),
+            entity(4f, timestamp = doseTime + minutes(30))
+        )
+        val doses = JournalIobCalculator.dosesFromEntities(entries, presets)
+        val result = JournalIobCalculator.compute(doses, doseTime + minutes(30))
+        // First dose half delivered (5U) + second dose fully on board (4U).
+        assertEquals(9f, result.iobUnits, 0.05f)
+        // First dose: remaining 0.5 * peak activity 1.0 * 10U = 5U;
+        // second dose still at zero activity.
+        assertEquals(5f, result.eiobUnits, 0.05f)
+    }
+
+    @Test
+    fun summaryIncludesFreshBolusBeforeActivityOnset() {
+        val presets = mapOf(2L to onsetPreset())
+        val at = doseTime + minutes(10)
+        val summary = JournalIobCalculator.buildActiveInsulinSummary(
+            listOf(model(10f, presetId = 2L)), presets, at
+        )
+        assertNotNull(summary)
+        summary!!
+        assertEquals(1, summary.activeEntryCount)
+        assertEquals(10f, summary.iobUnits, 0.05f)
+        assertEquals(0f, summary.eiobUnits, 0.05f)
+        assertEquals(0, summary.weightedActivityPercent)
+    }
+
+    @Test
+    fun summaryNullWhenAllDosesExpired() {
+        val presets = mapOf(1L to trianglePreset())
+        val summary = JournalIobCalculator.buildActiveInsulinSummary(
+            listOf(model(10f)), presets, doseTime + minutes(120)
+        )
+        assertNull(summary)
+    }
+
+    @Test
+    fun summaryMatchesComputeMidCurve() {
+        val presets = mapOf(1L to trianglePreset())
+        val at = doseTime + minutes(15)
+        val entries = listOf(model(10f))
+        val summary = JournalIobCalculator.buildActiveInsulinSummary(entries, presets, at)
+        val result = JournalIobCalculator.compute(
+            JournalIobCalculator.dosesFromModels(entries, presets), at
+        )
+        assertNotNull(summary)
+        summary!!
+        assertEquals(result.iobUnits, summary.iobUnits, 0.0001f)
+        assertEquals(result.eiobUnits, summary.eiobUnits, 0.0001f)
+        assertEquals(10f, summary.totalUnits, 0.001f)
+        assertEquals(50, summary.weightedActivityPercent)
+    }
+}


### PR DESCRIPTION
GlucoDataHandler stopped showing IoB with NG. It gets IOB either by polling the webserver's /pebble endpoint or from the glucodata.Minute broadcast extras. /pebble reads the old native amounts store, which the journal never writes to (so: always 0.00), and the broadcast extras were never filled at all. This fills the broadcast side.

The IOB math moved out of OutboundApiJournalSnapshot into a shared JournalIobCalculator (unit tested), so the journal UI, the outbound API and the broadcast all compute the same numbers. The broadcast sends classic remaining-action IOB under glucodata.Minute.IOB (counts the full dose from injection, which is what consumers of that field expect), plus COB and gdh.IOB_COB_time. The activity-weighted value goes out under its own key, glucodata.Minute.eIOB: starts at 0 after a bolus, equals IOB at the activity peak, never exceeds it. GDH ignores keys it doesn't know, so that one is harmless today.

Extras are only attached when the journal is enabled and actually has insulin or carb entries. People still using the native amounts keep their /pebble polling and don't get a competing 0.00 from the broadcast.

While in there, a few journal display fixes that fell out of testing this:

- the metrics card shows classic IOB now with eIOB in the detail line, and the card and the chart pill expand with the full breakdown. Before, only the activity-gated value was visible anywhere, so a fresh Fiasp bolus didn't show up for ~19 minutes.
- the metrics froze until you switched tabs (nowMillis was only set on recomposition), they tick every 30s now like the dashboard already did
- new toggle to hide eIOB for people who only want the classic number, en + de strings

src/main reaches the mobile-only journal via reflection, same pattern as OutboundApi, so wear/small compile unchanged. R8 keep rules included. Outbound API JSON gains eiob/journal_eiob.

Running this on my own phone (Libre 3) next to GDH. If you test with GDH, turn its Juggluco webserver IOB polling off first, the polled 0.00 overwrites the broadcast value every cycle. #80 fixes /pebble itself.
