### PR TITLE
Trend estimator is reached by reflection and silently falls back in every release build

### DIFF
--- a/Common/src/main/java/tk/glucodata/TrendAccess.kt
+++ b/Common/src/main/java/tk/glucodata/TrendAccess.kt
@@ -2,30 +2,66 @@ package tk.glucodata
 
 import kotlin.math.abs
 
+/**
+ * Bridge from the shared code to the app's trend estimator.
+ *
+ * This used to find the estimator by name at runtime. R8 keeps the class name but renames its
+ * members -- mapping.txt of a release build reads
+ * `tk.glucodata.logic.TrendEngine -> tk.glucodata.logic.TrendEngine:` with
+ * `calculateTrend(java.util.List,boolean,boolean) -> a` -- so the method lookup threw in every
+ * minified build. The failure was invisible: [calculateVelocity] just returned [fallbackVelocity],
+ * a slope over the last two readings, and every caller (the notification arrow and the
+ * computed-trend broadcast) shipped that number as if it were the app's trend. After a direction
+ * turn the two disagree outright.
+ *
+ * A keep rule would paper over the symptom and stays fragile -- the commented-out "doesnt work"
+ * attempts in proguard-rules.pro show how that goes here. The detour itself was the problem, so the
+ * implementation is registered explicitly instead ([register], from the mobile Specific.start()),
+ * leaving an ordinary interface call that R8 renames on both sides.
+ */
 object TrendAccess {
-    private const val CLASS_NAME = "tk.glucodata.logic.TrendEngine"
+    private const val LOG_ID = "TrendAccess"
 
-    private val holder by lazy { runCatching { Class.forName(CLASS_NAME) }.getOrNull() }
-    private val instance by lazy { runCatching { holder?.getField("INSTANCE")?.get(null) }.getOrNull() }
-    private val calculateTrendMethod by lazy {
-        runCatching {
-            holder?.getMethod("calculateTrend", List::class.java, Boolean::class.javaPrimitiveType, Boolean::class.javaPrimitiveType)
-        }.getOrNull()
+    @Volatile
+    private var provider: TrendVelocityProvider? = null
+
+    /** Registered at startup, before any reading can be drawn or broadcast. */
+    @JvmStatic
+    fun register(provider: TrendVelocityProvider) {
+        this.provider = provider
     }
-    private val velocityMethod by lazy {
-        runCatching { Class.forName("tk.glucodata.logic.TrendEngine\$TrendResult").getMethod("getVelocity") }.getOrNull()
+
+    internal data class Resolution(val velocity: Float, val usedFallback: Boolean)
+
+    /**
+     * Pure decision, so the degraded path is testable without the Android log: the estimator's
+     * velocity, or the fallback plus the flag that something is wrong.
+     */
+    internal fun resolve(
+        provider: TrendVelocityProvider?,
+        points: List<GlucosePoint>,
+        useRaw: Boolean,
+        isMmol: Boolean
+    ): Resolution {
+        if (provider != null) {
+            val velocity = runCatching { provider.velocity(points, useRaw, isMmol) }.getOrNull()
+            if (velocity != null && velocity.isFinite()) {
+                return Resolution(velocity, usedFallback = false)
+            }
+        }
+        return Resolution(fallbackVelocity(points, useRaw), usedFallback = true)
     }
 
     @JvmStatic
     fun calculateVelocity(points: List<GlucosePoint>, useRaw: Boolean, isMmol: Boolean): Float {
-        val reflected = runCatching {
-            val result = calculateTrendMethod?.invoke(instance, points, useRaw, isMmol)
-            velocityMethod?.invoke(result) as? Float
-        }.getOrNull()
-        if (reflected != null && reflected.isFinite()) {
-            return reflected
+        val resolution = resolve(provider, points, useRaw, isMmol)
+        if (resolution.usedFallback) {
+            // Deliberately not behind doLog: without the provider every arrow and every outgoing
+            // rate quietly carries a two-point slope instead of the app's trend. A value other
+            // apps rotate their arrow by must never degrade in silence.
+            Log.e(LOG_ID, "TrendVelocityProvider missing or unusable - degraded to two-point slope")
         }
-        return fallbackVelocity(points, useRaw)
+        return resolution.velocity
     }
 
     private fun fallbackVelocity(points: List<GlucosePoint>, useRaw: Boolean): Float {

--- a/Common/src/main/java/tk/glucodata/TrendVelocityProvider.kt
+++ b/Common/src/main/java/tk/glucodata/TrendVelocityProvider.kt
@@ -1,0 +1,17 @@
+package tk.glucodata
+
+/**
+ * The app's trend estimator, handed to [TrendAccess] once at startup.
+ *
+ * The estimator itself lives in the mobile source set, which the shared code cannot reference at
+ * compile time. Registering an implementation through this interface keeps the call site a plain
+ * interface invoke: R8 renames both sides consistently, so it survives minification. Looking the
+ * estimator up by name at runtime does not -- see [TrendAccess].
+ */
+fun interface TrendVelocityProvider {
+    /**
+     * @param points glucose history, either order; the estimator decides its own window.
+     * @return trend in mg/dL per minute, or a non-finite value when it cannot say.
+     */
+    fun velocity(points: List<GlucosePoint>, useRaw: Boolean, isMmol: Boolean): Float
+}

--- a/Common/src/mobile/java/tk/glucodata/Specific.java
+++ b/Common/src/mobile/java/tk/glucodata/Specific.java
@@ -26,6 +26,10 @@ import android.content.IntentFilter;
 
 public class Specific {
 	static void start(Application context) {
+		// Hand the shared code this variant's trend estimator before anything can draw an
+		// arrow or broadcast a rate. Explicit registration, not a runtime name lookup: R8
+		// renames the estimator's members in release builds (see TrendAccess).
+		TrendAccess.register(tk.glucodata.logic.TrendEngineVelocityProvider.INSTANCE);
 		watchdrip.set(Natives.getwatchdrip());
 		SuperGattCallback.doGadgetbridge = Natives.getgadgetbridge();
 	}

--- a/Common/src/mobile/java/tk/glucodata/logic/TrendEngineVelocityProvider.kt
+++ b/Common/src/mobile/java/tk/glucodata/logic/TrendEngineVelocityProvider.kt
@@ -1,0 +1,14 @@
+package tk.glucodata.logic
+
+import tk.glucodata.GlucosePoint
+import tk.glucodata.TrendVelocityProvider
+
+/**
+ * Hands the shared code the very estimator the UI draws its arrow from, so the notification arrow
+ * and the outgoing broadcast rate cannot drift apart from the dashboard. Registered once in
+ * Specific.start(); see [tk.glucodata.TrendAccess] for why this is not looked up reflectively.
+ */
+object TrendEngineVelocityProvider : TrendVelocityProvider {
+    override fun velocity(points: List<GlucosePoint>, useRaw: Boolean, isMmol: Boolean): Float =
+        TrendEngine.calculateTrend(points, useRaw, isMmol).velocity
+}

--- a/Common/src/test/java/tk/glucodata/TrendAccessProviderTests.kt
+++ b/Common/src/test/java/tk/glucodata/TrendAccessProviderTests.kt
@@ -1,0 +1,120 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.logic.TrendEngine
+import kotlin.math.abs
+
+/**
+ * TrendAccess used to reach the TrendEngine by name at runtime. R8 keeps the class name but renames
+ * the members (release mapping.txt: calculateTrend(java.util.List,boolean,boolean) -> a), so the
+ * lookup threw in every minified build and calculateVelocity() silently degraded to a two-point
+ * slope over the last two readings. Every consumer -- the notification arrow and the computed-trend
+ * broadcast -- shipped that number as the app's trend.
+ *
+ * These tests pin the explicit provider path and, more importantly, that the fallback is a
+ * *different* number: on a direction turn the two disagree on the sign, which is exactly what the
+ * bug looked like in the field (a receiver's arrow pointing up while the app's own trend fell).
+ *
+ * Deliberately asserted on velocity rather than the rendered angle: the arrow mapping lives in
+ * TrendArrowAngle, which is a deterministic function of velocity and is covered by its own tests,
+ * so equal velocities imply equal angles.
+ */
+class TrendAccessProviderTests {
+
+    /** The Flat state's dead zone in TrendEngine: |v| <= 0.5 mg/dL/min renders flat. */
+    private val flatDeadZone = 0.5f
+
+    private val t0 = 1_700_000_000_000L
+    private fun p(minutesAgo: Long, value: Float) = GlucosePoint(t0 - minutesAgo * 60_000L, value, 0f)
+
+    /** Falling for 20 minutes, then a single +8 uptick on the newest reading. Oldest-first. */
+    private val turnSeries = listOf(p(20, 160f), p(15, 150f), p(10, 140f), p(5, 128f), p(0, 136f))
+
+    /** Sub-dead-zone drift: the trend must read as flat, whichever way the noise leans. */
+    private val flatSeries = listOf(p(20, 100f), p(15, 100.5f), p(10, 100f), p(5, 100.5f), p(0, 100f))
+
+    private val engineProvider = TrendVelocityProvider { points, useRaw, isMmol ->
+        TrendEngine.calculateTrend(points, useRaw, isMmol).velocity
+    }
+
+    private fun engineVelocity(points: List<GlucosePoint>) =
+        TrendEngine.calculateTrend(points, false, false).velocity
+
+    // ---- The divergence the bug rode on ----
+
+    @Test
+    fun engineAndTwoPointSlopeDisagreeOnADirectionTurn() {
+        val engine = engineVelocity(turnSeries)
+        val fallback = TrendAccess.resolve(null, turnSeries, false, false).velocity
+        // The regression over the window still falls; the last pair alone rises.
+        assertTrue("engine should read the 20-min trend as falling, was $engine", engine < 0f)
+        assertTrue("two-point slope should read the last uptick as rising, was $fallback", fallback > 0f)
+        // Opposite signs: the arrows literally point different ways.
+        assertNotEquals(engine, fallback, 0.1f)
+    }
+
+    // ---- Provider registered ----
+
+    @Test
+    fun registeredProviderReturnsEngineVelocity() {
+        val r = TrendAccess.resolve(engineProvider, turnSeries, false, false)
+        assertFalse("provider present -> must not degrade", r.usedFallback)
+        assertEquals(engineVelocity(turnSeries), r.velocity, 0.0001f)
+    }
+
+    @Test
+    fun registeredProviderKeepsTheEngineSignNotTheFallbackSign() {
+        val viaProvider = TrendAccess.resolve(engineProvider, turnSeries, false, false).velocity
+        val viaFallback = TrendAccess.resolve(null, turnSeries, false, false).velocity
+        assertTrue("provider path must keep falling", viaProvider < 0f)
+        assertTrue("fallback path rises", viaFallback > 0f)
+    }
+
+    @Test
+    fun flatDriftStaysInsideTheDeadZoneOnTheProviderPath() {
+        val r = TrendAccess.resolve(engineProvider, flatSeries, false, false)
+        assertFalse(r.usedFallback)
+        assertEquals(engineVelocity(flatSeries), r.velocity, 0.0001f)
+        assertTrue(
+            "sub-dead-zone drift must not pick a direction, was ${r.velocity}",
+            abs(r.velocity) <= flatDeadZone
+        )
+    }
+
+    // ---- Provider missing / failing -> fallback, and it is flagged (the Log.e trigger) ----
+
+    @Test
+    fun missingProviderFallsBackAndFlagsIt() {
+        val r = TrendAccess.resolve(null, turnSeries, false, false)
+        assertTrue("no provider -> must be flagged so the caller can log loudly", r.usedFallback)
+        // Two-point slope over the last 5 minutes: (136 - 128) / 5.
+        assertEquals(1.6f, r.velocity, 0.0001f)
+    }
+
+    @Test
+    fun throwingProviderFallsBackAndFlagsIt() {
+        val boom = TrendVelocityProvider { _, _, _ -> throw IllegalStateException("boom") }
+        val r = TrendAccess.resolve(boom, turnSeries, false, false)
+        assertTrue(r.usedFallback)
+        assertEquals(1.6f, r.velocity, 0.0001f)
+    }
+
+    @Test
+    fun nonFiniteProviderResultFallsBackAndFlagsIt() {
+        val nan = TrendVelocityProvider { _, _, _ -> Float.NaN }
+        val r = TrendAccess.resolve(nan, turnSeries, false, false)
+        assertTrue(r.usedFallback)
+        assertEquals(1.6f, r.velocity, 0.0001f)
+    }
+
+    @Test
+    fun tooFewPointsFallsBackToZero() {
+        val r = TrendAccess.resolve(null, listOf(p(0, 100f)), false, false)
+        assertTrue(r.usedFallback)
+        assertEquals(0f, r.velocity, 0.0001f)
+    }
+}


### PR DESCRIPTION
**Symptom**

With a receiver reading the app's rate, the arrow it draws can point the opposite way to the app's own trend right after a direction turn. On a +8 uptick the receiver rotates up while the dashboard, reading its 20-minute regression, still falls. The dashboard is never wrong here, because it calls the TrendEngine directly. Everything that goes through `TrendAccess` is.

**Why**

`TrendAccess` reaches the estimator by name at runtime:

```kotlin
Class.forName("tk.glucodata.logic.TrendEngine")
holder?.getMethod("calculateTrend", List::class.java, Boolean::class.javaPrimitiveType, Boolean::class.javaPrimitiveType)
```

R8 keeps the class name but renames the members. From `mapping.txt` of a minified release build:

```
tk.glucodata.logic.TrendEngine -> tk.glucodata.logic.TrendEngine:
    2:9:tk.glucodata.logic.TrendEngine$TrendResult calculateTrend(java.util.List,boolean,boolean):23:23 -> a
```

So `Class.forName` resolves, `getMethod("calculateTrend", ...)` throws, `calculateTrendMethod` stays null, and `calculateVelocity()` returns `fallbackVelocity()`, a slope over the last two readings. Nothing logged, nothing threw. Every release build has quietly shipped that two-point number as the app's trend. Debug builds are not minified, which is why this never showed up in testing.

Both consumers are affected. `DisplayTrendSource.resolveArrowRate` feeds `makearrownotification`, and `makeseparatenotification` calls `TrendAccess.calculateVelocity` directly, so the notification arrow ran on the fallback too, not just anything reading the rate out of the app.

**Fix**

Register the implementation instead of looking it up. A `TrendVelocityProvider` interface in the shared code, implemented in the mobile source set against the TrendEngine, handed over in `Specific.start()` before anything can draw or send a reading. What remains is an ordinary interface call, which R8 renames on both sides.

Not a keep rule. That would only pin the name the detour depends on, and the commented-out "doesnt work" attempts already in `proguard-rules.pro` are a fair warning about how reliable that is here. The detour itself was the problem.

`fallbackVelocity` stays as a last resort but is no longer silent. It logs at error level, never behind `doLog`. A value other apps rotate an arrow by should not be allowed to degrade unnoticed.

**Verification**

Unit tests cover the provider path, the missing, throwing and non-finite provider falling back, and the divergence itself: on the turn series the engine reads -1.4 mg/dL/min while the two-point slope reads +1.6, so the test fails if the two are ever confused again.

Checked against a minified release build rather than assumed. R8 inlines the whole indirection, and the resulting bytecode shows the registration and the read wired to each other:

```
# in tk.glucodata.Applic (Specific.start inlined into initproc)
sget-object v0, Ltk/glucodata/logic/a;.a:Ltk/glucodata/logic/a;   # TrendEngineVelocityProvider.INSTANCE
sput-object v0, Ltn7;.a:Ltk/glucodata/logic/a;                    # -> TrendAccess's provider field

# in the inlined TrendAccess.calculateVelocity
sget-object v0, Ltn7;.a:Ltk/glucodata/logic/a;
```

One write, one read, no other writer. The field's type is the concrete provider, so R8 devirtualised the call entirely. The loud fallback branch survives, so if the provider is ever missing it says so.

**Context**

`TrendAccess` came in with #77. #87 is where the divergence becomes visible from the outside, since that option is what puts this number in front of another app. Anything whose effect depends on the TrendEngine actually being called was partially inert in release builds until now.
