### PR TITLE
Dashboard trend: compute from measured data, not the smoothed series

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -1165,7 +1165,9 @@ fun DashboardScreen(
                             sensorProgress = sensorProgress,
                             sensorHoursRemaining = sensorHoursRemaining,
                             currentDay = currentDay,
-                            history = consumerHistory, // Advanced Trend (smoothed when active)
+                            history = glucoseHistory, // Trend must see measured data: visual smoothing
+                            // reshapes the recent slope, and the notification/broadcast
+                            // arrow computes from unsmoothed history
                             calibratedValue = calibratedValue,
                             currentSnapshot = dashboardCurrentSnapshot,
                             dataState = dashboardDataState,
@@ -1400,7 +1402,9 @@ fun DashboardScreen(
                             sensorProgress = sensorProgress,
                             sensorHoursRemaining = sensorHoursRemaining,
                             currentDay = currentDay,
-                            history = consumerHistory, // Advanced Trend (smoothed when active)
+                            history = glucoseHistory, // Trend must see measured data: visual smoothing
+                            // reshapes the recent slope, and the notification/broadcast
+                            // arrow computes from unsmoothed history
                             calibratedValue = calibratedValue,
                             currentSnapshot = dashboardCurrentSnapshot,
                             dataState = dashboardDataState,


### PR DESCRIPTION
Applies to main, independent of the other open PRs.

With visual smoothing active, the dashboard arrow keeps disagreeing with the notification arrow for the same reading. I first noticed the angle and the double-head decision differing, then with forecast coloring (#78) enabled the two even picked different colors, red on the dashboard next to a green notification arrow.

Both surfaces run the same TrendEngine over the same 20 minute window. The difference is the input: the dashboard header handed it consumerHistory, the smoothing-processed series the chart draws, while the notification computes from plain history. Smoothing reshapes the last few points, which is exactly the segment the trend reads, so around direction changes the two velocities drift far enough apart to cross the double-head threshold or a forecast boundary.

The header trend now gets the unsmoothed series (the history parameter feeds nothing but the trend computation, so this changes no other consumer). The chart keeps drawing the smoothed line. Users without smoothing, or with it set to graph-only, were never affected since consumerHistory is the raw series for them.
