### PR TITLE
Selectable glucose colour palette: presets + per-band overrides

### DIFF
--- a/Common/src/main/java/tk/glucodata/Applic.java
+++ b/Common/src/main/java/tk/glucodata/Applic.java
@@ -831,6 +831,11 @@ public class Applic extends Application implements androidx.work.Configuration.P
             SuperGattCallback.initAlarmTalk();
             initialize();
 
+            // Load the glucose colour palette + per-band overrides before any
+            // drawing happens, so the notification chart (which runs outside
+            // Compose) renders with the user's choice too.
+            GlucoseRangeColors.initFromPrefs(this);
+
             // Preserve an explicit non-active selection across startup. Historical sensors
             // are still valid dashboard targets even if they are not in activeSensors().
             // Virtual/cloud-only sensors must not stay in native lastsensorname: native

--- a/Common/src/main/java/tk/glucodata/GlucoseRangeColors.java
+++ b/Common/src/main/java/tk/glucodata/GlucoseRangeColors.java
@@ -260,9 +260,12 @@ public final class GlucoseRangeColors {
         return isMmol ? DEFAULT_VERY_HIGH_MMOL : DEFAULT_VERY_HIGH_MGDL;
     }
 
-    // Traffic-light palette for coloring the current value itself (GDH-style):
-    // green inside the target range, yellow between target and alarm bounds,
-    // red beyond the alarms. Dark variants are lighter for dark backgrounds.
+    // Traffic-light palette for colouring the current value (and trend arrow,
+    // and the notification value): green inside the target range, yellow between
+    // target and alarm bounds, red beyond the alarms. This is a 3-tier system,
+    // distinct from the 5 AGP bands above, but it follows the active preset too
+    // so switching to Vibrant / GDH-like visibly recolours the value and arrow.
+    // The MUTED constants are the historical tones, kept bit-identical.
     public static final int VALUE_IN_RANGE = 0xFF2E7D32;
     public static final int VALUE_IN_RANGE_DARK = 0xFF81C784;
     public static final int VALUE_BORDERLINE = 0xFFF9A825;
@@ -270,16 +273,40 @@ public final class GlucoseRangeColors {
     public static final int VALUE_OUT = 0xFFC62828;
     public static final int VALUE_OUT_DARK = 0xFFE57373;
 
+    // Per-preset traffic tiers: [in-range, borderline, out].
+    private static final int[] MUTED_TRAFFIC_LIGHT = { VALUE_IN_RANGE, VALUE_BORDERLINE, VALUE_OUT };
+    private static final int[] MUTED_TRAFFIC_DARK = { VALUE_IN_RANGE_DARK, VALUE_BORDERLINE_DARK, VALUE_OUT_DARK };
+    private static final int[] VIBRANT_TRAFFIC_LIGHT = { 0xFF00A651, 0xFFFFB300, 0xFFD50000 };
+    private static final int[] VIBRANT_TRAFFIC_DARK = { 0xFF69F0AE, 0xFFFFD24D, 0xFFFF5252 };
+    private static final int[] GDH_TRAFFIC_LIGHT = { 0xFF00FF00, 0xFFFFDC00, 0xFFFF0000 };
+    private static final int[] GDH_TRAFFIC_DARK = GDH_TRAFFIC_LIGHT;
+
+    private static int[] trafficFor(Palette palette, boolean darkTheme) {
+        switch (palette) {
+            case VIBRANT:
+                return darkTheme ? VIBRANT_TRAFFIC_DARK : VIBRANT_TRAFFIC_LIGHT;
+            case GDH_LIKE:
+                return darkTheme ? GDH_TRAFFIC_DARK : GDH_TRAFFIC_LIGHT;
+            case MUTED:
+            case CUSTOM:
+            default:
+                return darkTheme ? MUTED_TRAFFIC_DARK : MUTED_TRAFFIC_LIGHT;
+        }
+    }
+
     public static int valueInRange(boolean darkTheme) {
-        return darkTheme ? VALUE_IN_RANGE_DARK : VALUE_IN_RANGE;
+        // The in-range tier honours an explicit IN_RANGE override so the user's
+        // chosen in-range colour applies to the value too, not just the bands.
+        final Integer override = overrides[Band.IN_RANGE.ordinal()];
+        return override != null ? override : trafficFor(activePalette, darkTheme)[0];
     }
 
     public static int valueBorderline(boolean darkTheme) {
-        return darkTheme ? VALUE_BORDERLINE_DARK : VALUE_BORDERLINE;
+        return trafficFor(activePalette, darkTheme)[1];
     }
 
     public static int valueOut(boolean darkTheme) {
-        return darkTheme ? VALUE_OUT_DARK : VALUE_OUT;
+        return trafficFor(activePalette, darkTheme)[2];
     }
 
     public static int trafficColorForValue(

--- a/Common/src/main/java/tk/glucodata/GlucoseRangeColors.java
+++ b/Common/src/main/java/tk/glucodata/GlucoseRangeColors.java
@@ -1,10 +1,23 @@
 package tk.glucodata;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
 /**
  * Shared glucose range tones. The hue order follows AGP convention:
  * below range is red/dark red, in range is green, above range is amber/orange.
+ *
+ * <p>The five band colours are selectable at runtime. A {@link Palette} preset
+ * supplies the base tones; optional per-band {@link Band} overrides are layered
+ * on top of whichever preset is active. Resolution order for every getter is
+ * <em>override &rarr; active preset &rarr; dark/light variant</em>. The getter
+ * signatures are deliberately unchanged so existing call sites keep working; a
+ * palette switch takes effect everywhere they are read.</p>
  */
 public final class GlucoseRangeColors {
+    // Muted preset (the historical default). Kept as the public constants so any
+    // remaining direct reference still resolves to the original tones. Dark ==
+    // light: the muted palette is intentionally identical in both themes.
     public static final int VERY_LOW = 0xFFC7655C;
     public static final int LOW = 0xFFC97970;
     public static final int IN_RANGE = 0xFF4E8A55;
@@ -16,6 +29,187 @@ public final class GlucoseRangeColors {
     public static final int IN_RANGE_DARK = IN_RANGE;
     public static final int HIGH_DARK = HIGH;
     public static final int VERY_HIGH_DARK = VERY_HIGH;
+
+    /** Selectable colour presets. CUSTOM is a UI label for "base + overrides". */
+    public enum Palette { MUTED, VIBRANT, GDH_LIKE, CUSTOM }
+
+    /** The five glucose bands, ordered below-range to above-range. */
+    public enum Band { VERY_LOW, LOW, IN_RANGE, HIGH, VERY_HIGH }
+
+    // Preset colour tables, indexed by Band.ordinal(). Each preset carries its
+    // own dark variant; on dark surfaces saturated tones are lightened so they
+    // do not glare. MUTED stays bit-identical to the light values by design.
+    private static final int[] MUTED_LIGHT = { VERY_LOW, LOW, IN_RANGE, HIGH, VERY_HIGH };
+    private static final int[] MUTED_DARK = MUTED_LIGHT;
+
+    // Vibrant: a saturated traffic palette tuned for Material 3 surfaces (not the
+    // raw RGB primaries GDH uses). Light leans on the 600-800 Material shades,
+    // dark on the 200-400 shades so contrast holds on dark backgrounds.
+    private static final int[] VIBRANT_LIGHT = {
+            0xFFC62828, // VERY_LOW  – Red 800
+            0xFFE53935, // LOW       – Red 600
+            0xFF43A047, // IN_RANGE  – Green 600
+            0xFFFFA000, // HIGH      – Amber 700
+            0xFFEF6C00, // VERY_HIGH – Orange 800
+    };
+    private static final int[] VIBRANT_DARK = {
+            0xFFEF5350, // VERY_LOW  – Red 400
+            0xFFE57373, // LOW       – Red 300
+            0xFF81C784, // IN_RANGE  – Green 300
+            0xFFFFCA28, // HIGH      – Amber 400
+            0xFFFFA726, // VERY_HIGH – Orange 400
+    };
+
+    // GDH-like: GlucoDataHandler's three colour tiers mapped onto five bands
+    // (in-range <- colorOK, high/low <- colorOutOfRange, very-high/very-low <-
+    // colorAlarm). These are the raw primaries GDH renders on black widget
+    // backgrounds, offered verbatim for switchers; dark == light on purpose.
+    private static final int[] GDH_LIGHT = {
+            0xFFFF0000, // VERY_LOW  – colorAlarm (red)
+            0xFFFFDC00, // LOW       – colorOutOfRange (yellow)
+            0xFF00FF00, // IN_RANGE  – colorOK (green)
+            0xFFFFDC00, // HIGH      – colorOutOfRange (yellow)
+            0xFFFF0000, // VERY_HIGH – colorAlarm (red)
+    };
+    private static final int[] GDH_DARK = GDH_LIGHT;
+
+    // SharedPreferences contract (shared with the app-start init and the UI).
+    public static final String PREF_FILE = "tk.glucodata_preferences";
+    public static final String PREF_PALETTE = "glucose_color_palette";
+    public static final String[] PREF_OVERRIDE_KEYS = {
+            "glucose_color_very_low",
+            "glucose_color_low",
+            "glucose_color_in_range",
+            "glucose_color_high",
+            "glucose_color_very_high",
+    };
+
+    private static volatile Palette activePalette = Palette.MUTED;
+    // null entry = no override for that band. Overrides apply to both themes.
+    private static final Integer[] overrides = new Integer[Band.values().length];
+    // Notified after any state change so the Compose layer can recompose.
+    private static volatile Runnable changeListener;
+
+    private static int[] tableFor(Palette palette, boolean darkTheme) {
+        switch (palette) {
+            case VIBRANT:
+                return darkTheme ? VIBRANT_DARK : VIBRANT_LIGHT;
+            case GDH_LIKE:
+                return darkTheme ? GDH_DARK : GDH_LIGHT;
+            case MUTED:
+            case CUSTOM: // custom layers overrides on the muted base
+            default:
+                return darkTheme ? MUTED_DARK : MUTED_LIGHT;
+        }
+    }
+
+    private static int resolve(Band band, boolean darkTheme) {
+        final Integer override = overrides[band.ordinal()];
+        if (override != null) {
+            return override;
+        }
+        return tableFor(activePalette, darkTheme)[band.ordinal()];
+    }
+
+    /** Preset tone for a band, ignoring any override (used for previews/reset). */
+    public static int presetColor(Palette palette, Band band, boolean darkTheme) {
+        return tableFor(palette, darkTheme)[band.ordinal()];
+    }
+
+    public static Palette getPalette() {
+        return activePalette;
+    }
+
+    public static void setPalette(Palette palette) {
+        if (palette == null) {
+            palette = Palette.MUTED;
+        }
+        if (palette != activePalette) {
+            activePalette = palette;
+            notifyChanged();
+        }
+    }
+
+    public static Integer getOverride(Band band) {
+        return overrides[band.ordinal()];
+    }
+
+    public static boolean hasAnyOverride() {
+        for (Integer override : overrides) {
+            if (override != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Set (argb) or clear (null) the override for a single band. */
+    public static void setOverride(Band band, Integer argb) {
+        final int idx = band.ordinal();
+        if (!java.util.Objects.equals(overrides[idx], argb)) {
+            overrides[idx] = argb;
+            notifyChanged();
+        }
+    }
+
+    public static void clearOverride(Band band) {
+        setOverride(band, null);
+    }
+
+    public static void clearOverrides() {
+        boolean changed = false;
+        for (int i = 0; i < overrides.length; i++) {
+            if (overrides[i] != null) {
+                overrides[i] = null;
+                changed = true;
+            }
+        }
+        if (changed) {
+            notifyChanged();
+        }
+    }
+
+    /** Register a callback invoked after any palette/override change. */
+    public static void setChangeListener(Runnable listener) {
+        changeListener = listener;
+    }
+
+    private static void notifyChanged() {
+        final Runnable listener = changeListener;
+        if (listener != null) {
+            listener.run();
+        }
+    }
+
+    private static Palette parsePalette(String raw) {
+        if (raw != null) {
+            try {
+                return Palette.valueOf(raw.toUpperCase(java.util.Locale.ROOT));
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        return Palette.MUTED;
+    }
+
+    /**
+     * Load the active preset and per-band overrides from SharedPreferences.
+     * Called early at app start (before the notification chart draws) so the
+     * non-Compose consumers pick up the user's choice. Missing keys keep the
+     * historical MUTED / no-override behaviour.
+     */
+    public static void initFromPrefs(Context context) {
+        try {
+            final SharedPreferences prefs = context.getSharedPreferences(PREF_FILE, Context.MODE_PRIVATE);
+            activePalette = parsePalette(prefs.getString(PREF_PALETTE, Palette.MUTED.name()));
+            for (int i = 0; i < overrides.length; i++) {
+                overrides[i] = prefs.contains(PREF_OVERRIDE_KEYS[i])
+                        ? prefs.getInt(PREF_OVERRIDE_KEYS[i], 0)
+                        : null;
+            }
+        } catch (Throwable ignored) {
+            // Any failure falls back to the compiled-in muted defaults.
+        }
+    }
 
     public static final float DEFAULT_LOW_MGDL = 70.0f;
     public static final float DEFAULT_HIGH_MGDL = 180.0f;
@@ -31,23 +225,23 @@ public final class GlucoseRangeColors {
     }
 
     public static int veryLow(boolean darkTheme) {
-        return darkTheme ? VERY_LOW_DARK : VERY_LOW;
+        return resolve(Band.VERY_LOW, darkTheme);
     }
 
     public static int low(boolean darkTheme) {
-        return darkTheme ? LOW_DARK : LOW;
+        return resolve(Band.LOW, darkTheme);
     }
 
     public static int inRange(boolean darkTheme) {
-        return darkTheme ? IN_RANGE_DARK : IN_RANGE;
+        return resolve(Band.IN_RANGE, darkTheme);
     }
 
     public static int high(boolean darkTheme) {
-        return darkTheme ? HIGH_DARK : HIGH;
+        return resolve(Band.HIGH, darkTheme);
     }
 
     public static int veryHigh(boolean darkTheme) {
-        return darkTheme ? VERY_HIGH_DARK : VERY_HIGH;
+        return resolve(Band.VERY_HIGH, darkTheme);
     }
 
     public static float defaultLow(boolean isMmol) {

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1589,6 +1589,24 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="glucose_chart_range_colors_desc">Ampelfarben für die Glukoselinie im Benachrichtigungs- und AOD-Diagramm</string>
     <string name="glucose_app_chart_range_colors_title">App-Diagrammlinien einfärben</string>
     <string name="glucose_app_chart_range_colors_desc">Ampelfarben für die Glukoselinie in Dashboard-, Verlaufs-, Journal- und Statistik-Diagrammen</string>
+    <!-- Glukose-Farbpalette -->
+    <string name="glucose_palette_title">Glukose-Farbpalette</string>
+    <string name="glucose_palette_edit_title">Glukose-Farben</string>
+    <string name="glucose_palette_preset_label">Voreinstellung</string>
+    <string name="glucose_palette_bands_label">Farben je Bereich</string>
+    <string name="glucose_palette_preset_muted">Gedämpft</string>
+    <string name="glucose_palette_preset_vibrant">Kräftig</string>
+    <string name="glucose_palette_preset_gdh">GDH-ähnlich</string>
+    <string name="glucose_palette_preset_custom">Benutzerdefiniert</string>
+    <string name="glucose_palette_custom_suffix">+ Anpassungen</string>
+    <string name="glucose_palette_band_very_low">Sehr niedrig</string>
+    <string name="glucose_palette_band_low">Niedrig</string>
+    <string name="glucose_palette_band_in_range">Im Zielbereich</string>
+    <string name="glucose_palette_band_high">Hoch</string>
+    <string name="glucose_palette_band_very_high">Sehr hoch</string>
+    <string name="glucose_palette_edit">Ändern</string>
+    <string name="glucose_palette_reset">Zurücksetzen</string>
+    <string name="glucose_palette_reset_all">Alle Farben zurücksetzen</string>
     <string name="notification_iob_cob_risk_title">Warnen, wenn Insulin die Kohlenhydrate übersteigt</string>
     <string name="notification_iob_cob_risk_desc">IOB/COB einfärben, wenn in den nächsten 30 Minuten wirkendes Insulin die Glukose voraussichtlich unter den Zielbereich senkt</string>
     <string name="notification_iob_risk_without_cob_title">Auch ohne Kohlenhydrate warnen</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1848,6 +1848,24 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="glucose_chart_range_colors_desc">Traffic colors for the glucose line in the notification and AOD charts</string>
     <string name="glucose_app_chart_range_colors_title">Color in-app chart lines</string>
     <string name="glucose_app_chart_range_colors_desc">Traffic colors for the glucose line in dashboard, history, journal and statistics charts</string>
+    <!-- Glucose colour palette -->
+    <string name="glucose_palette_title">Glucose color palette</string>
+    <string name="glucose_palette_edit_title">Glucose colors</string>
+    <string name="glucose_palette_preset_label">Preset</string>
+    <string name="glucose_palette_bands_label">Per-band colors</string>
+    <string name="glucose_palette_preset_muted">Muted</string>
+    <string name="glucose_palette_preset_vibrant">Vibrant</string>
+    <string name="glucose_palette_preset_gdh">GDH-like</string>
+    <string name="glucose_palette_preset_custom">Custom</string>
+    <string name="glucose_palette_custom_suffix">+ adjustments</string>
+    <string name="glucose_palette_band_very_low">Very low</string>
+    <string name="glucose_palette_band_low">Low</string>
+    <string name="glucose_palette_band_in_range">In range</string>
+    <string name="glucose_palette_band_high">High</string>
+    <string name="glucose_palette_band_very_high">Very high</string>
+    <string name="glucose_palette_edit">Edit</string>
+    <string name="glucose_palette_reset">Reset</string>
+    <string name="glucose_palette_reset_all">Reset all colors</string>
     <string name="notification_iob_cob_risk_title">Warn when insulin outweighs carbs</string>
     <string name="notification_iob_cob_risk_desc">Color IOB/COB when insulin acting in the next 30 minutes is projected to drop glucose below target</string>
     <string name="notification_iob_risk_without_cob_title">Warn without carbs on board</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
@@ -786,6 +786,9 @@ fun InteractiveGlucoseChart(
 ) {
     // --- THEME & PAINTS ---
     val isDark = isSystemInDarkTheme()
+    // Observe the glucose palette so target band / band tints recompute live
+    // when the user switches presets or edits a band colour (no restart).
+    val glucosePaletteRevision = GlucosePaletteState.revision
     // User requested stronger dark mode lines ("oddly pale").
     // Standard M3 dark primary is pastel. We use a more saturated blue for data.
     val primaryColor = MaterialTheme.colorScheme.primary
@@ -793,10 +796,9 @@ fun InteractiveGlucoseChart(
     val tertiaryColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f) // Lighter shade for 3rd line
     val pointColor = MaterialTheme.colorScheme.onSurface
     val gridColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.125f)
-    // 1. Select the correct Material Green shade (300 for Dark, 700 for Light)
-    val materialGreen = if (isDark) Color(0xFF81C784) else Color(0xFF388E3C)
-    // 2. Apply "Container" level opacity (0.12f is standard for M3 highlights)
-    val targetBandColor = materialGreen.copy(alpha = 0.12f)
+    // Target band inherits the active in-range band colour (was a hardcoded
+    // Material green). Keep the 0.12f container-level opacity.
+    val targetBandColor = Color(GlucoseRangeColors.inRange(isDark)).copy(alpha = 0.12f)
 //    val targetBandColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
     val hoverLineColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
     val minMaxLineColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
@@ -2041,7 +2043,8 @@ fun InteractiveGlucoseChart(
                 primaryLineTintFraction,
                 primaryIdentityColor,
                 appChartRangeColors,
-                appTrafficDark
+                appTrafficDark,
+                glucosePaletteRevision
             ) {
                 if (chartHeightPx <= 0f) {
                     Brush.linearGradient(listOf(Color.Transparent, Color.Transparent))
@@ -2057,7 +2060,7 @@ fun InteractiveGlucoseChart(
                     // the value/notification coloring uses, incl. green in range.
                     val veryHighTint = identityTinted(
                         if (appChartRangeColors) Color(GlucoseRangeColors.valueOut(appTrafficDark))
-                        else Color(GlucoseRangeColors.VERY_HIGH)
+                        else Color(GlucoseRangeColors.veryHigh(isDark))
                     )
                     val highTint = identityTinted(
                         if (appChartRangeColors) Color(GlucoseRangeColors.valueBorderline(appTrafficDark))
@@ -2069,7 +2072,7 @@ fun InteractiveGlucoseChart(
                     )
                     val veryLowTint = identityTinted(
                         if (appChartRangeColors) Color(GlucoseRangeColors.valueOut(appTrafficDark))
-                        else Color(GlucoseRangeColors.VERY_LOW)
+                        else Color(GlucoseRangeColors.veryLow(isDark))
                     )
                     val inRangeTint = identityTinted(
                         if (appChartRangeColors) Color(GlucoseRangeColors.valueInRange(appTrafficDark))
@@ -2107,13 +2110,14 @@ fun InteractiveGlucoseChart(
                 chartHeightPx,
                 highOutOfRangeTintBase,
                 lowOutOfRangeTintBase,
-                peerNeutralBase
+                peerNeutralBase,
+                glucosePaletteRevision
             ) {
                 if (chartHeightPx <= 0f) {
                     emptyMap()
                 } else {
-                    val veryHighTint = Color(GlucoseRangeColors.VERY_HIGH)
-                    val veryLowTint = Color(GlucoseRangeColors.VERY_LOW)
+                    val veryHighTint = Color(GlucoseRangeColors.veryHigh(isDark))
+                    val veryLowTint = Color(GlucoseRangeColors.veryLow(isDark))
                     val fadePx = 18f
                     peerChartSeries.associate { series ->
                         // Tone down the coloring (desaturate toward the neutral

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -408,7 +408,9 @@ fun DashboardCombinedHeader(
         targetLow,
         targetHigh,
         veryLowThreshold,
-        veryHighThreshold
+        veryHighThreshold,
+        // Recompose the band tint when the user switches palette / edits a band.
+        GlucosePaletteState.revision
     ) {
         glucoseHeroTone(
             value = dvs?.primaryValue,

--- a/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
@@ -268,6 +268,7 @@ fun NotificationSettingsScreen(
                 icon = null,
                 position = CardPosition.MIDDLE
             )
+            GlucosePaletteCard(position = CardPosition.MIDDLE)
             SettingsSwitchItem(
                 title = stringResource(R.string.notification_show_iob_title),
                 subtitle = stringResource(R.string.notification_show_iob_desc),

--- a/Common/src/mobile/java/tk/glucodata/ui/GlucosePaletteSettings.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/GlucosePaletteSettings.kt
@@ -1,0 +1,383 @@
+package tk.glucodata.ui
+
+import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import tk.glucodata.GlucoseRangeColors
+import tk.glucodata.GlucoseRangeColors.Band
+import tk.glucodata.GlucoseRangeColors.Palette
+import tk.glucodata.R
+import tk.glucodata.ui.components.CardPosition
+import tk.glucodata.ui.components.SettingsItem
+
+// The three selectable base presets (CUSTOM is a derived state, not a chip).
+private val BASE_PRESETS = listOf(Palette.MUTED, Palette.VIBRANT, Palette.GDH_LIKE)
+
+private fun presetLabelRes(palette: Palette): Int = when (palette) {
+    Palette.MUTED -> R.string.glucose_palette_preset_muted
+    Palette.VIBRANT -> R.string.glucose_palette_preset_vibrant
+    Palette.GDH_LIKE -> R.string.glucose_palette_preset_gdh
+    Palette.CUSTOM -> R.string.glucose_palette_preset_custom
+}
+
+private val BAND_ORDER = listOf(
+    Band.VERY_LOW, Band.LOW, Band.IN_RANGE, Band.HIGH, Band.VERY_HIGH
+)
+
+private fun bandLabelRes(band: Band): Int = when (band) {
+    Band.VERY_LOW -> R.string.glucose_palette_band_very_low
+    Band.LOW -> R.string.glucose_palette_band_low
+    Band.IN_RANGE -> R.string.glucose_palette_band_in_range
+    Band.HIGH -> R.string.glucose_palette_band_high
+    Band.VERY_HIGH -> R.string.glucose_palette_band_very_high
+}
+
+/** Effective ARGB for a band (override or preset), for the given theme. */
+private fun effectiveBandColor(band: Band, dark: Boolean): Int = when (band) {
+    Band.VERY_LOW -> GlucoseRangeColors.veryLow(dark)
+    Band.LOW -> GlucoseRangeColors.low(dark)
+    Band.IN_RANGE -> GlucoseRangeColors.inRange(dark)
+    Band.HIGH -> GlucoseRangeColors.high(dark)
+    Band.VERY_HIGH -> GlucoseRangeColors.veryHigh(dark)
+}
+
+/**
+ * Settings entry for the glucose colour palette. Renders a row with an inline
+ * live preview of the five bands; tapping it opens the editor (preset choice +
+ * per-band custom colours). Reads [GlucosePaletteState.revision] so both the
+ * preview and the editor update the instant a colour changes.
+ */
+@Composable
+fun GlucosePaletteCard(position: CardPosition = CardPosition.SINGLE) {
+    val revision = GlucosePaletteState.revision
+    val isDark = isSystemInDarkTheme()
+    var showEditor by remember { mutableStateOf(false) }
+
+    val activePreset = remember(revision) { GlucosePaletteState.palette() }
+    val hasOverrides = remember(revision) { GlucosePaletteState.hasAnyOverride() }
+    val subtitle = buildString {
+        append(stringResource(presetLabelRes(activePreset)))
+        if (hasOverrides) {
+            append(" ")
+            append(stringResource(R.string.glucose_palette_custom_suffix))
+        }
+    }
+
+    SettingsItem(
+        title = stringResource(R.string.glucose_palette_title),
+        subtitle = subtitle,
+        onClick = { showEditor = true },
+        position = position,
+        trailingContent = {
+            Row(horizontalArrangement = Arrangement.spacedBy(3.dp)) {
+                BAND_ORDER.forEach { band ->
+                    Box(
+                        modifier = Modifier
+                            .size(14.dp)
+                            .border(0.5.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape)
+                            .background(Color(effectiveBandColor(band, isDark)), CircleShape)
+                    )
+                }
+            }
+        }
+    )
+
+    if (showEditor) {
+        GlucosePaletteEditorDialog(onDismiss = { showEditor = false })
+    }
+}
+
+@Composable
+private fun GlucosePaletteEditorDialog(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val revision = GlucosePaletteState.revision
+    val isDark = isSystemInDarkTheme()
+    val activePreset = remember(revision) { GlucosePaletteState.palette() }
+    val hasOverrides = remember(revision) { GlucosePaletteState.hasAnyOverride() }
+    var editingBand by remember { mutableStateOf<Band?>(null) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.glucose_palette_edit_title)) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                Text(
+                    stringResource(R.string.glucose_palette_preset_label),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Spacer(Modifier.height(6.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    BASE_PRESETS.forEach { preset ->
+                        FilterChip(
+                            selected = activePreset == preset && !hasOverrides,
+                            onClick = { GlucosePaletteState.setPalette(context, preset) },
+                            label = { Text(stringResource(presetLabelRes(preset))) }
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    stringResource(R.string.glucose_palette_bands_label),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Spacer(Modifier.height(6.dp))
+                BAND_ORDER.forEach { band ->
+                    val overridden = GlucosePaletteState.override(band) != null
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(28.dp)
+                                .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+                                .background(Color(effectiveBandColor(band, isDark)), RoundedCornerShape(8.dp))
+                                .pointerInput(band) { detectTapGestures { editingBand = band } }
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Text(
+                            stringResource(bandLabelRes(band)),
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.weight(1f)
+                        )
+                        if (overridden) {
+                            TextButton(onClick = { GlucosePaletteState.setOverride(context, band, null) }) {
+                                Text(stringResource(R.string.glucose_palette_reset))
+                            }
+                        }
+                        TextButton(onClick = { editingBand = band }) {
+                            Text(stringResource(R.string.glucose_palette_edit))
+                        }
+                    }
+                }
+
+                if (hasOverrides) {
+                    Spacer(Modifier.height(4.dp))
+                    TextButton(onClick = { GlucosePaletteState.clearOverrides(context) }) {
+                        Text(stringResource(R.string.glucose_palette_reset_all))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(android.R.string.ok)) }
+        }
+    )
+
+    editingBand?.let { band ->
+        val initial = effectiveBandColor(band, isDark)
+        HsvColorPickerDialog(
+            title = stringResource(bandLabelRes(band)),
+            initialArgb = initial,
+            isOverridden = GlucosePaletteState.override(band) != null,
+            onConfirm = { argb ->
+                GlucosePaletteState.setOverride(context, band, argb)
+                editingBand = null
+            },
+            onReset = {
+                GlucosePaletteState.setOverride(context, band, null)
+                editingBand = null
+            },
+            onDismiss = { editingBand = null }
+        )
+    }
+}
+
+/**
+ * Lightweight HSV colour picker (saturation/value panel + hue slider). No
+ * external dependency. Overrides intentionally apply to both themes.
+ */
+@Composable
+private fun HsvColorPickerDialog(
+    title: String,
+    initialArgb: Int,
+    isOverridden: Boolean,
+    onConfirm: (Int) -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val hsv = remember(initialArgb) {
+        FloatArray(3).also { AndroidColor.colorToHSV(initialArgb or (0xFF shl 24), it) }
+    }
+    var hue by remember(initialArgb) { mutableFloatStateOf(hsv[0]) }
+    var sat by remember(initialArgb) { mutableFloatStateOf(hsv[1]) }
+    var value by remember(initialArgb) { mutableFloatStateOf(hsv[2]) }
+
+    val currentArgb = AndroidColor.HSVToColor(floatArrayOf(hue, sat, value))
+    val hexText = String.format("#%06X", currentArgb and 0xFFFFFF)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+                            .background(Color(currentArgb), RoundedCornerShape(8.dp))
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Text(hexText, style = MaterialTheme.typography.titleMedium)
+                }
+                Spacer(Modifier.height(12.dp))
+                SaturationValuePanel(
+                    hue = hue,
+                    saturation = sat,
+                    value = value,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(1.4f)
+                ) { s, v -> sat = s; value = v }
+                Spacer(Modifier.height(12.dp))
+                HueSlider(
+                    hue = hue,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(24.dp)
+                ) { hue = it }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(currentArgb or (0xFF shl 24)) }) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            Row {
+                if (isOverridden) {
+                    TextButton(onClick = onReset) {
+                        Text(stringResource(R.string.glucose_palette_reset))
+                    }
+                }
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun SaturationValuePanel(
+    hue: Float,
+    saturation: Float,
+    value: Float,
+    modifier: Modifier = Modifier,
+    onChange: (Float, Float) -> Unit
+) {
+    var panelSize by remember { mutableStateOf(IntSize.Zero) }
+    val hueColor = Color(AndroidColor.HSVToColor(floatArrayOf(hue, 1f, 1f)))
+
+    fun report(pos: Offset) {
+        val w = panelSize.width.coerceAtLeast(1)
+        val h = panelSize.height.coerceAtLeast(1)
+        val s = (pos.x / w).coerceIn(0f, 1f)
+        val v = (1f - pos.y / h).coerceIn(0f, 1f)
+        onChange(s, v)
+    }
+
+    Box(
+        modifier = modifier
+            .onSizeChanged { panelSize = it }
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+            .pointerInput(Unit) { detectTapGestures { report(it) } }
+            .pointerInput(Unit) {
+                detectDragGestures(onDragStart = { report(it) }) { change, _ -> report(change.position) }
+            }
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawRect(hueColor)
+            drawRect(Brush.horizontalGradient(listOf(Color.White, Color.Transparent)))
+            drawRect(Brush.verticalGradient(listOf(Color.Transparent, Color.Black)))
+            val cx = saturation * size.width
+            val cy = (1f - value) * size.height
+            drawCircle(Color.White, radius = 7f, center = Offset(cx, cy))
+            drawCircle(Color.Black, radius = 7f, center = Offset(cx, cy), style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2f))
+        }
+    }
+}
+
+@Composable
+private fun HueSlider(
+    hue: Float,
+    modifier: Modifier = Modifier,
+    onHueChange: (Float) -> Unit
+) {
+    var barSize by remember { mutableStateOf(IntSize.Zero) }
+    val hueColors = remember {
+        (0..360 step 30).map { Color(AndroidColor.HSVToColor(floatArrayOf(it.toFloat(), 1f, 1f))) }
+    }
+
+    fun report(x: Float) {
+        val w = barSize.width.coerceAtLeast(1)
+        onHueChange((x / w).coerceIn(0f, 1f) * 360f)
+    }
+
+    Box(
+        modifier = modifier
+            .onSizeChanged { barSize = it }
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(12.dp))
+            .pointerInput(Unit) { detectTapGestures { report(it.x) } }
+            .pointerInput(Unit) {
+                detectDragGestures(onDragStart = { report(it.x) }) { change, _ -> report(change.position.x) }
+            }
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawRoundRect(
+                brush = Brush.horizontalGradient(hueColors),
+                cornerRadius = androidx.compose.ui.geometry.CornerRadius(size.height / 2f)
+            )
+            val cx = (hue / 360f) * size.width
+            drawCircle(Color.White, radius = size.height / 2f - 2f, center = Offset(cx, size.height / 2f), style = androidx.compose.ui.graphics.drawscope.Stroke(width = 3f))
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/GlucosePaletteState.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/GlucosePaletteState.kt
@@ -1,0 +1,67 @@
+package tk.glucodata.ui
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.core.content.edit
+import tk.glucodata.GlucoseRangeColors
+import tk.glucodata.GlucoseRangeColors.Band
+import tk.glucodata.GlucoseRangeColors.Palette
+
+/**
+ * Compose-facing bridge over the static [GlucoseRangeColors] palette state.
+ *
+ * The colour getters in [GlucoseRangeColors] are plain statics, so Compose does
+ * not observe them: without help, a palette switch would only show up after an
+ * app restart. This object exposes a [revision] snapshot-int that is bumped on
+ * every palette/override change. Composables that read [revision] before
+ * resolving a band colour (typically as a `remember` key) recompose live when
+ * the user changes the palette — no restart needed.
+ *
+ * Non-Compose consumers ([tk.glucodata.NotificationChartDrawer]) keep reading
+ * the static getters directly; they pick up changes the next time they draw.
+ */
+object GlucosePaletteState {
+    private var revisionState by mutableIntStateOf(0)
+
+    init {
+        // Any palette/override change funnels through here into Compose.
+        GlucoseRangeColors.setChangeListener { revisionState++ }
+    }
+
+    /** Read this in a composable (e.g. as a remember key) to observe changes. */
+    val revision: Int get() = revisionState
+
+    fun palette(): Palette = GlucoseRangeColors.getPalette()
+
+    fun override(band: Band): Int? = GlucoseRangeColors.getOverride(band)
+
+    fun hasAnyOverride(): Boolean = GlucoseRangeColors.hasAnyOverride()
+
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(
+            GlucoseRangeColors.PREF_FILE, Context.MODE_PRIVATE
+        )
+
+    fun setPalette(context: Context, palette: Palette) {
+        prefs(context).edit { putString(GlucoseRangeColors.PREF_PALETTE, palette.name) }
+        GlucoseRangeColors.setPalette(palette)
+    }
+
+    /** Set (argb) or clear (null) a single band override; persists and applies. */
+    fun setOverride(context: Context, band: Band, argb: Int?) {
+        val key = GlucoseRangeColors.PREF_OVERRIDE_KEYS[band.ordinal]
+        prefs(context).edit {
+            if (argb == null) remove(key) else putInt(key, argb)
+        }
+        GlucoseRangeColors.setOverride(band, argb)
+    }
+
+    fun clearOverrides(context: Context) {
+        prefs(context).edit {
+            GlucoseRangeColors.PREF_OVERRIDE_KEYS.forEach { remove(it) }
+        }
+        GlucoseRangeColors.clearOverrides()
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/GlucosePaletteState.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/GlucosePaletteState.kt
@@ -47,6 +47,7 @@ object GlucosePaletteState {
     fun setPalette(context: Context, palette: Palette) {
         prefs(context).edit { putString(GlucoseRangeColors.PREF_PALETTE, palette.name) }
         GlucoseRangeColors.setPalette(palette)
+        refreshNotification()
     }
 
     /** Set (argb) or clear (null) a single band override; persists and applies. */
@@ -56,6 +57,7 @@ object GlucosePaletteState {
             if (argb == null) remove(key) else putInt(key, argb)
         }
         GlucoseRangeColors.setOverride(band, argb)
+        refreshNotification()
     }
 
     fun clearOverrides(context: Context) {
@@ -63,5 +65,16 @@ object GlucosePaletteState {
             GlucoseRangeColors.PREF_OVERRIDE_KEYS.forEach { remove(it) }
         }
         GlucoseRangeColors.clearOverrides()
+        refreshNotification()
+    }
+
+    // Compose recomposes on its own via [revision], but the ongoing notification
+    // is a rendered bitmap that only refreshes on a new reading. Repaint it now
+    // so a palette change is visible there immediately, not minutes later.
+    private fun refreshNotification() {
+        try {
+            tk.glucodata.Notify.showoldglucose()
+        } catch (_: Throwable) {
+        }
     }
 }

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsReportExporter.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsReportExporter.kt
@@ -361,11 +361,13 @@ object StatsReportExporter {
                 )
             }
 
-            val colorTirVeryLow = GlucoseRangeColors.VERY_LOW
-            val colorTirLow = GlucoseRangeColors.LOW
-            val colorTirInRange = GlucoseRangeColors.IN_RANGE
-            val colorTirHigh = GlucoseRangeColors.HIGH
-            val colorTirVeryHigh = GlucoseRangeColors.VERY_HIGH
+            // Follow the active glucose palette + overrides (light variant for
+            // the printed/exported report, which has no dark theme).
+            val colorTirVeryLow = GlucoseRangeColors.veryLow(false)
+            val colorTirLow = GlucoseRangeColors.low(false)
+            val colorTirInRange = GlucoseRangeColors.inRange(false)
+            val colorTirHigh = GlucoseRangeColors.high(false)
+            val colorTirVeryHigh = GlucoseRangeColors.veryHigh(false)
 
             fun loadFontSafely(fontRes: Int): android.graphics.Typeface? =
                 runCatching { ResourcesCompat.getFont(context, fontRes) }

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsScreen.kt
@@ -150,11 +150,14 @@ import kotlinx.coroutines.launch
 import tk.glucodata.GlucoseRangeColors
 import tk.glucodata.ui.theme.labelLargeExpressive
 
-private val TirVeryLowColor = Color(GlucoseRangeColors.VERY_LOW)
-private val TirLowColor = Color(GlucoseRangeColors.LOW)
-private val TirInRangeColor = Color(GlucoseRangeColors.IN_RANGE)
-private val TirHighColor = Color(GlucoseRangeColors.HIGH)
-private val TirVeryHighColor = Color(GlucoseRangeColors.VERY_HIGH)
+// Follow the active glucose palette (and any per-band overrides). Computed on
+// access so a palette switch shows up when the stats screen is (re)entered.
+// Light variant only, matching the historical theme-independent behaviour.
+private val TirVeryLowColor get() = Color(GlucoseRangeColors.veryLow(false))
+private val TirLowColor get() = Color(GlucoseRangeColors.low(false))
+private val TirInRangeColor get() = Color(GlucoseRangeColors.inRange(false))
+private val TirHighColor get() = Color(GlucoseRangeColors.high(false))
+private val TirVeryHighColor get() = Color(GlucoseRangeColors.veryHigh(false))
 private const val PrefKeyReportPdfStyle = "stats_report_pdf_style"
 
 private enum class TirBand {

--- a/Common/src/test/java/tk/glucodata/GlucoseRangeColorsPaletteTests.kt
+++ b/Common/src/test/java/tk/glucodata/GlucoseRangeColorsPaletteTests.kt
@@ -88,6 +88,33 @@ class GlucoseRangeColorsPaletteTests {
     }
 
     @Test
+    fun valueTrafficColorsFollowThePreset() {
+        // MUTED keeps the historical traffic tones (regression guarantee).
+        GlucoseRangeColors.setPalette(Palette.MUTED)
+        assertEquals(0xFF2E7D32.toInt(), GlucoseRangeColors.valueInRange(false))
+        assertEquals(0xFFC62828.toInt(), GlucoseRangeColors.valueOut(false))
+
+        // GDH_LIKE drives the value/arrow colouring to GDH's pure primaries.
+        GlucoseRangeColors.setPalette(Palette.GDH_LIKE)
+        assertEquals(0xFF00FF00.toInt(), GlucoseRangeColors.valueInRange(false))
+        assertEquals(0xFFFFDC00.toInt(), GlucoseRangeColors.valueBorderline(false))
+        assertEquals(0xFFFF0000.toInt(), GlucoseRangeColors.valueOut(false))
+
+        // Vibrant differs from muted for the value colouring too.
+        GlucoseRangeColors.setPalette(Palette.VIBRANT)
+        assertNotEquals(0xFF2E7D32.toInt(), GlucoseRangeColors.valueInRange(false))
+        assertNotEquals(0xFFC62828.toInt(), GlucoseRangeColors.valueOut(false))
+    }
+
+    @Test
+    fun inRangeOverrideFlowsToValueInRange() {
+        GlucoseRangeColors.setPalette(Palette.MUTED)
+        GlucoseRangeColors.setOverride(Band.IN_RANGE, 0xFF0000FF.toInt())
+        assertEquals(0xFF0000FF.toInt(), GlucoseRangeColors.valueInRange(false))
+        assertEquals(0xFF0000FF.toInt(), GlucoseRangeColors.valueInRange(true))
+    }
+
+    @Test
     fun changeListenerFiresOnEveryEffectiveChange() {
         var count = 0
         GlucoseRangeColors.setChangeListener { count++ }

--- a/Common/src/test/java/tk/glucodata/GlucoseRangeColorsPaletteTests.kt
+++ b/Common/src/test/java/tk/glucodata/GlucoseRangeColorsPaletteTests.kt
@@ -1,0 +1,100 @@
+package tk.glucodata
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import tk.glucodata.GlucoseRangeColors.Band
+import tk.glucodata.GlucoseRangeColors.Palette
+
+/**
+ * Covers the palette resolution order (override -> active preset -> dark/light)
+ * and the regression guarantee that MUTED with no overrides is bit-identical to
+ * the historical hard-coded tones.
+ */
+class GlucoseRangeColorsPaletteTests {
+
+    @Before
+    @After
+    fun reset() {
+        GlucoseRangeColors.setChangeListener(null)
+        GlucoseRangeColors.setPalette(Palette.MUTED)
+        GlucoseRangeColors.clearOverrides()
+    }
+
+    @Test
+    fun mutedDefaultsAreBitIdentical() {
+        assertEquals(0xFFC7655C.toInt(), GlucoseRangeColors.veryLow(false))
+        assertEquals(0xFFC97970.toInt(), GlucoseRangeColors.low(false))
+        assertEquals(0xFF4E8A55.toInt(), GlucoseRangeColors.inRange(false))
+        assertEquals(0xFFD0A23A.toInt(), GlucoseRangeColors.high(false))
+        assertEquals(0xFFC56F33.toInt(), GlucoseRangeColors.veryHigh(false))
+        // MUTED is intentionally identical in dark and light.
+        assertEquals(GlucoseRangeColors.veryLow(false), GlucoseRangeColors.veryLow(true))
+        assertEquals(GlucoseRangeColors.inRange(false), GlucoseRangeColors.inRange(true))
+        assertEquals(GlucoseRangeColors.veryHigh(false), GlucoseRangeColors.veryHigh(true))
+    }
+
+    @Test
+    fun vibrantHasDistinctDarkVariantAndDiffersFromMuted() {
+        GlucoseRangeColors.setPalette(Palette.VIBRANT)
+        assertNotEquals(GlucoseRangeColors.inRange(false), GlucoseRangeColors.inRange(true))
+        assertNotEquals(0xFF4E8A55.toInt(), GlucoseRangeColors.inRange(false))
+    }
+
+    @Test
+    fun gdhLikeMapsThreeTiersToFiveBands() {
+        GlucoseRangeColors.setPalette(Palette.GDH_LIKE)
+        assertEquals(0xFF00FF00.toInt(), GlucoseRangeColors.inRange(false)) // colorOK
+        assertEquals(0xFFFFDC00.toInt(), GlucoseRangeColors.low(false))     // colorOutOfRange
+        assertEquals(0xFFFFDC00.toInt(), GlucoseRangeColors.high(false))
+        assertEquals(0xFFFF0000.toInt(), GlucoseRangeColors.veryLow(false)) // colorAlarm
+        assertEquals(0xFFFF0000.toInt(), GlucoseRangeColors.veryHigh(false))
+    }
+
+    @Test
+    fun overrideWinsOverPresetAndAppliesToBothThemes() {
+        GlucoseRangeColors.setPalette(Palette.VIBRANT)
+        val custom = 0xFF123456.toInt()
+        GlucoseRangeColors.setOverride(Band.IN_RANGE, custom)
+        assertEquals(custom, GlucoseRangeColors.inRange(false))
+        assertEquals(custom, GlucoseRangeColors.inRange(true))
+        // Non-overridden bands still follow the active preset.
+        assertEquals(
+            GlucoseRangeColors.presetColor(Palette.VIBRANT, Band.HIGH, false),
+            GlucoseRangeColors.high(false)
+        )
+    }
+
+    @Test
+    fun clearingOverrideFallsBackToPreset() {
+        GlucoseRangeColors.setPalette(Palette.GDH_LIKE)
+        GlucoseRangeColors.setOverride(Band.LOW, 0xFF00FF00.toInt())
+        assertEquals(0xFF00FF00.toInt(), GlucoseRangeColors.low(false))
+        GlucoseRangeColors.clearOverride(Band.LOW)
+        assertEquals(0xFFFFDC00.toInt(), GlucoseRangeColors.low(false))
+    }
+
+    @Test
+    fun hasAnyOverrideTracksState() {
+        assertFalse(GlucoseRangeColors.hasAnyOverride())
+        GlucoseRangeColors.setOverride(Band.HIGH, 0xFF010203.toInt())
+        assertTrue(GlucoseRangeColors.hasAnyOverride())
+        GlucoseRangeColors.clearOverrides()
+        assertFalse(GlucoseRangeColors.hasAnyOverride())
+    }
+
+    @Test
+    fun changeListenerFiresOnEveryEffectiveChange() {
+        var count = 0
+        GlucoseRangeColors.setChangeListener { count++ }
+        GlucoseRangeColors.setPalette(Palette.VIBRANT)        // 1
+        GlucoseRangeColors.setPalette(Palette.VIBRANT)        // no-op, no fire
+        GlucoseRangeColors.setOverride(Band.LOW, 0xFF111111.toInt()) // 2
+        GlucoseRangeColors.clearOverrides()                   // 3
+        assertEquals(3, count)
+    }
+}


### PR DESCRIPTION
The glucose band colours in `GlucoseRangeColors` are a single fixed muted palette, and the `*_DARK` constants are all equal to their light counterparts, so the `darkTheme` parameter threaded through every getter does nothing today. This makes the palette selectable and gives dark mode real values.

`GlucoseRangeColors` gets a `Palette { MUTED, VIBRANT, GDH_LIKE, CUSTOM }` base plus optional per-band overrides. The five getters resolve override, then active preset, then dark/light, with their signatures unchanged, so the existing call sites don't need touching. MUTED stays byte-for-byte the current tones (dark == light) so nothing changes unless you opt in. VIBRANT is a saturated palette tuned for M3 surfaces. GDH_LIKE maps GlucoDataHandler's three tiers onto the five bands (in-range from colorOK, high/low from colorOutOfRange, very-high/very-low from colorAlarm).

Preset and per-band overrides persist in prefs and load at app start, so the notification chart, which draws outside Compose, picks them up too. A small revision snapshot bridges the static getters into Compose so a change applies live without a restart, and the notification is repainted right away.

The traffic-light value colouring (the value, arrow and chart line behind the existing "Color glucose by range" toggles) follows the preset as well, so switching to Vibrant or GDH-like actually recolours the value and arrow, not just the AGP bands. A few places that read the raw constants directly (the TIR bars and PDF export, a couple of chart tints, and a hard-coded target-band green) now go through the getters so the switch is consistent everywhere.

The UI sits next to the existing glucose-colour toggles: preset chips, a live preview of the five bands, and a small HSV picker per band with reset. No new dependency. Strings are EN/DE. Unit tests cover the resolution order and that MUTED with no overrides equals the old palette exactly.

One thing I left deliberate: overrides apply to both light and dark rather than separate values per theme, to keep the picker simple. Easy to split if you'd rather.

Builds on the range-colouring work already in main (the value/arrow/notification colouring reuses `VALUE_*`). A full build currently also needs #94 (Somali strings escaping fix), which is unrelated to this change.
