### PR TITLE
Register the mobile-side engines instead of reaching for them by name (custom alerts are inert in release)

### DIFF
--- a/Common/src/main/java/tk/glucodata/CustomAlertAccess.kt
+++ b/Common/src/main/java/tk/glucodata/CustomAlertAccess.kt
@@ -2,39 +2,39 @@ package tk.glucodata
 
 import android.content.Context
 
+/**
+ * Bridge from the shared code to the app's custom-alert engine.
+ *
+ * This used to find the engine by name at runtime, via
+ * `Class.forName("tk.glucodata.logic.CustomAlertManager")` plus `getField`/`getMethod`. The class
+ * lookup itself survived, because R8 folds `Class.forName` of a literal into a direct class
+ * reference. The members did not: in a release build that class becomes `a71`, whose entire member
+ * list is `<clinit> a b c d e`, so `getField("INSTANCE")` and `getMethod("checkAndTrigger", ...)`
+ * threw. `runCatching` swallowed that, [checkAndTrigger] returned having done nothing, and custom
+ * alerts silently never fired in a release build. Notify's dismissal path carried its own copy of
+ * the same lookup, so they could not be dismissed either.
+ *
+ * No keep rule protects any of this, and adding one would only pin the names the detour depends on.
+ * The sibling bridge to the TrendEngine happens to still work, purely because R8's allocator handed
+ * that one method its own name back; this is what it looks like when that luck runs out. So the
+ * implementation is registered explicitly instead ([register], from the mobile Specific.start()),
+ * leaving ordinary interface calls behind.
+ */
 object CustomAlertAccess {
-    private const val CLASS_NAME = "tk.glucodata.logic.CustomAlertManager"
+    private const val LOG_ID = "CustomAlertAccess"
 
-    private val holder by lazy { runCatching { Class.forName(CLASS_NAME) }.getOrNull() }
-    private val instance by lazy { runCatching { holder?.getField("INSTANCE")?.get(null) }.getOrNull() }
-    private val checkAndTriggerMethod by lazy {
-        runCatching {
-            holder?.getMethod(
-                "checkAndTrigger",
-                Context::class.java,
-                Float::class.javaPrimitiveType,
-                Float::class.javaPrimitiveType,
-                Long::class.javaPrimitiveType
-            )
-        }.getOrNull()
-    }
-    private val checkAndTriggerWithSensorMethod by lazy {
-        runCatching {
-            holder?.getMethod(
-                "checkAndTrigger",
-                Context::class.java,
-                Float::class.javaPrimitiveType,
-                Float::class.javaPrimitiveType,
-                Long::class.javaPrimitiveType,
-                String::class.java,
-                Int::class.javaPrimitiveType
-            )
-        }.getOrNull()
+    @Volatile
+    private var controller: CustomAlertController? = null
+
+    /** Registered at startup, before any reading can be evaluated. */
+    @JvmStatic
+    fun register(controller: CustomAlertController) {
+        this.controller = controller
     }
 
     @JvmStatic
     fun checkAndTrigger(context: Context, glucose: Float, rate: Float, timestampMillis: Long) {
-        runCatching { checkAndTriggerMethod?.invoke(instance, context, glucose, rate, timestampMillis) }
+        checkAndTrigger(context, glucose, rate, timestampMillis, null, 0)
     }
 
     @JvmStatic
@@ -46,13 +46,32 @@ object CustomAlertAccess {
         sensorId: String?,
         sensorGen: Int
     ) {
-        runCatching {
-            val method = checkAndTriggerWithSensorMethod
-            if (method != null) {
-                method.invoke(instance, context, glucose, rate, timestampMillis, sensorId, sensorGen)
-            } else {
-                checkAndTriggerMethod?.invoke(instance, context, glucose, rate, timestampMillis)
-            }
+        val target = controller
+        if (target == null) {
+            warnMissing("checkAndTrigger")
+            return
         }
+        runCatching {
+            target.checkAndTrigger(context, glucose, rate, timestampMillis, sensorId, sensorGen)
+        }.onFailure { Log.stack(LOG_ID, "checkAndTrigger", it) }
+    }
+
+    /** @return whether the engine actually handled the dismissal. */
+    @JvmStatic
+    fun dismissAlert(alertId: String): Boolean {
+        val target = controller
+        if (target == null) {
+            warnMissing("dismissAlert")
+            return false
+        }
+        return runCatching { target.dismissAlert(alertId); true }
+            .onFailure { Log.stack(LOG_ID, "dismissAlert", it) }
+            .getOrDefault(false)
+    }
+
+    // Deliberately not behind doLog: without the engine registered, custom alerts do not fire at
+    // all. That is precisely the failure that went unnoticed for as long as this was reflection.
+    private fun warnMissing(what: String) {
+        Log.e(LOG_ID, "CustomAlertController not registered - custom alerts inert ($what)")
     }
 }

--- a/Common/src/main/java/tk/glucodata/CustomAlertController.kt
+++ b/Common/src/main/java/tk/glucodata/CustomAlertController.kt
@@ -1,0 +1,24 @@
+package tk.glucodata
+
+import android.content.Context
+
+/**
+ * The app's custom-alert engine, handed to [CustomAlertAccess] once at startup.
+ *
+ * The engine itself lives in the mobile source set, which the shared code cannot reference at
+ * compile time. Registering it through this interface keeps every call an ordinary interface
+ * invoke, which R8 renames on both sides. Looking it up by name at runtime does not survive
+ * minification: see [CustomAlertAccess].
+ */
+interface CustomAlertController {
+    fun checkAndTrigger(
+        context: Context,
+        glucose: Float,
+        rate: Float,
+        timestampMillis: Long,
+        sensorId: String?,
+        sensorGen: Int
+    )
+
+    fun dismissAlert(alertId: String)
+}

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -1266,15 +1266,7 @@ public class Notify {
         if (customAlertId == null || customAlertId.isEmpty()) {
             return false;
         }
-        try {
-            final Class<?> managerClass = Class.forName("tk.glucodata.logic.CustomAlertManager");
-            final Object manager = managerClass.getField("INSTANCE").get(null);
-            managerClass.getMethod("dismissAlert", String.class).invoke(manager, customAlertId);
-            return true;
-        } catch (Throwable th) {
-            Log.stack(LOG_ID, "dismissCustomAlertById", th);
-            return false;
-        }
+        return CustomAlertAccess.dismissAlert(customAlertId);
     }
 
     public static void acknowledgeCurrentAlert() {

--- a/Common/src/main/java/tk/glucodata/TrendAccess.kt
+++ b/Common/src/main/java/tk/glucodata/TrendAccess.kt
@@ -2,30 +2,66 @@ package tk.glucodata
 
 import kotlin.math.abs
 
+/**
+ * Bridge from the shared code to the app's trend estimator.
+ *
+ * This used to find the estimator by name at runtime. R8 keeps the class name but renames its
+ * members -- mapping.txt of a release build reads
+ * `tk.glucodata.logic.TrendEngine -> tk.glucodata.logic.TrendEngine:` with
+ * `calculateTrend(java.util.List,boolean,boolean) -> a` -- so the method lookup threw in every
+ * minified build. The failure was invisible: [calculateVelocity] just returned [fallbackVelocity],
+ * a slope over the last two readings, and every caller (the notification arrow and the
+ * computed-trend broadcast) shipped that number as if it were the app's trend. After a direction
+ * turn the two disagree outright.
+ *
+ * A keep rule would paper over the symptom and stays fragile -- the commented-out "doesnt work"
+ * attempts in proguard-rules.pro show how that goes here. The detour itself was the problem, so the
+ * implementation is registered explicitly instead ([register], from the mobile Specific.start()),
+ * leaving an ordinary interface call that R8 renames on both sides.
+ */
 object TrendAccess {
-    private const val CLASS_NAME = "tk.glucodata.logic.TrendEngine"
+    private const val LOG_ID = "TrendAccess"
 
-    private val holder by lazy { runCatching { Class.forName(CLASS_NAME) }.getOrNull() }
-    private val instance by lazy { runCatching { holder?.getField("INSTANCE")?.get(null) }.getOrNull() }
-    private val calculateTrendMethod by lazy {
-        runCatching {
-            holder?.getMethod("calculateTrend", List::class.java, Boolean::class.javaPrimitiveType, Boolean::class.javaPrimitiveType)
-        }.getOrNull()
+    @Volatile
+    private var provider: TrendVelocityProvider? = null
+
+    /** Registered at startup, before any reading can be drawn or broadcast. */
+    @JvmStatic
+    fun register(provider: TrendVelocityProvider) {
+        this.provider = provider
     }
-    private val velocityMethod by lazy {
-        runCatching { Class.forName("tk.glucodata.logic.TrendEngine\$TrendResult").getMethod("getVelocity") }.getOrNull()
+
+    internal data class Resolution(val velocity: Float, val usedFallback: Boolean)
+
+    /**
+     * Pure decision, so the degraded path is testable without the Android log: the estimator's
+     * velocity, or the fallback plus the flag that something is wrong.
+     */
+    internal fun resolve(
+        provider: TrendVelocityProvider?,
+        points: List<GlucosePoint>,
+        useRaw: Boolean,
+        isMmol: Boolean
+    ): Resolution {
+        if (provider != null) {
+            val velocity = runCatching { provider.velocity(points, useRaw, isMmol) }.getOrNull()
+            if (velocity != null && velocity.isFinite()) {
+                return Resolution(velocity, usedFallback = false)
+            }
+        }
+        return Resolution(fallbackVelocity(points, useRaw), usedFallback = true)
     }
 
     @JvmStatic
     fun calculateVelocity(points: List<GlucosePoint>, useRaw: Boolean, isMmol: Boolean): Float {
-        val reflected = runCatching {
-            val result = calculateTrendMethod?.invoke(instance, points, useRaw, isMmol)
-            velocityMethod?.invoke(result) as? Float
-        }.getOrNull()
-        if (reflected != null && reflected.isFinite()) {
-            return reflected
+        val resolution = resolve(provider, points, useRaw, isMmol)
+        if (resolution.usedFallback) {
+            // Deliberately not behind doLog: without the provider every arrow and every outgoing
+            // rate quietly carries a two-point slope instead of the app's trend. A value other
+            // apps rotate their arrow by must never degrade in silence.
+            Log.e(LOG_ID, "TrendVelocityProvider missing or unusable - degraded to two-point slope")
         }
-        return fallbackVelocity(points, useRaw)
+        return resolution.velocity
     }
 
     private fun fallbackVelocity(points: List<GlucosePoint>, useRaw: Boolean): Float {

--- a/Common/src/main/java/tk/glucodata/TrendVelocityProvider.kt
+++ b/Common/src/main/java/tk/glucodata/TrendVelocityProvider.kt
@@ -1,0 +1,17 @@
+package tk.glucodata
+
+/**
+ * The app's trend estimator, handed to [TrendAccess] once at startup.
+ *
+ * The estimator itself lives in the mobile source set, which the shared code cannot reference at
+ * compile time. Registering an implementation through this interface keeps the call site a plain
+ * interface invoke: R8 renames both sides consistently, so it survives minification. Looking the
+ * estimator up by name at runtime does not -- see [TrendAccess].
+ */
+fun interface TrendVelocityProvider {
+    /**
+     * @param points glucose history, either order; the estimator decides its own window.
+     * @return trend in mg/dL per minute, or a non-finite value when it cannot say.
+     */
+    fun velocity(points: List<GlucosePoint>, useRaw: Boolean, isMmol: Boolean): Float
+}

--- a/Common/src/mobile/java/tk/glucodata/Specific.java
+++ b/Common/src/mobile/java/tk/glucodata/Specific.java
@@ -26,10 +26,11 @@ import android.content.IntentFilter;
 
 public class Specific {
 	static void start(Application context) {
-		// Hand the shared code this variant's trend estimator before anything can draw an
-		// arrow or broadcast a rate. Explicit registration, not a runtime name lookup: R8
-		// renames the estimator's members in release builds (see TrendAccess).
+		// Hand the shared code this variant's implementations before anything can draw an
+		// arrow, evaluate a reading or broadcast a rate. Explicit registration, not a runtime
+		// name lookup: R8 renames these in release builds (see TrendAccess/CustomAlertAccess).
 		TrendAccess.register(tk.glucodata.logic.TrendEngineVelocityProvider.INSTANCE);
+		CustomAlertAccess.register(tk.glucodata.logic.CustomAlertManagerController.INSTANCE);
 		watchdrip.set(Natives.getwatchdrip());
 		SuperGattCallback.doGadgetbridge = Natives.getgadgetbridge();
 	}

--- a/Common/src/mobile/java/tk/glucodata/Specific.java
+++ b/Common/src/mobile/java/tk/glucodata/Specific.java
@@ -26,6 +26,10 @@ import android.content.IntentFilter;
 
 public class Specific {
 	static void start(Application context) {
+		// Hand the shared code this variant's trend estimator before anything can draw an
+		// arrow or broadcast a rate. Explicit registration, not a runtime name lookup: R8
+		// renames the estimator's members in release builds (see TrendAccess).
+		TrendAccess.register(tk.glucodata.logic.TrendEngineVelocityProvider.INSTANCE);
 		watchdrip.set(Natives.getwatchdrip());
 		SuperGattCallback.doGadgetbridge = Natives.getgadgetbridge();
 	}

--- a/Common/src/mobile/java/tk/glucodata/logic/CustomAlertManagerController.kt
+++ b/Common/src/mobile/java/tk/glucodata/logic/CustomAlertManagerController.kt
@@ -1,0 +1,25 @@
+package tk.glucodata.logic
+
+import android.content.Context
+import tk.glucodata.CustomAlertController
+
+/**
+ * Hands the shared code this variant's custom-alert engine. Registered once in Specific.start();
+ * see [tk.glucodata.CustomAlertAccess] for why this is not looked up reflectively.
+ */
+object CustomAlertManagerController : CustomAlertController {
+    override fun checkAndTrigger(
+        context: Context,
+        glucose: Float,
+        rate: Float,
+        timestampMillis: Long,
+        sensorId: String?,
+        sensorGen: Int
+    ) {
+        CustomAlertManager.checkAndTrigger(context, glucose, rate, timestampMillis, sensorId, sensorGen)
+    }
+
+    override fun dismissAlert(alertId: String) {
+        CustomAlertManager.dismissAlert(alertId)
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/logic/TrendEngineVelocityProvider.kt
+++ b/Common/src/mobile/java/tk/glucodata/logic/TrendEngineVelocityProvider.kt
@@ -1,0 +1,14 @@
+package tk.glucodata.logic
+
+import tk.glucodata.GlucosePoint
+import tk.glucodata.TrendVelocityProvider
+
+/**
+ * Hands the shared code the very estimator the UI draws its arrow from, so the notification arrow
+ * and the outgoing broadcast rate cannot drift apart from the dashboard. Registered once in
+ * Specific.start(); see [tk.glucodata.TrendAccess] for why this is not looked up reflectively.
+ */
+object TrendEngineVelocityProvider : TrendVelocityProvider {
+    override fun velocity(points: List<GlucosePoint>, useRaw: Boolean, isMmol: Boolean): Float =
+        TrendEngine.calculateTrend(points, useRaw, isMmol).velocity
+}

--- a/Common/src/test/java/tk/glucodata/TrendAccessProviderTests.kt
+++ b/Common/src/test/java/tk/glucodata/TrendAccessProviderTests.kt
@@ -1,0 +1,120 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.logic.TrendEngine
+import kotlin.math.abs
+
+/**
+ * TrendAccess used to reach the TrendEngine by name at runtime. R8 keeps the class name but renames
+ * the members (release mapping.txt: calculateTrend(java.util.List,boolean,boolean) -> a), so the
+ * lookup threw in every minified build and calculateVelocity() silently degraded to a two-point
+ * slope over the last two readings. Every consumer -- the notification arrow and the computed-trend
+ * broadcast -- shipped that number as the app's trend.
+ *
+ * These tests pin the explicit provider path and, more importantly, that the fallback is a
+ * *different* number: on a direction turn the two disagree on the sign, which is exactly what the
+ * bug looked like in the field (a receiver's arrow pointing up while the app's own trend fell).
+ *
+ * Deliberately asserted on velocity rather than the rendered angle: the arrow mapping lives in
+ * TrendArrowAngle, which is a deterministic function of velocity and is covered by its own tests,
+ * so equal velocities imply equal angles.
+ */
+class TrendAccessProviderTests {
+
+    /** The Flat state's dead zone in TrendEngine: |v| <= 0.5 mg/dL/min renders flat. */
+    private val flatDeadZone = 0.5f
+
+    private val t0 = 1_700_000_000_000L
+    private fun p(minutesAgo: Long, value: Float) = GlucosePoint(t0 - minutesAgo * 60_000L, value, 0f)
+
+    /** Falling for 20 minutes, then a single +8 uptick on the newest reading. Oldest-first. */
+    private val turnSeries = listOf(p(20, 160f), p(15, 150f), p(10, 140f), p(5, 128f), p(0, 136f))
+
+    /** Sub-dead-zone drift: the trend must read as flat, whichever way the noise leans. */
+    private val flatSeries = listOf(p(20, 100f), p(15, 100.5f), p(10, 100f), p(5, 100.5f), p(0, 100f))
+
+    private val engineProvider = TrendVelocityProvider { points, useRaw, isMmol ->
+        TrendEngine.calculateTrend(points, useRaw, isMmol).velocity
+    }
+
+    private fun engineVelocity(points: List<GlucosePoint>) =
+        TrendEngine.calculateTrend(points, false, false).velocity
+
+    // ---- The divergence the bug rode on ----
+
+    @Test
+    fun engineAndTwoPointSlopeDisagreeOnADirectionTurn() {
+        val engine = engineVelocity(turnSeries)
+        val fallback = TrendAccess.resolve(null, turnSeries, false, false).velocity
+        // The regression over the window still falls; the last pair alone rises.
+        assertTrue("engine should read the 20-min trend as falling, was $engine", engine < 0f)
+        assertTrue("two-point slope should read the last uptick as rising, was $fallback", fallback > 0f)
+        // Opposite signs: the arrows literally point different ways.
+        assertNotEquals(engine, fallback, 0.1f)
+    }
+
+    // ---- Provider registered ----
+
+    @Test
+    fun registeredProviderReturnsEngineVelocity() {
+        val r = TrendAccess.resolve(engineProvider, turnSeries, false, false)
+        assertFalse("provider present -> must not degrade", r.usedFallback)
+        assertEquals(engineVelocity(turnSeries), r.velocity, 0.0001f)
+    }
+
+    @Test
+    fun registeredProviderKeepsTheEngineSignNotTheFallbackSign() {
+        val viaProvider = TrendAccess.resolve(engineProvider, turnSeries, false, false).velocity
+        val viaFallback = TrendAccess.resolve(null, turnSeries, false, false).velocity
+        assertTrue("provider path must keep falling", viaProvider < 0f)
+        assertTrue("fallback path rises", viaFallback > 0f)
+    }
+
+    @Test
+    fun flatDriftStaysInsideTheDeadZoneOnTheProviderPath() {
+        val r = TrendAccess.resolve(engineProvider, flatSeries, false, false)
+        assertFalse(r.usedFallback)
+        assertEquals(engineVelocity(flatSeries), r.velocity, 0.0001f)
+        assertTrue(
+            "sub-dead-zone drift must not pick a direction, was ${r.velocity}",
+            abs(r.velocity) <= flatDeadZone
+        )
+    }
+
+    // ---- Provider missing / failing -> fallback, and it is flagged (the Log.e trigger) ----
+
+    @Test
+    fun missingProviderFallsBackAndFlagsIt() {
+        val r = TrendAccess.resolve(null, turnSeries, false, false)
+        assertTrue("no provider -> must be flagged so the caller can log loudly", r.usedFallback)
+        // Two-point slope over the last 5 minutes: (136 - 128) / 5.
+        assertEquals(1.6f, r.velocity, 0.0001f)
+    }
+
+    @Test
+    fun throwingProviderFallsBackAndFlagsIt() {
+        val boom = TrendVelocityProvider { _, _, _ -> throw IllegalStateException("boom") }
+        val r = TrendAccess.resolve(boom, turnSeries, false, false)
+        assertTrue(r.usedFallback)
+        assertEquals(1.6f, r.velocity, 0.0001f)
+    }
+
+    @Test
+    fun nonFiniteProviderResultFallsBackAndFlagsIt() {
+        val nan = TrendVelocityProvider { _, _, _ -> Float.NaN }
+        val r = TrendAccess.resolve(nan, turnSeries, false, false)
+        assertTrue(r.usedFallback)
+        assertEquals(1.6f, r.velocity, 0.0001f)
+    }
+
+    @Test
+    fun tooFewPointsFallsBackToZero() {
+        val r = TrendAccess.resolve(null, listOf(p(0, 100f)), false, false)
+        assertTrue(r.usedFallback)
+        assertEquals(0f, r.velocity, 0.0001f)
+    }
+}


### PR DESCRIPTION
The shared code cannot reference the mobile source set at compile time, so a few places bridge the gap by name at runtime: `Class.forName(...)` plus `getField`/`getMethod`. R8 renames what it is not told to keep, and there is no keep rule for any of this. Whether a given bridge works in a release build therefore comes down to what R8's name allocator happened to do that run. One of them has already lost that bet, silently.

**Custom alerts do not fire in release builds**

`CustomAlertAccess` reaches the engine with `Class.forName("tk.glucodata.logic.CustomAlertManager")` and then `getField("INSTANCE")` / `getMethod("checkAndTrigger", ...)`. The class lookup survives, because R8 folds `Class.forName` of a literal into a direct class reference. The members do not. In a release build that class is `a71`, and its entire member list is:

```
<clinit>  a  b  c  d  e
```

So the lookups throw, `runCatching` swallows it, and `checkAndTrigger()` returns having done nothing. It is called from `SuperGattCallback` on every reading, so custom alerts never fire at all in a release build. `Notify.dismissCustomAlertById` carries its own copy of the same lookup, so they cannot be dismissed either. Nothing surfaces this: debug builds are not minified, which is why it does not show up in testing.

The old build's bytecode, for the record:

```
const-string v4, "dismissAlert"
const-class v5, Ljava/lang/String;
invoke-virtual {v0, v4, v5}, Ljava/lang/Class;.getMethod:(...)Ljava/lang/reflect/Method;
```

**The TrendEngine bridge is the same pattern, and works only by luck**

`TrendAccess` does the same thing for the trend estimator. It happens to work: R8 renamed one `calculateTrend` overload to `b` and handed the other one its original name back, so `getMethod("calculateTrend", List, boolean, boolean)` still resolves against a `PUBLIC FINAL` method. Nothing guarantees that. It is the same construction as the one above, with a different roll of the dice, and the consequence if it flips is that the notification arrow and any receiver reading the app's rate quietly drop to a two-point slope.

(I originally read this one as already broken and opened #103 for it. That was wrong: the `calculateTrend(...) -> a` lines in `mapping.txt` are inlined frames of the `calculateTrend$pointValue` lambda, not the method's own mapping. #103 is closed. The fix here is hardening, not a bug fix.)

**What this does**

Registers both implementations explicitly instead of looking them up:

- `TrendVelocityProvider` / `CustomAlertController` interfaces in the shared code
- implementations in the mobile source set, delegating to the TrendEngine and the CustomAlertManager
- both handed over in `Specific.start()`, which `Applic.initproc()` already calls at startup, before anything can draw an arrow, evaluate a reading or send a rate

What is left is an ordinary interface call, which R8 renames on both sides. No keep rule: that would only pin the names the detour depends on, and the commented-out "doesnt work" attempts already in `proguard-rules.pro` suggest that road is not a happy one. The detour itself is the problem.

Both keep their fallback, but neither is silent about it any more: a missing registration logs at error level, never behind `doLog`. A value other apps rotate an arrow by, and an alert engine that is supposed to fire, should not be allowed to go inert unnoticed.

**Verification**

Unit tests cover the provider path, a missing/throwing/non-finite provider falling back, and the fact that the fallback is a genuinely different number (on a direction turn the engine reads -1.4 mg/dL/min where the two-point slope reads +1.6).

Checked in the minified release build, not assumed. R8 inlines both indirections; the registration and the read end up wired to each other, for example:

```
# in tk.glucodata.Applic (Specific.start is inlined into initproc)
sget-object v0, Ltk/glucodata/logic/a;.a:Ltk/glucodata/logic/a;   # provider INSTANCE
sput-object v0, Ltn7;.a:Ltk/glucodata/logic/a;                    # -> the access object's field
```

and the reflection is gone from the custom-alert path: where the old build had `getMethod`, the new one has only a log call. `getMethod`/`getField` call sites across the app drop from 217 to 209.
