### PR TITLE
feat(alerts): sustained-low gate for LOW/VERY_LOW

### DIFF
--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -1,5 +1,6 @@
 package tk.glucodata.alerts
 
+import java.util.EnumSet
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -31,6 +32,8 @@ object AlertRuntimeManager {
     private var lastRate: Float = Float.NaN
     private var lastDisplaySnapshot: CurrentDisplaySource.Snapshot? = null
     private var persistentHighStartedAtMs: Long = 0L
+    private val sustainedLowStartedAtMs = mutableMapOf<AlertType, Long>()
+    private val sustainedLowEligible = EnumSet.of(AlertType.LOW, AlertType.VERY_LOW)
     private val standardEpisodes = AlertEpisodeState<AlertType>()
     private val sensorExpiryState = SensorExpiryAlertState()
     private val calibrationReadingBarrier = ReadingTimestampBarrier()
@@ -148,7 +151,7 @@ object AlertRuntimeManager {
         val standardAlertEvaluation = if (glucoseAlertsBlocked) {
             AlertRuntimeEvaluation()
         } else {
-            evaluateStandardGlucoseAlertsLocked()
+            evaluateStandardGlucoseAlertsLocked(nowMs)
         }
         evaluateMissedReadingLocked(nowMs)
         if (!glucoseAlertsBlocked) {
@@ -198,7 +201,7 @@ object AlertRuntimeManager {
         }
     }
 
-    private fun evaluateStandardGlucoseAlertsLocked(): AlertRuntimeEvaluation {
+    private fun evaluateStandardGlucoseAlertsLocked(nowMs: Long): AlertRuntimeEvaluation {
         val glucoseValue = currentGlucoseValueLocked() ?: return AlertRuntimeEvaluation()
         val rate = currentRateLocked()
         val configs = standardGlucoseAlertTypes.associateWith { AlertRepository.loadConfig(it) }
@@ -210,11 +213,18 @@ object AlertRuntimeManager {
             clearRuntimeAlert(type, "standard-condition-cleared")
         }
 
+        updateSustainedLowTimersLocked(activeTypes, configs, nowMs)
+
         val type = standardGlucoseAlertTypes.firstOrNull { it in activeTypes }
             ?: return AlertRuntimeEvaluation()
         val condition = activeConditions[type] ?: return AlertRuntimeEvaluation()
 
         if (!transition.shouldTryFire(type)) {
+            return AlertRuntimeEvaluation(standardGlucoseAlertHandled = true)
+        }
+
+        if (!isSustainedLowSatisfiedLocked(type, configs[type], nowMs)) {
+            standardEpisodes.markPendingDelivery(type)
             return AlertRuntimeEvaluation(standardGlucoseAlertHandled = true)
         }
 
@@ -240,6 +250,33 @@ object AlertRuntimeManager {
             standardGlucoseAlertHandled = true,
             standardGlucoseAlertStarted = triggered
         )
+    }
+
+    private fun updateSustainedLowTimersLocked(
+        activeTypes: Set<AlertType>,
+        configs: Map<AlertType, AlertConfig>,
+        nowMs: Long
+    ) {
+        activeTypes.filter { it in sustainedLowEligible }.forEach { type ->
+            val cfg = configs[type]
+            val sustainedMs = (cfg?.durationMinutes ?: 0) * 60_000L
+            if (sustainedMs > 0L && sustainedLowStartedAtMs[type] == null) {
+                sustainedLowStartedAtMs[type] = lastReadingTimeMs.takeIf { it > 0L } ?: nowMs
+            }
+        }
+        sustainedLowEligible.forEach { type ->
+            if (type !in activeTypes) {
+                sustainedLowStartedAtMs.remove(type)
+            }
+        }
+    }
+
+    private fun isSustainedLowSatisfiedLocked(type: AlertType, config: AlertConfig?, nowMs: Long): Boolean {
+        if (type !in sustainedLowEligible) return true
+        val minutes = config?.durationMinutes ?: return true
+        if (minutes <= 0) return true
+        val started = sustainedLowStartedAtMs[type] ?: return true
+        return nowMs - started >= minutes * 60_000L
     }
 
     private fun resolveActiveStandardGlucoseAlerts(

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -725,6 +725,10 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="alert_persistent_high">Aanhoudend hoog</string>
     <string name="alert_sensor_expiry">Sensor verloopt</string>
     <string name="missed_reading_channel_description">Alerts when no glucose reading arrives for the configured duration</string>
+    <string name="sustained_low_toggle">Aanhoudend laag vereisen</string>
+    <string name="sustained_low_duration">Aanhoudende duur</string>
+    <string name="sustained_low_toggle_desc">Alleen waarschuwen als de glucose gedurende de gekozen tijd onder de drempel blijft. Voorkomt korte compressie-lows door de sensor.</string>
+    <string name="sustained_low_alert_suffix"> (aanhoudend %1$d min)</string>
     <string name="sensor_expiry_channel_description">Alerts when the current sensor is nearing expiry</string>
     <string name="alert_value_available">Waarde beschikbaar</string>
     <string name="alert_very_high">Zeer hoog</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -807,6 +807,10 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="alert_persistent_high">Persistent High</string>
     <string name="alert_sensor_expiry">Sensor Expiry</string>
     <string name="missed_reading_channel_description">Alerts when no glucose reading arrives for the configured duration</string>
+    <string name="sustained_low_toggle">Require sustained below threshold</string>
+    <string name="sustained_low_duration">Sustained duration</string>
+    <string name="sustained_low_toggle_desc">Only alert when glucose stays below the threshold for the chosen duration. Helps suppress brief sensor compression lows.</string>
+    <string name="sustained_low_alert_suffix"> (sustained %1$d min)</string>
     <string name="sensor_expiry_channel_description">Alerts when the current sensor is nearing expiry</string>
     <string name="alert_value_available">Value Available</string>
     <string name="alert_amount">Amount Alert</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
@@ -1057,17 +1057,21 @@ private fun AlertSettingsExpanded(
                 }
                 
                 // === Durations Section (If applicable) ===
-                if (config.durationMinutes != null || config.forecastMinutes != null) {
+                val showGenericDuration = config.durationMinutes != null &&
+                    config.type != AlertType.LOW && config.type != AlertType.VERY_LOW
+                if (showGenericDuration || config.forecastMinutes != null) {
                      Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        config.durationMinutes?.let {
-                            Box(Modifier.weight(1f)) {
-                                DurationSlider(
-                                    label = stringResource(R.string.alert_after),
-                                    value = it,
-                                    range = 5..120,
-                                    stepSize = 5,
-                                    onValueChange = { v -> onConfigChange(config.copy(durationMinutes = v)) }
-                                )
+                        if (showGenericDuration) {
+                            config.durationMinutes?.let {
+                                Box(Modifier.weight(1f)) {
+                                    DurationSlider(
+                                        label = stringResource(R.string.alert_after),
+                                        value = it,
+                                        range = 5..120,
+                                        stepSize = 5,
+                                        onValueChange = { v -> onConfigChange(config.copy(durationMinutes = v)) }
+                                    )
+                                }
                             }
                         }
                         config.forecastMinutes?.let {
@@ -1083,10 +1087,55 @@ private fun AlertSettingsExpanded(
                         }
                     }
                 }
+
+                // === Sustained Low Toggle (LOW / VERY_LOW only) ===
+                if (config.type == AlertType.LOW || config.type == AlertType.VERY_LOW) {
+                    val sustainedEnabled = config.durationMinutes != null
+                    val otherDurationActive = config.forecastMinutes != null
+                    Column(modifier = Modifier.padding(top = 12.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Column(modifier = Modifier.weight(1f).padding(end = 12.dp)) {
+                                Text(
+                                    stringResource(R.string.sustained_low_toggle),
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                                Text(
+                                    stringResource(R.string.sustained_low_toggle_desc),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            StyledSwitch(
+                                checked = sustainedEnabled,
+                                onCheckedChange = { on ->
+                                    if (on) {
+                                        val seed = config.durationMinutes ?: 10
+                                        onConfigChange(config.copy(durationMinutes = seed))
+                                    } else if (!otherDurationActive) {
+                                        onConfigChange(config.copy(durationMinutes = null))
+                                    }
+                                }
+                            )
+                        }
+                        if (sustainedEnabled) {
+                            DurationSlider(
+                                label = stringResource(R.string.sustained_low_duration),
+                                value = config.durationMinutes ?: 10,
+                                range = 5..30,
+                                stepSize = 5,
+                                onValueChange = { v -> onConfigChange(config.copy(durationMinutes = v)) }
+                            )
+                        }
+                    }
+                }
             }
         )
     }
-}    
+}
         
 //        HorizontalDivider()
         


### PR DESCRIPTION
## Summary

Optional per-type debounce mirroring the existing `PERSISTENT_HIGH` mechanism: when a user sets `durationMinutes` on `LOW` or `VERY_LOW`, the alert only fires after glucose has stayed below threshold continuously for that many minutes. The default is off (`durationMinutes == null`), so existing installs see no change.

## Why

CGM sensors (Libre, Dexcom, …) periodically report false compression lows that last one or two readings. AAPS and Loop implement analogous "rise above / persist below" filtering; LibreLink applies it implicitly through smoothing. This surfaces the same idea in JugglucoNG for users who do not use a closed loop, applied at the notification-fire layer rather than the controller layer.

## What changes

- `AlertRuntimeManager` (`Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt`): a new `sustainedLowStartedAtMs` map plus `isSustainedLowSatisfiedLocked` gate, evaluated inside `evaluateStandardGlucoseAlertsLocked` for `LOW` / `VERY_LOW`. The timer is anchored to the first reading time below the line, and is cleared as soon as the reading leaves the low band so the next qualifying reading starts a fresh window.
- `AlertSettingsScreen` (`Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt`): a new *"Require sustained below threshold"* toggle plus a 5–30 min slider in the expanded section. While the toggle is on, the generic *"Alert after"* slider is suppressed for `LOW` / `VERY_LOW` (its `durationMinutes` is being used as the gate).
- `strings.xml` (en) and `values-nl/strings.xml` (nl): four new string keys (`sustained_low_toggle`, `sustained_low_duration`, `sustained_low_toggle_desc`, `sustained_low_alert_suffix`).

## Interaction with other alerts

- Independent of `PRE_LOW` (which stays a forecast alert with no gate).
- Independent of `PERSISTENT_HIGH`, `MISSED_READING`, `SENSOR_EXPIRY`. Those use the same field internally for their own purposes; the UI distinguishes the surfaces.
- Stacks with snooze: a sustained low that finally fires can still be snoozed; on next entry into the threshold band the gate re-arms from zero.
- Not applied to `HIGH` / `VERY_HIGH` (compressed spikes are not a known sensor artefact, so a plain threshold is sufficient).

## Build verification

- `./gradlew :Common:compileMobileLibre3SiDexNogoogleReleaseKotlin` → BUILD SUCCESSFUL (warnings only) on `ctqvva/JugglucoNG@921144467` with this patch applied.
- The `values-so/strings.xml` resource merge in upstream `main` is currently broken by a separate Unicode-escape issue introduced in #90 (somali localization); this is unrelated to this PR. I sidestepped it during verification by temporarily moving the resource directory aside.

## Notes for reviewer

- The UI uses the existing `AlertConfig.durationMinutes` field; no new field is added. The field is repurposed on `LOW` / `VERY_LOW` only. If you would prefer a dedicated `sustainedLowMinutes: Int?` field, I can rework the patch.
- The `MissingTranslation` lint baseline for the new strings is not included in this PR because the upstream tree does not carry a `Common/lint-baseline.xml`; the strings will surface as lint warnings on the other ~12 locales. Happy to add a baseline or translations if you would like.
- Origin: this was first shipped as `GlucoDroid/app#7` against a different tree (JugglucoNG 1.0.3-Alpha + GlucoDroid patches), which is why the diff here looks "clean" rather than a rebase of that PR.
