### PR TITLE
Trend arrow: match the CGM angle convention, fill the notification glyph

### DIFF
--- a/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
+++ b/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
@@ -916,15 +916,9 @@ public class NotificationChartDrawer {
             outlinePaint.setStrokeWidth(strokeWidth * 2.2f);
         }
 
-        // Rotation Formula: Rate -> Degrees
-        // 45 deg per mg/dL/min, vertical at +/-2, matching TrendIndicator and
-        // the classic CGM arrow convention.
-        float sensitivity = 45f;
-        float rotation = (-rate * sensitivity);
-        if (rotation < -90f)
-            rotation = -90f;
-        if (rotation > 90f)
-            rotation = 90f;
+        // Shared rotation math (45 deg per mg/dL/min, vertical at +/-2, flat
+        // below the Flat trend state) — must match TrendIndicator.
+        float rotation = TrendArrowAngle.rotationDegrees(rate);
 
         // Base Dimensions from TrendIndicator.kt
         float headSpan = drawSize * 0.5f;

--- a/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
+++ b/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
@@ -917,10 +917,9 @@ public class NotificationChartDrawer {
         }
 
         // Rotation Formula: Rate -> Degrees
-        // 2.0 -> 50 deg? No, TrendIndicator uses:
-        // sensitivity = 25f
-        // rotation = (-velocity * sensitivity).coerceIn(-90f, 90f)
-        float sensitivity = 25f;
+        // 45 deg per mg/dL/min, vertical at +/-2, matching TrendIndicator and
+        // the classic CGM arrow convention.
+        float sensitivity = 45f;
         float rotation = (-rate * sensitivity);
         if (rotation < -90f)
             rotation = -90f;
@@ -934,20 +933,26 @@ public class NotificationChartDrawer {
 
         boolean showDouble = Math.abs(rate) > 2.0f;
 
-        // Total Length Calculation
-        // arrowLenFactor = if (showDouble) 0.35f else 0.6f
-        float arrowLenFactor = showDouble ? 0.3f : 0.5f;
+        // Total Length Calculation. The arrow rotates around the bitmap
+        // center, so a shaft of up to ~95% of the box never clips at any
+        // angle; the old 50% factor left a stubby glyph next to what other
+        // apps render for the same rate.
+        float arrowLenFactor = showDouble ? 0.62f : 0.82f;
 
-        // Apply Scaling Logic (TrendIndicator uses baseScale + pulse)
-        // We pulse a static scale here to look "Active"
-        float totalScale = 1.0f;
+        // Slight growth with speed, capped so the double-head variant still
+        // fits inside the bitmap.
         float speed = Math.abs(rate);
-        totalScale = 1.0f + (Math.min(speed * 0.12f, 0.5f)); // baseScale
+        float totalScale = 1.0f + (Math.min(speed * 0.05f, 0.12f));
 
         float arrowLen = drawSize * arrowLenFactor * totalScale;
         float totalVisualLen = arrowLen;
         if (showDouble) {
             totalVisualLen += gap + headDepth;
+        }
+        if (totalVisualLen > drawSize * 0.95f) {
+            float shrink = (drawSize * 0.95f) / totalVisualLen;
+            arrowLen *= shrink;
+            totalVisualLen = drawSize * 0.95f;
         }
 
         float cx = bitmapSize / 2.0f;

--- a/Common/src/main/java/tk/glucodata/TrendArrowAngle.java
+++ b/Common/src/main/java/tk/glucodata/TrendArrowAngle.java
@@ -1,0 +1,48 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+/**
+ * Shared rotation math for the trend arrow: 45 degrees per mg/dL per minute,
+ * vertical at +/-2 (the CGM arrow convention), rendered flat below the Flat
+ * trend state threshold. Under 0.5 mg/dL per minute the sign of the rate is
+ * noise — two honest estimators regularly disagree on it for the same data —
+ * so a slow drift must not tilt the arrow in either direction.
+ */
+public final class TrendArrowAngle {
+    public static final float DEGREES_PER_UNIT = 45f;
+    public static final float FLAT_BELOW_RATE = 0.5f;
+
+    private TrendArrowAngle() {
+    }
+
+    /**
+     * Rotation in degrees for a rate in mg/dL per minute; negative result =
+     * arrow tip up (rising), positive = down, matching the screen-space
+     * rotation both renderers apply.
+     */
+    public static float rotationDegrees(float rateMgdlPerMin) {
+        if (!Float.isFinite(rateMgdlPerMin) || Math.abs(rateMgdlPerMin) < FLAT_BELOW_RATE)
+            return 0f;
+        float rotation = -rateMgdlPerMin * DEGREES_PER_UNIT;
+        if (rotation < -90f)
+            return -90f;
+        if (rotation > 90f)
+            return 90f;
+        return rotation;
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/components/TrendIndicator.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/TrendIndicator.kt
@@ -27,12 +27,10 @@ fun TrendIndicator(
 ) {
     // "Optically Correct Arrow" Engine
     // 1. Visual: 90-degree Head, Round Caps/Joins, Optical Centering.
-    // 2. Logic: 45 deg per mg/dL/min, vertical at +/-2 — the classic CGM
-    // arrow convention, and what GDH-style receivers show for the same rate.
-    
-    // Formula: Rate 2.0 -> 50 deg.
-    val sensitivity = 45f
-    val targetRotation = (-trendResult.velocity * sensitivity).coerceIn(-90f, 90f)
+    // 2. Logic: shared TrendArrowAngle math — 45 deg per mg/dL/min, vertical
+    // at +/-2 (classic CGM convention), flat below the Flat trend state so a
+    // noise-level drift never tilts the arrow. Must match the notification.
+    val targetRotation = tk.glucodata.TrendArrowAngle.rotationDegrees(trendResult.velocity)
 
     // Animate Rotation
     val rotation by animateFloatAsState(

--- a/Common/src/mobile/java/tk/glucodata/ui/components/TrendIndicator.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/TrendIndicator.kt
@@ -27,10 +27,11 @@ fun TrendIndicator(
 ) {
     // "Optically Correct Arrow" Engine
     // 1. Visual: 90-degree Head, Round Caps/Joins, Optical Centering.
-    // 2. Logic: User Tuned (25f).
+    // 2. Logic: 45 deg per mg/dL/min, vertical at +/-2 — the classic CGM
+    // arrow convention, and what GDH-style receivers show for the same rate.
     
     // Formula: Rate 2.0 -> 50 deg.
-    val sensitivity = 25f
+    val sensitivity = 45f
     val targetRotation = (-trendResult.velocity * sensitivity).coerceIn(-90f, 90f)
 
     // Animate Rotation

--- a/Common/src/test/java/tk/glucodata/TrendArrowAngleTests.kt
+++ b/Common/src/test/java/tk/glucodata/TrendArrowAngleTests.kt
@@ -1,0 +1,39 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TrendArrowAngleTests {
+
+    @Test
+    fun slowDriftRendersFlat() {
+        // Below the Flat trend state (|v| < 0.5 mg/dL/min) the sign of the
+        // rate is noise; two estimators can disagree on it (native -0.2 vs
+        // regression +0.3 for the same data). The arrow must not pick a side.
+        assertEquals(0f, TrendArrowAngle.rotationDegrees(0.3f), 0.001f)
+        assertEquals(0f, TrendArrowAngle.rotationDegrees(-0.3f), 0.001f)
+        assertEquals(0f, TrendArrowAngle.rotationDegrees(0.49f), 0.001f)
+        assertEquals(0f, TrendArrowAngle.rotationDegrees(0f), 0.001f)
+    }
+
+    @Test
+    fun realTrendsRotateAtCgmConvention() {
+        // 45 degrees per mg/dL/min, negative rate points down (positive
+        // rotation in screen coordinates handled by callers via the sign).
+        assertEquals(-45f, TrendArrowAngle.rotationDegrees(1f), 0.001f)
+        assertEquals(45f, TrendArrowAngle.rotationDegrees(-1f), 0.001f)
+        assertEquals(-22.5f, TrendArrowAngle.rotationDegrees(0.5f), 0.001f)
+    }
+
+    @Test
+    fun clampsAtVertical() {
+        assertEquals(-90f, TrendArrowAngle.rotationDegrees(2f), 0.001f)
+        assertEquals(-90f, TrendArrowAngle.rotationDegrees(3.7f), 0.001f)
+        assertEquals(90f, TrendArrowAngle.rotationDegrees(-5f), 0.001f)
+    }
+
+    @Test
+    fun nonFiniteRendersFlat() {
+        assertEquals(0f, TrendArrowAngle.rotationDegrees(Float.NaN), 0.001f)
+    }
+}


### PR DESCRIPTION
Independent of #76-#78, applies to main.

Ran GDH next to NG and the arrows disagree for the same rate. Both get the identical value from the broadcast, GDH rotates 45° per mg/dL/min and is vertical at ±2 (the usual CGM convention, single up/down = more than 2), NG rotates 25° per unit and only goes vertical at 3.6. A -2 fall renders as a mild slope here, which understates it.

The comment in TrendIndicator says the 25 was hand-tuned, so take this as a proposal: 45°/unit saturating at ±2, in the dashboard indicator and the notification arrow. Nice side effect, the existing double arrowhead (drawn above 2) now appears exactly when the arrow turns vertical, which is what double-down means everywhere else.

Also made the notification arrow longer while I was at it. The shaft only got 50% of the 20dp bitmap and looked stubby next to other apps; it rotates around the bitmap center, so ~82% fits without clipping at any angle (clamped so the double-head variant still fits).

Purely visual, no functional changes. Can add before/after screenshots if useful.


Second commit: slow drifts render flat. Below 0.5 mg/dL/min (the Flat trend state) the sign of the rate is noise, and two honest estimators regularly disagree on it for the same data (I had the native rate say -0.2 while the trend window said +0.3, arrows tilting in opposite directions side by side). GDH hides that zone with its own +/-14 degree dead band; NG now renders 0 degrees below the Flat threshold. The rotation math moved into a shared, unit-tested TrendArrowAngle used by both the dashboard indicator and the notification arrow.
