### PR TITLE
Multiple configurable sensor-expiry warnings instead of a fixed 24h

### DIFF
--- a/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
@@ -58,6 +58,15 @@ fun sanitizeAlertDurationSeconds(value: Int): Int {
         ?: DEFAULT_ALERT_DURATION_SECONDS
 }
 
+// Sensor-expiry pre-warning thresholds (minutes before end), single source of
+// truth for the UI chips and validation. Descending = longest lead time first.
+val EXPIRY_WARNING_PRESETS: List<Int> = listOf(4320, 2880, 1440, 720, 360, 120, 60)
+const val DEFAULT_EXPIRY_WARNING_MINUTES = 1440   // 24h — preserves today's behaviour
+
+/** Keep only recognised presets, so stray persisted values can't leak through. */
+fun sanitizeExpiryWarningMinutes(values: Set<Int>): Set<Int> =
+    values.filter { it in EXPIRY_WARNING_PRESETS }.toSet()
+
 /**
  * Delivery mode for alerts.
  */
@@ -112,7 +121,11 @@ data class AlertConfig(
     // === NEW: Retry settings ("try again if no reaction") ===
     val retryEnabled: Boolean = false,
     val retryIntervalMinutes: Int = 5,      // Re-alert every X minutes
-    val retryCount: Int = 3                 // Max number of retries (0 = unlimited until dismissed)
+    val retryCount: Int = 3,                // Max number of retries (0 = unlimited until dismissed)
+
+    // Sensor-expiry only: warn this many minutes before the sensor ends. Each
+    // selected threshold fires once per sensor. Empty = no pre-warning.
+    val expiryWarningMinutes: Set<Int> = emptySet()
 ) {
     /**
      * Whether this alert should use the old system alarm path (AlarmActivity).
@@ -290,7 +303,8 @@ object AlertDefaults {
                 deliveryMode = AlertDeliveryMode.NOTIFICATION_ONLY,
                 hapticProfile = HapticProfile.SOFT,
                 soundEnabled = true,
-                defaultSnoozeMinutes = 120
+                defaultSnoozeMinutes = 120,
+                expiryWarningMinutes = setOf(DEFAULT_EXPIRY_WARNING_MINUTES)
             )
             AlertType.LOSS -> AlertConfig(
                 type = type,

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -52,6 +52,17 @@ object AlertRepository {
     private fun keyRetryEnabled(type: AlertType) = "alert_${type.id}_retryOn"
     private fun keyRetryInterval(type: AlertType) = "alert_${type.id}_retryInt"
     private fun keyRetryCount(type: AlertType) = "alert_${type.id}_retryCnt"
+    // Sensor-expiry pre-warning thresholds (minutes), stored as a StringSet.
+    private fun keyExpiryWarnings(type: AlertType) = "alert_${type.id}_expiryWarnings"
+
+    /** Missing key -> default (24h migration); present-but-empty -> no pre-warning. */
+    private fun readExpiryWarnings(type: AlertType, default: Set<Int>): Set<Int> {
+        if (!prefs.contains(keyExpiryWarnings(type))) {
+            return default
+        }
+        val raw = prefs.getStringSet(keyExpiryWarnings(type), null) ?: return default
+        return sanitizeExpiryWarningMinutes(raw.mapNotNull { it.toIntOrNull() }.toSet())
+    }
 
     private inline fun <reified T : Enum<T>> parseEnumPref(value: String?, fallback: T): T {
         return value?.let { raw ->
@@ -241,10 +252,11 @@ object AlertRepository {
             activeEndMinute = prefs.getInt(keyActiveEndMinute(type), -1).takeIf { it >= 0 },
             retryEnabled = prefs.getBoolean(keyRetryEnabled(type), false),
             retryIntervalMinutes = prefs.getInt(keyRetryInterval(type), 5),
-            retryCount = prefs.getInt(keyRetryCount(type), 3)
+            retryCount = prefs.getInt(keyRetryCount(type), 3),
+            expiryWarningMinutes = readExpiryWarnings(type, default.expiryWarningMinutes)
         )
     }
-    
+
     /**
      * Save configuration for an alert type.
      * For legacy types, writes to both SharedPreferences and Natives.
@@ -289,6 +301,13 @@ object AlertRepository {
             putBoolean(keyRetryEnabled(config.type), config.retryEnabled)
             putInt(keyRetryInterval(config.type), config.retryIntervalMinutes)
             putInt(keyRetryCount(config.type), config.retryCount)
+            // Type-specific: only the sensor-expiry alert carries pre-warnings.
+            if (config.type == AlertType.SENSOR_EXPIRY) {
+                putStringSet(
+                    keyExpiryWarnings(config.type),
+                    sanitizeExpiryWarningMinutes(config.expiryWarningMinutes).map { it.toString() }.toSet()
+                )
+            }
         }
     }
     

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -19,7 +19,6 @@ data class AlertRuntimeEvaluation(
 object AlertRuntimeManager {
     private const val LOG_ID = "AlertRuntimeManager"
     private const val CHECK_INTERVAL_MS = 15_000L
-    private const val SENSOR_EXPIRY_WARNING_MS = 24L * 60L * 60L * 1000L
 
     private val scheduler = Executors.newSingleThreadScheduledExecutor()
     private val lock = Any()
@@ -373,18 +372,21 @@ object AlertRuntimeManager {
             0L
         }
 
+        val thresholds = config.expiryWarningMinutes
         val activeNow = config.isActiveNow()
         val snoozed = SnoozeManager.isSnoozed(type)
-        val shouldTrigger = sensorExpiryState.shouldTrigger(
+        val triggered = sensorExpiryState.triggeredThresholds(
             enabled = true,
             activeNow = activeNow,
             snoozed = snoozed,
             endTimeMs = endTimeMs,
             nowMs = nowMs,
-            warningMs = SENSOR_EXPIRY_WARNING_MS
+            thresholdsMinutes = thresholds
         )
 
-        if (endTimeMs <= 0L || endTimeMs - nowMs > SENSOR_EXPIRY_WARNING_MS) {
+        // Not yet within even the longest configured lead time -> nothing pending.
+        val largestThresholdMs = (thresholds.maxOrNull() ?: 0).toLong() * 60_000L
+        if (endTimeMs <= 0L || thresholds.isEmpty() || endTimeMs - nowMs > largestThresholdMs) {
             clearRuntimeAlert(type, "sensor-expiry-not-due")
             return
         }
@@ -393,16 +395,29 @@ object AlertRuntimeManager {
             clearRuntimeAlert(type, "sensor-expiry-time-inactive")
             return
         }
-        if (snoozed || !shouldTrigger) {
+        if (snoozed || triggered.isEmpty()) {
             return
         }
 
         val glucoseValue = currentGlucoseValueLocked() ?: return
-        val remainingHours = ((endTimeMs - nowMs).coerceAtLeast(0L) / 3_600_000L).toInt().coerceAtLeast(1)
-        val message = Applic.app.getString(R.string.alert_sensor_expiry) + " - " +
-            Applic.app.getString(R.string.hours_short, remainingHours)
+        val message = sensorExpiryMessage(triggered.first())
 
         triggerAlert(type, glucoseValue, currentRateLocked(), message)
+    }
+
+    /** Notification text naming the threshold that fired ("... in 3 days" / "... in 6 hours"). */
+    private fun sensorExpiryMessage(thresholdMinutes: Int): String {
+        val res = Applic.app.resources
+        return when {
+            thresholdMinutes >= 1440 && thresholdMinutes % 1440 == 0 -> {
+                val days = thresholdMinutes / 1440
+                res.getQuantityString(R.plurals.sensor_expires_in_days, days, days)
+            }
+            else -> {
+                val hours = (thresholdMinutes / 60).coerceAtLeast(1)
+                res.getQuantityString(R.plurals.sensor_expires_in_hours, hours, hours)
+            }
+        }
     }
 
     private fun triggerAlert(type: AlertType, glucoseValue: Float, rate: Float, message: String): Boolean {

--- a/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
@@ -1,62 +1,110 @@
 package tk.glucodata.alerts
 
+/**
+ * Edge-triggered latch for the sensor-expiry pre-warnings, one latch per
+ * configured threshold. Each threshold fires exactly once per sensor when the
+ * clock first crosses into its warning window (`endTimeMs - now <= threshold`).
+ *
+ * Preserved semantics from the original single-threshold version, now per
+ * threshold:
+ *  - **Edge-triggered:** fire on window entry, not on every 15s tick.
+ *  - **New sensor** (`endTimeMs` changes): rearm every threshold.
+ *  - **Baseline:** the first active pass only records current window membership
+ *    and fires nothing, so starting the app already inside several windows does
+ *    not produce a burst of alerts.
+ *  - **Newly enabled thresholds** whose window is already past are adopted like
+ *    the baseline (marked warned, never fired retroactively).
+ *  - **Cascade guard:** if several thresholds come due in the same tick (e.g. the
+ *    app resumes deep inside multiple windows), fire only the smallest (most
+ *    urgent) and silently mark the rest as warned.
+ */
 internal class SensorExpiryAlertState {
     private var baselineReady = false
     private var lastEndTimeMs = 0L
-    private var wasInWarningWindow = false
-    private var alertedForEndTimeMs = 0L
+    private val wasInWindow = mutableMapOf<Int, Boolean>()   // threshold -> inside window last tick
+    private val alertedForEnd = mutableMapOf<Int, Long>()    // threshold -> endTime already warned for
 
     fun reset() {
         baselineReady = false
         lastEndTimeMs = 0L
-        wasInWarningWindow = false
-        alertedForEndTimeMs = 0L
+        wasInWindow.clear()
+        alertedForEnd.clear()
     }
 
-    fun shouldTrigger(
+    /**
+     * @return the thresholds (in minutes) that should fire an alert right now.
+     *   At most one element (cascade guard); empty means do nothing.
+     */
+    fun triggeredThresholds(
         enabled: Boolean,
         activeNow: Boolean,
         snoozed: Boolean,
         endTimeMs: Long,
         nowMs: Long,
-        warningMs: Long
-    ): Boolean {
-        if (!enabled || endTimeMs <= 0L || warningMs <= 0L) {
+        thresholdsMinutes: Set<Int>
+    ): Set<Int> {
+        if (!enabled || endTimeMs <= 0L || thresholdsMinutes.isEmpty()) {
             reset()
-            return false
+            return emptySet()
         }
 
+        // New sensor -> new episode: rearm everything.
         if (endTimeMs != lastEndTimeMs) {
             baselineReady = false
             lastEndTimeMs = endTimeMs
-            wasInWarningWindow = false
-            alertedForEndTimeMs = 0L
+            wasInWindow.clear()
+            alertedForEnd.clear()
         }
+
+        // Forget thresholds the user has removed so the maps stay bounded.
+        wasInWindow.keys.retainAll(thresholdsMinutes)
+        alertedForEnd.keys.retainAll(thresholdsMinutes)
 
         if (!activeNow || snoozed) {
-            return false
+            return emptySet()
         }
 
-        val inWarningWindow = endTimeMs - nowMs <= warningMs
+        fun inWindow(minutes: Int): Boolean =
+            endTimeMs - nowMs <= minutes.toLong() * 60_000L
+
+        // First active pass: adopt current membership, fire nothing.
         if (!baselineReady) {
             baselineReady = true
-            wasInWarningWindow = inWarningWindow
-            if (inWarningWindow) {
-                alertedForEndTimeMs = endTimeMs
+            for (t in thresholdsMinutes) {
+                val inside = inWindow(t)
+                wasInWindow[t] = inside
+                if (inside) alertedForEnd[t] = endTimeMs
             }
-            return false
+            return emptySet()
         }
 
-        if (!inWarningWindow) {
-            wasInWarningWindow = false
-            return false
+        val newlyDue = mutableListOf<Int>()
+        for (t in thresholdsMinutes) {
+            val inside = inWindow(t)
+            val known = wasInWindow.containsKey(t)
+            val prev = wasInWindow[t] ?: false
+            wasInWindow[t] = inside
+            if (!known) {
+                // Threshold enabled mid-episode: adopt like the baseline, never
+                // fire retroactively for a window that is already open.
+                if (inside) alertedForEnd[t] = endTimeMs
+                continue
+            }
+            if (inside && !prev && alertedForEnd[t] != endTimeMs) {
+                newlyDue.add(t)
+            }
         }
 
-        val shouldTrigger = !wasInWarningWindow && alertedForEndTimeMs != endTimeMs
-        wasInWarningWindow = true
-        if (shouldTrigger) {
-            alertedForEndTimeMs = endTimeMs
+        if (newlyDue.isEmpty()) {
+            return emptySet()
         }
-        return shouldTrigger
+
+        // Cascade guard: fire only the most urgent (smallest lead time); mark the
+        // rest as warned so they never fire late.
+        val fire = newlyDue.min()
+        for (t in newlyDue) {
+            alertedForEnd[t] = endTimeMs
+        }
+        return setOf(fire)
     }
 }

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -723,6 +723,19 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="alert_sensor_expiry">Sensorablauf</string>
     <string name="missed_reading_channel_description">Alerts when no glucose reading arrives for the configured duration</string>
     <string name="sensor_expiry_channel_description">Alerts when the current sensor is nearing expiry</string>
+    <!-- Sensor-Ablauf-Vorwarnungen -->
+    <string name="sensor_expiry_warnings_title">Vor Ablauf warnen</string>
+    <string name="sensor_expiry_warnings_desc">Jede gewählte Zeit warnt einmal pro Sensor</string>
+    <string name="sensor_expiry_group_days">Tage</string>
+    <string name="sensor_expiry_group_hours">Stunden</string>
+    <plurals name="sensor_expires_in_days">
+        <item quantity="one">Sensor läuft in %d Tag ab</item>
+        <item quantity="other">Sensor läuft in %d Tagen ab</item>
+    </plurals>
+    <plurals name="sensor_expires_in_hours">
+        <item quantity="one">Sensor läuft in %d Stunde ab</item>
+        <item quantity="other">Sensor läuft in %d Stunden ab</item>
+    </plurals>
     <string name="alert_value_available">Wert verfügbar</string>
     <string name="alert_very_high">Sehr hoch</string>
     <string name="alert_very_low">Sehr niedrig</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -808,6 +808,19 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="alert_sensor_expiry">Sensor Expiry</string>
     <string name="missed_reading_channel_description">Alerts when no glucose reading arrives for the configured duration</string>
     <string name="sensor_expiry_channel_description">Alerts when the current sensor is nearing expiry</string>
+    <!-- Sensor-expiry pre-warnings -->
+    <string name="sensor_expiry_warnings_title">Warn before expiry</string>
+    <string name="sensor_expiry_warnings_desc">Each selected time warns once per sensor</string>
+    <string name="sensor_expiry_group_days">Days</string>
+    <string name="sensor_expiry_group_hours">Hours</string>
+    <plurals name="sensor_expires_in_days">
+        <item quantity="one">Sensor expires in %d day</item>
+        <item quantity="other">Sensor expires in %d days</item>
+    </plurals>
+    <plurals name="sensor_expires_in_hours">
+        <item quantity="one">Sensor expires in %d hour</item>
+        <item quantity="other">Sensor expires in %d hours</item>
+    </plurals>
     <string name="alert_value_available">Value Available</string>
     <string name="alert_amount">Amount Alert</string>
 

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
@@ -1083,10 +1083,81 @@ private fun AlertSettingsExpanded(
                         }
                     }
                 }
+
+                // === Sensor-expiry pre-warnings (multi-select, this type only) ===
+                if (config.type == AlertType.SENSOR_EXPIRY) {
+                    SensorExpiryThresholdSelector(
+                        selected = config.expiryWarningMinutes,
+                        onToggle = { minutes ->
+                            val next = if (minutes in config.expiryWarningMinutes) {
+                                config.expiryWarningMinutes - minutes
+                            } else {
+                                config.expiryWarningMinutes + minutes
+                            }
+                            onConfigChange(config.copy(expiryWarningMinutes = next))
+                        }
+                    )
+                }
             }
         )
     }
-}    
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun SensorExpiryThresholdSelector(
+    selected: Set<Int>,
+    onToggle: (Int) -> Unit
+) {
+    val days = EXPIRY_WARNING_PRESETS.filter { it >= 1440 }
+    val hours = EXPIRY_WARNING_PRESETS.filter { it < 1440 }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            stringResource(R.string.sensor_expiry_warnings_title),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            stringResource(R.string.sensor_expiry_warnings_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Text(
+            stringResource(R.string.sensor_expiry_group_days),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            days.forEach { minutes ->
+                val on = minutes in selected
+                FilterChip(
+                    selected = on,
+                    onClick = { onToggle(minutes) },
+                    label = { Text(stringResource(R.string.days_short, minutes / 1440)) },
+                    leadingIcon = { if (on) Icon(Icons.Filled.Check, contentDescription = null) }
+                )
+            }
+        }
+
+        Text(
+            stringResource(R.string.sensor_expiry_group_hours),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            hours.forEach { minutes ->
+                val on = minutes in selected
+                FilterChip(
+                    selected = on,
+                    onClick = { onToggle(minutes) },
+                    label = { Text(stringResource(R.string.hours_short, minutes / 60)) },
+                    leadingIcon = { if (on) Icon(Icons.Filled.Check, contentDescription = null) }
+                )
+            }
+        }
+    }
+}
         
 //        HorizontalDivider()
         

--- a/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
@@ -1,114 +1,134 @@
 package tk.glucodata.alerts
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SensorExpiryAlertStateTests {
-    private val warningMs = 24L * 60L * 60L * 1000L
+
+    // A sensor end far enough in the future that "N minutes before end" is always positive.
+    private val end = 100L * 24 * 60 * 60 * 1000
+
+    private fun min(m: Int) = m.toLong() * 60_000L
+
+    /** Evaluate a tick "minutesBefore" minutes before [endMs]. */
+    private fun SensorExpiryAlertState.fire(
+        minutesBefore: Int,
+        thresholds: Set<Int>,
+        endMs: Long = end,
+        snoozed: Boolean = false,
+        active: Boolean = true
+    ): Set<Int> = triggeredThresholds(
+        enabled = true,
+        activeNow = active,
+        snoozed = snoozed,
+        endTimeMs = endMs,
+        nowMs = endMs - min(minutesBefore),
+        thresholdsMinutes = thresholds
+    )
+
+    private val T3D = 4320
+    private val T1D = 1440
+    private val T6H = 360
 
     @Test
-    fun firstObservationInsideWarningWindowDoesNotFire() {
-        val state = SensorExpiryAlertState()
-        val endTime = 1_000_000L
+    fun singleThresholdFiresOnceOnEntry() {
+        val s = SensorExpiryAlertState()
+        val t = setOf(T1D)
+        assertEquals(emptySet<Int>(), s.fire(1800, t))     // 30h before: baseline, outside window
+        assertEquals(emptySet<Int>(), s.fire(1500, t))     // 25h before: still outside
+        assertEquals(setOf(T1D), s.fire(1440, t))          // 24h before: crosses in -> fire
+        assertEquals(emptySet<Int>(), s.fire(1200, t))     // inside: no re-fire
+        assertEquals(emptySet<Int>(), s.fire(60, t))
+    }
 
-        assertFalse(
-            state.shouldTrigger(
-                enabled = true,
-                activeNow = true,
-                snoozed = false,
-                endTimeMs = endTime,
-                nowMs = endTime - 60_000L,
-                warningMs = warningMs
-            )
+    @Test
+    fun firstObservationInsideWindowDoesNotFire() {
+        val s = SensorExpiryAlertState()
+        assertEquals(emptySet<Int>(), s.fire(60, setOf(T1D)))   // baseline already inside
+        assertEquals(emptySet<Int>(), s.fire(30, setOf(T1D)))
+    }
+
+    @Test
+    fun multipleThresholdsEachFireOnceInOrder() {
+        val s = SensorExpiryAlertState()
+        val t = setOf(T3D, T1D, T6H)
+        assertEquals(emptySet<Int>(), s.fire(5760, t))     // 4d before: baseline, outside all
+        assertEquals(setOf(T3D), s.fire(4320, t))          // enter 3d
+        assertEquals(emptySet<Int>(), s.fire(4000, t))     // inside 3d, no new edge
+        assertEquals(setOf(T1D), s.fire(1440, t))          // enter 1d
+        assertEquals(setOf(T6H), s.fire(360, t))           // enter 6h
+        assertEquals(emptySet<Int>(), s.fire(30, t))
+    }
+
+    @Test
+    fun baselineInsideSeveralWindowsFiresNothing() {
+        val s = SensorExpiryAlertState()
+        val t = setOf(T3D, T1D, T6H)
+        assertEquals(emptySet<Int>(), s.fire(300, t))      // 5h before: inside all three -> baseline
+        assertEquals(emptySet<Int>(), s.fire(120, t))      // still nothing
+    }
+
+    @Test
+    fun newSensorRearmsAllThresholds() {
+        val s = SensorExpiryAlertState()
+        val t = setOf(T1D)
+        s.fire(1800, t)
+        assertEquals(setOf(T1D), s.fire(1440, t))
+        // A different end time = new sensor: the whole sequence runs again.
+        val end2 = end + 14L * 24 * 60 * 60 * 1000
+        assertEquals(emptySet<Int>(), s.fire(1800, t, endMs = end2))   // baseline for new sensor
+        assertEquals(setOf(T1D), s.fire(1440, t, endMs = end2))
+    }
+
+    @Test
+    fun addingThresholdInsideItsWindowDoesNotFireRetroactively() {
+        val s = SensorExpiryAlertState()
+        s.fire(4320, setOf(T6H))                           // baseline outside the 6h window (with 6h only)
+        // Now 3h before end, user adds the 1d threshold whose window opened long ago.
+        val res = s.fire(180, setOf(T6H, T1D))
+        assertEquals(setOf(T6H), res)                      // 6h crosses now and fires; 1d is NOT retroactive
+    }
+
+    @Test
+    fun cascadeFiresOnlySmallestWhenSeveralComeDueAtOnce() {
+        val s = SensorExpiryAlertState()
+        val t = setOf(T3D, T1D, T6H)
+        s.fire(5760, t)                                    // baseline outside all
+        // Big jump (e.g. app resumed) straight to 30 min before end.
+        assertEquals(setOf(T6H), s.fire(30, t))            // only the most urgent fires
+        assertEquals(emptySet<Int>(), s.fire(20, t))       // rest silently marked warned
+    }
+
+    @Test
+    fun snoozeDefersButDoesNotSwallowThreshold() {
+        val s = SensorExpiryAlertState()
+        val t = setOf(T3D, T1D)
+        s.fire(5760, t)                                    // baseline outside
+        assertEquals(setOf(T3D), s.fire(4320, t))          // 3d fires
+        // Snoozed while the 1d window is crossed: nothing now...
+        assertEquals(emptySet<Int>(), s.fire(1440, t, snoozed = true))
+        // ...but once snooze ends it still fires (not swallowed).
+        assertEquals(setOf(T1D), s.fire(1400, t))
+    }
+
+    @Test
+    fun emptyOrDisabledFiresNothing() {
+        val s = SensorExpiryAlertState()
+        assertEquals(emptySet<Int>(), s.fire(60, emptySet()))
+        assertEquals(
+            emptySet<Int>(),
+            s.triggeredThresholds(false, true, false, end, end - min(60), setOf(T1D))
         )
     }
 
     @Test
-    fun crossingIntoWarningWindowFiresOnce() {
-        val state = SensorExpiryAlertState()
-        val endTime = 2_000_000_000L
-
-        assertFalse(
-            state.shouldTrigger(
-                enabled = true,
-                activeNow = true,
-                snoozed = false,
-                endTimeMs = endTime,
-                nowMs = endTime - warningMs - 1_000L,
-                warningMs = warningMs
-            )
-        )
-        assertTrue(
-            state.shouldTrigger(
-                enabled = true,
-                activeNow = true,
-                snoozed = false,
-                endTimeMs = endTime,
-                nowMs = endTime - warningMs,
-                warningMs = warningMs
-            )
-        )
-        assertFalse(
-            state.shouldTrigger(
-                enabled = true,
-                activeNow = true,
-                snoozed = false,
-                endTimeMs = endTime,
-                nowMs = endTime - warningMs + 60_000L,
-                warningMs = warningMs
-            )
-        )
+    fun defaultSensorExpiryConfigKeeps24hThreshold() {
+        val cfg = AlertDefaults.defaultConfig(AlertType.SENSOR_EXPIRY, isMmol = false)
+        assertEquals(setOf(1440), cfg.expiryWarningMinutes)
     }
 
     @Test
-    fun newSensorEndTimeStartsANewEpisode() {
-        val state = SensorExpiryAlertState()
-        val firstEndTime = 2_000_000_000L
-        val secondEndTime = firstEndTime + (14L * 24L * 60L * 60L * 1000L)
-
-        state.shouldTrigger(true, true, false, firstEndTime, firstEndTime - warningMs - 1_000L, warningMs)
-        assertTrue(state.shouldTrigger(true, true, false, firstEndTime, firstEndTime - warningMs, warningMs))
-
-        assertFalse(
-            state.shouldTrigger(
-                enabled = true,
-                activeNow = true,
-                snoozed = false,
-                endTimeMs = secondEndTime,
-                nowMs = secondEndTime - warningMs - 1_000L,
-                warningMs = warningMs
-            )
-        )
-        assertTrue(
-            state.shouldTrigger(
-                enabled = true,
-                activeNow = true,
-                snoozed = false,
-                endTimeMs = secondEndTime,
-                nowMs = secondEndTime - warningMs,
-                warningMs = warningMs
-            )
-        )
-    }
-
-    @Test
-    fun disabledStateResetsBaseline() {
-        val state = SensorExpiryAlertState()
-        val endTime = 2_000_000_000L
-
-        state.shouldTrigger(true, true, false, endTime, endTime - warningMs - 1_000L, warningMs)
-        assertFalse(state.shouldTrigger(false, true, false, endTime, endTime - warningMs, warningMs))
-
-        assertFalse(
-            state.shouldTrigger(
-                enabled = true,
-                activeNow = true,
-                snoozed = false,
-                endTimeMs = endTime,
-                nowMs = endTime - warningMs,
-                warningMs = warningMs
-            )
-        )
+    fun sanitizeDropsUnknownThresholds() {
+        assertEquals(setOf(1440, 360), sanitizeExpiryWarningMinutes(setOf(1440, 360, 999, 7)))
     }
 }


### PR DESCRIPTION
`SENSOR_EXPIRY` fires once, 24h before the sensor ends, from a hard-coded `SENSOR_EXPIRY_WARNING_MS`. This lets you choose several lead times at once (3d, 2d, 1d, 12h, 6h, 2h, 1h), each firing once per sensor.

`AlertConfig` gets `expiryWarningMinutes: Set<Int>` with the presets in a single constant, defaulting to `setOf(1440)` so existing users see no change. It persists as a StringSet under the existing key scheme; a missing key migrates to 24h, and present-but-empty means no pre-warning. The field is specific to this alert type, so it stays out of apply-to-all and `sameMasterDraft` on purpose.

The real work is in `SensorExpiryAlertState`, which latched a single threshold. It's now a latch per threshold, keeping the existing semantics for each: edge-triggered on window entry, a full reset when the sensor end time changes, and the baseline behaviour so opening the app already inside several windows doesn't fire a burst of catch-up alerts. A threshold enabled after its window has already passed is adopted like the baseline instead of firing retroactively, and when several come due in the same tick only the most urgent fires while the rest are marked as warned.

`AlertRuntimeManager` drops the constant, bails against the largest active threshold, and names the threshold that fired in the notification ("expires in 3 days", "in 6 hours") using plurals. The multi-select FilterChip UI shows only for SENSOR_EXPIRY. `SensorExpiryAlertState` had no tests before; this adds coverage for single and multiple thresholds, the baseline, a new sensor, a runtime add, the cascade guard, and snooze deferral.

Unrelated, noticed while in here: `AlertRuntimeManager` bails with `currentGlucoseValueLocked() ?: return` before firing, so the expiry alert depends on a current glucose reading, which has nothing to do with sensor runtime. Left it alone, happy to open a separate issue.

A full build currently needs #94 (Somali strings escaping fix), which is unrelated to this change.
