### PR TITLE
TrendEngine: regression slope instead of decay-weighted deltas

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/logic/TrendEngine.kt
+++ b/Common/src/mobile/java/tk/glucodata/logic/TrendEngine.kt
@@ -65,64 +65,59 @@ object TrendEngine {
 
         if (validPoints.size < 2) return TrendResult(TrendState.Flat, 0f, 0f, 0f, 0f)
 
-        // Calculate Average Velocity (Weighted towards recent)
-        // Simple Linear Regression or Weighted Delta could work. 
-        // Let's use a weighted delta between adjacent points to prioritize recent change 
-        // while smoothing out single-point noise.
-        
-        var totalWeightedVelocity = 0f
-        var totalWeight = 0f
-        
-        // Use correct value source
-        val pFirst = validPoints.first()
-        val firstVal = if (useRaw && pFirst.rawValue > 0) pFirst.rawValue else pFirst.value
-
         // Use explicit flag
         val conversionFactor = if (isMmol) GlucoseFormatter.MGDL_PER_MMOL else 1.0f
 
+        fun pointValue(p: GlucosePoint): Float = if (useRaw && p.rawValue > 0) p.rawValue else p.value
+
         // Collect values for noise calculation (in NATIVE units - no conversion!)
         val rawValueList = mutableListOf<Float>()
-        // Collect values for velocity calculation (in mg/dL)
-        val mgdlValueList = mutableListOf<Float>()
+        validPoints.forEach { rawValueList.add(pointValue(it)) }
 
-        // Analyze pairs
+        // Velocity: least-squares slope over the window, in mg/dL per minute.
+        // The previous estimator averaged adjacent minute-deltas with a 0.6^i
+        // recency decay, which put 40% of the total weight on the newest
+        // single delta — effectively a 3 minute slope that rode every noisy
+        // reading and regularly showed far steeper than the sensor's own
+        // ~15 minute averaged rate, the number every broadcast receiver
+        // rotates its arrow by. A regression reads the trend, not the jitter.
+        //
+        // A non-physiological jump between adjacent points (calibration step,
+        // >20 mg/dL per minute) ends the window: only the segment newer than
+        // the artifact describes the current trend.
+        var usable = validPoints.size
         for (i in 0 until validPoints.size - 1) {
             val p1 = validPoints[i]
-            val p2 = validPoints[i+1]
+            val p2 = validPoints[i + 1]
             val timeDeltaMin = (p1.timestamp - p2.timestamp) / 60000f
-            
-            val v1 = if (useRaw && p1.rawValue > 0) p1.rawValue else p1.value
-            rawValueList.add(v1) // Native units for noise
-            mgdlValueList.add(v1 * conversionFactor) // mg/dL for velocity
-            
-            if (timeDeltaMin > 0) {
-                // Normalize delta to mg/dL
-                val v2 = if (useRaw && p2.rawValue > 0) p2.rawValue else p2.value
-                
-                val valueDelta = (v1 - v2) * conversionFactor
-                val instantVelocity = valueDelta / timeDeltaMin
-
-                // Outlier Rejection: Ignore non-physiological jumps (e.g. calibration artifacts)
-                // Threshold: 20 mg/dL per minute (~1.1 mmol/L per min) is extremely high 
-                // (Max normal rise is ~3-5).
-                if (Math.abs(instantVelocity) > 20f) {
-                    continue
-                }
-                
-                // Weight: More recent = higher weight
-                // Decay weight by 0.6 per step (was 0.8) for higher responsiveness
-                val weight = Math.pow(0.6, i.toDouble()).toFloat()
-                
-                totalWeightedVelocity += instantVelocity * weight
-                totalWeight += weight
+            if (timeDeltaMin > 0f &&
+                Math.abs((pointValue(p1) - pointValue(p2)) * conversionFactor / timeDeltaMin) > 20f
+            ) {
+                usable = i + 1
+                break
             }
         }
-        // Add last point's value
-        val pLast = validPoints.last()
-        val lastVal = if (useRaw && pLast.rawValue > 0) pLast.rawValue else pLast.value
-        rawValueList.add(lastVal)
 
-        val velocity = if (totalWeight > 0) totalWeightedVelocity / totalWeight else 0f
+        val newestTs = validPoints.first().timestamp
+        var sx = 0.0
+        var sy = 0.0
+        var sxy = 0.0
+        var sxx = 0.0
+        for (i in 0 until usable) {
+            val p = validPoints[i]
+            val xMinutes = (p.timestamp - newestTs) / 60000.0
+            val yMgdl = (pointValue(p) * conversionFactor).toDouble()
+            sx += xMinutes
+            sy += yMgdl
+            sxy += xMinutes * yMgdl
+            sxx += xMinutes * xMinutes
+        }
+        val denominator = usable * sxx - sx * sx
+        val velocity = if (usable >= 2 && denominator > 1e-6) {
+            ((usable * sxy - sx * sy) / denominator).toFloat()
+        } else {
+            0f
+        }
 
         // Acceleration: Compare velocity of first half vs second half of window
         // (Rough approximation)

--- a/Common/src/test/java/tk/glucodata/logic/TrendEngineVelocityTests.kt
+++ b/Common/src/test/java/tk/glucodata/logic/TrendEngineVelocityTests.kt
@@ -1,0 +1,73 @@
+package tk.glucodata.logic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.GlucosePoint
+
+class TrendEngineVelocityTests {
+
+    private val nowMillis = 1_700_000_000_000L
+
+    // Newest-first series: value(i) = base + slopePerMin * i means the series
+    // FALLS by slopePerMin per minute toward now.
+    private fun series(count: Int, base: Float, risePerMinuteGoingBack: Float): MutableList<GlucosePoint> {
+        val points = mutableListOf<GlucosePoint>()
+        for (i in 0 until count) {
+            points.add(GlucosePoint(nowMillis - i * 60_000L, base + risePerMinuteGoingBack * i, 0f))
+        }
+        return points
+    }
+
+    @Test
+    fun cleanLinearFallRecoversExactSlope() {
+        val points = series(20, base = 100f, risePerMinuteGoingBack = 1.5f)
+        val result = TrendEngine.calculateTrend(points, useRaw = false, isMmol = false)
+        assertEquals(-1.5f, result.velocity, 0.01f)
+        assertEquals(TrendEngine.TrendState.SingleDown, result.state)
+    }
+
+    @Test
+    fun singleNoisyReadingDoesNotDominateTheTrend() {
+        // Steady fall of 0.5 mg/dL/min, but the newest reading sits 3 mg/dL
+        // above the line — ordinary sensor jitter. One noisy minute must not
+        // flip a falling trend into a rising arrow.
+        val points = series(20, base = 100f, risePerMinuteGoingBack = 0.5f)
+        points[0] = GlucosePoint(points[0].timestamp, points[0].value + 3f, 0f)
+        val result = TrendEngine.calculateTrend(points, useRaw = false, isMmol = false)
+        assertTrue("velocity ${result.velocity} should stay negative", result.velocity < -0.2f)
+        assertTrue("velocity ${result.velocity} drifted too far", result.velocity > -0.7f)
+    }
+
+    @Test
+    fun mmolSeriesYieldsMgdlVelocity() {
+        // Falling 0.1 mmol/L per minute = about 1.8 mg/dL per minute.
+        val points = series(20, base = 5.5f, risePerMinuteGoingBack = 0.1f)
+        val result = TrendEngine.calculateTrend(points, useRaw = false, isMmol = true)
+        assertEquals(-1.8f, result.velocity, 0.1f)
+    }
+
+    @Test
+    fun calibrationStepEndsTheRegressionWindow() {
+        // Newest 6 points fall 1 mg/dL/min; before them a +40 step from a
+        // calibration. Only the segment newer than the artifact describes the
+        // current trend.
+        val points = mutableListOf<GlucosePoint>()
+        for (i in 0 until 6) {
+            points.add(GlucosePoint(nowMillis - i * 60_000L, 100f + i * 1.0f, 0f))
+        }
+        for (i in 6 until 15) {
+            points.add(GlucosePoint(nowMillis - i * 60_000L, 146f, 0f))
+        }
+        val result = TrendEngine.calculateTrend(points, useRaw = false, isMmol = false)
+        assertEquals(-1.0f, result.velocity, 0.05f)
+    }
+
+    @Test
+    fun tooFewPointsAreFlatZero() {
+        val single = series(1, base = 100f, risePerMinuteGoingBack = 0f)
+        val result = TrendEngine.calculateTrend(single, useRaw = false, isMmol = false)
+        assertEquals(0f, result.velocity, 0.0001f)
+        assertEquals(TrendEngine.TrendState.Flat, result.state)
+    }
+}


### PR DESCRIPTION
Applies to main. Related to #83 in effect (both make the arrow tell the truth), independent in code.

Running GDH next to NG, the NG arrow keeps looking dramatically more severe during rises and falls. Both apps rotate at 45 degrees per mg/dL/min since #79; they just rotate different numbers. GDH shows the rate from the broadcast, which is the sensor's own estimate, averaged over roughly 15 minutes. NG's TrendEngine averaged adjacent minute-deltas weighted by 0.6^i, and that decay is brutal: the newest single minute-delta carries 40% of the total weight, the newest three about 78%. The documented "20 minute window" effectively displayed a 3 minute slope. Normal sensor jitter of 3 mg/dL between two readings is one minute at 3 mg/dL/min, enough to swing the arrow visibly, flip a slow fall into a rise, or flash the double-down head.

Velocity is now an ordinary least-squares slope over the window:

- clean linear data gives the exact same slope as before (the estimators agree there)
- a single noisy reading moves the result by tenths of a mg/dL/min instead of owning it
- a non-physiological jump between adjacent points (calibration step, >20 mg/dL/min) ends the regression window, because only the segment newer than the artifact describes the current trend. The old code skipped that one pair but then happily averaged the regimes on both sides of the step together.

Everything that consumes the velocity calms down with it: the trend state (when double-up/down shows), the dashboard and notification arrows, and the forecast coloring from #78 if that's enabled. On steady trends the arrow now agrees with the sensor's own rate and with receivers of the broadcast. During fast moves it deliberately stays ahead of the native rate, which lags: I watched it claim about -1.4 while consecutive readings fell at 3 mg/dL per minute.

Unit-tested (new TrendEngineVelocityTests): slope recovery on clean data, jitter damping, mmol conversion, calibration truncation, too-few-points. The jitter test fails against the old estimator, it computed +0.7 mg/dL/min for a series falling steadily at 0.5.

I considered gating this behind a setting and decided against proposing that: the old behavior isn't a different preference, it's a window that doesn't do what it says, and a toggle would keep that alive forever. If you'd rather have a "more responsive" trend as an option, the honest knob would be a shorter regression window, happy to add that instead.

