### PR TITLE
Momentum extrapolates only the journal-unexplained slope (prediction double-count)

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/data/prediction/GlucosePrediction.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/prediction/GlucosePrediction.kt
@@ -62,36 +62,41 @@ fun buildGlucosePrediction(
     val safeAbsorption = settings.carbAbsorptionGramsPerHour.coerceAtLeast(5f)
     val stepMinutes = settings.stepMinutes.coerceIn(3, 15)
     val horizonMinutes = settings.horizonMinutes.coerceIn(30, 360)
-    val trendSlopePerMinute = if (settings.trendMomentumEnabled) {
-        recentTrendSlopePerMinute(history, baselineTime).let { slope ->
-            val maxSlope = if (isMmol) 0.16f else 3f
-            slope.coerceIn(-maxSlope, maxSlope)
-        }
-    } else {
-        0f
-    }
     val targetCenter = ((targetLow + targetHigh) * 0.5f).takeIf { it.isFinite() && it > 0f }
         ?: baseline.value
     val relevantEntries = journalEntries.filter { entry ->
         entry.timestamp in (baselineTime - 36L * 60L * 60L * 1000L)..(baselineTime + horizonMinutes * 60_000L)
     }
 
+    fun journalDeltaAt(timestamp: Long): Float = relevantEntries.sumOf { entry ->
+        entry.projectedDisplayDelta(
+            atMillis = timestamp,
+            baselineMillis = baselineTime,
+            sensitivityDisplay = sensitivity,
+            carbRatioGramsPerUnit = safeCarbRatio,
+            carbAbsorptionGramsPerHour = safeAbsorption,
+            foodMacrosEnabled = settings.foodMacrosEnabled,
+            insulinPresetsById = insulinPresetsById
+        ).toDouble()
+    }.toFloat()
+
+    val trendSlopePerMinute = if (settings.trendMomentumEnabled) {
+        // Regress over journal-residualized samples so momentum carries only the slope
+        // the journal model does not already explain; the modelled part is re-added
+        // through journalDeltaAt below, and would otherwise be counted twice.
+        recentResidualSlopePerMinute(history, baselineTime, ::journalDeltaAt).let { slope ->
+            val maxSlope = if (isMmol) 0.16f else 3f
+            slope.coerceIn(-maxSlope, maxSlope)
+        }
+    } else {
+        0f
+    }
+
     fun projectedDeltaAt(timestamp: Long): Float {
         val minutesFuture = ((timestamp - baselineTime) / 60_000f).coerceAtLeast(0f)
         val trend = trendSlopePerMinute * minutesFuture * exp(-minutesFuture / 70f)
         val settling = (targetCenter - baseline.value) * (1f - exp(-minutesFuture / 240f)) * 0.18f
-        val journalDelta = relevantEntries.sumOf { entry ->
-            entry.projectedDisplayDelta(
-                atMillis = timestamp,
-                baselineMillis = baselineTime,
-                sensitivityDisplay = sensitivity,
-                carbRatioGramsPerUnit = safeCarbRatio,
-                carbAbsorptionGramsPerHour = safeAbsorption,
-                foodMacrosEnabled = settings.foodMacrosEnabled,
-                insulinPresetsById = insulinPresetsById
-            ).toDouble()
-        }.toFloat()
-        return trend + settling + journalDelta
+        return trend + settling + journalDeltaAt(timestamp)
     }
 
     val lowClamp = if (isMmol) 1.0f else 18f
@@ -116,7 +121,11 @@ fun buildGlucosePrediction(
     }
 }
 
-private fun recentTrendSlopePerMinute(history: List<GlucosePoint>, baselineTime: Long): Float {
+private fun recentResidualSlopePerMinute(
+    history: List<GlucosePoint>,
+    baselineTime: Long,
+    modeledDeltaAt: (Long) -> Float
+): Float {
     val recent = history
         .asReversed()
         .asSequence()
@@ -128,14 +137,15 @@ private fun recentTrendSlopePerMinute(history: List<GlucosePoint>, baselineTime:
     if (recent.size < 2) return 0f
 
     val firstTime = recent.first().timestamp
-    val xMean = recent.map { (it.timestamp - firstTime) / 60_000f }.average().toFloat()
-    val yMean = recent.map { it.value }.average().toFloat()
+    val xs = recent.map { (it.timestamp - firstTime) / 60_000f }
+    val ys = recent.map { it.value - modeledDeltaAt(it.timestamp) }
+    val xMean = xs.average().toFloat()
+    val yMean = ys.average().toFloat()
     var numerator = 0f
     var denominator = 0f
-    recent.forEach { point ->
-        val x = (point.timestamp - firstTime) / 60_000f
-        val dx = x - xMean
-        numerator += dx * (point.value - yMean)
+    for (index in recent.indices) {
+        val dx = xs[index] - xMean
+        numerator += dx * (ys[index] - yMean)
         denominator += dx * dx
     }
     return if (denominator > 0.001f) numerator / denominator else 0f

--- a/Common/src/testMobile/java/tk/glucodata/data/prediction/GlucosePredictionResidualTests.kt
+++ b/Common/src/testMobile/java/tk/glucodata/data/prediction/GlucosePredictionResidualTests.kt
@@ -1,0 +1,184 @@
+package tk.glucodata.data.prediction
+
+import kotlin.math.abs
+import kotlin.math.exp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.data.journal.JournalEntry
+import tk.glucodata.data.journal.JournalEntrySource
+import tk.glucodata.data.journal.JournalEntryType
+import tk.glucodata.data.journal.JournalInsulinPreset
+import tk.glucodata.data.journal.JournalIntensity
+import tk.glucodata.ui.GlucosePoint
+
+class GlucosePredictionResidualTests {
+
+    private val baselineTime = 1_700_000_000_000L
+    private val sensitivity = 54f
+
+    private fun settings(momentum: Boolean) = PredictiveSimulationSettings(
+        enabled = true,
+        trendMomentumEnabled = momentum,
+        insulinSensitivityMgDlPerUnit = sensitivity
+    )
+
+    private fun history(valueAtMinutesBeforeBaseline: (Float) -> Float): List<GlucosePoint> {
+        return (9 downTo 0).map { step ->
+            val minutesBefore = step * 5f
+            GlucosePoint(
+                value = valueAtMinutesBeforeBaseline(minutesBefore),
+                time = "",
+                timestamp = baselineTime - (minutesBefore * 60_000f).toLong()
+            )
+        }
+    }
+
+    private fun entry(
+        type: JournalEntryType,
+        timestamp: Long,
+        amount: Float? = null,
+        durationMinutes: Int? = null,
+        intensity: JournalIntensity? = null,
+        insulinPresetId: Long? = null
+    ) = JournalEntry(
+        id = 1L,
+        timestamp = timestamp,
+        sensorSerial = null,
+        type = type,
+        title = "",
+        note = null,
+        amount = amount,
+        glucoseValueMgDl = null,
+        durationMinutes = durationMinutes,
+        intensity = intensity,
+        insulinPresetId = insulinPresetId,
+        foodId = null,
+        proteinGrams = null,
+        fatGrams = null,
+        source = JournalEntrySource.MANUAL,
+        sourceRecordId = null,
+        createdAt = 0L,
+        updatedAt = 0L
+    )
+
+    private fun predictAt(
+        minutesAhead: Int,
+        history: List<GlucosePoint>,
+        entries: List<JournalEntry> = emptyList(),
+        presets: Map<Long, JournalInsulinPreset> = emptyMap(),
+        momentum: Boolean
+    ): Float {
+        val points = buildGlucosePrediction(
+            history = history,
+            journalEntries = entries,
+            insulinPresetsById = presets,
+            unit = "mg/dl",
+            targetLow = 70f,
+            targetHigh = 180f,
+            settings = settings(momentum)
+        )
+        val target = baselineTime + minutesAhead * 60_000L
+        return points.first { it.timestamp == target }.value
+    }
+
+    @Test
+    fun momentumStillExtrapolatesUnexplainedSlope() {
+        // Falling 1 mg/dl per minute with nothing logged: the whole slope is
+        // unexplained, so momentum must carry it exactly as before.
+        val falling = history { minutesBefore -> 150f - 1f * (45f - minutesBefore) }
+        val withMomentum = predictAt(30, falling, momentum = true)
+        val withoutMomentum = predictAt(30, falling, momentum = false)
+        val expectedTrend = -1f * 30f * exp(-30f / 70f)
+        assertEquals(expectedTrend, withMomentum - withoutMomentum, 1f)
+    }
+
+    @Test
+    fun insulinExplainedFallIsNotDoubleCounted() {
+        // Triangle action curve 0:0 -> 60:1 -> 120:0 integrates to a closed-form
+        // cumulative fraction of t^2/7200 while t <= 60. A 2 U bolus at the start
+        // of the regression window whose measured fall tracks that model exactly
+        // must leave no residual slope for momentum to extrapolate.
+        val preset = JournalInsulinPreset(
+            id = 7L,
+            displayName = "test-rapid",
+            onsetMinutes = 0,
+            durationMinutes = 120,
+            accentColor = 0,
+            curveJson = "0:0;60:1;120:0",
+            isBuiltIn = false,
+            isArchived = false,
+            countsTowardIob = true,
+            sortOrder = 0
+        )
+        val bolusTime = baselineTime - 45L * 60_000L
+        val bolus = entry(
+            JournalEntryType.INSULIN,
+            timestamp = bolusTime,
+            amount = 2f,
+            insulinPresetId = 7L
+        )
+        val totalDrop = 2f * sensitivity
+        val explained = history { minutesBefore ->
+            val elapsed = 45f - minutesBefore
+            150f - totalDrop * (elapsed * elapsed / 7200f)
+        }
+        val presets = mapOf(7L to preset)
+        val entries = listOf(bolus)
+
+        val withoutMomentum = predictAt(30, explained, entries, presets, momentum = false)
+        assertTrue(
+            "journal model should keep projecting the bolus fall",
+            withoutMomentum < explained.last().value
+        )
+        for (minutesAhead in intArrayOf(30, 60, 90)) {
+            val on = predictAt(minutesAhead, explained, entries, presets, momentum = true)
+            val off = predictAt(minutesAhead, explained, entries, presets, momentum = false)
+            assertTrue(
+                "momentum re-added a model-explained fall at +$minutesAhead (diff ${on - off})",
+                abs(on - off) < 0.6f
+            )
+        }
+    }
+
+    @Test
+    fun activityExplainedFallIsNotDoubleCounted() {
+        // Intense activity drops sensitivity * 0.22 per hour, linearly over its
+        // duration: 0.198 mg/dl per minute here. A measured fall matching that
+        // exactly must not be extrapolated a second time.
+        val activityStart = baselineTime - 45L * 60_000L
+        val activity = entry(
+            JournalEntryType.ACTIVITY,
+            timestamp = activityStart,
+            durationMinutes = 240,
+            intensity = JournalIntensity.INTENSE
+        )
+        val modeledSlope = sensitivity * 0.22f / 60f
+        val explained = history { minutesBefore -> 140f - modeledSlope * (45f - minutesBefore) }
+        val on = predictAt(30, explained, listOf(activity), momentum = true)
+        val off = predictAt(30, explained, listOf(activity), momentum = false)
+        assertTrue(
+            "momentum re-added a model-explained activity fall (diff ${on - off})",
+            abs(on - off) < 0.6f
+        )
+    }
+
+    @Test
+    fun unexplainedShareOfTheFallSurvivesResidualization() {
+        // Measured fall = the modelled activity fall plus 0.5 mg/dl per minute
+        // from an unlogged cause: momentum must keep exactly the unlogged share.
+        val activityStart = baselineTime - 45L * 60_000L
+        val activity = entry(
+            JournalEntryType.ACTIVITY,
+            timestamp = activityStart,
+            durationMinutes = 240,
+            intensity = JournalIntensity.INTENSE
+        )
+        val modeledSlope = sensitivity * 0.22f / 60f
+        val mixed = history { minutesBefore -> 140f - (modeledSlope + 0.5f) * (45f - minutesBefore) }
+        val on = predictAt(30, mixed, listOf(activity), momentum = true)
+        val off = predictAt(30, mixed, listOf(activity), momentum = false)
+        val expectedResidualTrend = -0.5f * 30f * exp(-30f / 70f)
+        assertEquals(expectedResidualTrend, on - off, 1f)
+    }
+}


### PR DESCRIPTION
Implements the matched-window residualization you described in #99.

`recentTrendSlopePerMinute` is now `recentResidualSlopePerMinute`: for every sample that feeds the 45-minute regression it subtracts the journal model's cumulative effect at that sample's time, then regresses the residuals. The clamp and the extrapolation are unchanged, and the future journal delta is added as before. Momentum now carries only the slope the model does not explain:

    forecast = current glucose + unexplained momentum + remaining logged-treatment effect + settling

The subtraction goes through the same `projectedDisplayDelta` the forward projection uses, so insulin, carbs (including the protein/fat tail) and activity entries are all covered by one model. With momentum disabled, or nothing active logged, nothing changes. An unlogged fall (dawn phenomenon, basal mismatch) still extrapolates at full strength.

Tests live in a new `Common/src/testMobile` source set so the wear and small variants never compile against the mobile-only classes:

- no journal entries: momentum extrapolates the measured slope, unchanged
- a bolus on a triangle action curve whose measured fall matches the model exactly: momentum-on equals momentum-off at +30/60/90 min, where the old code projected the fall a second time
- the same for an activity entry
- a fall that is half modelled activity, half unlogged: only the unlogged share survives into the momentum term

I left the momentum expression itself (`slope * t * exp(-t/70)`) and the graph-versus-PRE_LOW semantics alone, per your comment.

Fixes #99 and possibly #75
