### PR TITLE
Falling/rising-fast delta alarms, and a 1-or-5-minute delta interval

### DIFF
--- a/Common/src/main/java/tk/glucodata/GlucoseDelta.java
+++ b/Common/src/main/java/tk/glucodata/GlucoseDelta.java
@@ -1,0 +1,67 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import java.util.Locale;
+
+/**
+ * The "Δ" readout: measured change over the last ~5 minutes, in display
+ * units. Unlike the trend arrow (an estimate over a window) this is a raw
+ * measurement, an independent number to sanity-check the arrow's angle and
+ * color against. Five minutes rather than one: adjacent readings repeat on
+ * plain sensor noise, so a one-minute delta shows "0" next to a visibly
+ * climbing chart — GDH's 5-minute-delta option exists for the same reason.
+ */
+public final class GlucoseDelta {
+    public static final long WINDOW_MILLIS = 5L * 60L * 1000L;
+    // Callers walk back to a point at least this much older than the newest.
+    public static final long MIN_GAP_MILLIS = 4L * 60L * 1000L + 30_000L;
+    // A pair further apart says nothing about the current change.
+    private static final long MAX_GAP_MILLIS = 20L * 60L * 1000L;
+
+    private GlucoseDelta() {
+    }
+
+    /**
+     * Change over the pair's gap scaled to a 5-minute equivalent; NaN when
+     * the pair is closer than half the window (extrapolating a single noisy
+     * minute 5x would defeat the purpose) or further than 20 minutes.
+     */
+    public static float fiveMinuteDelta(long newMillis, float newValue, long prevMillis, float prevValue) {
+        if (!Float.isFinite(newValue) || !Float.isFinite(prevValue))
+            return Float.NaN;
+        final long gap = newMillis - prevMillis;
+        if (gap < WINDOW_MILLIS / 2L || gap > MAX_GAP_MILLIS)
+            return Float.NaN;
+        return (newValue - prevValue) * ((float) WINDOW_MILLIS / gap);
+    }
+
+    /**
+     * Compact signed text: mg/dL as integer when close to one ("-1", "+2"),
+     * one decimal otherwise; mmol always one decimal. Dot separator like the
+     * value displays of GDH-style receivers.
+     */
+    public static String format(float deltaPerMinute, boolean isMmol) {
+        if (!Float.isFinite(deltaPerMinute))
+            return "";
+        final float rounded = Math.round(deltaPerMinute * 10f) / 10f;
+        final String sign = rounded > 0f ? "+" : "";
+        if (!isMmol && Math.abs(rounded - Math.round(rounded)) < 0.05f)
+            return sign + Math.round(rounded);
+        return sign + String.format(Locale.ROOT, "%.1f", rounded);
+    }
+}

--- a/Common/src/main/java/tk/glucodata/GlucoseDelta.java
+++ b/Common/src/main/java/tk/glucodata/GlucoseDelta.java
@@ -19,16 +19,20 @@ package tk.glucodata;
 import java.util.Locale;
 
 /**
- * The "Δ" readout: measured change over the last ~5 minutes, in display
- * units. Unlike the trend arrow (an estimate over a window) this is a raw
- * measurement, an independent number to sanity-check the arrow's angle and
- * color against. Five minutes rather than one: adjacent readings repeat on
- * plain sensor noise, so a one-minute delta shows "0" next to a visibly
- * climbing chart — GDH's 5-minute-delta option exists for the same reason.
+ * The "Δ" readout: measured change over a configurable interval (1 or 5
+ * minutes), in display units. Unlike the trend arrow (an estimate over a
+ * window) this is a raw measurement, an independent number to sanity-check
+ * the arrow's angle and color against. Five minutes rather than one: adjacent
+ * readings repeat on plain sensor noise, so a one-minute delta shows "0" next
+ * to a visibly climbing chart — GDH exposes the same 1-vs-5-minute choice for
+ * the same reason. The interval is a global setting; the same value drives the
+ * readout and the FALLING_FAST / RISING_FAST delta alarms.
  */
 public final class GlucoseDelta {
+    public static final int DEFAULT_INTERVAL_MINUTES = 5;
     public static final long WINDOW_MILLIS = 5L * 60L * 1000L;
-    // Callers walk back to a point at least this much older than the newest.
+    // Callers walk back to a point at least this much older than the newest
+    // (kept for the 5-minute path; use minGapMillis(interval) for others).
     public static final long MIN_GAP_MILLIS = 4L * 60L * 1000L + 30_000L;
     // A pair further apart says nothing about the current change.
     private static final long MAX_GAP_MILLIS = 20L * 60L * 1000L;
@@ -36,18 +40,38 @@ public final class GlucoseDelta {
     private GlucoseDelta() {
     }
 
+    public static int sanitizeIntervalMinutes(int intervalMinutes) {
+        return intervalMinutes == 1 ? 1 : DEFAULT_INTERVAL_MINUTES;
+    }
+
+    public static long windowMillis(int intervalMinutes) {
+        return (long) sanitizeIntervalMinutes(intervalMinutes) * 60L * 1000L;
+    }
+
+    /** Walk-back target: a point at least ~90% of the window older than the newest. */
+    public static long minGapMillis(int intervalMinutes) {
+        final long window = windowMillis(intervalMinutes);
+        return window - window / 10L;   // 4.5 min for 5-minute, 54 s for 1-minute
+    }
+
     /**
-     * Change over the pair's gap scaled to a 5-minute equivalent; NaN when
-     * the pair is closer than half the window (extrapolating a single noisy
-     * minute 5x would defeat the purpose) or further than 20 minutes.
+     * Change over the pair's gap scaled to the interval's window; NaN when the
+     * pair is closer than half the window (extrapolating a single noisy sample
+     * up would defeat the purpose) or further than 20 minutes.
      */
-    public static float fiveMinuteDelta(long newMillis, float newValue, long prevMillis, float prevValue) {
+    public static float delta(long newMillis, float newValue, long prevMillis, float prevValue, int intervalMinutes) {
         if (!Float.isFinite(newValue) || !Float.isFinite(prevValue))
             return Float.NaN;
         final long gap = newMillis - prevMillis;
-        if (gap < WINDOW_MILLIS / 2L || gap > MAX_GAP_MILLIS)
+        final long window = windowMillis(intervalMinutes);
+        if (gap < window / 2L || gap > MAX_GAP_MILLIS)
             return Float.NaN;
-        return (newValue - prevValue) * ((float) WINDOW_MILLIS / gap);
+        return (newValue - prevValue) * ((float) window / gap);
+    }
+
+    /** Convenience wrapper for the default 5-minute interval. */
+    public static float fiveMinuteDelta(long newMillis, float newValue, long prevMillis, float prevValue) {
+        return delta(newMillis, newValue, prevMillis, prevValue, DEFAULT_INTERVAL_MINUTES);
     }
 
     /**

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -3357,6 +3357,7 @@ public class Notify {
         boolean showStatus = prefs.getBoolean("notification_show_status", true);
         boolean showIob = prefs.getBoolean("notification_show_iob", false);
         boolean showCob = prefs.getBoolean("notification_show_cob", false);
+        boolean showDelta = prefs.getBoolean("notification_show_delta", false);
         boolean iobCobRiskColored = prefs.getBoolean("notification_iob_cob_risk_colored", false);
         boolean arrowForecastColored = prefs.getBoolean("glucose_arrow_forecast_colors_enabled", false);
         boolean showChart = prefs.getBoolean("notification_chart_enabled", true);
@@ -3464,6 +3465,39 @@ public class Notify {
                 newStatusText = (sensorStatusText == null || sensorStatusText.isEmpty())
                         ? iobLine
                         : new android.text.SpannableStringBuilder(iobLine).append(" · ").append(sensorStatusText);
+        }
+        // The "Δ" readout: measured change over the last ~5 minutes — a raw
+        // number to sanity-check the estimated arrow against. Leftmost, right
+        // next to the arrow. Walks back to the first point old enough for the
+        // window; the tail can hold near-duplicates (persisted vs live
+        // timestamp of the same reading), so never take blind indices.
+        if (showDelta && nativePoints.size() >= 2) {
+            final GlucosePoint newest = nativePoints.get(nativePoints.size() - 1);
+            final float newestValue = (isRawMode && newest.rawValue > 0f) ? newest.rawValue : newest.value;
+            GlucosePoint previous = null;
+            for (int i = nativePoints.size() - 2; i >= 0; i--) {
+                final GlucosePoint p = nativePoints.get(i);
+                final float value = (isRawMode && p.rawValue > 0f) ? p.rawValue : p.value;
+                if (value > 0.1f && newest.timestamp - p.timestamp >= GlucoseDelta.MIN_GAP_MILLIS) {
+                    previous = p;
+                    break;
+                }
+            }
+            final float previousValue = previous == null ? Float.NaN
+                    : (isRawMode && previous.rawValue > 0f) ? previous.rawValue : previous.value;
+            final String deltaText = previous == null ? "" : GlucoseDelta.format(
+                    GlucoseDelta.fiveMinuteDelta(newest.timestamp, newestValue, previous.timestamp, previousValue),
+                    isMmol);
+            if (doLog)
+                Log.i(LOG_ID, "notification delta=" + deltaText
+                        + " points=" + nativePoints.size()
+                        + " gap=" + (previous == null ? -1L : (newest.timestamp - previous.timestamp)));
+            if (!deltaText.isEmpty()) {
+                newStatusText = (newStatusText == null || newStatusText.length() == 0)
+                        ? "Δ " + deltaText
+                        : new android.text.SpannableStringBuilder("Δ ").append(deltaText)
+                                .append(" · ").append(newStatusText);
+            }
         }
 
         // Apply Style to Status Text too

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -3358,6 +3358,7 @@ public class Notify {
         boolean showIob = prefs.getBoolean("notification_show_iob", false);
         boolean showCob = prefs.getBoolean("notification_show_cob", false);
         boolean showDelta = prefs.getBoolean("notification_show_delta", false);
+        int deltaIntervalMinutes = prefs.getInt("delta_interval_minutes", GlucoseDelta.DEFAULT_INTERVAL_MINUTES);
         boolean iobCobRiskColored = prefs.getBoolean("notification_iob_cob_risk_colored", false);
         boolean arrowForecastColored = prefs.getBoolean("glucose_arrow_forecast_colors_enabled", false);
         boolean showChart = prefs.getBoolean("notification_chart_enabled", true);
@@ -3478,7 +3479,7 @@ public class Notify {
             for (int i = nativePoints.size() - 2; i >= 0; i--) {
                 final GlucosePoint p = nativePoints.get(i);
                 final float value = (isRawMode && p.rawValue > 0f) ? p.rawValue : p.value;
-                if (value > 0.1f && newest.timestamp - p.timestamp >= GlucoseDelta.MIN_GAP_MILLIS) {
+                if (value > 0.1f && newest.timestamp - p.timestamp >= GlucoseDelta.minGapMillis(deltaIntervalMinutes)) {
                     previous = p;
                     break;
                 }
@@ -3486,7 +3487,7 @@ public class Notify {
             final float previousValue = previous == null ? Float.NaN
                     : (isRawMode && previous.rawValue > 0f) ? previous.rawValue : previous.value;
             final String deltaText = previous == null ? "" : GlucoseDelta.format(
-                    GlucoseDelta.fiveMinuteDelta(newest.timestamp, newestValue, previous.timestamp, previousValue),
+                    GlucoseDelta.delta(newest.timestamp, newestValue, previous.timestamp, previousValue, deltaIntervalMinutes),
                     isMmol);
             if (doLog)
                 Log.i(LOG_ID, "notification delta=" + deltaText

--- a/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
@@ -89,9 +89,10 @@ data class AlertConfig(
     val forecastMinutes: Int? = null,       // For forecast alerts (how far ahead to predict)
 
     // Delta-counter settings (FALLING_FAST / RISING_FAST): GDH-style robust rate-of-change alarm.
-    val deltaThreshold: Float? = null,      // Min per-reading change (display units) to count as steep
-    val deltaCount: Int? = null,            // How many consecutive steep readings must accumulate
+    val deltaThreshold: Float? = null,      // Min change per interval (display units) to count as steep
+    val deltaCount: Int? = null,            // How many consecutive steep intervals must accumulate
     val deltaBorder: Float? = null,         // Only alarm once the value is past this bound (below/above)
+    val deltaIntervalMinutes: Int? = null,  // Own delta window (1 or 5); null = follow the Δ readout's global interval
 
     // Delivery settings
     val deliveryMode: AlertDeliveryMode = AlertDeliveryMode.SYSTEM_ALARM,

--- a/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
@@ -93,6 +93,7 @@ data class AlertConfig(
     val deltaCount: Int? = null,            // How many consecutive steep intervals must accumulate
     val deltaBorder: Float? = null,         // Only alarm once the value is past this bound (below/above)
     val deltaIntervalMinutes: Int? = null,  // Own delta window (1 or 5); null = follow the Δ readout's global interval
+    val earlyTriggerEnabled: Boolean = false, // Also fire once the total distance (count x threshold) is covered
 
     // Delivery settings
     val deliveryMode: AlertDeliveryMode = AlertDeliveryMode.SYSTEM_ALARM,

--- a/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
@@ -17,7 +17,9 @@ enum class AlertType(val id: Int, val nameResId: Int) {
     PRE_HIGH(8, R.string.alert_forecast_high),         
     MISSED_READING(9, R.string.alert_missed_reading),
     PERSISTENT_HIGH(10, R.string.alert_persistent_high),
-    SENSOR_EXPIRY(11, R.string.alert_sensor_expiry);
+    SENSOR_EXPIRY(11, R.string.alert_sensor_expiry),
+    FALLING_FAST(12, R.string.alert_falling_fast),
+    RISING_FAST(13, R.string.alert_rising_fast);
 
     companion object {
         fun fromId(id: Int): AlertType? = entries.find { it.id == id }
@@ -37,7 +39,9 @@ enum class AlertType(val id: Int, val nameResId: Int) {
             MISSED_READING,
             PERSISTENT_HIGH,
             LOSS,
-            SENSOR_EXPIRY
+            SENSOR_EXPIRY,
+            FALLING_FAST,
+            RISING_FAST
         )
     }
 }
@@ -83,7 +87,12 @@ data class AlertConfig(
     val threshold: Float? = null,           // Glucose value (null for non-threshold alerts)
     val durationMinutes: Int? = null,       // For persistent high / missed reading alerts
     val forecastMinutes: Int? = null,       // For forecast alerts (how far ahead to predict)
-    
+
+    // Delta-counter settings (FALLING_FAST / RISING_FAST): GDH-style robust rate-of-change alarm.
+    val deltaThreshold: Float? = null,      // Min per-reading change (display units) to count as steep
+    val deltaCount: Int? = null,            // How many consecutive steep readings must accumulate
+    val deltaBorder: Float? = null,         // Only alarm once the value is past this bound (below/above)
+
     // Delivery settings
     val deliveryMode: AlertDeliveryMode = AlertDeliveryMode.SYSTEM_ALARM,
     val overrideDND: Boolean = false,       // Override Do Not Disturb
@@ -203,6 +212,18 @@ object AlertDefaults {
     const val MISSED_READING_MINUTES = 30
     const val PERSISTENT_HIGH_MINUTES = 60
     const val FORECAST_LOOK_AHEAD_MINUTES = 20
+
+    // Delta-counter defaults (FALLING_FAST / RISING_FAST). Tunable; disabled by default.
+    // Change over the delta interval that counts as steep (~10 mg/dL / 0.6 mmol per 5 min).
+    const val DELTA_THRESHOLD_MGDL = 10f
+    const val DELTA_THRESHOLD_MMOL = 0.6f
+    // Consecutive steep readings required.
+    const val DELTA_COUNT_DEFAULT = 3
+    // Only warn once the value is already heading toward trouble.
+    const val FALLING_BORDER_MGDL = 120f     // alarm only at/below this
+    const val FALLING_BORDER_MMOL = 6.7f
+    const val RISING_BORDER_MGDL = 180f      // alarm only at/above this
+    const val RISING_BORDER_MMOL = 10.0f
     
     // Snooze presets (minutes)
     val SNOOZE_PRESETS = listOf(5, 10, 15, 30, 60, 90, 120)
@@ -298,6 +319,26 @@ object AlertDefaults {
                 durationMinutes = 30,
                 deliveryMode = AlertDeliveryMode.NOTIFICATION_ONLY,
                 hapticProfile = HapticProfile.STEADY,
+                defaultSnoozeMinutes = 30
+            )
+            AlertType.FALLING_FAST -> AlertConfig(
+                type = type,
+                enabled = false,
+                deltaThreshold = if (isMmol) DELTA_THRESHOLD_MMOL else DELTA_THRESHOLD_MGDL,
+                deltaCount = DELTA_COUNT_DEFAULT,
+                deltaBorder = if (isMmol) FALLING_BORDER_MMOL else FALLING_BORDER_MGDL,
+                deliveryMode = AlertDeliveryMode.SYSTEM_ALARM,
+                hapticProfile = HapticProfile.SOFT,
+                defaultSnoozeMinutes = 20
+            )
+            AlertType.RISING_FAST -> AlertConfig(
+                type = type,
+                enabled = false,
+                deltaThreshold = if (isMmol) DELTA_THRESHOLD_MMOL else DELTA_THRESHOLD_MGDL,
+                deltaCount = DELTA_COUNT_DEFAULT,
+                deltaBorder = if (isMmol) RISING_BORDER_MMOL else RISING_BORDER_MGDL,
+                deliveryMode = AlertDeliveryMode.SYSTEM_ALARM,
+                hapticProfile = HapticProfile.SOFT,
                 defaultSnoozeMinutes = 30
             )
             else -> AlertConfig(type = type)

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import tk.glucodata.Applic
+import tk.glucodata.GlucoseDelta
 import tk.glucodata.Natives
 import tk.glucodata.SuperGattCallback
 
@@ -56,6 +57,7 @@ object AlertRepository {
     private fun keyDeltaThreshold(type: AlertType) = "alert_${type.id}_deltaThreshold"
     private fun keyDeltaCount(type: AlertType) = "alert_${type.id}_deltaCount"
     private fun keyDeltaBorder(type: AlertType) = "alert_${type.id}_deltaBorder"
+    private fun keyDeltaInterval(type: AlertType) = "alert_${type.id}_deltaInterval"
 
     private inline fun <reified T : Enum<T>> parseEnumPref(value: String?, fallback: T): T {
         return value?.let { raw ->
@@ -248,7 +250,10 @@ object AlertRepository {
             retryCount = prefs.getInt(keyRetryCount(type), 3),
             deltaThreshold = prefs.getFloat(keyDeltaThreshold(type), default.deltaThreshold ?: 0f).takeIf { it > 0 },
             deltaCount = prefs.getInt(keyDeltaCount(type), default.deltaCount ?: 0).takeIf { it > 0 },
-            deltaBorder = prefs.getFloat(keyDeltaBorder(type), default.deltaBorder ?: 0f).takeIf { it > 0 }
+            deltaBorder = prefs.getFloat(keyDeltaBorder(type), default.deltaBorder ?: 0f).takeIf { it > 0 },
+            // Missing/0 = follow the Δ readout's global interval.
+            deltaIntervalMinutes = prefs.getInt(keyDeltaInterval(type), 0).takeIf { it > 0 }
+                ?.let { GlucoseDelta.sanitizeIntervalMinutes(it) }
         )
     }
 
@@ -299,6 +304,7 @@ object AlertRepository {
             if (config.deltaThreshold != null) putFloat(keyDeltaThreshold(config.type), config.deltaThreshold) else remove(keyDeltaThreshold(config.type))
             if (config.deltaCount != null) putInt(keyDeltaCount(config.type), config.deltaCount) else remove(keyDeltaCount(config.type))
             if (config.deltaBorder != null) putFloat(keyDeltaBorder(config.type), config.deltaBorder) else remove(keyDeltaBorder(config.type))
+            if (config.deltaIntervalMinutes != null) putInt(keyDeltaInterval(config.type), config.deltaIntervalMinutes) else remove(keyDeltaInterval(config.type))
         }
     }
     

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -58,6 +58,7 @@ object AlertRepository {
     private fun keyDeltaCount(type: AlertType) = "alert_${type.id}_deltaCount"
     private fun keyDeltaBorder(type: AlertType) = "alert_${type.id}_deltaBorder"
     private fun keyDeltaInterval(type: AlertType) = "alert_${type.id}_deltaInterval"
+    private fun keyEarlyTrigger(type: AlertType) = "alert_${type.id}_earlyTrigger"
 
     private inline fun <reified T : Enum<T>> parseEnumPref(value: String?, fallback: T): T {
         return value?.let { raw ->
@@ -253,7 +254,8 @@ object AlertRepository {
             deltaBorder = prefs.getFloat(keyDeltaBorder(type), default.deltaBorder ?: 0f).takeIf { it > 0 },
             // Missing/0 = follow the Δ readout's global interval.
             deltaIntervalMinutes = prefs.getInt(keyDeltaInterval(type), 0).takeIf { it > 0 }
-                ?.let { GlucoseDelta.sanitizeIntervalMinutes(it) }
+                ?.let { GlucoseDelta.sanitizeIntervalMinutes(it) },
+            earlyTriggerEnabled = prefs.getBoolean(keyEarlyTrigger(type), false)
         )
     }
 
@@ -305,6 +307,7 @@ object AlertRepository {
             if (config.deltaCount != null) putInt(keyDeltaCount(config.type), config.deltaCount) else remove(keyDeltaCount(config.type))
             if (config.deltaBorder != null) putFloat(keyDeltaBorder(config.type), config.deltaBorder) else remove(keyDeltaBorder(config.type))
             if (config.deltaIntervalMinutes != null) putInt(keyDeltaInterval(config.type), config.deltaIntervalMinutes) else remove(keyDeltaInterval(config.type))
+            putBoolean(keyEarlyTrigger(config.type), config.earlyTriggerEnabled)
         }
     }
     

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -52,6 +52,10 @@ object AlertRepository {
     private fun keyRetryEnabled(type: AlertType) = "alert_${type.id}_retryOn"
     private fun keyRetryInterval(type: AlertType) = "alert_${type.id}_retryInt"
     private fun keyRetryCount(type: AlertType) = "alert_${type.id}_retryCnt"
+    // Delta-counter keys (FALLING_FAST / RISING_FAST)
+    private fun keyDeltaThreshold(type: AlertType) = "alert_${type.id}_deltaThreshold"
+    private fun keyDeltaCount(type: AlertType) = "alert_${type.id}_deltaCount"
+    private fun keyDeltaBorder(type: AlertType) = "alert_${type.id}_deltaBorder"
 
     private inline fun <reified T : Enum<T>> parseEnumPref(value: String?, fallback: T): T {
         return value?.let { raw ->
@@ -241,10 +245,13 @@ object AlertRepository {
             activeEndMinute = prefs.getInt(keyActiveEndMinute(type), -1).takeIf { it >= 0 },
             retryEnabled = prefs.getBoolean(keyRetryEnabled(type), false),
             retryIntervalMinutes = prefs.getInt(keyRetryInterval(type), 5),
-            retryCount = prefs.getInt(keyRetryCount(type), 3)
+            retryCount = prefs.getInt(keyRetryCount(type), 3),
+            deltaThreshold = prefs.getFloat(keyDeltaThreshold(type), default.deltaThreshold ?: 0f).takeIf { it > 0 },
+            deltaCount = prefs.getInt(keyDeltaCount(type), default.deltaCount ?: 0).takeIf { it > 0 },
+            deltaBorder = prefs.getFloat(keyDeltaBorder(type), default.deltaBorder ?: 0f).takeIf { it > 0 }
         )
     }
-    
+
     /**
      * Save configuration for an alert type.
      * For legacy types, writes to both SharedPreferences and Natives.
@@ -289,6 +296,9 @@ object AlertRepository {
             putBoolean(keyRetryEnabled(config.type), config.retryEnabled)
             putInt(keyRetryInterval(config.type), config.retryIntervalMinutes)
             putInt(keyRetryCount(config.type), config.retryCount)
+            if (config.deltaThreshold != null) putFloat(keyDeltaThreshold(config.type), config.deltaThreshold) else remove(keyDeltaThreshold(config.type))
+            if (config.deltaCount != null) putInt(keyDeltaCount(config.type), config.deltaCount) else remove(keyDeltaCount(config.type))
+            if (config.deltaBorder != null) putFloat(keyDeltaBorder(config.type), config.deltaBorder) else remove(keyDeltaBorder(config.type))
         }
     }
     

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -463,7 +463,8 @@ object AlertRuntimeManager {
             deltaThreshold = deltaThreshold,
             deltaCount = deltaCount,
             deltaBorder = deltaBorder,
-            intervalMinutes = config.deltaIntervalMinutes ?: deltaIntervalMinutesLocked()
+            intervalMinutes = config.deltaIntervalMinutes ?: deltaIntervalMinutesLocked(),
+            earlyTriggerEnabled = config.earlyTriggerEnabled
         )
 
         if (!activeNow) {

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import tk.glucodata.Applic
 import tk.glucodata.CurrentDisplaySource
+import tk.glucodata.GlucoseDelta
 import tk.glucodata.Log
 import tk.glucodata.Natives
 import tk.glucodata.Notify
@@ -33,6 +34,8 @@ object AlertRuntimeManager {
     private var persistentHighStartedAtMs: Long = 0L
     private val standardEpisodes = AlertEpisodeState<AlertType>()
     private val sensorExpiryState = SensorExpiryAlertState()
+    private val fallingDeltaState = DeltaAlarmState(falling = true)
+    private val risingDeltaState = DeltaAlarmState(falling = false)
     private val calibrationReadingBarrier = ReadingTimestampBarrier()
 
     private val standardGlucoseAlertTypes = listOf(
@@ -67,6 +70,10 @@ object AlertRuntimeManager {
         synchronized(lock) {
             val suppressThroughMs = maxOf(lastReadingTimeMs, currentReadingTimeMs)
             calibrationReadingBarrier.suppressThrough(suppressThroughMs)
+            // A recalibration shifts the displayed value without a real new sample; drop the delta
+            // baseline so the jump can't be mistaken for a steep fall/rise.
+            fallingDeltaState.resetBaseline()
+            risingDeltaState.resetBaseline()
             if (suppressThroughMs > 0L) {
                 Log.i(LOG_ID, "Calibration changed; glucose alerts wait for reading after $suppressThroughMs")
             }
@@ -153,6 +160,7 @@ object AlertRuntimeManager {
         evaluateMissedReadingLocked(nowMs)
         if (!glucoseAlertsBlocked) {
             evaluatePersistentHighLocked(nowMs)
+            evaluateDeltaAlarmsLocked()
         }
         evaluateSensorExpiryLocked(nowMs)
         return standardAlertEvaluation
@@ -402,6 +410,71 @@ object AlertRuntimeManager {
         val message = Applic.app.getString(R.string.alert_sensor_expiry) + " - " +
             Applic.app.getString(R.string.hours_short, remainingHours)
 
+        triggerAlert(type, glucoseValue, currentRateLocked(), message)
+    }
+
+    private fun evaluateDeltaAlarmsLocked() {
+        evaluateDeltaAlarmLocked(AlertType.FALLING_FAST, fallingDeltaState)
+        evaluateDeltaAlarmLocked(AlertType.RISING_FAST, risingDeltaState)
+    }
+
+    private fun deltaIntervalMinutesLocked(): Int {
+        return try {
+            GlucoseDelta.sanitizeIntervalMinutes(
+                Applic.app
+                    .getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+                    .getInt("delta_interval_minutes", GlucoseDelta.DEFAULT_INTERVAL_MINUTES)
+            )
+        } catch (t: Throwable) {
+            GlucoseDelta.DEFAULT_INTERVAL_MINUTES
+        }
+    }
+
+    private fun evaluateDeltaAlarmLocked(type: AlertType, state: DeltaAlarmState) {
+        val config = AlertRepository.loadConfig(type)
+        val deltaThreshold = config.deltaThreshold
+        val deltaCount = config.deltaCount
+        val deltaBorder = config.deltaBorder
+
+        if (!config.enabled || deltaThreshold == null || deltaCount == null || deltaBorder == null) {
+            state.reset()
+            clearRuntimeAlert(type, "delta-alarm-disabled")
+            return
+        }
+
+        val glucoseValue = currentGlucoseValueLocked()
+        if (glucoseValue == null) {
+            // Keep the run intact; a missing sample is not a movement.
+            return
+        }
+
+        val activeNow = config.isActiveNow()
+        val snoozed = SnoozeManager.isSnoozed(type)
+        // The state advances its run counter here (once per genuinely newer reading) and only
+        // returns true while active and not snoozed. The delta is measured over the global
+        // interval, the same one that drives the Δ readout.
+        val shouldTrigger = state.shouldTrigger(
+            enabled = true,
+            activeNow = activeNow,
+            snoozed = snoozed,
+            value = glucoseValue,
+            readingTimeMs = lastReadingTimeMs,
+            deltaThreshold = deltaThreshold,
+            deltaCount = deltaCount,
+            deltaBorder = deltaBorder,
+            intervalMinutes = deltaIntervalMinutesLocked()
+        )
+
+        if (!activeNow) {
+            clearRuntimeAlert(type, "delta-alarm-time-inactive")
+            return
+        }
+        if (snoozed || !shouldTrigger) {
+            return
+        }
+
+        val label = Applic.app.getString(type.nameResId)
+        val message = "$label ${Notify.glucosestr(glucoseValue)}"
         triggerAlert(type, glucoseValue, currentRateLocked(), message)
     }
 

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -450,9 +450,10 @@ object AlertRuntimeManager {
 
         val activeNow = config.isActiveNow()
         val snoozed = SnoozeManager.isSnoozed(type)
-        // The state advances its run counter here (once per genuinely newer reading) and only
-        // returns true while active and not snoozed. The delta is measured over the global
-        // interval, the same one that drives the Δ readout.
+        // The state advances its run counter at interval checkpoints and only returns true while
+        // active and not snoozed. The delta is measured over the alert's own window when one is
+        // set, else over the global interval that drives the Δ readout; the state resets itself
+        // when the effective window changes, so a run never mixes windows.
         val shouldTrigger = state.shouldTrigger(
             enabled = true,
             activeNow = activeNow,
@@ -462,7 +463,7 @@ object AlertRuntimeManager {
             deltaThreshold = deltaThreshold,
             deltaCount = deltaCount,
             deltaBorder = deltaBorder,
-            intervalMinutes = deltaIntervalMinutesLocked()
+            intervalMinutes = config.deltaIntervalMinutes ?: deltaIntervalMinutesLocked()
         )
 
         if (!activeNow) {

--- a/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
@@ -42,6 +42,7 @@ internal class DeltaAlarmState(private val falling: Boolean) {
     private val history = ArrayDeque<Sample>()
     private var lastReadingTimeMs = NO_READING
     private var lastCheckpointMs = NO_READING
+    private var lastIntervalMinutes = 0   // 0 = no reading judged yet
     private var count = 0
     private var armed = true
 
@@ -49,6 +50,7 @@ internal class DeltaAlarmState(private val falling: Boolean) {
         history.clear()
         lastReadingTimeMs = NO_READING
         lastCheckpointMs = NO_READING
+        lastIntervalMinutes = 0
         count = 0
         armed = true
     }
@@ -80,12 +82,20 @@ internal class DeltaAlarmState(private val falling: Boolean) {
             return false
         }
 
+        // The window scales both the walk-back and the checkpoint spacing, so a run measured
+        // over mixed windows is meaningless: when the effective interval changes, start over.
+        val interval = GlucoseDelta.sanitizeIntervalMinutes(intervalMinutes)
+        if (lastIntervalMinutes != 0 && interval != lastIntervalMinutes) {
+            resetBaseline()
+        }
+        lastIntervalMinutes = interval
+
         // Advance the run counter only on a genuinely newer, finite reading.
         if (value.isFinite() && readingTimeMs > lastReadingTimeMs) {
-            advanceRun(value, readingTimeMs, deltaThreshold, intervalMinutes)
+            advanceRun(value, readingTimeMs, deltaThreshold, interval)
             history.addLast(Sample(readingTimeMs, value))
             lastReadingTimeMs = readingTimeMs
-            pruneOld(readingTimeMs, intervalMinutes)
+            pruneOld(readingTimeMs, interval)
         }
 
         if (!activeNow || snoozed) {

--- a/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
@@ -26,6 +26,12 @@ import tk.glucodata.GlucoseDelta
  * next checkpoint decides. A NaN delta (no usable history, or the pair straddles a data gap)
  * breaks the run at once.
  *
+ * The configuration implies a total distance (`deltaCount × deltaThreshold`). With the optional
+ * early trigger, the alarm also fires as soon as the value has moved that far from the run's
+ * anchor (the older sample of the run-starting delta, so distance is measured consistently with
+ * the delta metric) — checked on every reading, not just at checkpoints, and sharing the
+ * once-per-run arming with the checkpoint path.
+ *
  * One instance per direction, fed the current display value on every evaluation. It advances only
  * on a genuinely newer reading timestamp, so scheduler ticks (which re-pass the same reading) and
  * calibration-only display changes cannot inflate the counter. It fires once per steep run and
@@ -44,6 +50,7 @@ internal class DeltaAlarmState(private val falling: Boolean) {
     private var lastCheckpointMs = NO_READING
     private var lastIntervalMinutes = 0   // 0 = no reading judged yet
     private var count = 0
+    private var runReferenceValue = Float.NaN   // anchor of the current run, for the early trigger
     private var armed = true
 
     fun reset() {
@@ -52,6 +59,7 @@ internal class DeltaAlarmState(private val falling: Boolean) {
         lastCheckpointMs = NO_READING
         lastIntervalMinutes = 0
         count = 0
+        runReferenceValue = Float.NaN
         armed = true
     }
 
@@ -63,6 +71,7 @@ internal class DeltaAlarmState(private val falling: Boolean) {
         history.clear()
         lastCheckpointMs = NO_READING
         count = 0
+        runReferenceValue = Float.NaN
         armed = true
     }
 
@@ -75,7 +84,8 @@ internal class DeltaAlarmState(private val falling: Boolean) {
         deltaThreshold: Float,
         deltaCount: Int,
         deltaBorder: Float,
-        intervalMinutes: Int
+        intervalMinutes: Int,
+        earlyTriggerEnabled: Boolean = false
     ): Boolean {
         if (!enabled || deltaThreshold <= 0f || deltaCount <= 0) {
             reset()
@@ -103,7 +113,14 @@ internal class DeltaAlarmState(private val falling: Boolean) {
         }
 
         val pastBorder = if (falling) value <= deltaBorder else value >= deltaBorder
-        val triggering = armed && count >= deltaCount && value.isFinite() && pastBorder
+        val runComplete = count >= deltaCount
+        // Optional escalation: once the value has covered the configured total distance
+        // (count x threshold) from the run's anchor, the remaining checkpoints add nothing.
+        // Checked on every reading; NaN anchor or value makes the comparison false.
+        val distanceCovered = if (falling) runReferenceValue - value else value - runReferenceValue
+        val earlyTrigger = earlyTriggerEnabled && count > 0 &&
+            distanceCovered >= deltaCount * deltaThreshold
+        val triggering = armed && value.isFinite() && pastBorder && (runComplete || earlyTrigger)
         if (triggering) {
             armed = false
             return true
@@ -139,9 +156,11 @@ internal class DeltaAlarmState(private val falling: Boolean) {
         val steep = if (falling) delta <= -deltaThreshold else delta >= deltaThreshold
         if (count == 0) {
             if (steep) {
-                // Run start: this rolling delta already spans one interval of movement.
+                // Run start: this rolling delta already spans one interval of movement. Its
+                // older sample anchors the early trigger's distance measurement.
                 count = 1
                 lastCheckpointMs = readingTimeMs
+                runReferenceValue = prev?.value ?: Float.NaN
             }
             return
         }
@@ -169,6 +188,7 @@ internal class DeltaAlarmState(private val falling: Boolean) {
     private fun breakRun() {
         count = 0
         lastCheckpointMs = NO_READING
+        runReferenceValue = Float.NaN
         armed = true  // run broken -> eligible to fire again on the next run
     }
 

--- a/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
@@ -5,15 +5,26 @@ import tk.glucodata.GlucoseDelta
 /**
  * GDH-style delta run-length counter behind the FALLING_FAST / RISING_FAST alarms.
  *
- * Robust, model-free "you're dropping/rising fast" detection: it counts consecutive readings whose
- * change over the configured interval (via [GlucoseDelta]) exceeds [deltaThreshold] in the alarming
- * direction, and fires once a run of [deltaCount] such readings has accumulated while the value is
- * past [deltaBorder]. No extrapolation, no insulin, no smoothing.
+ * Robust, model-free "you're dropping/rising fast" detection: it counts consecutive
+ * non-overlapping intervals whose change (via [GlucoseDelta]) exceeds [deltaThreshold] in the
+ * alarming direction, and fires once a run of [deltaCount] such intervals has accumulated while
+ * the value is past [deltaBorder]. No extrapolation, no insulin, no smoothing.
  *
- * The delta is measured over the same 1-or-5-minute window as NG's Δ readout, so the threshold is
- * cadence-independent: "10 mg/dl per 5 min" means the same on a 1-minute sensor and a 5-minute one.
- * The state keeps a short reading history to walk back to the sample one interval old, exactly like
- * the readout does.
+ * The delta itself stays rolling: it is recomputed for every reading over the configured
+ * 1-or-5-minute window, exactly like NG's Δ readout, so the threshold is cadence-independent:
+ * "10 mg/dl per 5 min" means the same on a 1-minute sensor and a 5-minute one. The *counter*,
+ * however, advances only at interval checkpoints: the first steep delta starts the run (that
+ * delta already covers one interval of movement), and it is re-judged at the first reading a
+ * full interval later, whose rolling delta covers the adjacent, non-overlapping interval. On a
+ * fast stream, consecutive rolling windows overlap almost entirely, so counting every reading
+ * would satisfy [deltaCount] within a few readings instead of `deltaCount × interval` minutes.
+ * On a sensor that reports exactly once per interval, every reading is a checkpoint and the
+ * behaviour is the same as counting readings.
+ *
+ * Between checkpoints, a delta reversed against the alarming direction breaks the run
+ * immediately; a delta that is merely no longer steep enough leaves the run standing until the
+ * next checkpoint decides. A NaN delta (no usable history, or the pair straddles a data gap)
+ * breaks the run at once.
  *
  * One instance per direction, fed the current display value on every evaluation. It advances only
  * on a genuinely newer reading timestamp, so scheduler ticks (which re-pass the same reading) and
@@ -30,12 +41,14 @@ internal class DeltaAlarmState(private val falling: Boolean) {
 
     private val history = ArrayDeque<Sample>()
     private var lastReadingTimeMs = NO_READING
+    private var lastCheckpointMs = NO_READING
     private var count = 0
     private var armed = true
 
     fun reset() {
         history.clear()
         lastReadingTimeMs = NO_READING
+        lastCheckpointMs = NO_READING
         count = 0
         armed = true
     }
@@ -46,6 +59,7 @@ internal class DeltaAlarmState(private val falling: Boolean) {
      */
     fun resetBaseline() {
         history.clear()
+        lastCheckpointMs = NO_READING
         count = 0
         armed = true
     }
@@ -108,16 +122,44 @@ internal class DeltaAlarmState(private val falling: Boolean) {
 
         if (delta.isNaN()) {
             // Not enough history yet, or the pair straddles a data gap: break the run.
-            count = 0
-            armed = true
+            breakRun()
             return
         }
 
         val steep = if (falling) delta <= -deltaThreshold else delta >= deltaThreshold
-        count = if (steep) count + 1 else 0
         if (count == 0) {
-            armed = true  // run broken -> eligible to fire again on the next run
+            if (steep) {
+                // Run start: this rolling delta already spans one interval of movement.
+                count = 1
+                lastCheckpointMs = readingTimeMs
+            }
+            return
         }
+
+        // A reversal against the alarming direction breaks the run immediately, even between
+        // checkpoints; a merely-not-steep-enough delta is left for the next checkpoint to judge.
+        val reversed = if (falling) delta > 0f else delta < 0f
+        if (reversed) {
+            breakRun()
+            return
+        }
+
+        // Checkpoint: the first reading a full interval past the last one. Its rolling delta
+        // covers the adjacent, non-overlapping interval; between checkpoints the counter holds.
+        if (readingTimeMs - lastCheckpointMs >= GlucoseDelta.windowMillis(intervalMinutes)) {
+            if (steep) {
+                count += 1
+                lastCheckpointMs = readingTimeMs
+            } else {
+                breakRun()
+            }
+        }
+    }
+
+    private fun breakRun() {
+        count = 0
+        lastCheckpointMs = NO_READING
+        armed = true  // run broken -> eligible to fire again on the next run
     }
 
     private fun pruneOld(readingTimeMs: Long, intervalMinutes: Int) {

--- a/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
@@ -1,0 +1,130 @@
+package tk.glucodata.alerts
+
+import tk.glucodata.GlucoseDelta
+
+/**
+ * GDH-style delta run-length counter behind the FALLING_FAST / RISING_FAST alarms.
+ *
+ * Robust, model-free "you're dropping/rising fast" detection: it counts consecutive readings whose
+ * change over the configured interval (via [GlucoseDelta]) exceeds [deltaThreshold] in the alarming
+ * direction, and fires once a run of [deltaCount] such readings has accumulated while the value is
+ * past [deltaBorder]. No extrapolation, no insulin, no smoothing.
+ *
+ * The delta is measured over the same 1-or-5-minute window as NG's Δ readout, so the threshold is
+ * cadence-independent: "10 mg/dl per 5 min" means the same on a 1-minute sensor and a 5-minute one.
+ * The state keeps a short reading history to walk back to the sample one interval old, exactly like
+ * the readout does.
+ *
+ * One instance per direction, fed the current display value on every evaluation. It advances only
+ * on a genuinely newer reading timestamp, so scheduler ticks (which re-pass the same reading) and
+ * calibration-only display changes cannot inflate the counter. It fires once per steep run and
+ * re-arms only when the run breaks; repeat nagging is left to the shared snooze / retry machinery.
+ */
+internal class DeltaAlarmState(private val falling: Boolean) {
+    private companion object {
+        // Sentinel for "no reading ingested yet"; real reading timestamps are positive epoch millis.
+        const val NO_READING = -1L
+    }
+
+    private class Sample(val timeMs: Long, val value: Float)
+
+    private val history = ArrayDeque<Sample>()
+    private var lastReadingTimeMs = NO_READING
+    private var count = 0
+    private var armed = true
+
+    fun reset() {
+        history.clear()
+        lastReadingTimeMs = NO_READING
+        count = 0
+        armed = true
+    }
+
+    /**
+     * Drop the reading history so the next reading starts a fresh run without counting the jump to
+     * it. Used when a recalibration shifts the displayed value without a real new sample.
+     */
+    fun resetBaseline() {
+        history.clear()
+        count = 0
+        armed = true
+    }
+
+    fun shouldTrigger(
+        enabled: Boolean,
+        activeNow: Boolean,
+        snoozed: Boolean,
+        value: Float,
+        readingTimeMs: Long,
+        deltaThreshold: Float,
+        deltaCount: Int,
+        deltaBorder: Float,
+        intervalMinutes: Int
+    ): Boolean {
+        if (!enabled || deltaThreshold <= 0f || deltaCount <= 0) {
+            reset()
+            return false
+        }
+
+        // Advance the run counter only on a genuinely newer, finite reading.
+        if (value.isFinite() && readingTimeMs > lastReadingTimeMs) {
+            advanceRun(value, readingTimeMs, deltaThreshold, intervalMinutes)
+            history.addLast(Sample(readingTimeMs, value))
+            lastReadingTimeMs = readingTimeMs
+            pruneOld(readingTimeMs, intervalMinutes)
+        }
+
+        if (!activeNow || snoozed) {
+            return false
+        }
+
+        val pastBorder = if (falling) value <= deltaBorder else value >= deltaBorder
+        val triggering = armed && count >= deltaCount && value.isFinite() && pastBorder
+        if (triggering) {
+            armed = false
+            return true
+        }
+        return false
+    }
+
+    private fun advanceRun(value: Float, readingTimeMs: Long, deltaThreshold: Float, intervalMinutes: Int) {
+        val minGap = GlucoseDelta.minGapMillis(intervalMinutes)
+        // Walk back to the newest sample old enough to span (about) one interval, like the readout.
+        var prev: Sample? = null
+        val iterator = history.listIterator(history.size)
+        while (iterator.hasPrevious()) {
+            val sample = iterator.previous()
+            if (readingTimeMs - sample.timeMs >= minGap) {
+                prev = sample
+                break
+            }
+        }
+
+        val delta = if (prev != null) {
+            GlucoseDelta.delta(readingTimeMs, value, prev.timeMs, prev.value, intervalMinutes)
+        } else {
+            Float.NaN
+        }
+
+        if (delta.isNaN()) {
+            // Not enough history yet, or the pair straddles a data gap: break the run.
+            count = 0
+            armed = true
+            return
+        }
+
+        val steep = if (falling) delta <= -deltaThreshold else delta >= deltaThreshold
+        count = if (steep) count + 1 else 0
+        if (count == 0) {
+            armed = true  // run broken -> eligible to fire again on the next run
+        }
+    }
+
+    private fun pruneOld(readingTimeMs: Long, intervalMinutes: Int) {
+        // Keep a little more than the max usable gap so the walk-back always has candidates.
+        val keepMillis = GlucoseDelta.minGapMillis(intervalMinutes) + 21L * 60_000L
+        while (history.isNotEmpty() && readingTimeMs - history.first().timeMs > keepMillis) {
+            history.removeFirst()
+        }
+    }
+}

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -723,6 +723,14 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="alert_sensor_expiry">Sensorablauf</string>
     <string name="missed_reading_channel_description">Alerts when no glucose reading arrives for the configured duration</string>
     <string name="sensor_expiry_channel_description">Alerts when the current sensor is nearing expiry</string>
+    <string name="alert_falling_fast">Schnell fallend</string>
+    <string name="alert_rising_fast">Schnell steigend</string>
+    <string name="delta_change_label">Änderung pro %1$d Min</string>
+    <string name="delta_count_label">Messwerte in Folge</string>
+    <string name="delta_border_below_label">Nur unterhalb alarmieren</string>
+    <string name="delta_border_above_label">Nur oberhalb alarmieren</string>
+    <string name="falling_fast_explanation">Warnt, wenn %1$d Messwerte in Folge um mehr als %2$s fallen und der Wert bei oder unter %3$s liegt. Keine Vorhersage, nur der rohe Trend.</string>
+    <string name="rising_fast_explanation">Warnt, wenn %1$d Messwerte in Folge um mehr als %2$s steigen und der Wert bei oder über %3$s liegt. Keine Vorhersage, nur der rohe Trend.</string>
     <string name="alert_value_available">Wert verfügbar</string>
     <string name="alert_very_high">Sehr hoch</string>
     <string name="alert_very_low">Sehr niedrig</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -729,8 +729,10 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="delta_count_label">Messwerte in Folge</string>
     <string name="delta_border_below_label">Nur unterhalb alarmieren</string>
     <string name="delta_border_above_label">Nur oberhalb alarmieren</string>
-    <string name="falling_fast_explanation">Warnt, wenn %1$d Messwerte in Folge um mehr als %2$s fallen und der Wert bei oder unter %3$s liegt. Keine Vorhersage, nur der rohe Trend.</string>
-    <string name="rising_fast_explanation">Warnt, wenn %1$d Messwerte in Folge um mehr als %2$s steigen und der Wert bei oder über %3$s liegt. Keine Vorhersage, nur der rohe Trend.</string>
+    <string name="falling_fast_explanation">Warnt nach %1$d aufeinanderfolgenden %2$d-Minuten-Intervallen mit Abfall ≥ %3$s (≈ %4$d Min anhaltender Fall), wenn der Wert bei oder unter %5$s liegt. Keine Vorhersage, nur der rohe Trend.</string>
+    <string name="rising_fast_explanation">Warnt nach %1$d aufeinanderfolgenden %2$d-Minuten-Intervallen mit Anstieg ≥ %3$s (≈ %4$d Min anhaltender Anstieg), wenn der Wert bei oder über %5$s liegt. Keine Vorhersage, nur der rohe Trend.</string>
+    <string name="delta_alarm_interval_label">Delta-Fenster</string>
+    <string name="delta_alarm_interval_follow">Wie Δ-Anzeige (aktuell %1$d Min)</string>
     <string name="alert_value_available">Wert verfügbar</string>
     <string name="alert_very_high">Sehr hoch</string>
     <string name="alert_very_low">Sehr niedrig</string>
@@ -1590,7 +1592,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="dashboard_show_delta_title">Delta (Δ) auf dem Dashboard</string>
     <string name="dashboard_show_delta_desc">Gemessene Änderung über das Delta-Intervall, unter dem Trendpfeil</string>
     <string name="delta_interval_title">Delta-Intervall (Δ)</string>
-    <string name="delta_interval_desc">Zeitfenster für die Δ-Anzeige und die Schnell-fallend/steigend-Alarme</string>
+    <string name="delta_interval_desc">Zeitfenster für die Δ-Anzeige; die Schnell-fallend/steigend-Alarme folgen ihm, solange kein eigenes Fenster gesetzt ist</string>
     <string name="delta_interval_1min">1 Min</string>
     <string name="delta_interval_5min">5 Min</string>
     <string name="glucose_range_colors_title">Glukose nach Bereich einfärben</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -733,6 +733,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="rising_fast_explanation">Warnt nach %1$d aufeinanderfolgenden %2$d-Minuten-Intervallen mit Anstieg ≥ %3$s (≈ %4$d Min anhaltender Anstieg), wenn der Wert bei oder über %5$s liegt. Keine Vorhersage, nur der rohe Trend.</string>
     <string name="delta_alarm_interval_label">Delta-Fenster</string>
     <string name="delta_alarm_interval_follow">Wie Δ-Anzeige (aktuell %1$d Min)</string>
+    <string name="delta_early_trigger_label">Frühauslösung</string>
+    <string name="delta_early_trigger_desc">Auch auslösen, sobald die Gesamtstrecke (%1$s %2$s) erreicht ist – unabhängig davon, wie viele Intervalle vergangen sind</string>
     <string name="alert_value_available">Wert verfügbar</string>
     <string name="alert_very_high">Sehr hoch</string>
     <string name="alert_very_low">Sehr niedrig</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1577,6 +1577,10 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="notification_show_iob_desc">IOB/eIOB aus dem Journal in der Statuszeile</string>
     <string name="notification_show_cob_title">Kohlenhydrate an Bord anzeigen</string>
     <string name="notification_show_cob_desc">COB aus dem Journal in der Statuszeile</string>
+    <string name="notification_show_delta_title">Delta (Δ) anzeigen</string>
+    <string name="notification_show_delta_desc">Gemessene Änderung der letzten 5 Minuten neben dem Pfeil</string>
+    <string name="dashboard_show_delta_title">Delta (Δ) auf dem Dashboard</string>
+    <string name="dashboard_show_delta_desc">Gemessene Änderung der letzten 5 Minuten unter dem Trendpfeil</string>
     <string name="glucose_range_colors_title">Glukose nach Bereich einfärben</string>
     <string name="glucose_range_colors_desc">Grün im Zielbereich, Gelb grenzwertig, Rot jenseits von sehr niedrig/hoch — Benachrichtigung und Dashboard</string>
     <string name="very_range_title">Sehr niedrig / sehr hoch</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1578,9 +1578,13 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="notification_show_cob_title">Kohlenhydrate an Bord anzeigen</string>
     <string name="notification_show_cob_desc">COB aus dem Journal in der Statuszeile</string>
     <string name="notification_show_delta_title">Delta (Δ) anzeigen</string>
-    <string name="notification_show_delta_desc">Gemessene Änderung der letzten 5 Minuten neben dem Pfeil</string>
+    <string name="notification_show_delta_desc">Gemessene Änderung über das Delta-Intervall, neben dem Pfeil</string>
     <string name="dashboard_show_delta_title">Delta (Δ) auf dem Dashboard</string>
-    <string name="dashboard_show_delta_desc">Gemessene Änderung der letzten 5 Minuten unter dem Trendpfeil</string>
+    <string name="dashboard_show_delta_desc">Gemessene Änderung über das Delta-Intervall, unter dem Trendpfeil</string>
+    <string name="delta_interval_title">Delta-Intervall (Δ)</string>
+    <string name="delta_interval_desc">Zeitfenster für die Δ-Anzeige und die Schnell-fallend/steigend-Alarme</string>
+    <string name="delta_interval_1min">1 Min</string>
+    <string name="delta_interval_5min">5 Min</string>
     <string name="glucose_range_colors_title">Glukose nach Bereich einfärben</string>
     <string name="glucose_range_colors_desc">Grün im Zielbereich, Gelb grenzwertig, Rot jenseits von sehr niedrig/hoch — Benachrichtigung und Dashboard</string>
     <string name="very_range_title">Sehr niedrig / sehr hoch</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -817,6 +817,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="rising_fast_explanation">Warns after %1$d consecutive %2$d-minute intervals each rising by at least %3$s (≈ %4$d min of sustained rise) while the value is at or above %5$s. No prediction, just the raw trend.</string>
     <string name="delta_alarm_interval_label">Delta window</string>
     <string name="delta_alarm_interval_follow">Like Δ readout (currently %1$d min)</string>
+    <string name="delta_early_trigger_label">Early trigger</string>
+    <string name="delta_early_trigger_desc">Also fire as soon as the total distance (%1$s %2$s) is covered, no matter how many intervals have passed</string>
     <string name="alert_value_available">Value Available</string>
     <string name="alert_amount">Amount Alert</string>
 

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1833,6 +1833,10 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_iob_desc">IOB/eIOB from the journal in the status line</string>
     <string name="notification_show_cob_title">Show carbs on board</string>
     <string name="notification_show_cob_desc">COB from the journal in the status line</string>
+    <string name="notification_show_delta_title">Show delta (Δ)</string>
+    <string name="notification_show_delta_desc">Measured change of the last 5 minutes next to the arrow</string>
+    <string name="dashboard_show_delta_title">Delta (Δ) on the dashboard</string>
+    <string name="dashboard_show_delta_desc">Measured change of the last 5 minutes below the trend arrow</string>
     <string name="glucose_range_colors_title">Color glucose by range</string>
     <string name="glucose_range_colors_desc">Green in target, yellow borderline, red beyond very low/high — notification and dashboard</string>
     <string name="very_range_title">Very low / very high</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -807,6 +807,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="alert_sensor_expiry">Sensor Expiry</string>
     <string name="missed_reading_channel_description">Alerts when no glucose reading arrives for the configured duration</string>
     <string name="sensor_expiry_channel_description">Alerts when the current sensor is nearing expiry</string>
+    <string name="alert_falling_fast">Falling Fast</string>
+    <string name="alert_rising_fast">Rising Fast</string>
+    <string name="delta_change_label">Change per %1$d min</string>
+    <string name="delta_count_label">Readings in a row</string>
+    <string name="delta_border_below_label">Alarm only below</string>
+    <string name="delta_border_above_label">Alarm only above</string>
+    <string name="falling_fast_explanation">Warns when %1$d readings in a row each drop by more than %2$s and the value is at or below %3$s. No prediction, just the raw trend.</string>
+    <string name="rising_fast_explanation">Warns when %1$d readings in a row each rise by more than %2$s and the value is at or above %3$s. No prediction, just the raw trend.</string>
     <string name="alert_value_available">Value Available</string>
     <string name="alert_amount">Amount Alert</string>
 

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -813,8 +813,10 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="delta_count_label">Readings in a row</string>
     <string name="delta_border_below_label">Alarm only below</string>
     <string name="delta_border_above_label">Alarm only above</string>
-    <string name="falling_fast_explanation">Warns when %1$d readings in a row each drop by more than %2$s and the value is at or below %3$s. No prediction, just the raw trend.</string>
-    <string name="rising_fast_explanation">Warns when %1$d readings in a row each rise by more than %2$s and the value is at or above %3$s. No prediction, just the raw trend.</string>
+    <string name="falling_fast_explanation">Warns after %1$d consecutive %2$d-minute intervals each falling by at least %3$s (≈ %4$d min of sustained fall) while the value is at or below %5$s. No prediction, just the raw trend.</string>
+    <string name="rising_fast_explanation">Warns after %1$d consecutive %2$d-minute intervals each rising by at least %3$s (≈ %4$d min of sustained rise) while the value is at or above %5$s. No prediction, just the raw trend.</string>
+    <string name="delta_alarm_interval_label">Delta window</string>
+    <string name="delta_alarm_interval_follow">Like Δ readout (currently %1$d min)</string>
     <string name="alert_value_available">Value Available</string>
     <string name="alert_amount">Amount Alert</string>
 
@@ -1846,7 +1848,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="dashboard_show_delta_title">Delta (Δ) on the dashboard</string>
     <string name="dashboard_show_delta_desc">Measured change over the delta interval, below the trend arrow</string>
     <string name="delta_interval_title">Delta (Δ) interval</string>
-    <string name="delta_interval_desc">Time window used for the Δ readout and the falling/rising alarms</string>
+    <string name="delta_interval_desc">Time window for the Δ readout; the falling/rising alarms follow it unless given their own window</string>
     <string name="delta_interval_1min">1 min</string>
     <string name="delta_interval_5min">5 min</string>
     <string name="glucose_range_colors_title">Color glucose by range</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1834,9 +1834,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_cob_title">Show carbs on board</string>
     <string name="notification_show_cob_desc">COB from the journal in the status line</string>
     <string name="notification_show_delta_title">Show delta (Δ)</string>
-    <string name="notification_show_delta_desc">Measured change of the last 5 minutes next to the arrow</string>
+    <string name="notification_show_delta_desc">Measured change over the delta interval, next to the arrow</string>
     <string name="dashboard_show_delta_title">Delta (Δ) on the dashboard</string>
-    <string name="dashboard_show_delta_desc">Measured change of the last 5 minutes below the trend arrow</string>
+    <string name="dashboard_show_delta_desc">Measured change over the delta interval, below the trend arrow</string>
+    <string name="delta_interval_title">Delta (Δ) interval</string>
+    <string name="delta_interval_desc">Time window used for the Δ readout and the falling/rising alarms</string>
+    <string name="delta_interval_1min">1 min</string>
+    <string name="delta_interval_5min">5 min</string>
     <string name="glucose_range_colors_title">Color glucose by range</string>
     <string name="glucose_range_colors_desc">Green in target, yellow borderline, red beyond very low/high — notification and dashboard</string>
     <string name="very_range_title">Very low / very high</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -277,6 +277,7 @@ fun DashboardCombinedHeader(
     veryHighThreshold: Float = fallbackVeryHighThreshold(isMmol),
     valueRangeColorsEnabled: Boolean = false,
     arrowForecastColorsEnabled: Boolean = false,
+    showDelta: Boolean = false,
     peerReadings: List<tk.glucodata.ui.viewmodel.DashboardViewModel.PeerCurrentReading> = emptyList(),
     onPeerReadingClick: (String) -> Unit = {},
     onHeroClick: () -> Unit = {}
@@ -308,6 +309,32 @@ fun DashboardCombinedHeader(
         } else {
             tk.glucodata.logic.TrendEngine.TrendResult(tk.glucodata.logic.TrendEngine.TrendState.Unknown, 0f, 0f, 0f, 0f)
         }
+    }
+    // "Δ" readout: the measured change over the last ~5 minutes — a raw
+    // number to sanity-check the estimated arrow against. Walks back to the
+    // first point old enough for the window instead of taking blind indices.
+    val heroDeltaText = if (showDelta) {
+        remember(history, isMmol) {
+            val newest = history.lastOrNull()
+            val previous = newest?.let { n ->
+                history.asReversed().firstOrNull { p ->
+                    p.value > 0.1f && n.timestamp - p.timestamp >= tk.glucodata.GlucoseDelta.MIN_GAP_MILLIS
+                }
+            }
+            if (newest != null && previous != null) {
+                val delta = tk.glucodata.GlucoseDelta.fiveMinuteDelta(
+                    newest.timestamp, newest.value,
+                    previous.timestamp, previous.value
+                )
+                tk.glucodata.GlucoseDelta.format(delta, isMmol)
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { "Δ $it" }
+            } else {
+                null
+            }
+        }
+    } else {
+        null
     }
     val isLandscape = rememberAdaptiveWindowMetrics().isLandscape
     val cornerWeights = remember(trendResult.velocity) { trendCornerWeightsFromVelocity(trendResult.velocity) }
@@ -647,10 +674,12 @@ fun DashboardCombinedHeader(
                                 )
                             }
 
-                            tk.glucodata.ui.components.TrendIndicator(
+                            HeroTrendWithDelta(
                                 trendResult = trendResult,
-                                modifier = Modifier.size(resolvedTrendIconSize),
-                                color = heroArrowColor
+                                arrowColor = heroArrowColor,
+                                deltaText = heroDeltaText,
+                                contentColor = glucoseContentColor,
+                                iconSize = resolvedTrendIconSize
                             )
                         }
 
@@ -745,10 +774,12 @@ fun DashboardCombinedHeader(
 
                             Spacer(modifier = Modifier.width(resolvedClusterGap))
 
-                            tk.glucodata.ui.components.TrendIndicator(
+                            HeroTrendWithDelta(
                                 trendResult = trendResult,
-                                modifier = Modifier.size(resolvedTrendIconSize),
-                                color = heroArrowColor
+                                arrowColor = heroArrowColor,
+                                deltaText = heroDeltaText,
+                                contentColor = glucoseContentColor,
+                                iconSize = resolvedTrendIconSize
                             )
                         }
 
@@ -959,6 +990,32 @@ fun DashboardCombinedHeader(
                 Modifier
                     .weight(0.3f)
                     .fillMaxHeight()
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeroTrendWithDelta(
+    trendResult: tk.glucodata.logic.TrendEngine.TrendResult,
+    arrowColor: Color,
+    deltaText: String?,
+    contentColor: Color,
+    iconSize: androidx.compose.ui.unit.Dp
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        tk.glucodata.ui.components.TrendIndicator(
+            trendResult = trendResult,
+            modifier = Modifier.size(iconSize),
+            color = arrowColor
+        )
+        if (!deltaText.isNullOrEmpty()) {
+            Text(
+                text = deltaText,
+                style = MaterialTheme.typography.labelSmall.copy(fontFeatureSettings = "tnum"),
+                color = contentColor.copy(alpha = 0.75f),
+                softWrap = false,
+                maxLines = 1
             )
         }
     }

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -278,6 +278,7 @@ fun DashboardCombinedHeader(
     valueRangeColorsEnabled: Boolean = false,
     arrowForecastColorsEnabled: Boolean = false,
     showDelta: Boolean = false,
+    deltaIntervalMinutes: Int = tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES,
     peerReadings: List<tk.glucodata.ui.viewmodel.DashboardViewModel.PeerCurrentReading> = emptyList(),
     onPeerReadingClick: (String) -> Unit = {},
     onHeroClick: () -> Unit = {}
@@ -314,17 +315,18 @@ fun DashboardCombinedHeader(
     // number to sanity-check the estimated arrow against. Walks back to the
     // first point old enough for the window instead of taking blind indices.
     val heroDeltaText = if (showDelta) {
-        remember(history, isMmol) {
+        remember(history, isMmol, deltaIntervalMinutes) {
             val newest = history.lastOrNull()
             val previous = newest?.let { n ->
                 history.asReversed().firstOrNull { p ->
-                    p.value > 0.1f && n.timestamp - p.timestamp >= tk.glucodata.GlucoseDelta.MIN_GAP_MILLIS
+                    p.value > 0.1f && n.timestamp - p.timestamp >= tk.glucodata.GlucoseDelta.minGapMillis(deltaIntervalMinutes)
                 }
             }
             if (newest != null && previous != null) {
-                val delta = tk.glucodata.GlucoseDelta.fiveMinuteDelta(
+                val delta = tk.glucodata.GlucoseDelta.delta(
                     newest.timestamp, newest.value,
-                    previous.timestamp, previous.value
+                    previous.timestamp, previous.value,
+                    deltaIntervalMinutes
                 )
                 tk.glucodata.GlucoseDelta.format(delta, isMmol)
                     .takeIf { it.isNotEmpty() }

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -313,6 +313,7 @@ fun DashboardScreen(
     val glucoseRangeColorsDisplayEnabled by viewModel.glucoseValueRangeColorsEnabled.collectAsState()
     val glucoseArrowForecastEnabled by viewModel.glucoseArrowForecastColorsEnabled.collectAsState()
     val appChartRangeColorsEnabled by viewModel.glucoseAppChartRangeColorsEnabled.collectAsState()
+    val dashboardShowDelta by viewModel.dashboardShowDelta.collectAsState()
     val journalDoseCalculatorEnabled by viewModel.journalDoseCalculatorEnabled.collectAsState()
     val journalFoodMacrosEnabled by viewModel.journalFoodMacrosEnabled.collectAsState()
     val journalFoodLibraryEnabled by viewModel.journalFoodLibraryEnabled.collectAsState()
@@ -1181,6 +1182,7 @@ fun DashboardScreen(
                             veryLowThreshold = veryLowThreshold,
                             veryHighThreshold = veryHighThreshold,
                             valueRangeColorsEnabled = glucoseRangeColorsDisplayEnabled,
+                            showDelta = dashboardShowDelta,
                             arrowForecastColorsEnabled = glucoseArrowForecastEnabled,
                             onHeroClick = {
                                 val autoVal = latestPoint?.value ?: tk.glucodata.GlucoseValueParser.parseFirstOrZero(currentGlucose)
@@ -1420,6 +1422,7 @@ fun DashboardScreen(
                             veryLowThreshold = veryLowThreshold,
                             veryHighThreshold = veryHighThreshold,
                             valueRangeColorsEnabled = glucoseRangeColorsDisplayEnabled,
+                            showDelta = dashboardShowDelta,
                             arrowForecastColorsEnabled = glucoseArrowForecastEnabled,
                             onHeroClick = {
                                 val autoVal = latestPoint?.value ?: tk.glucodata.GlucoseValueParser.parseFirstOrZero(currentGlucose)

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -314,6 +314,7 @@ fun DashboardScreen(
     val glucoseArrowForecastEnabled by viewModel.glucoseArrowForecastColorsEnabled.collectAsState()
     val appChartRangeColorsEnabled by viewModel.glucoseAppChartRangeColorsEnabled.collectAsState()
     val dashboardShowDelta by viewModel.dashboardShowDelta.collectAsState()
+    val deltaIntervalMinutes by viewModel.deltaIntervalMinutes.collectAsState()
     val journalDoseCalculatorEnabled by viewModel.journalDoseCalculatorEnabled.collectAsState()
     val journalFoodMacrosEnabled by viewModel.journalFoodMacrosEnabled.collectAsState()
     val journalFoodLibraryEnabled by viewModel.journalFoodLibraryEnabled.collectAsState()
@@ -1183,6 +1184,7 @@ fun DashboardScreen(
                             veryHighThreshold = veryHighThreshold,
                             valueRangeColorsEnabled = glucoseRangeColorsDisplayEnabled,
                             showDelta = dashboardShowDelta,
+                            deltaIntervalMinutes = deltaIntervalMinutes,
                             arrowForecastColorsEnabled = glucoseArrowForecastEnabled,
                             onHeroClick = {
                                 val autoVal = latestPoint?.value ?: tk.glucodata.GlucoseValueParser.parseFirstOrZero(currentGlucose)
@@ -1423,6 +1425,7 @@ fun DashboardScreen(
                             veryHighThreshold = veryHighThreshold,
                             valueRangeColorsEnabled = glucoseRangeColorsDisplayEnabled,
                             showDelta = dashboardShowDelta,
+                            deltaIntervalMinutes = deltaIntervalMinutes,
                             arrowForecastColorsEnabled = glucoseArrowForecastEnabled,
                             onHeroClick = {
                                 val autoVal = latestPoint?.value ?: tk.glucodata.GlucoseValueParser.parseFirstOrZero(currentGlucose)

--- a/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
@@ -96,6 +96,7 @@ fun NotificationSettingsScreen(
     val arrowForecastEnabled by viewModel.glucoseArrowForecastColorsEnabled.collectAsState()
     val chartRangeColorsEnabled by viewModel.glucoseChartRangeColorsEnabled.collectAsState()
     val appChartRangeColorsEnabled by viewModel.glucoseAppChartRangeColorsEnabled.collectAsState()
+    val dashboardDeltaEnabled by viewModel.dashboardShowDelta.collectAsState()
 
     var fontSize by rememberSaveable { mutableFloatStateOf(prefs.getFloat("notification_font_size", 1.0f)) }
     var fontType by rememberSaveable { mutableIntStateOf(prefs.getInt("notification_font_family", 0)) }
@@ -106,6 +107,7 @@ fun NotificationSettingsScreen(
     var showTargetRange by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_chart_target_range", true)) }
     var showIob by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_show_iob", false)) }
     var showCob by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_show_cob", false)) }
+    var showDelta by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_show_delta", false)) }
     var iobCobRiskColored by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_iob_cob_risk_colored", false)) }
     var iobRiskWithoutCob by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_iob_risk_without_cob", false)) }
     var statusIconScale by rememberSaveable { mutableFloatStateOf(prefs.getFloat("notification_status_icon_scale", 1.0f)) }
@@ -121,6 +123,7 @@ fun NotificationSettingsScreen(
             .putBoolean("notification_chart_target_range", showTargetRange)
             .putBoolean("notification_show_iob", showIob)
             .putBoolean("notification_show_cob", showCob)
+            .putBoolean("notification_show_delta", showDelta)
             .putBoolean("notification_iob_cob_risk_colored", iobCobRiskColored)
             .putBoolean("notification_iob_risk_without_cob", iobRiskWithoutCob)
             .putFloat("notification_status_icon_scale", statusIconScale)
@@ -265,6 +268,22 @@ fun NotificationSettingsScreen(
                 subtitle = stringResource(R.string.glucose_app_chart_range_colors_desc),
                 checked = appChartRangeColorsEnabled,
                 onCheckedChange = { viewModel.setGlucoseAppChartRangeColorsEnabled(it) },
+                icon = null,
+                position = CardPosition.MIDDLE
+            )
+            SettingsSwitchItem(
+                title = stringResource(R.string.dashboard_show_delta_title),
+                subtitle = stringResource(R.string.dashboard_show_delta_desc),
+                checked = dashboardDeltaEnabled,
+                onCheckedChange = { viewModel.setDashboardShowDelta(it) },
+                icon = null,
+                position = CardPosition.MIDDLE
+            )
+            SettingsSwitchItem(
+                title = stringResource(R.string.notification_show_delta_title),
+                subtitle = stringResource(R.string.notification_show_delta_desc),
+                checked = showDelta,
+                onCheckedChange = { showDelta = it; save() },
                 icon = null,
                 position = CardPosition.MIDDLE
             )

--- a/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
@@ -97,6 +97,7 @@ fun NotificationSettingsScreen(
     val chartRangeColorsEnabled by viewModel.glucoseChartRangeColorsEnabled.collectAsState()
     val appChartRangeColorsEnabled by viewModel.glucoseAppChartRangeColorsEnabled.collectAsState()
     val dashboardDeltaEnabled by viewModel.dashboardShowDelta.collectAsState()
+    val deltaIntervalMinutes by viewModel.deltaIntervalMinutes.collectAsState()
 
     var fontSize by rememberSaveable { mutableFloatStateOf(prefs.getFloat("notification_font_size", 1.0f)) }
     var fontType by rememberSaveable { mutableIntStateOf(prefs.getInt("notification_font_family", 0)) }
@@ -287,6 +288,32 @@ fun NotificationSettingsScreen(
                 icon = null,
                 position = CardPosition.MIDDLE
             )
+            Column(
+                modifier = Modifier.padding(horizontal = legacySettingsHorizontalPadding, vertical = 8.dp)
+            ) {
+                Text(
+                    stringResource(R.string.delta_interval_title),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    stringResource(R.string.delta_interval_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    FilterChip(
+                        selected = deltaIntervalMinutes == 1,
+                        onClick = { viewModel.setDeltaIntervalMinutes(1) },
+                        label = { Text(stringResource(R.string.delta_interval_1min)) }
+                    )
+                    FilterChip(
+                        selected = deltaIntervalMinutes == 5,
+                        onClick = { viewModel.setDeltaIntervalMinutes(5) },
+                        label = { Text(stringResource(R.string.delta_interval_5min)) }
+                    )
+                }
+            }
             SettingsSwitchItem(
                 title = stringResource(R.string.notification_show_iob_title),
                 subtitle = stringResource(R.string.notification_show_iob_desc),

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
@@ -1205,6 +1205,19 @@ private fun DeltaAlarmSettings(
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant
     )
+
+    // Optional escalation on the implied total distance (count x threshold).
+    ClickableToggleRow(
+        icon = Icons.Default.Bolt,
+        title = stringResource(R.string.delta_early_trigger_label),
+        subtitle = stringResource(
+            R.string.delta_early_trigger_desc,
+            formatThreshold(deltaCount * deltaThreshold, isMmol),
+            stringResource(if (isMmol) R.string.unit_mmol else R.string.unit_mg)
+        ),
+        checked = config.earlyTriggerEnabled,
+        onCheckedChange = { onConfigChange(config.copy(earlyTriggerEnabled = it)) }
+    )
 }
 
 @Composable

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
@@ -155,7 +155,9 @@ fun AlertSettingsScreen(
     val predictiveAlerts = remember {
         listOf(
             AlertType.PRE_LOW,
+            AlertType.FALLING_FAST,
             AlertType.PRE_HIGH,
+            AlertType.RISING_FAST,
             AlertType.PERSISTENT_HIGH
         )
     }
@@ -954,6 +956,12 @@ private fun AlertCard(
                             if (isNotEmpty()) append(" • ")
                             append(stringResource(R.string.minutes_short_format, it))
                         }
+                        config.deltaThreshold?.let { dt ->
+                            if (isNotEmpty()) append(" • ")
+                            append(formatThreshold(dt, isMmol))
+                            append(" ×")
+                            append(config.deltaCount ?: AlertDefaults.DELTA_COUNT_DEFAULT)
+                        }
                         // Add time range if enabled
                         if (config.timeRangeEnabled) {
                             if (isNotEmpty()) append(" • ")
@@ -1045,6 +1053,15 @@ private fun AlertSettingsExpanded(
             onPickSound = { onPickSound() },
             onTest = onTest,
             headerContent = {
+                // === Delta-counter Section (FALLING_FAST / RISING_FAST) ===
+                if (config.type == AlertType.FALLING_FAST || config.type == AlertType.RISING_FAST) {
+                    DeltaAlarmSettings(
+                        config = config,
+                        isMmol = isMmol,
+                        onConfigChange = onConfigChange
+                    )
+                }
+
                  // === Threshold Section (If applicable) ===
                 if (config.threshold != null) {
                     ThresholdSlider(
@@ -1091,6 +1108,75 @@ private fun AlertSettingsExpanded(
 //        HorizontalDivider()
         
 
+
+/**
+ * Type-specific inputs for the GDH-style delta alarms: how big a per-reading change counts as
+ * steep, how many such readings in a row are needed, and the value past which it may alarm.
+ */
+@Composable
+private fun DeltaAlarmSettings(
+    config: AlertConfig,
+    isMmol: Boolean,
+    onConfigChange: (AlertConfig) -> Unit
+) {
+    val falling = config.type == AlertType.FALLING_FAST
+    val deltaThreshold = config.deltaThreshold
+        ?: if (isMmol) AlertDefaults.DELTA_THRESHOLD_MMOL else AlertDefaults.DELTA_THRESHOLD_MGDL
+    val deltaCount = config.deltaCount ?: AlertDefaults.DELTA_COUNT_DEFAULT
+    val deltaBorder = config.deltaBorder ?: if (falling) {
+        if (isMmol) AlertDefaults.FALLING_BORDER_MMOL else AlertDefaults.FALLING_BORDER_MGDL
+    } else {
+        if (isMmol) AlertDefaults.RISING_BORDER_MMOL else AlertDefaults.RISING_BORDER_MGDL
+    }
+    // The delta is measured over the global interval (1 or 5 min); label the threshold with it.
+    val intervalMinutes = remember {
+        tk.glucodata.GlucoseDelta.sanitizeIntervalMinutes(
+            Applic.app
+                .getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+                .getInt("delta_interval_minutes", tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES)
+        )
+    }
+
+    ThresholdSlider(
+        label = stringResource(R.string.delta_change_label, intervalMinutes),
+        value = deltaThreshold,
+        isMmol = isMmol,
+        range = if (isMmol) 0.1f..2.5f else 1f..40f,
+        onValueChange = { onConfigChange(config.copy(deltaThreshold = it)) }
+    )
+
+    DurationSlider(
+        label = stringResource(R.string.delta_count_label),
+        value = deltaCount,
+        range = 2..12,
+        stepSize = 1,
+        onValueChange = { onConfigChange(config.copy(deltaCount = it)) },
+        valueText = { "$it" }
+    )
+
+    ThresholdSlider(
+        label = stringResource(if (falling) R.string.delta_border_below_label else R.string.delta_border_above_label),
+        value = deltaBorder,
+        isMmol = isMmol,
+        range = if (falling) {
+            if (isMmol) 4.0f..11.0f else 70f..200f
+        } else {
+            if (isMmol) 7.0f..17.0f else 120f..300f
+        },
+        onValueChange = { onConfigChange(config.copy(deltaBorder = it)) }
+    )
+
+    Text(
+        text = stringResource(
+            if (falling) R.string.falling_fast_explanation else R.string.rising_fast_explanation,
+            deltaCount,
+            formatThreshold(deltaThreshold, isMmol),
+            formatThreshold(deltaBorder, isMmol)
+        ),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+}
 
 @Composable
 private fun ThresholdSlider(
@@ -1883,6 +1969,8 @@ private fun getAlertIconAndColor(type: AlertType, isDark: Boolean): Pair<ImageVe
         AlertType.VERY_HIGH -> Icons.Default.Warning to Color(GlucoseRangeColors.veryHigh(isDark))
         AlertType.PRE_LOW -> Icons.AutoMirrored.Filled.TrendingDown to Color(GlucoseRangeColors.low(isDark))
         AlertType.PRE_HIGH -> Icons.AutoMirrored.Filled.TrendingUp to Color(GlucoseRangeColors.high(isDark))
+        AlertType.FALLING_FAST -> Icons.AutoMirrored.Filled.TrendingDown to Color(GlucoseRangeColors.veryLow(isDark))
+        AlertType.RISING_FAST -> Icons.AutoMirrored.Filled.TrendingUp to Color(GlucoseRangeColors.veryHigh(isDark))
         AlertType.PERSISTENT_HIGH -> Icons.Default.Timer to Color(GlucoseRangeColors.veryHigh(isDark))
         AlertType.MISSED_READING -> Icons.Default.SignalWifiOff to Color(0xFF78909C)
         AlertType.LOSS -> Icons.Default.BluetoothDisabled to Color(0xFF90A4AE)

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
@@ -1110,9 +1110,11 @@ private fun AlertSettingsExpanded(
 
 
 /**
- * Type-specific inputs for the GDH-style delta alarms: how big a per-reading change counts as
- * steep, how many such readings in a row are needed, and the value past which it may alarm.
+ * Type-specific inputs for the GDH-style delta alarms: how big a change per interval counts as
+ * steep, how many consecutive intervals are needed, the value past which it may alarm, and the
+ * interval itself (own window, or follow the Δ readout's global one).
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun DeltaAlarmSettings(
     config: AlertConfig,
@@ -1128,17 +1130,18 @@ private fun DeltaAlarmSettings(
     } else {
         if (isMmol) AlertDefaults.RISING_BORDER_MMOL else AlertDefaults.RISING_BORDER_MGDL
     }
-    // The delta is measured over the global interval (1 or 5 min); label the threshold with it.
-    val intervalMinutes = remember {
+    // The alarm follows the Δ readout's global interval unless this alert sets its own window.
+    val displayIntervalMinutes = remember {
         tk.glucodata.GlucoseDelta.sanitizeIntervalMinutes(
             Applic.app
                 .getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
                 .getInt("delta_interval_minutes", tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES)
         )
     }
+    val effectiveIntervalMinutes = config.deltaIntervalMinutes ?: displayIntervalMinutes
 
     ThresholdSlider(
-        label = stringResource(R.string.delta_change_label, intervalMinutes),
+        label = stringResource(R.string.delta_change_label, effectiveIntervalMinutes),
         value = deltaThreshold,
         isMmol = isMmol,
         range = if (isMmol) 0.1f..2.5f else 1f..40f,
@@ -1166,11 +1169,37 @@ private fun DeltaAlarmSettings(
         onValueChange = { onConfigChange(config.copy(deltaBorder = it)) }
     )
 
+    // With checkpoint counting the window directly scales the confirmation time
+    // (count x window), so it must not silently change with a display preference.
+    Text(
+        text = stringResource(R.string.delta_alarm_interval_label),
+        style = MaterialTheme.typography.bodyLarge
+    )
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        FilterChip(
+            selected = config.deltaIntervalMinutes == null,
+            onClick = { onConfigChange(config.copy(deltaIntervalMinutes = null)) },
+            label = { Text(stringResource(R.string.delta_alarm_interval_follow, displayIntervalMinutes)) }
+        )
+        FilterChip(
+            selected = config.deltaIntervalMinutes == 1,
+            onClick = { onConfigChange(config.copy(deltaIntervalMinutes = 1)) },
+            label = { Text(stringResource(R.string.delta_interval_1min)) }
+        )
+        FilterChip(
+            selected = config.deltaIntervalMinutes == 5,
+            onClick = { onConfigChange(config.copy(deltaIntervalMinutes = 5)) },
+            label = { Text(stringResource(R.string.delta_interval_5min)) }
+        )
+    }
+
     Text(
         text = stringResource(
             if (falling) R.string.falling_fast_explanation else R.string.rising_fast_explanation,
             deltaCount,
+            effectiveIntervalMinutes,
             formatThreshold(deltaThreshold, isMmol),
+            deltaCount * effectiveIntervalMinutes,
             formatThreshold(deltaBorder, isMmol)
         ),
         style = MaterialTheme.typography.bodySmall,

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
@@ -116,6 +116,7 @@ class DashboardViewModel(
         const val ARROW_FORECAST_COLORS_KEY = "glucose_arrow_forecast_colors_enabled"
         const val CHART_RANGE_COLORS_KEY = "glucose_chart_range_colors_enabled"
         const val APP_CHART_RANGE_COLORS_KEY = "glucose_app_chart_range_colors_enabled"
+        const val DASHBOARD_SHOW_DELTA_KEY = "dashboard_show_delta"
         const val JOURNAL_HEALTH_CONNECT_ACTIVITY_KEY = "dashboard_journal_health_connect_activity_enabled"
         const val PREDICTION_CARB_RATIO_KEY = "dashboard_prediction_carb_ratio_g_per_u"
         const val PREDICTION_INSULIN_SENSITIVITY_KEY = "dashboard_prediction_insulin_sensitivity_mgdl_per_u"
@@ -311,6 +312,9 @@ class DashboardViewModel(
 
     private val _glucoseAppChartRangeColorsEnabled = MutableStateFlow(false)
     val glucoseAppChartRangeColorsEnabled = _glucoseAppChartRangeColorsEnabled.asStateFlow()
+
+    private val _dashboardShowDelta = MutableStateFlow(false)
+    val dashboardShowDelta = _dashboardShowDelta.asStateFlow()
 
     private val _journalHealthConnectActivityEnabled = MutableStateFlow(false)
     val journalHealthConnectActivityEnabled = _journalHealthConnectActivityEnabled.asStateFlow()
@@ -568,6 +572,7 @@ class DashboardViewModel(
         _glucoseArrowForecastColorsEnabled.value = prefs.getBoolean(ARROW_FORECAST_COLORS_KEY, false)
         _glucoseChartRangeColorsEnabled.value = prefs.getBoolean(CHART_RANGE_COLORS_KEY, false)
         _glucoseAppChartRangeColorsEnabled.value = prefs.getBoolean(APP_CHART_RANGE_COLORS_KEY, false)
+        _dashboardShowDelta.value = prefs.getBoolean(DASHBOARD_SHOW_DELTA_KEY, false)
         _journalHealthConnectActivityEnabled.value = prefs.getBoolean(JOURNAL_HEALTH_CONNECT_ACTIVITY_KEY, false)
         _aapsJournalImportEnabled.value = AapsJournalImport.isEnabled(context)
         _predictiveSimulationEnabled.value = prefs.getBoolean("dashboard_predictive_simulation_enabled", true)
@@ -1324,6 +1329,13 @@ class DashboardViewModel(
         prefs.edit().putBoolean(GLUCOSE_RANGE_COLORS_KEY, enabled).apply()
         _glucoseValueRangeColorsEnabled.value = enabled
         refreshNotificationPredictionSurfaces(context)
+    }
+
+    fun setDashboardShowDelta(enabled: Boolean) {
+        val context = tk.glucodata.Applic.app
+        val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(DASHBOARD_SHOW_DELTA_KEY, enabled).apply()
+        _dashboardShowDelta.value = enabled
     }
 
     fun setGlucoseArrowForecastColorsEnabled(enabled: Boolean) {

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
@@ -117,6 +117,7 @@ class DashboardViewModel(
         const val CHART_RANGE_COLORS_KEY = "glucose_chart_range_colors_enabled"
         const val APP_CHART_RANGE_COLORS_KEY = "glucose_app_chart_range_colors_enabled"
         const val DASHBOARD_SHOW_DELTA_KEY = "dashboard_show_delta"
+        const val DELTA_INTERVAL_KEY = "delta_interval_minutes"
         const val JOURNAL_HEALTH_CONNECT_ACTIVITY_KEY = "dashboard_journal_health_connect_activity_enabled"
         const val PREDICTION_CARB_RATIO_KEY = "dashboard_prediction_carb_ratio_g_per_u"
         const val PREDICTION_INSULIN_SENSITIVITY_KEY = "dashboard_prediction_insulin_sensitivity_mgdl_per_u"
@@ -315,6 +316,9 @@ class DashboardViewModel(
 
     private val _dashboardShowDelta = MutableStateFlow(false)
     val dashboardShowDelta = _dashboardShowDelta.asStateFlow()
+
+    private val _deltaIntervalMinutes = MutableStateFlow(tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES)
+    val deltaIntervalMinutes = _deltaIntervalMinutes.asStateFlow()
 
     private val _journalHealthConnectActivityEnabled = MutableStateFlow(false)
     val journalHealthConnectActivityEnabled = _journalHealthConnectActivityEnabled.asStateFlow()
@@ -573,6 +577,9 @@ class DashboardViewModel(
         _glucoseChartRangeColorsEnabled.value = prefs.getBoolean(CHART_RANGE_COLORS_KEY, false)
         _glucoseAppChartRangeColorsEnabled.value = prefs.getBoolean(APP_CHART_RANGE_COLORS_KEY, false)
         _dashboardShowDelta.value = prefs.getBoolean(DASHBOARD_SHOW_DELTA_KEY, false)
+        _deltaIntervalMinutes.value = tk.glucodata.GlucoseDelta.sanitizeIntervalMinutes(
+            prefs.getInt(DELTA_INTERVAL_KEY, tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES)
+        )
         _journalHealthConnectActivityEnabled.value = prefs.getBoolean(JOURNAL_HEALTH_CONNECT_ACTIVITY_KEY, false)
         _aapsJournalImportEnabled.value = AapsJournalImport.isEnabled(context)
         _predictiveSimulationEnabled.value = prefs.getBoolean("dashboard_predictive_simulation_enabled", true)
@@ -1336,6 +1343,19 @@ class DashboardViewModel(
         val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
         prefs.edit().putBoolean(DASHBOARD_SHOW_DELTA_KEY, enabled).apply()
         _dashboardShowDelta.value = enabled
+    }
+
+    /**
+     * Global delta interval (1 or 5 minutes). Drives both the Δ readout and the
+     * FALLING_FAST / RISING_FAST alarms, so it is stored in the shared display prefs.
+     */
+    fun setDeltaIntervalMinutes(minutes: Int) {
+        val context = tk.glucodata.Applic.app
+        val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+        val sanitized = tk.glucodata.GlucoseDelta.sanitizeIntervalMinutes(minutes)
+        prefs.edit().putInt(DELTA_INTERVAL_KEY, sanitized).apply()
+        _deltaIntervalMinutes.value = sanitized
+        refreshNotificationPredictionSurfaces(context)
     }
 
     fun setGlucoseArrowForecastColorsEnabled(enabled: Boolean) {

--- a/Common/src/test/java/tk/glucodata/AlertTestValuePolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/AlertTestValuePolicyTests.kt
@@ -25,7 +25,9 @@ class AlertTestValuePolicyTests {
                 AlertType.AMOUNT,
                 AlertType.LOSS,
                 AlertType.MISSED_READING,
-                AlertType.SENSOR_EXPIRY -> null
+                AlertType.SENSOR_EXPIRY,
+                AlertType.FALLING_FAST,
+                AlertType.RISING_FAST -> null
             }
             val config = AlertConfig(type = type, threshold = threshold)
             val value = AlertTestValuePolicy.resolve(type, config, true, 8.8f)
@@ -44,7 +46,9 @@ class AlertTestValuePolicyTests {
                 AlertType.AMOUNT,
                 AlertType.LOSS,
                 AlertType.MISSED_READING,
-                AlertType.SENSOR_EXPIRY -> assertEquals(8.8f, value, 0.001f)
+                AlertType.SENSOR_EXPIRY,
+                AlertType.FALLING_FAST,
+                AlertType.RISING_FAST -> assertEquals(8.8f, value, 0.001f)
             }
         }
     }

--- a/Common/src/test/java/tk/glucodata/GlucoseDeltaTests.kt
+++ b/Common/src/test/java/tk/glucodata/GlucoseDeltaTests.kt
@@ -1,0 +1,54 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GlucoseDeltaTests {
+
+    private val t0 = 1_700_000_000_000L
+
+    @Test
+    fun fiveMinutePairGivesRawChange() {
+        val d = GlucoseDelta.fiveMinuteDelta(t0, 215f, t0 - 5 * 60_000L, 219f)
+        assertEquals(-4f, d, 0.001f)
+    }
+
+    @Test
+    fun widerGapsNormalizeToFiveMinutes() {
+        // 10 minutes apart, +10 -> +5 per five minutes.
+        val d = GlucoseDelta.fiveMinuteDelta(t0, 130f, t0 - 10 * 60_000L, 120f)
+        assertEquals(5f, d, 0.001f)
+    }
+
+    @Test
+    fun tooClosePairsGiveNaN() {
+        // A single-minute pair says almost nothing (readings repeat on noise)
+        // and extrapolating it to five minutes would amplify that noise 5x.
+        assertTrue(GlucoseDelta.fiveMinuteDelta(t0, 119f, t0 - 60_000L, 120f).isNaN())
+        assertTrue(GlucoseDelta.fiveMinuteDelta(t0, 119f, t0, 120f).isNaN())
+    }
+
+    @Test
+    fun staleOrInvalidPairsGiveNaN() {
+        // Gap beyond 20 minutes says nothing about the current change.
+        assertTrue(GlucoseDelta.fiveMinuteDelta(t0, 119f, t0 - 21 * 60_000L, 140f).isNaN())
+        // Wrong order.
+        assertTrue(GlucoseDelta.fiveMinuteDelta(t0, 119f, t0 + 60_000L, 120f).isNaN())
+        assertTrue(GlucoseDelta.fiveMinuteDelta(t0, Float.NaN, t0 - 5 * 60_000L, 120f).isNaN())
+    }
+
+    @Test
+    fun formatsMgdlCompactlyWithSign() {
+        assertEquals("+2", GlucoseDelta.format(2f, false))
+        assertEquals("-1", GlucoseDelta.format(-1f, false))
+        assertEquals("-1.5", GlucoseDelta.format(-1.5f, false))
+        assertEquals("0", GlucoseDelta.format(0f, false))
+    }
+
+    @Test
+    fun formatsMmolWithOneDecimal() {
+        assertEquals("-0.1", GlucoseDelta.format(-0.1f, true))
+        assertEquals("+0.2", GlucoseDelta.format(0.15f, true))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/GlucoseDeltaTests.kt
+++ b/Common/src/test/java/tk/glucodata/GlucoseDeltaTests.kt
@@ -39,6 +39,43 @@ class GlucoseDeltaTests {
     }
 
     @Test
+    fun oneMinuteIntervalGivesRawChangeForAdjacentReadings() {
+        // 1-minute interval, 1-minute gap -> raw change, no scaling.
+        val d = GlucoseDelta.delta(t0, 219f, t0 - 60_000L, 215f, 1)
+        assertEquals(4f, d, 0.001f)
+    }
+
+    @Test
+    fun oneMinuteIntervalNormalizesWiderGaps() {
+        // 1-minute interval over a 5-minute gap: +10 -> +2 per minute.
+        val d = GlucoseDelta.delta(t0, 130f, t0 - 5 * 60_000L, 120f, 1)
+        assertEquals(2f, d, 0.001f)
+    }
+
+    @Test
+    fun oneMinuteIntervalRejectsSubHalfWindowPairs() {
+        // Closer than half of a 1-minute window (< 30 s) says nothing.
+        assertTrue(GlucoseDelta.delta(t0, 119f, t0 - 20_000L, 120f, 1).isNaN())
+    }
+
+    @Test
+    fun minGapScalesWithInterval() {
+        // 5-minute interval keeps the historical walk-back constant.
+        assertEquals(GlucoseDelta.MIN_GAP_MILLIS, GlucoseDelta.minGapMillis(5))
+        // 1-minute interval walks back only ~54 s.
+        assertEquals(54_000L, GlucoseDelta.minGapMillis(1))
+    }
+
+    @Test
+    fun fiveMinuteDeltaStillMatchesGeneralInterval() {
+        assertEquals(
+            GlucoseDelta.delta(t0, 130f, t0 - 10 * 60_000L, 120f, 5),
+            GlucoseDelta.fiveMinuteDelta(t0, 130f, t0 - 10 * 60_000L, 120f),
+            0.001f
+        )
+    }
+
+    @Test
     fun formatsMgdlCompactlyWithSign() {
         assertEquals("+2", GlucoseDelta.format(2f, false))
         assertEquals("-1", GlucoseDelta.format(-1f, false))

--- a/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
@@ -1,0 +1,313 @@
+package tk.glucodata.alerts
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the GDH-style delta run-length counter behind FALLING_FAST / RISING_FAST.
+ *
+ * The counter is the fragile, safety-critical part (it decides whether a hypo/hyper warning
+ * fires), so it lives in an isolated, purely computational class exercised here without Android,
+ * SharedPreferences, or the clock.
+ *
+ * The delta is measured over the configured interval (1 or 5 minutes) via GlucoseDelta, so the
+ * threshold is cadence-independent: the same "10 mg/dl per 5 min" fires the same way on a 1-minute
+ * sensor and a 5-minute sensor. Timestamps here are in minutes-from-zero for readability.
+ */
+class DeltaAlarmStateTests {
+
+    private val MIN = 60_000L
+
+    // Feed one reading (time given in minutes) and return whether it triggers.
+    private fun DeltaAlarmState.feed(
+        value: Float,
+        atMinute: Long,
+        interval: Int = 5,
+        threshold: Float = 10f,
+        count: Int = 3,
+        border: Float = 120f,
+        enabled: Boolean = true,
+        activeNow: Boolean = true,
+        snoozed: Boolean = false
+    ): Boolean = shouldTrigger(
+        enabled = enabled,
+        activeNow = activeNow,
+        snoozed = snoozed,
+        value = value,
+        readingTimeMs = atMinute * MIN,
+        deltaThreshold = threshold,
+        deltaCount = count,
+        deltaBorder = border,
+        intervalMinutes = interval
+    )
+
+    // ---- 1. Run length over 5-minute readings ----
+
+    @Test
+    fun threeSteepFiveMinuteDropsFire() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))   // baseline, no 5-min-old sample yet
+        assertFalse(state.feed(140f, 5))   // -10 over 5 min -> drop 1
+        assertFalse(state.feed(130f, 10))  // drop 2
+        assertTrue(state.feed(120f, 15))   // drop 3 -> fire, 120 <= border
+    }
+
+    @Test
+    fun twoSteepDropsDoNotFire() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))
+        assertFalse(state.feed(130f, 10))
+    }
+
+    @Test
+    fun shallowDropsNeverAccumulate() {
+        val state = DeltaAlarmState(falling = true)
+        // 6 mg/dl per 5 min is below the 10 threshold.
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(144f, 5))
+        assertFalse(state.feed(138f, 10))
+        assertFalse(state.feed(132f, 15))
+        assertFalse(state.feed(126f, 20))
+    }
+
+    // ---- 2. Cadence independence: 1-minute sensor, 5-minute interval ----
+
+    @Test
+    fun oneMinuteSensorWithFiveMinuteIntervalMatchesFiveMinuteSensor() {
+        // Readings every minute, still dropping 2 mg/dl/min = 10 per 5 min.
+        val state = DeltaAlarmState(falling = true)
+        var fired = false
+        var v = 150f
+        for (m in 0..15) {
+            fired = state.feed(v, m.toLong())
+            v -= 2f
+        }
+        // By minute 15 (value 120) three consecutive 5-min deltas of -10 have accrued.
+        assertTrue(fired)
+    }
+
+    @Test
+    fun oneMinuteSensorNeedsFullWindowBeforeCounting() {
+        val state = DeltaAlarmState(falling = true)
+        // First 4 minutes: no sample is a full ~5 min old yet, so nothing accrues.
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(148f, 1))
+        assertFalse(state.feed(146f, 2))
+        assertFalse(state.feed(144f, 3))
+        assertFalse(state.feed(142f, 4))
+    }
+
+    // ---- 3. Reset on counter-movement ----
+
+    @Test
+    fun flatWindowResetsCounterThenReaccumulates() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))   // drop 1
+        assertFalse(state.feed(130f, 10))  // drop 2
+        assertFalse(state.feed(130f, 15))  // flat over 5 min -> reset
+        assertFalse(state.feed(120f, 20))  // drop 1 again
+        assertFalse(state.feed(110f, 25))  // drop 2
+        assertTrue(state.feed(100f, 30))   // drop 3 -> fire
+    }
+
+    @Test
+    fun risingWindowResetsFallingCounter() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))   // drop 1
+        assertFalse(state.feed(130f, 10))  // drop 2
+        assertFalse(state.feed(145f, 15))  // jumps up -> reset
+        assertFalse(state.feed(135f, 20))  // drop 1
+        assertFalse(state.feed(125f, 25))  // drop 2
+        assertTrue(state.feed(115f, 30))   // drop 3 -> fire
+    }
+
+    // ---- 4. Border ----
+
+    @Test
+    fun steepDropsAboveBorderDoNotFireUntilBelow() {
+        val state = DeltaAlarmState(falling = true)
+        // border 130: only warn once at/below 130.
+        assertFalse(state.feed(170f, 0, border = 130f))
+        assertFalse(state.feed(160f, 5, border = 130f))  // drop 1
+        assertFalse(state.feed(150f, 10, border = 130f)) // drop 2
+        assertFalse(state.feed(140f, 15, border = 130f)) // drop 3 but 140 > 130 -> no fire
+        assertTrue(state.feed(130f, 20, border = 130f))  // drop 4, 130 <= 130 -> fire
+    }
+
+    // ---- 5. Fire once per run, re-arm only when the run breaks ----
+
+    @Test
+    fun doesNotReFireWhileTheDropContinues() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))
+        assertFalse(state.feed(130f, 10))
+        assertTrue(state.feed(120f, 15))   // fires
+        assertFalse(state.feed(110f, 20))  // still dropping, already alarmed this run
+        assertFalse(state.feed(100f, 25))
+    }
+
+    @Test
+    fun reArmsAndFiresAgainAfterTheRunBreaks() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))
+        assertFalse(state.feed(130f, 10))
+        assertTrue(state.feed(120f, 15))   // first alarm
+        assertFalse(state.feed(120f, 20))  // flat -> run breaks, re-arm
+        assertFalse(state.feed(110f, 25))  // drop 1
+        assertFalse(state.feed(100f, 30))  // drop 2
+        assertTrue(state.feed(90f, 35))    // drop 3 -> alarm again
+    }
+
+    // ---- 6. Only genuinely newer readings advance the counter ----
+
+    @Test
+    fun duplicateTimestampDoesNotAdvanceOrResetCounter() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))   // drop 1
+        assertFalse(state.feed(130f, 10))  // drop 2
+        assertFalse(state.feed(130f, 10))  // SAME timestamp -> ignored (not a flat reset)
+        assertTrue(state.feed(120f, 15))   // drop 3 -> fire (proves the duplicate was ignored)
+    }
+
+    // ---- 7. Suppression while inactive / snoozed, then firing once allowed ----
+
+    @Test
+    fun inactiveWindowSuppressesButRunStaysArmed() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0, activeNow = false))
+        assertFalse(state.feed(140f, 5, activeNow = false))
+        assertFalse(state.feed(130f, 10, activeNow = false))
+        assertFalse(state.feed(120f, 15, activeNow = false)) // would fire, but window inactive
+        // A later tick with the same reading, now inside the active window, fires.
+        assertTrue(state.feed(120f, 15, activeNow = true))
+    }
+
+    @Test
+    fun snoozeSuppressesFiring() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0, snoozed = true))
+        assertFalse(state.feed(140f, 5, snoozed = true))
+        assertFalse(state.feed(130f, 10, snoozed = true))
+        assertFalse(state.feed(120f, 15, snoozed = true))  // suppressed by snooze
+        assertTrue(state.feed(120f, 15, snoozed = false))  // snooze cleared -> fires
+    }
+
+    // ---- 8. Disabled resets everything ----
+
+    @Test
+    fun disabledResetsAndRequiresRebuild() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))
+        assertFalse(state.feed(130f, 10))
+        assertFalse(state.feed(120f, 15, enabled = false)) // disabled -> reset, no fire
+        // Re-enabled: history is gone, must rebuild the whole run.
+        assertFalse(state.feed(110f, 20))  // new baseline
+        assertFalse(state.feed(100f, 25))  // drop 1
+        assertFalse(state.feed(90f, 30))   // drop 2
+        assertTrue(state.feed(80f, 35))    // drop 3 -> fire
+    }
+
+    // ---- 9. Rising mirror ----
+
+    @Test
+    fun risingDirectionFiresOnSteepRisesAboveBorder() {
+        val state = DeltaAlarmState(falling = false)
+        // border 200: only warn once at/above 200.
+        assertFalse(state.feed(170f, 0, border = 200f))
+        assertFalse(state.feed(180f, 5, border = 200f))  // rise 1
+        assertFalse(state.feed(190f, 10, border = 200f)) // rise 2, still < 200
+        assertTrue(state.feed(200f, 15, border = 200f))  // rise 3, 200 >= 200 -> fire
+    }
+
+    @Test
+    fun risingCounterResetsOnDrop() {
+        val state = DeltaAlarmState(falling = false)
+        assertFalse(state.feed(170f, 0, border = 200f))
+        assertFalse(state.feed(180f, 5, border = 200f))  // rise 1
+        assertFalse(state.feed(190f, 10, border = 200f)) // rise 2
+        assertFalse(state.feed(180f, 15, border = 200f)) // drop -> reset
+        assertFalse(state.feed(200f, 20, border = 200f)) // rise 1
+        assertFalse(state.feed(210f, 25, border = 200f)) // rise 2
+        assertTrue(state.feed(220f, 30, border = 200f))  // rise 3 -> fire
+    }
+
+    // ---- 10. Calibration baseline reset ----
+
+    @Test
+    fun resetBaselinePreventsCalibrationJumpFromCounting() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))   // drop 1
+        state.resetBaseline()              // recalibration shifts the displayed value
+        assertFalse(state.feed(100f, 10))  // huge apparent drop, but it is the new baseline
+        assertFalse(state.feed(90f, 15))   // drop 1
+        assertFalse(state.feed(80f, 20))   // drop 2
+        assertTrue(state.feed(70f, 25))    // drop 3 -> fire (calibration jump did not count)
+    }
+
+    // ---- 11. Data gap breaks the run ----
+
+    @Test
+    fun aLongDataGapBreaksTheRun() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))   // drop 1
+        assertFalse(state.feed(130f, 10))  // drop 2
+        // 30-minute outage: the next pair is further apart than the max gap -> no usable delta.
+        assertFalse(state.feed(120f, 40))  // gap too large -> run does not advance to 3
+        assertFalse(state.feed(110f, 45))  // drop 1 of a fresh run
+        assertFalse(state.feed(100f, 50))  // drop 2
+        assertTrue(state.feed(90f, 55))    // drop 3 -> fire
+    }
+
+    // ---- 12. Config guards ----
+
+    @Test
+    fun nonPositiveThresholdNeverFires() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0, threshold = 0f))
+        assertFalse(state.feed(140f, 5, threshold = 0f))
+        assertFalse(state.feed(130f, 10, threshold = 0f))
+        assertFalse(state.feed(120f, 15, threshold = 0f))
+    }
+
+    @Test
+    fun nonPositiveCountNeverFires() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0, count = 0))
+        assertFalse(state.feed(140f, 5, count = 0))
+        assertFalse(state.feed(130f, 10, count = 0))
+    }
+
+    // ---- 13. NaN handling ----
+
+    @Test
+    fun nonFiniteValueIsIgnored() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))          // drop 1
+        assertFalse(state.feed(Float.NaN, 10))    // gap reading dropped, run preserved
+        assertFalse(state.feed(130f, 10))         // (same minute as the NaN) still drop 2 vs 140@5
+        assertTrue(state.feed(120f, 15))          // drop 3 -> fire
+    }
+
+    // ---- 14. One-minute interval on a one-minute sensor ----
+
+    @Test
+    fun oneMinuteIntervalCountsPerMinuteDeltas() {
+        val state = DeltaAlarmState(falling = true)
+        // interval 1, threshold 3 mg/dl per minute, count 3, below the default 120 border.
+        assertFalse(state.feed(115f, 0, interval = 1, threshold = 3f))
+        assertFalse(state.feed(111f, 1, interval = 1, threshold = 3f)) // -4/min -> drop 1
+        assertFalse(state.feed(107f, 2, interval = 1, threshold = 3f)) // drop 2
+        assertTrue(state.feed(103f, 3, interval = 1, threshold = 3f))  // drop 3 -> fire (103 <= 120)
+    }
+}

--- a/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
@@ -385,6 +385,22 @@ class DeltaAlarmStateTests {
         assertTrue(state.feed(116f, 17))   // checkpoint -> count 3 -> fire (116 <= 120)
     }
 
+    // ---- 16. Effective window change resets the run ----
+
+    @Test
+    fun changingTheIntervalMidRunDiscardsRunAndHistory() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))   // drop 1
+        assertFalse(state.feed(130f, 10))  // drop 2
+        // The effective window flips to 1 minute: run and history no longer match it.
+        // The next reading is only a fresh baseline, however steep it looks.
+        assertFalse(state.feed(120f, 11, interval = 1, threshold = 3f))
+        assertFalse(state.feed(116f, 12, interval = 1, threshold = 3f)) // -4/min -> drop 1
+        assertFalse(state.feed(112f, 13, interval = 1, threshold = 3f)) // drop 2
+        assertTrue(state.feed(108f, 14, interval = 1, threshold = 3f))  // drop 3 -> fire
+    }
+
     @Test
     fun aShallowSameSignDeltaBetweenCheckpointsDoesNotBreakTheRun() {
         val state = DeltaAlarmState(falling = true)

--- a/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
@@ -1,5 +1,6 @@
 package tk.glucodata.alerts
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -309,5 +310,92 @@ class DeltaAlarmStateTests {
         assertFalse(state.feed(111f, 1, interval = 1, threshold = 3f)) // -4/min -> drop 1
         assertFalse(state.feed(107f, 2, interval = 1, threshold = 3f)) // drop 2
         assertTrue(state.feed(103f, 3, interval = 1, threshold = 3f))  // drop 3 -> fire (103 <= 120)
+    }
+
+    // ---- 15. Non-overlapping checkpoints on fast streams ----
+
+    @Test
+    fun overlappingRollingDeltasOnAOneMinuteStreamDoNotSatisfyTheCount() {
+        // Live regression (2026-07-16): threshold 10/5min, count 3, border 145. A ~7-minute
+        // drop from 157 to 141 produced three overlapping rolling deltas (-13, -14, -13) on
+        // consecutive minutes; they cover the SAME fall and must count as one interval, not three.
+        val state = DeltaAlarmState(falling = true)
+        val values = listOf(157f, 156f, 154f, 151f, 148f, 144f, 142f, 141f)
+        values.forEachIndexed { m, v ->
+            assertFalse("minute $m", state.feed(v, m.toLong(), border = 145f))
+        }
+    }
+
+    @Test
+    fun countOneStillFiresOnTheFirstSteepDelta() {
+        val state = DeltaAlarmState(falling = true)
+        val values = listOf(157f, 156f, 154f, 151f, 148f)
+        values.forEachIndexed { m, v ->
+            assertFalse(state.feed(v, m.toLong(), count = 1, border = 145f))
+        }
+        // First steep rolling delta (-13 vs minute 0) -> immediate alarm, 144 <= 145.
+        assertTrue(state.feed(144f, 5, count = 1, border = 145f))
+    }
+
+    @Test
+    fun fifteenMinutesOfSustainedFallFireAtTheSecondCheckpointAfterRunStart() {
+        // 1-minute stream falling 2.5 mg/dl per minute: every rolling 5-min delta is -12.5.
+        // Run starts at minute 5, checkpoints at 10 and 15 -> count 3 after ~15 min of fall.
+        val state = DeltaAlarmState(falling = true)
+        var v = 150f
+        for (m in 0..14L) {
+            assertFalse("minute $m", state.feed(v, m))
+            v -= 2.5f
+        }
+        assertTrue(state.feed(v, 15))  // 112.5 <= 120 border
+    }
+
+    @Test
+    fun sameTrajectoryFiresAtTheSameTimeOnOneAndFiveMinuteCadence() {
+        // Identical fall (-2 mg/dl per minute from 150) sampled at both cadences: the 5-minute
+        // series behaves exactly like the per-reading counter used to, and the 1-minute series
+        // matches it instead of firing three times earlier.
+        fun valueAt(m: Long) = 150f - 2f * m
+
+        val fiveMinute = DeltaAlarmState(falling = true)
+        var firedAtFive = -1L
+        for (m in 0..15L step 5) if (fiveMinute.feed(valueAt(m), m)) firedAtFive = m
+
+        val oneMinute = DeltaAlarmState(falling = true)
+        var firedAtOne = -1L
+        for (m in 0..15L) if (oneMinute.feed(valueAt(m), m)) firedAtOne = m
+
+        assertEquals(15L, firedAtFive)
+        assertEquals(15L, firedAtOne)
+    }
+
+    @Test
+    fun reversedSignBetweenCheckpointsBreaksTheRunImmediately() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(148f, 1))
+        assertFalse(state.feed(146f, 2))
+        assertFalse(state.feed(144f, 3))
+        assertFalse(state.feed(142f, 4))
+        assertFalse(state.feed(140f, 5))   // -10 vs minute 0 -> run starts
+        assertFalse(state.feed(152f, 6))   // +4 vs minute 1 -> reversed sign -> run breaks NOW
+        // A fresh steep run must accumulate from scratch: start at 7, checkpoints at 12 and 17.
+        assertFalse(state.feed(136f, 7))   // -10 vs minute 2 -> run restarts (count 1)
+        assertFalse(state.feed(126f, 12))  // checkpoint -> count 2
+        assertTrue(state.feed(116f, 17))   // checkpoint -> count 3 -> fire (116 <= 120)
+    }
+
+    @Test
+    fun aShallowSameSignDeltaBetweenCheckpointsDoesNotBreakTheRun() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(148f, 1))
+        assertFalse(state.feed(146f, 2))
+        assertFalse(state.feed(144f, 3))
+        assertFalse(state.feed(142f, 4))
+        assertFalse(state.feed(140f, 5))   // -10 vs minute 0 -> run starts
+        assertFalse(state.feed(139f, 6))   // -9 vs minute 1: same sign, not steep -> run stands
+        assertFalse(state.feed(130f, 10))  // checkpoint: -10 vs minute 5 -> count 2
+        assertTrue(state.feed(120f, 15))   // checkpoint: -10 -> count 3 -> fire
     }
 }

--- a/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
@@ -30,7 +30,8 @@ class DeltaAlarmStateTests {
         border: Float = 120f,
         enabled: Boolean = true,
         activeNow: Boolean = true,
-        snoozed: Boolean = false
+        snoozed: Boolean = false,
+        earlyTrigger: Boolean = false
     ): Boolean = shouldTrigger(
         enabled = enabled,
         activeNow = activeNow,
@@ -40,7 +41,8 @@ class DeltaAlarmStateTests {
         deltaThreshold = threshold,
         deltaCount = count,
         deltaBorder = border,
-        intervalMinutes = interval
+        intervalMinutes = interval,
+        earlyTriggerEnabled = earlyTrigger
     )
 
     // ---- 1. Run length over 5-minute readings ----
@@ -413,5 +415,59 @@ class DeltaAlarmStateTests {
         assertFalse(state.feed(139f, 6))   // -9 vs minute 1: same sign, not steep -> run stands
         assertFalse(state.feed(130f, 10))  // checkpoint: -10 vs minute 5 -> count 2
         assertTrue(state.feed(120f, 15))   // checkpoint: -10 -> count 3 -> fire
+    }
+
+    // ---- 17. Early trigger on the implied total distance (count x threshold) ----
+
+    @Test
+    fun withoutEarlyTriggerAFastFullDistanceDropStillWaitsForTheCheckpoints() {
+        val state = DeltaAlarmState(falling = true)
+        // -5/min: the full implied distance (3 x 10 = 30) is covered within ~6 minutes,
+        // but with the escalation off the alarm still waits for the third checkpoint.
+        var v = 150f
+        for (m in 0..14L) {
+            assertFalse("minute $m", state.feed(v, m))
+            v -= 5f
+        }
+        assertTrue(state.feed(v, 15))  // third checkpoint -> count 3
+    }
+
+    @Test
+    fun earlyTriggerFiresWhenTheFirstDeltaCoversTheFullDistance() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0, earlyTrigger = true))
+        // One rolling delta of -30: the run starts and the full distance is already covered.
+        assertTrue(state.feed(120f, 5, earlyTrigger = true))
+        // Shared arming: the continuing drop must not fire a second alarm this run.
+        assertFalse(state.feed(90f, 10, earlyTrigger = true))
+        assertFalse(state.feed(60f, 15, earlyTrigger = true))
+    }
+
+    @Test
+    fun earlyTriggerFiresBetweenCheckpointsOnceTheDistanceIsCovered() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0, earlyTrigger = true))
+        assertFalse(state.feed(132f, 5, earlyTrigger = true))  // -18 -> run starts, 18 of 30 covered
+        // 33 covered from the anchor: fires between checkpoints, not at the third one.
+        assertTrue(state.feed(117f, 8, earlyTrigger = true))
+    }
+
+    @Test
+    fun earlyTriggerStillRespectsTheBorder() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(190f, 0, earlyTrigger = true))
+        assertFalse(state.feed(155f, 5, earlyTrigger = true))  // 35 covered, but 155 > 120 border
+        assertTrue(state.feed(120f, 10, earlyTrigger = true))  // at the border -> fire
+    }
+
+    @Test
+    fun aRunBreakDiscardsTheEarlyTriggerAnchor() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0, earlyTrigger = true))
+        assertFalse(state.feed(132f, 5, earlyTrigger = true))  // -18 -> run starts, anchored at 150
+        assertFalse(state.feed(140f, 10, earlyTrigger = true)) // reversal -> run breaks, anchor discarded
+        assertFalse(state.feed(120f, 15, earlyTrigger = true)) // new run anchored at 140: 20 of 30
+        // 28 from the NEW anchor -> no alarm; the stale 150 anchor would have given 38.
+        assertFalse(state.feed(112f, 18, earlyTrigger = true))
     }
 }


### PR DESCRIPTION
Two commits. Stacks on #86 (the Δ readout) — the first commit makes that readout's window configurable, so until #86 merges this diff includes it.

**1. Configurable delta interval (1 or 5 minutes)**

The Δ readout was fixed at a 5-minute window. On a 1-minute sensor that is usually the right choice, since a raw one-minute delta is mostly noise, but not always, and GDH lets you pick. This adds a global "delta interval" setting (1 or 5 min, default 5) and generalizes `GlucoseDelta` to honour it. The 5-minute path is unchanged and still covered by its existing tests. The notification and dashboard Δ readouts both read the setting.

**2. Falling/rising-fast delta alarms**

A new pair of alert types, `FALLING_FAST` and `RISING_FAST`, that sit next to `PRE_LOW`/`PRE_HIGH` rather than replacing them. Instead of extrapolating (`glucose + rate * minutes`), they count consecutive readings whose change over the delta interval crosses a threshold and fire once enough pile up while the value is past a border. No prediction and no insulin model, which means you can always say why one fired.

The counting lives in a small `DeltaAlarmState` with its own unit tests, since the run-length logic is the part that can go wrong. It is fed the interval-normalized delta from `GlucoseDelta`, so the threshold means the same thing on a 1-minute and a 5-minute sensor: "10 mg/dl per 5 min" behaves identically on both. It advances once per genuinely new reading, so scheduler ticks and calibration-only display shifts cannot inflate it. It fires once per run and re-arms when the run breaks; snooze and retry handle any repeat nagging.

Disabled by default. `PRE_LOW`/`PRE_HIGH` and the forecast math are left alone.

Per-alarm config is change-per-interval, readings-in-a-row, and the border, persisted under the existing `alert_${type.id}_*` scheme. Strings are in English and German.


---

**Semantics fix (follow-up commits):** The counter previously advanced on every incoming reading. With a 5-minute delta window on a 1-minute stream, consecutive windows overlap by 80%, so `deltaCount = 3` was satisfiable within 3 minutes instead of the intended 3 × 5. Field report: threshold 10/5min, count 3 fired after a ~7-minute drop, right as the curve was flattening. The counter now advances only at non-overlapping interval checkpoints: count 3 with a 5-minute window means three consecutive 5-minute deltas, about 15 minutes of sustained fall. The rolling delta computation is unchanged (still updates per reading, like the Δ readout); a sign reversal between checkpoints breaks the run immediately, a merely-not-steep-enough intermediate delta is judged at the next checkpoint. On a sensor reporting exactly once per interval the behaviour is unchanged (covered by test).

With checkpoint semantics the window directly scales the alarm's confirmation time, so it no longer silently inherits the global Δ readout preference: the alarm now has its own window setting (`1 min` / `5 min` / follow the readout, which is the default). Changing the effective window resets the run state. The default `deltaCount` stays at 3: combined with the border it places the alert meaningfully above the low alarm's territory, and genuinely faster drops are covered by the new optional early trigger.

**Optional early trigger:** the configuration implies a total distance (`deltaCount × threshold`, e.g. 3 × 10 = 30). With `earlyTriggerEnabled`, the alarm also fires as soon as the value has fallen that full distance from the run's reference point, even within one or two intervals, instead of waiting out the remaining checkpoints. Off by default; shares the once-per-run arming with the checkpoint path.
