### PR TITLE
Delayed alarm sound: vibrate first, audible alarm after N seconds

### DIFF
--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -918,6 +918,10 @@ public class Notify {
     private static AlertSoundHandle delayedAlertSoundHandle = null;
     private static long nextAlertEffectStartAllowedMs = 0L;
     private static long manualEffectBypassUntilMs = 0L;
+    // "Vibrate first, audio after N seconds": the scheduled audible-alarm start.
+    // Distinct from the anti-overlap debounce above; cancelled on any stop.
+    private static ScheduledFuture<?> delayedSoundSchedule = null;
+    private static long delayedSoundGeneration = 0L;
 
     private static final class AlertRetrySession {
         int kind;
@@ -1579,7 +1583,9 @@ public class Notify {
     }
 
     private static void cancelDelayedAlertEffectsLocked(String reason) {
-        final boolean hadDelayed = delayedAlertEffectSchedule != null || delayedAlertSoundHandle != null;
+        final boolean hadDelayed = delayedAlertEffectSchedule != null
+                || delayedAlertSoundHandle != null
+                || delayedSoundSchedule != null;
         if (delayedAlertEffectSchedule != null) {
             delayedAlertEffectSchedule.cancel(false);
             delayedAlertEffectSchedule = null;
@@ -1588,6 +1594,13 @@ public class Notify {
             stopSoundHandleQuietly(delayedAlertSoundHandle);
             delayedAlertSoundHandle = null;
         }
+        // Cancel a pending "vibrate first, audio later" sound so it never fires
+        // after a dismiss / snooze / resolution / retry.
+        if (delayedSoundSchedule != null) {
+            delayedSoundSchedule.cancel(false);
+            delayedSoundSchedule = null;
+        }
+        delayedSoundGeneration++;
         delayedAlertEffectPriority = Integer.MIN_VALUE;
         delayedAlertEffectGeneration++;
         if (hadDelayed && doLog) {
@@ -1989,16 +2002,14 @@ public class Notify {
         // MOVED EFFECTS START HERE - SAFER
         final String resolvedHapticProfile = (hapticProfile != null) ? hapticProfile : getHapticProfile(kind);
 
-        if (sound) {
-            if (doplaysound[0] && hasSoundHandle) {
-                if (soundHandle != null) {
-                    soundHandle.setMaxVolume(soundVolumeForProfile(resolvedHapticProfile));
-                    soundHandle.play();
-                } else if (doLog) {
-                    Log.w(LOG_ID, "playringhier: sound handle is null");
-                }
-            }
-        }
+        // Sound delay ("vibrate first, audio after N seconds"): start vibration
+        // and flash immediately; add the audible alarm only after the configured
+        // delay. Only when both sound and vibration are on for this alert (else
+        // there is either nothing to delay, or a silent gap with no signal).
+        final int soundDelaySeconds = (sound && vibrate) ? getSoundDelaySeconds(kind) : 0;
+        final long soundDelayMs = TimeUnit.SECONDS.toMillis(soundDelaySeconds);
+        final boolean canPlaySound = sound && doplaysound[0] && hasSoundHandle && soundHandle != null;
+
         if (!isWearable) {
             if (flash) {
                 Flash.start(app, 200L);
@@ -2008,7 +2019,43 @@ public class Notify {
             vibratealarm(kind, resolvedHapticProfile, duration);
         }
 
-        stopschedule = Applic.scheduler.schedule(runstopalarm, stopDelayMs, TimeUnit.MILLISECONDS);
+        if (canPlaySound) {
+            soundHandle.setMaxVolume(soundVolumeForProfile(resolvedHapticProfile));
+            if (soundDelayMs > 0L) {
+                // Delay only the play() call; the gradual fade-in lives inside
+                // play() and carries over unchanged, just starting later.
+                final AlertSoundHandle delayedHandle = soundHandle;
+                final long soundGeneration;
+                synchronized (alertEffectLock) {
+                    soundGeneration = ++delayedSoundGeneration;
+                    delayedSoundSchedule = Applic.scheduler.schedule(() -> {
+                        synchronized (alertEffectLock) {
+                            if (soundGeneration != delayedSoundGeneration) {
+                                return;
+                            }
+                            delayedSoundSchedule = null;
+                        }
+                        // Only sound if still alarming (not dismissed / snoozed /
+                        // resolved during the delay); play() is also a no-op once
+                        // the handle has been released.
+                        if (getisalarm()) {
+                            delayedHandle.play();
+                        }
+                    }, soundDelayMs, TimeUnit.MILLISECONDS);
+                }
+                if (doLog) {
+                    Log.i(LOG_ID, "Sound delayed by " + soundDelaySeconds + "s for kind=" + kind);
+                }
+            } else {
+                soundHandle.play();
+            }
+        } else if (sound && soundHandle == null && doLog) {
+            Log.w(LOG_ID, "playringhier: sound handle is null");
+        }
+
+        // Auto-stop counts the sound's play time from when it actually begins, so
+        // a delayed sound still plays for its full duration.
+        stopschedule = Applic.scheduler.schedule(runstopalarm, stopDelayMs + soundDelayMs, TimeUnit.MILLISECONDS);
 
     }
     private String getDeliveryMode(int kind) {
@@ -2071,6 +2118,27 @@ public class Notify {
             case "SOFT":      case "LOW":      return 0.4f;
             case "STEADY":    case "MEDIUM":   return 0.7f;
             default:                           return 1.0f;
+        }
+    }
+
+    // Resolved audible-alarm delay for this alert type, in seconds (0 = none).
+    // Re-applies the per-type hypo cap via the single source of truth in
+    // AlertConfig, independent of how the value was written.
+    private int getSoundDelaySeconds(int kind) {
+        final AlertType type = AlertType.Companion.fromId(kind);
+        if (type == null) {
+            return 0;
+        }
+        try {
+            final android.content.SharedPreferences prefs = Applic.app.getSharedPreferences(
+                    "tk.glucodata.alerts", android.content.Context.MODE_PRIVATE);
+            if (!prefs.getBoolean("alert_" + kind + "_soundDelayEnabled", false)) {
+                return 0;
+            }
+            final int requested = prefs.getInt("alert_" + kind + "_soundDelay", 0);
+            return tk.glucodata.alerts.AlertConfigKt.sanitizeSoundDelaySeconds(type, requested);
+        } catch (Exception e) {
+            return 0;
         }
     }
 

--- a/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
@@ -58,6 +58,23 @@ fun sanitizeAlertDurationSeconds(value: Int): Int {
         ?: DEFAULT_ALERT_DURATION_SECONDS
 }
 
+// --- Sound-delay caps (single source of truth for the hypo-safety policy) ---
+// A delayed audible alarm on a hypo is a double-edged sword, so LOW and
+// VERY_LOW are capped tighter than the rest. Change the policy here only.
+const val MAX_SOUND_DELAY_SECONDS = 300
+const val MAX_SOUND_DELAY_SECONDS_LOW = 60
+const val MAX_SOUND_DELAY_SECONDS_VERY_LOW = 30
+
+fun maxSoundDelaySecondsFor(type: AlertType): Int = when (type) {
+    AlertType.LOW -> MAX_SOUND_DELAY_SECONDS_LOW
+    AlertType.VERY_LOW -> MAX_SOUND_DELAY_SECONDS_VERY_LOW
+    else -> MAX_SOUND_DELAY_SECONDS
+}
+
+/** Clamp a requested delay to [0, cap-for-type]. Holds on every write path. */
+fun sanitizeSoundDelaySeconds(type: AlertType, value: Int): Int =
+    value.coerceIn(0, maxSoundDelaySecondsFor(type))
+
 /**
  * Delivery mode for alerts.
  */
@@ -94,6 +111,12 @@ data class AlertConfig(
     val vibrationEnabled: Boolean = true,
     val hapticProfile: HapticProfile = HapticProfile.STRONG,
     val flashEnabled: Boolean = false,
+
+    // Sound delay: vibrate first, add the audible alarm only after this delay.
+    // Only meaningful when soundEnabled && vibrationEnabled. 0 = immediate
+    // (today's behaviour). Capped per type for hypo safety (see caps below).
+    val soundDelayEnabled: Boolean = false,
+    val soundDelaySeconds: Int = 0,
     
     // Snooze settings
     val defaultSnoozeMinutes: Int = 15,

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -52,6 +52,14 @@ object AlertRepository {
     private fun keyRetryEnabled(type: AlertType) = "alert_${type.id}_retryOn"
     private fun keyRetryInterval(type: AlertType) = "alert_${type.id}_retryInt"
     private fun keyRetryCount(type: AlertType) = "alert_${type.id}_retryCnt"
+    // Sound delay ("vibrate first, audio after N seconds")
+    private fun keySoundDelayEnabled(type: AlertType) = "alert_${type.id}_soundDelayEnabled"
+    private fun keySoundDelaySeconds(type: AlertType) = "alert_${type.id}_soundDelay"
+
+    // Cap enforced on every read so a value written by any path (incl. the
+    // apply-to-all bulk edit onto LOW/VERY_LOW) can never exceed the hypo cap.
+    private fun readSoundDelaySeconds(type: AlertType): Int =
+        sanitizeSoundDelaySeconds(type, prefs.getInt(keySoundDelaySeconds(type), 0))
 
     private inline fun <reified T : Enum<T>> parseEnumPref(value: String?, fallback: T): T {
         return value?.let { raw ->
@@ -191,7 +199,9 @@ object AlertRepository {
             activeEndMinute = prefs.getInt(keyActiveEndMinute(type), -1).takeIf { it >= 0 },
             retryEnabled = prefs.getBoolean(keyRetryEnabled(type), false),
             retryIntervalMinutes = prefs.getInt(keyRetryInterval(type), 5),
-            retryCount = prefs.getInt(keyRetryCount(type), 3)
+            retryCount = prefs.getInt(keyRetryCount(type), 3),
+            soundDelayEnabled = prefs.getBoolean(keySoundDelayEnabled(type), false),
+            soundDelaySeconds = readSoundDelaySeconds(type)
         )
     }
 
@@ -241,10 +251,12 @@ object AlertRepository {
             activeEndMinute = prefs.getInt(keyActiveEndMinute(type), -1).takeIf { it >= 0 },
             retryEnabled = prefs.getBoolean(keyRetryEnabled(type), false),
             retryIntervalMinutes = prefs.getInt(keyRetryInterval(type), 5),
-            retryCount = prefs.getInt(keyRetryCount(type), 3)
+            retryCount = prefs.getInt(keyRetryCount(type), 3),
+            soundDelayEnabled = prefs.getBoolean(keySoundDelayEnabled(type), false),
+            soundDelaySeconds = readSoundDelaySeconds(type)
         )
     }
-    
+
     /**
      * Save configuration for an alert type.
      * For legacy types, writes to both SharedPreferences and Natives.
@@ -289,6 +301,8 @@ object AlertRepository {
             putBoolean(keyRetryEnabled(config.type), config.retryEnabled)
             putInt(keyRetryInterval(config.type), config.retryIntervalMinutes)
             putInt(keyRetryCount(config.type), config.retryCount)
+            putBoolean(keySoundDelayEnabled(config.type), config.soundDelayEnabled)
+            putInt(keySoundDelaySeconds(config.type), sanitizeSoundDelaySeconds(config.type, config.soundDelaySeconds))
         }
     }
     

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -664,6 +664,10 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="default_snooze">Standard-Schlummern</string>
     <string name="delete_custom_alert">Benutzerdefinierten Alarm loschen</string>
     <string name="duration_label">Dauer</string>
+    <string name="sound_delay_title">Alarmton verzögern</string>
+    <string name="sound_delay_desc">Zuerst nur vibrieren; der Alarmton setzt erst nach einer Verzögerung ein</string>
+    <string name="sound_delay_label">Ton-Verzögerung</string>
+    <string name="sound_delay_hypo_warning">Achtung: Dies verzögert den Alarmton bei einem Unterzucker-Alarm.</string>
     <string name="end">Ende</string>
     <string name="high_alert">Hoher Alarm</string>
     <string name="high_alerts">Hohe Alarme</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1195,6 +1195,10 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="default_snooze">Default snooze</string>
     <string name="delete_custom_alert">Delete custom alert</string>
     <string name="duration_label">Duration</string>
+    <string name="sound_delay_title">Delay alarm sound</string>
+    <string name="sound_delay_desc">Vibrate first; add the audible alarm only after a delay</string>
+    <string name="sound_delay_label">Sound delay</string>
+    <string name="sound_delay_hypo_warning">Caution: this delays the audible alarm for a low-glucose alert.</string>
     <string name="end">End</string>
     <string name="high_alert">High Alert</string>
     <string name="high_alerts">High Alerts</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
@@ -239,6 +239,8 @@ fun AlertSettingsScreen(
                                 retryEnabled = draft.retryEnabled,
                                 retryIntervalMinutes = draft.retryIntervalMinutes,
                                 retryCount = draft.retryCount,
+                                soundDelayEnabled = draft.soundDelayEnabled,
+                                soundDelaySeconds = draft.soundDelaySeconds,
                                 defaultSnoozeMinutes = draft.defaultSnoozeMinutes
                             )
                             persistConfigIfChanged(updated)

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/CommonAlertSettings.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/CommonAlertSettings.kt
@@ -17,9 +17,11 @@ import androidx.compose.ui.unit.dp
 import tk.glucodata.R
 import tk.glucodata.alerts.AlertConfig
 import tk.glucodata.alerts.AlertDeliveryMode
+import tk.glucodata.alerts.AlertType
 import tk.glucodata.alerts.MAX_ALERT_DURATION_SECONDS
 import tk.glucodata.alerts.MIN_ALERT_DURATION_SECONDS
 import tk.glucodata.alerts.HapticProfile
+import tk.glucodata.alerts.maxSoundDelaySecondsFor
 import tk.glucodata.ui.components.StyledSwitch
 import tk.glucodata.ui.util.ConnectedButtonGroup
 
@@ -195,6 +197,54 @@ fun CommonAlertSettings(
                 modifier = Modifier.padding(horizontal = sectionHorizontalPadding),
                 valueText = { seconds -> "$seconds ${stringResource(R.string.sec)}" }
             )
+        }
+
+        // === Sound delay (vibrate first, audio after N seconds) ===
+        // Only meaningful when both sound and vibration are on: otherwise there
+        // is nothing to delay, or a silent gap with no signal at all.
+        AnimatedVisibility(visible = config.soundEnabled && config.vibrationEnabled) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ClickableToggleRow(
+                    icon = Icons.Default.Timer,
+                    title = stringResource(R.string.sound_delay_title),
+                    subtitle = stringResource(R.string.sound_delay_desc),
+                    checked = config.soundDelayEnabled,
+                    onCheckedChange = { onConfigChange(config.copy(soundDelayEnabled = it)) }
+                )
+                AnimatedVisibility(visible = config.soundDelayEnabled) {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        val maxDelay = maxSoundDelaySecondsFor(config.type)
+                        DurationSlider(
+                            label = stringResource(R.string.sound_delay_label),
+                            value = config.soundDelaySeconds.coerceIn(0, maxDelay),
+                            range = 0..maxDelay,
+                            stepSize = 5,
+                            onValueChange = { onConfigChange(config.copy(soundDelaySeconds = it)) },
+                            modifier = Modifier.padding(horizontal = sectionHorizontalPadding),
+                            valueText = { seconds -> "$seconds ${stringResource(R.string.sec)}" }
+                        )
+                        if (config.type == AlertType.LOW || config.type == AlertType.VERY_LOW) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = sectionHorizontalPadding),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Icon(
+                                    Icons.Default.Warning,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Text(
+                                    stringResource(R.string.sound_delay_hypo_warning),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         // === Sound Settings (Conditional) ===

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/GlobalAlertSettingsCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/GlobalAlertSettingsCard.kt
@@ -269,5 +269,7 @@ internal fun AlertConfig.sameMasterDraft(other: AlertConfig): Boolean {
         retryEnabled == other.retryEnabled &&
         retryIntervalMinutes == other.retryIntervalMinutes &&
         retryCount == other.retryCount &&
+        soundDelayEnabled == other.soundDelayEnabled &&
+        soundDelaySeconds == other.soundDelaySeconds &&
         defaultSnoozeMinutes == other.defaultSnoozeMinutes
 }

--- a/Common/src/test/java/tk/glucodata/alerts/SoundDelayCapTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/SoundDelayCapTests.kt
@@ -1,0 +1,46 @@
+package tk.glucodata.alerts
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The hypo-safety cap policy for the delayed alarm sound. This is the single
+ * source of truth used by both persistence (AlertRepository) and playback
+ * (Notify.getSoundDelaySeconds), so it is worth pinning down.
+ */
+class SoundDelayCapTests {
+
+    @Test
+    fun capsAreTighterForHypoTypes() {
+        assertEquals(60, maxSoundDelaySecondsFor(AlertType.LOW))
+        assertEquals(30, maxSoundDelaySecondsFor(AlertType.VERY_LOW))
+        assertEquals(300, maxSoundDelaySecondsFor(AlertType.HIGH))
+        assertEquals(300, maxSoundDelaySecondsFor(AlertType.VERY_HIGH))
+        assertEquals(300, maxSoundDelaySecondsFor(AlertType.PRE_LOW))
+        assertEquals(300, maxSoundDelaySecondsFor(AlertType.MISSED_READING))
+    }
+
+    @Test
+    fun sanitizeClampsToTypeCap() {
+        assertEquals(60, sanitizeSoundDelaySeconds(AlertType.LOW, 120))
+        assertEquals(30, sanitizeSoundDelaySeconds(AlertType.VERY_LOW, 120))
+        assertEquals(120, sanitizeSoundDelaySeconds(AlertType.HIGH, 120))
+        assertEquals(300, sanitizeSoundDelaySeconds(AlertType.HIGH, 999))
+    }
+
+    @Test
+    fun sanitizeClampsNegativesToZero() {
+        assertEquals(0, sanitizeSoundDelaySeconds(AlertType.HIGH, -5))
+        assertEquals(0, sanitizeSoundDelaySeconds(AlertType.LOW, 0))
+        assertEquals(45, sanitizeSoundDelaySeconds(AlertType.LOW, 45))
+    }
+
+    @Test
+    fun defaultConfigHasNoDelayForEveryType() {
+        for (type in AlertType.entries) {
+            val cfg = AlertConfig(type = type)
+            assertEquals(false, cfg.soundDelayEnabled)
+            assertEquals(0, cfg.soundDelaySeconds)
+        }
+    }
+}

--- a/Common/src/test/java/tk/glucodata/ui/alerts/GlobalAlertSettingsCardTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/alerts/GlobalAlertSettingsCardTests.kt
@@ -52,6 +52,22 @@ class GlobalAlertSettingsCardTests {
         )
     }
 
+    @Test
+    fun applyIsEnabledWhenOnlySoundDelayChanged() {
+        // Guards that soundDelayEnabled/soundDelaySeconds are part of
+        // sameMasterDraft(); otherwise the Apply button stays inert.
+        val applied = soundOnlyDraft().copy(vibrationEnabled = true)
+        val changedDraft = applied.copy(soundDelayEnabled = true, soundDelaySeconds = 30)
+
+        assertTrue(
+            shouldEnableApplyToAll(
+                draftConfig = changedDraft,
+                appliedDraft = applied,
+                allConfigs = mapOf(AlertType.LOW to changedDraft)
+            )
+        )
+    }
+
     private fun soundOnlyDraft(): AlertConfig {
         return AlertConfig(
             type = AlertType.LOW,


### PR DESCRIPTION
Adds an optional per-alert delay so an alert vibrates (and flashes) first, and only starts the audible alarm after a configurable number of seconds. If you dismiss, snooze, or the value leaves the alarm condition within the delay, no sound plays. Same idea as GlucoDataHandler's alarm delay: a chance to react quietly at night or in a meeting before the phone gets loud.

`AlertConfig` gets `soundDelayEnabled` and `soundDelaySeconds`, both off/0 by default, so current behaviour is unchanged. The hypo-safety cap lives in one place: LOW caps at 60s, VERY_LOW at 30s, everything else at 300s, and the cap is re-applied on every read and write, so a value set through the apply-to-all bulk edit onto LOW/VERY_LOW can't slip past it.

In `Notify.playringhier`, vibration and flash start immediately and only `soundHandle.play()` is scheduled after the delay. The auto-stop timer is pushed out by the same amount so the sound still plays for its full duration once it starts, and the gradual fade-in inside `play()` carries over unchanged. The pending sound is cancelled through the shared `cancelDelayedAlertEffectsLocked` hook that every stop path already funnels through: dismiss, snooze, alert resolution, and retry.

Per-alert UI (a toggle and a delay slider) shows only when both sound and vibration are on, with a warning on the hypo alerts. The two fields are wired into apply-to-all and `sameMasterDraft`, so "set globally" keeps working. Strings EN/DE. Tests cover the cap policy, the no-delay defaults for every type, and that a delay-only change is picked up by `sameMasterDraft`.

On Doze: the delayed sound uses the same scheduler as the other alarm effects. For the short delays this targets, with the CGM foreground service already running, that held up in testing. An AlarmManager fallback would be the next step if longer delays turn out flaky.

A full build currently needs #94 (Somali strings escaping fix), which is unrelated to this change.
