### PR TITLE
Optional: broadcast the computed trend instead of the sensor rate

### DIFF
--- a/Common/src/main/java/tk/glucodata/BroadcastTrendRate.java
+++ b/Common/src/main/java/tk/glucodata/BroadcastTrendRate.java
@@ -1,0 +1,65 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+/**
+ * Opt-in replacement of the exchange rate: the outgoing rate normally
+ * carries the sensor's own estimate, which lags fast moves badly — a
+ * receiver rotating its arrow by it ends up contradicting this app's arrow
+ * and its own delta readout. With the toggle enabled, every exchange output
+ * (glucodata broadcast, xDrip-style, EverSense, watch, Gadgetbridge, API)
+ * carries the same trend the app's own arrows show instead.
+ */
+public final class BroadcastTrendRate {
+    public static final String PREF_KEY = "broadcast_computed_trend";
+    private static final String PREFS_NAME = "tk.glucodata_preferences";
+
+    private BroadcastTrendRate() {
+    }
+
+    public static boolean enabled() {
+        try {
+            return Applic.app
+                    .getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE)
+                    .getBoolean(PREF_KEY, false);
+        } catch (Throwable th) {
+            return false;
+        }
+    }
+
+    /**
+     * The app's trend over the usual 20-minute window for this sensor, in
+     * mg/dL per minute; falls back to the given native rate when history is
+     * too thin to say anything.
+     */
+    public static float computed(String sensorId, float nativeRate) {
+        try {
+            final boolean isMmol = Applic.unit == 1;
+            final java.util.List<GlucosePoint> points = NotificationHistorySource.getDisplayHistory(
+                    System.currentTimeMillis() - DisplayTrendSource.TREND_WINDOW_MS,
+                    isMmol,
+                    sensorId);
+            final int viewMode = Notify.resolveSensorViewMode(sensorId);
+            final float computed = DisplayTrendSource.resolveArrowRate(points, null, viewMode, isMmol, Float.NaN);
+            return Float.isFinite(computed) ? computed : nativeRate;
+        } catch (Throwable th) {
+            if (Log.doLog)
+                Log.i("BroadcastTrendRate", "computed failed: " + th);
+            return nativeRate;
+        }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/ExchangeGlucosePayload.java
+++ b/Common/src/main/java/tk/glucodata/ExchangeGlucosePayload.java
@@ -131,14 +131,21 @@ final class ExchangeGlucosePayload {
                     ? SensorIdentity.resolveAppSensorId(rawSensorId)
                     : rawSensorId;
             final String primaryText = formatPrimary(primaryDisplayValue, current.getPrimaryStr());
-            final float rate = Float.isFinite(current.getRate()) ? current.getRate() : fallbackRate;
+            final float nativeRate = Float.isFinite(current.getRate()) ? current.getRate() : fallbackRate;
             final long timeMillis = current.getTimeMillis() > 0L ? current.getTimeMillis() : fallbackTimeMillis;
             final int sensorGen = current.getSensorGen() != 0 ? current.getSensorGen() : fallbackSensorGen;
             final int primaryMgdl = toMgdl(primaryDisplayValue);
             final float autoValue = current.getAutoValue();
             final int autoMgdl = toMgdl(autoValue);
             final float rawValue = current.getRawValue();
-            final ExchangeTrend trend = ExchangeTrend.resolve(sensorId, timeMillis, rate);
+            // Opt-in: send the app's computed trend instead of the sensor's
+            // lagging estimate; index/name follow the sent rate so the
+            // outgoing extras stay consistent with each other.
+            final boolean computedTrend = BroadcastTrendRate.enabled();
+            final float rate = computedTrend ? BroadcastTrendRate.computed(sensorId, nativeRate) : nativeRate;
+            final ExchangeTrend trend = computedTrend
+                    ? ExchangeTrend.fromRate(rate)
+                    : ExchangeTrend.resolve(sensorId, timeMillis, rate);
             return new ExchangeGlucosePayload(
                     sensorId,
                     primaryText,
@@ -157,6 +164,10 @@ final class ExchangeGlucosePayload {
                 ? SensorIdentity.resolveAppSensorId(preferredSensorId)
                 : preferredSensorId;
 
+        final boolean computedTrend = BroadcastTrendRate.enabled();
+        final float outgoingRate = computedTrend
+                ? BroadcastTrendRate.computed(fallbackSensorId, fallbackRate)
+                : fallbackRate;
         return new ExchangeGlucosePayload(
                 fallbackSensorId,
                 formatPrimary(fallbackDisplayValue, fallbackPrimaryText),
@@ -165,8 +176,10 @@ final class ExchangeGlucosePayload {
                 Float.NaN,
                 0,
                 Float.NaN,
-                fallbackRate,
-                ExchangeTrend.resolve(fallbackSensorId, fallbackTimeMillis, fallbackRate),
+                outgoingRate,
+                computedTrend
+                        ? ExchangeTrend.fromRate(outgoingRate)
+                        : ExchangeTrend.resolve(fallbackSensorId, fallbackTimeMillis, fallbackRate),
                 fallbackTimeMillis,
                 fallbackSensorGen);
     }

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -1454,7 +1454,9 @@ public class Notify {
         return null;
     }
 
-    private static int resolveSensorViewMode(String sensorName) {
+    // Package-visible: BroadcastTrendRate resolves the same view mode when
+    // computing the outgoing trend.
+    static int resolveSensorViewMode(String sensorName) {
         if (sensorName == null || sensorName.isEmpty()) {
             return 0;
         }

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -775,6 +775,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="forget_sensor_desc">This will remove the sensor from the list. It may reappear if scanned again.</string>
     <string name="forget_sensor_title">Forget Sensor?</string>
     <string name="glucodata_subtitle">Glucodata</string>
+    <string name="broadcast_computed_trend_title">Berechneten Trend senden</string>
+    <string name="broadcast_computed_trend_desc">Sendet den 20-Minuten-Trend der App statt der Sensor-Schätzung als Rate in allen Ausgaben. Empfänger-Pfeile entsprechen dann dieser App.</string>
     <string name="glulisine">Insulin Glulisine/Apidra</string>
     <string name="googlescan">Google scan</string>
     <string name="gvi">GVI</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -213,6 +213,8 @@
     <string name="xdripbroadcast">Libre (patched App)</string>
     <string name="aaps_broadcast">Glucodata</string>
     <string name="glucodata_subtitle">GlucoDataHandler (GDH)</string>
+    <string name="broadcast_computed_trend_title">Broadcast computed trend</string>
+    <string name="broadcast_computed_trend_desc">Send the app\'s 20-minute trend as the rate in all outputs instead of the sensor\'s own estimate. Receiver arrows then match this app.</string>
     <string name="xdrip_compatible_title">xDrip broadcast</string>
     <string name="xdrip_compatible_desc">AAPS compatible</string>
     <string name="sensorpermission">Sensors permission</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
@@ -352,6 +352,7 @@ fun ExpressiveSettingsScreen(
             val exchangeColor = MaterialTheme.colorScheme.tertiary
             val xdripEnabled by viewModel.xDripBroadcastEnabled.collectAsState()
             val glucodataBroadcastEnabled by viewModel.glucodataBroadcastEnabled.collectAsState()
+            val broadcastComputedTrend by viewModel.broadcastComputedTrend.collectAsState()
 
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 SettingsSwitchItem(
@@ -376,10 +377,19 @@ fun ExpressiveSettingsScreen(
                     title = stringResource(R.string.aaps_broadcast),
                     subtitle = stringResource(R.string.glucodata_subtitle),
                     checked = glucodataBroadcastEnabled,
-                    icon = Icons.AutoMirrored.Filled.Send, 
+                    icon = Icons.AutoMirrored.Filled.Send,
                     iconTint = exchangeColor,
                     position = CardPosition.MIDDLE,
                     onCheckedChange = { viewModel.toggleGlucodataBroadcast(it) }
+                )
+                SettingsSwitchItem(
+                    title = stringResource(R.string.broadcast_computed_trend_title),
+                    subtitle = stringResource(R.string.broadcast_computed_trend_desc),
+                    checked = broadcastComputedTrend,
+                    icon = Icons.AutoMirrored.Filled.TrendingUp,
+                    iconTint = exchangeColor,
+                    position = CardPosition.MIDDLE,
+                    onCheckedChange = { viewModel.setBroadcastComputedTrend(it) }
                 )
                 SettingsItem(
                     title = stringResource(R.string.outbound_api_title),

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
@@ -184,6 +184,9 @@ class DashboardViewModel(
     private val _glucodataBroadcastEnabled = MutableStateFlow(false)
     val glucodataBroadcastEnabled = _glucodataBroadcastEnabled.asStateFlow()
 
+    private val _broadcastComputedTrend = MutableStateFlow(false)
+    val broadcastComputedTrend = _broadcastComputedTrend.asStateFlow()
+
     private val _glucoseHistory = MutableStateFlow<List<tk.glucodata.ui.GlucosePoint>>(emptyList())
     val glucoseHistory = _glucoseHistory.asStateFlow()
 
@@ -575,6 +578,7 @@ class DashboardViewModel(
         _xDripBroadcastEnabled.value = Natives.getxbroadcast()
         _patchedLibreBroadcastEnabled.value = Natives.getlibrelinkused()
         _glucodataBroadcastEnabled.value = Natives.getJugglucobroadcast()
+        _broadcastComputedTrend.value = prefs.getBoolean(tk.glucodata.BroadcastTrendRate.PREF_KEY, false)
 
         _hasLowAlarm.value = Natives.hasalarmlow()
         _lowAlarmThreshold.value = Natives.alarmlow()
@@ -1151,6 +1155,13 @@ class DashboardViewModel(
              tk.glucodata.XInfuus.setlibrenames()
         }
         _patchedLibreBroadcastEnabled.value = Natives.getlibrelinkused()
+    }
+
+    fun setBroadcastComputedTrend(enabled: Boolean) {
+        val context = tk.glucodata.Applic.app
+        val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(tk.glucodata.BroadcastTrendRate.PREF_KEY, enabled).apply()
+        _broadcastComputedTrend.value = enabled
     }
 
     fun toggleGlucodataBroadcast(enabled: Boolean) {


### PR DESCRIPTION
Applies to main, independent of the other open PRs (touches ExchangeGlucosePayload, which none of them do).

Receivers of our broadcasts rotate their arrows by the rate we send, and that rate is the sensor's own estimate, which lags fast moves badly. In testing it reported around -1.4 while consecutive readings fell at 3 mg/dL per minute: GlucoDataHandler drew a calm diagonal arrow next to its own delta of -3, and next to this app's vertical double-down. At trend turns the same thing happens in reverse, the sensor estimate still sits near zero while the app's arrow already tilts. Two apps on one phone end up disagreeing about the same data on a regular basis.

New switch in the data exchange settings, off by default. When enabled, the exchange payload carries the app's 20-minute trend, the same number its own arrows rotate by, instead of the native rate. It sits in ExchangeGlucosePayload so every output inherits it: glucodata broadcast, xDrip-style, EverSense, the watch, Gadgetbridge, the outbound API. Trend index and name are derived from the sent rate so the extras stay consistent with each other.

A first version only covered the glucodata broadcast, but there was no reason for that narrower scope. Nothing consuming these outputs calculates with the rate (loop-style apps derive their own deltas from the values), they all display arrows from it, and the watch should never disagree with the phone it mirrors.

Off means byte-identical behavior to before, and the sensor's own estimate stays what upstream Juggluco sends. That is why this is opt-in rather than a new default.
