### PR TITLE
Fix Anytime history and timeline cadence

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConstants.kt
@@ -240,8 +240,8 @@ object AnytimeConstants {
     /** Sensor rated lifetime. CT3 is 14, 15 or 16 days depending on chemistry. */
     const val DEFAULT_RATED_LIFETIME_DAYS = 16
 
-    /** Reading cadence — CT3 transmitter pushes ~every 1 minute via opcode 0x07. */
-    const val DEFAULT_READING_INTERVAL_MINUTES = 1
+    /** Reading cadence — CT3 records one glucose point every 3 minutes. */
+    const val DEFAULT_READING_INTERVAL_MINUTES = 3
 
     /** Warmup window before reliable readings. */
     const val DEFAULT_WARMUP_MINUTES = 60
@@ -284,7 +284,8 @@ object AnytimeConstants {
     /**
      * Per-prefix descriptor. `algorithm` is the int the JNI uses to dispatch into
      * the correct chemistry-specific pipeline inside libalgorithm-jni.so.
-     * `endNumber` is the maximum 5-min-tick packet count before session ends.
+     * `endNumber` is the approximate maximum 3-minute record count before the
+     * session ends (vendor tables include a small initialization allowance).
      */
     data class FamilyEntry(
         val prefix: String,
@@ -293,7 +294,7 @@ object AnytimeConstants {
         val endNumber: Int,
     ) {
         val ratedLifetimeDays: Int
-            get() = endNumber / 12 / 24 // 12 readings/hour × 24 hours
+            get() = endNumber / 20 / 24 // 20 readings/hour × 24 hours
 
         val matchUpper: String get() = prefix.uppercase(Locale.US)
     }

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeProfile.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeProfile.kt
@@ -1,6 +1,6 @@
 // AnytimeProfile.kt — Per-family lifecycle/cadence resolver.
 //
-// CT3 4/4H is the primary target (cadence ~1/min, 16-day rated). CT4 / CT3_PLUS
+// CT3 4/4H is the primary target (cadence 3 min, 14–16-day rated). CT4 / CT3_PLUS
 // have shorter or longer rated lives depending on chemistry. CT5 (no separate
 // transmitter) uses the same 3-minute tick scale in the official SDK
 // (`Anytime`, endNumber 7695 => 16 days) and adds an encrypted identity/data
@@ -15,7 +15,7 @@ data class AnytimeProfile(
     val ratedLifetimeDays: Int,
     /** SDK `algorithm` int (selects per-chemistry pipeline inside libalgorithm-jni.so). */
     val algorithmId: Int,
-    /** Maximum 5-min-tick packet count before session naturally ends. */
+    /** Approximate maximum 3-minute record count before session naturally ends. */
     val endNumber: Int,
     /** Battery-low threshold (Volts) for the family. */
     val lowBatteryVolts: Float,

--- a/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeProfileTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeProfileTests.kt
@@ -1,0 +1,27 @@
+package tk.glucodata.drivers.anytime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AnytimeProfileTests {
+
+    @Test
+    fun ct3YuwellUsesThreeMinuteCadenceAndFourteenDayProfile() {
+        val profile = AnytimeProfileResolver.resolve("SN26-test")
+
+        assertEquals(AnytimeConstants.Family.CT3_YUWELL, profile.family)
+        assertEquals(3, profile.readingIntervalMinutes)
+        assertEquals(14, profile.ratedLifetimeDays)
+        assertEquals(6740, profile.endNumber)
+    }
+
+    @Test
+    fun shorterVendorProfileStillUsesThreeMinuteCadence() {
+        val profile = AnytimeProfileResolver.resolve("SN28-test")
+
+        assertEquals(AnytimeConstants.Family.CT3_YUWELL, profile.family)
+        assertEquals(3, profile.readingIntervalMinutes)
+        assertEquals(7, profile.ratedLifetimeDays)
+        assertEquals(3380, profile.endNumber)
+    }
+}


### PR DESCRIPTION
## What changed

- Treat Anytime/CT3 glucose records as occurring every three minutes instead of every minute.
- Derive rated sensor lifetime using 20 readings per hour.
- Update the profile documentation to match the vendor record cadence.
- Add regression coverage for the 14-day and 7-day Yuwell profiles.

## Why

The Anytime profile used a one-minute default interval while the sensor stores glucose records on a three-minute cadence. It also interpreted the vendor `endNumber` using 12 readings per hour. Together, those assumptions produced incorrect history/timeline spacing and sensor lifetime values.

## Impact

Anytime history points now use their correct three-minute spacing, and the displayed/derived sensor lifetime matches the vendor profile tables.

## Validation

- `:Common:testMobileLibre3SiDexGoogleDebugUnitTest --tests tk.glucodata.drivers.anytime.AnytimeProfileTests`
