### PR TITLE
One canonical trend point list for every arrow

### DIFF
--- a/Common/src/main/java/tk/glucodata/DisplayTrendSource.kt
+++ b/Common/src/main/java/tk/glucodata/DisplayTrendSource.kt
@@ -57,6 +57,33 @@ object DisplayTrendSource {
         return merged
     }
 
+    /**
+     * The one point list every trend arrow regresses over: recent history plus
+     * the live reading, cut to [TREND_WINDOW_MS] anchored at the newest point.
+     *
+     * Anchoring at the newest point instead of the wall clock matters: the
+     * newest reading lags "now" by up to a full period, so a now-anchored load
+     * window keeps or drops the reading sitting at the very edge of the trend
+     * window depending on each consumer's own load timing. Two honest
+     * consumers then regress over lists that differ by one tail point — a
+     * nuance invisible everywhere except at the flat dead zone, where it flips
+     * the glyph categorically for a full period.
+     */
+    @JvmStatic
+    fun resolveTrendPoints(
+        historyPoints: List<GlucosePoint>?,
+        current: CurrentDisplaySource.Snapshot?,
+        activeSensorSerial: String?
+    ): List<GlucosePoint> {
+        val augmented = augmentHistory(historyPoints, current, activeSensorSerial, 0L)
+        val newestTimestamp = augmented.lastOrNull()?.timestamp ?: return augmented
+        val cutoff = newestTimestamp - TREND_WINDOW_MS
+        if (augmented.first().timestamp >= cutoff) {
+            return augmented
+        }
+        return augmented.filter { it.timestamp >= cutoff }
+    }
+
     @JvmStatic
     @JvmOverloads
     fun resolveArrowRate(

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -2930,8 +2930,17 @@ public class Notify {
 
                 float displayRate = glucose.rate;
                 try {
-                    boolean useRaw = (viewMode == 1 || viewMode == 3);
-                    displayRate = TrendAccess.calculateVelocity(nativePoints, useRaw, isMmol);
+                    // The alarm arrow must not disagree with the main notification and the
+                    // dashboard hero: regress over the same canonical trend list they use,
+                    // not a bare 10-minute wall-clock slice.
+                    final CurrentDisplaySource.Snapshot alarmSnapshot = resolveNotificationCurrentSnapshot(
+                            activeSensorSerial);
+                    java.util.List<GlucosePoint> trendPoints = NotificationHistorySource.getDisplayHistory(
+                            endT - 2 * DisplayTrendSource.TREND_WINDOW_MS, isMmol, activeSensorSerial);
+                    trendPoints = DisplayTrendSource.resolveTrendPoints(trendPoints, alarmSnapshot,
+                            activeSensorSerial);
+                    displayRate = DisplayTrendSource.resolveArrowRate(trendPoints, alarmSnapshot, viewMode, isMmol,
+                            glucose.rate);
                 } catch (Throwable t) {
                     // keep original rate if fails
                 }
@@ -3266,22 +3275,19 @@ public class Notify {
         } catch (Exception e) {
             chartPoints = new java.util.ArrayList<>();
         }
+
+        // The canonical trend list: derived from the same rows before the chart's own
+        // augmentation, so the arrow regresses over byte-identical points with the
+        // dashboard hero and the computed-trend broadcast.
+        java.util.List<GlucosePoint> nativePoints = DisplayTrendSource.resolveTrendPoints(chartPoints, resolvedDisplay,
+                activeSensorSerial);
+
         chartPoints = DisplayTrendSource.augmentHistory(chartPoints, resolvedDisplay, activeSensorSerial, startT);
 
         BatteryTrace.bump(
                 "notify.glucose.render",
                 20L,
                 "interactive=" + isScreenInteractive());
-
-        long recentStartT = endT - DisplayTrendSource.TREND_WINDOW_MS;
-        java.util.List<GlucosePoint> nativePoints = new java.util.ArrayList<>();
-        try {
-            nativePoints = NotificationHistorySource.getDisplayHistory(recentStartT, isMmol, activeSensorSerial);
-        } catch (Exception e) {
-            // Fall back to chart points if native fails
-            nativePoints = chartPoints;
-        }
-        nativePoints = DisplayTrendSource.augmentHistory(nativePoints, resolvedDisplay, activeSensorSerial, recentStartT);
 
         // Status Logic & ViewMode extraction
         String statusText = "";
@@ -3660,16 +3666,12 @@ public class Notify {
         } catch (Exception e) {
             chartPoints = new java.util.ArrayList<>();
         }
-        chartPoints = DisplayTrendSource.augmentHistory(chartPoints, current, activeSensorSerial, startT);
 
-        long recentStartT = endT - DisplayTrendSource.TREND_WINDOW_MS;
-        java.util.List<GlucosePoint> nativePoints = new java.util.ArrayList<>();
-        try {
-            nativePoints = NotificationHistorySource.getDisplayHistory(recentStartT, isMmol, activeSensorSerial);
-        } catch (Exception e) {
-            nativePoints = chartPoints;
-        }
-        nativePoints = DisplayTrendSource.augmentHistory(nativePoints, current, activeSensorSerial, recentStartT);
+        // Same canonical trend list as the update path, the dashboard hero and the broadcast.
+        java.util.List<GlucosePoint> nativePoints = DisplayTrendSource.resolveTrendPoints(chartPoints, current,
+                activeSensorSerial);
+
+        chartPoints = DisplayTrendSource.augmentHistory(chartPoints, current, activeSensorSerial, startT);
 
         // Identify ViewMode for Startup
         int viewMode = 0;

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -296,11 +296,14 @@ fun DashboardCombinedHeader(
     val sensorContentColor = if (isExpiring) MaterialTheme.colorScheme.onTertiaryContainer else MaterialTheme.colorScheme.onPrimaryContainer
 
     // Advanced Trend
-    val trendResult = remember(history, latestPoint) {
+    val trendResult = remember(history, latestPoint, currentSnapshot) {
         if (history.isNotEmpty()) {
              // Map Kotlin UI points to Native Java points for shared TrendEngine
              val nativeList = history.map { tk.glucodata.GlucosePoint(it.timestamp, it.value, it.rawValue) }
-             tk.glucodata.logic.TrendEngine.calculateTrend(nativeList, useRaw = (viewMode == 1 || viewMode == 3), isMmol = isMmol)
+             // The canonical trend list (live-augmented, newest-anchored window) —
+             // the same points the notification and broadcast arrows regress over.
+             val trendPoints = tk.glucodata.DisplayTrendSource.resolveTrendPoints(nativeList, currentSnapshot, null)
+             tk.glucodata.logic.TrendEngine.calculateTrend(trendPoints, useRaw = (viewMode == 1 || viewMode == 3), isMmol = isMmol)
         } else if (latestPoint != null) {
             // Fallback
              val nativeList = listOf(tk.glucodata.GlucosePoint(latestPoint.timestamp, latestPoint.value, latestPoint.rawValue))

--- a/Common/src/test/java/tk/glucodata/TrendConsumerPointListTests.kt
+++ b/Common/src/test/java/tk/glucodata/TrendConsumerPointListTests.kt
@@ -1,0 +1,164 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.logic.TrendEngine
+import tk.glucodata.ui.DisplayValues
+
+/**
+ * Every trend-arrow consumer must regress over the SAME point list. Historically
+ * each surface assembled its own: the dashboard hero skipped the live
+ * augmentation, and the notification paths cut their Room load at the wall
+ * clock while TrendEngine windows from the newest point — so whenever the newest
+ * reading lagged "now" (always, by up to a full period), the lists differed by
+ * one tail point. Invisible everywhere except the ±0.5 mg/dl/min flat dead zone,
+ * where the nuance flipped one glyph but not the other for a full period
+ * (observed live: dashboard ↗ vs notification → on an identical 134).
+ *
+ * DisplayTrendSource.resolveTrendPoints is the one canonical resolution now;
+ * these tests pin element-wise identity (timestamps AND values, per the
+ * acceptance criteria) and identical glyph decisions at the dead-zone edge.
+ */
+class TrendConsumerPointListTests {
+
+    private val minute = 60_000L
+    private val now = 1_700_000_000_000L
+    private val serial = "sensor-1"
+
+    /** Newest reading is 45 s old — the wall-clock lag the old cut tripped over. */
+    private val newestTs = now - 45_000L
+
+    /**
+     * 21 Room rows, 1-min apart. The interior 20 rise at exactly 0.48 mg/dl/min;
+     * the oldest row (exactly 20 min before the newest) dips below the line, so
+     * including or dropping it moves the regression across the 0.5 dead-zone
+     * edge — the construction that reproduced the live glyph split pre-fix.
+     */
+    private fun roomBase(): List<GlucosePoint> {
+        val points = ArrayList<GlucosePoint>()
+        points.add(GlucosePoint(newestTs - 20 * minute, 116f, 0f))
+        for (k in 19 downTo 0) {
+            points.add(GlucosePoint(newestTs - k * minute, 133.1f - 0.48f * k, 0f))
+        }
+        return points
+    }
+
+    private fun snapshot(ts: Long, value: Float) = CurrentDisplaySource.Snapshot(
+        timeMillis = ts,
+        rate = Float.NaN,
+        sensorId = serial,
+        sensorGen = 0,
+        index = 0,
+        viewMode = 0,
+        source = "test",
+        autoValue = value,
+        rawValue = 0f,
+        sharedDisplayValue = 0f,
+        sharedMgdl = 0,
+        isMmol = false,
+        displayValues = DisplayValues(primaryValue = value, primaryStr = "", fullFormatted = "")
+    )
+
+    // ---- The four consumers' trend lists, as production assembles them post-fix ----
+
+    /** Dashboard hero: full Room window + snapshot (DashboardComponents.kt). */
+    private fun dashboardList(base: List<GlucosePoint>, snap: CurrentDisplaySource.Snapshot?) =
+        DisplayTrendSource.resolveTrendPoints(base, snap, null)
+
+    /** Main notification: 3-h chart rows + snapshot (Notify.makearrownotification). */
+    private fun notificationList(base: List<GlucosePoint>, snap: CurrentDisplaySource.Snapshot?) =
+        DisplayTrendSource.resolveTrendPoints(base, snap, serial)
+
+    /** Alarm notification: rows since now-2×window + snapshot. */
+    private fun alarmList(base: List<GlucosePoint>, snap: CurrentDisplaySource.Snapshot?): List<GlucosePoint> {
+        val startT = now - 2 * DisplayTrendSource.TREND_WINDOW_MS
+        return DisplayTrendSource.resolveTrendPoints(base.filter { it.timestamp >= startT }, snap, serial)
+    }
+
+    /** GlucosePoint has no value equals — compare the fields the regression reads. */
+    private fun triples(points: List<GlucosePoint>) =
+        points.map { Triple(it.timestamp, it.value, it.rawValue) }
+
+    // ---- Acceptance 1: element-wise list identity, timestamps AND values ----
+
+    @Test
+    fun allConsumersResolveTheIdenticalPointList() {
+        val base = roomBase()
+        val snap = snapshot(newestTs, 133.1f)
+
+        val dashboard = triples(dashboardList(base, snap))
+        val notification = triples(notificationList(base, snap))
+        val alarm = triples(alarmList(base, snap))
+
+        assertEquals(dashboard, notification)
+        assertEquals(dashboard, alarm)
+        // The tail row exactly one window before the newest point stays in for everyone.
+        assertEquals(21, dashboard.size)
+        assertEquals(newestTs - 20 * minute, dashboard.first().first)
+    }
+
+    @Test
+    fun listsStayIdenticalWhenRoomLagsTheLiveReading() {
+        // The newest reading exists only as the live snapshot, not yet persisted.
+        val base = roomBase().dropLast(1)
+        val snap = snapshot(newestTs, 133.1f)
+
+        val dashboard = triples(dashboardList(base, snap))
+        val notification = triples(notificationList(base, snap))
+        val alarm = triples(alarmList(base, snap))
+
+        assertEquals(dashboard, notification)
+        assertEquals(dashboard, alarm)
+        // The live point is appended for every consumer, dashboard included.
+        assertEquals(newestTs, dashboard.last().first)
+        assertEquals(133.1f, dashboard.last().second)
+    }
+
+    // ---- Acceptance 2: identical glyph decision at the dead-zone edge ----
+
+    @Test
+    fun glyphDecisionIsIdenticalAtTheFlatDeadZoneEdge() {
+        val base = roomBase()
+        val snap = snapshot(newestTs, 133.1f)
+
+        // Dashboard hero (DashboardComponents.kt): canonical list into the engine.
+        val dashboardResult = TrendEngine.calculateTrend(dashboardList(base, snap), useRaw = false, isMmol = false)
+
+        // Main notification and alarm notification (Notify.java).
+        val notificationVelocity =
+            DisplayTrendSource.resolveArrowRate(notificationList(base, snap), snap, 0, false, Float.NaN)
+        val alarmVelocity =
+            DisplayTrendSource.resolveArrowRate(alarmList(base, snap), snap, 0, false, Float.NaN)
+
+        assertEquals(dashboardResult.velocity, notificationVelocity, 1e-6f)
+        assertEquals(dashboardResult.velocity, alarmVelocity, 1e-6f)
+
+        // Identical velocity means one glyph decision: every consumer sits on the
+        // same side of the ±0.5 dead zone, whatever the estimator reads for the
+        // fixture. Pre-fix, the one-tail-point list difference put the dashboard
+        // and the notification on opposite sides here.
+        fun deadZoneSide(v: Float) = when {
+            v > 0.5f -> 1
+            v < -0.5f -> -1
+            else -> 0
+        }
+        assertEquals(deadZoneSide(dashboardResult.velocity), deadZoneSide(notificationVelocity))
+        assertEquals(deadZoneSide(dashboardResult.velocity), deadZoneSide(alarmVelocity))
+    }
+
+    @Test
+    fun subDeadZoneDriftReadsFlatOnEveryConsumer() {
+        // Interior slope 0.48 with no tail dip: inside the dead zone for everyone.
+        val base = roomBase().drop(1)
+        val snap = snapshot(newestTs, 133.1f)
+
+        val dashboardResult = TrendEngine.calculateTrend(dashboardList(base, snap), useRaw = false, isMmol = false)
+        val notificationVelocity =
+            DisplayTrendSource.resolveArrowRate(notificationList(base, snap), snap, 0, false, Float.NaN)
+
+        assertEquals(dashboardResult.velocity, notificationVelocity, 1e-6f)
+        assertEquals(TrendEngine.TrendState.Flat, dashboardResult.state)
+        assertTrue("must stay inside the dead zone", kotlin.math.abs(notificationVelocity) <= 0.5f)
+    }
+}


### PR DESCRIPTION
Two arrows rendered from the same data disagreed for a full minute: the dashboard showed ↗ while the notification showed → on an identical 134. Live observation, and the third time the same root problem has surfaced, after the broadcast augmentHistory fix and dashboard-trend-unsmoothed: trend consumers that don't regress over the same point list.

Where the lists came apart:

- The dashboard hero hands its full Room window to TrendEngine, which cuts 20 minutes back from the newest point, but it never appends the live reading.
- The notification paths cut their Room load at the wall clock (now − 20 min) before augmenting. The newest reading lags the wall clock by up to a full period, so the reading sitting exactly at the edge of the trend window is kept by one consumer and dropped by the other.
- The alarm notification regressed over a bare 10-minute wall-clock slice with no augmentation at all.

The difference is one tail point and/or the live point. That nuance is invisible until the regression sits near the ±0.5 mg/dl/min flat dead zone, where one estimator crosses the threshold and the other doesn't, and the glyphs disagree until the next reading lands.

The fix is `DisplayTrendSource.resolveTrendPoints` (history plus live augmentation, cut to the trend window anchored at the newest point), and every arrow consumer now runs through it. The augmented path is canonical rather than the dashboard's bare Room flow because most consumers already augment, and dropping augmentation would re-open the persistence-lag divergence on fast moves. The dashboard was the only outlier.

Tests pin element-wise identity (timestamps and values) of the lists between consumers, the appended live point while Room persistence lags, and agreement on which side of the dead zone every consumer lands at the edge. Unit suite: 747 tests, with the 2 pre-existing failures (ManagedSensorStatusPolicy wall-clock test, DefaultParamCatalog org.json) unchanged.

Note: the test run needs #94 (Somali string escaping) on top, like every branch off current main.
