### PR TITLE
Broadcast rate regresses over the canonical trend point list

### DIFF
--- a/Common/src/main/java/tk/glucodata/BroadcastTrendRate.java
+++ b/Common/src/main/java/tk/glucodata/BroadcastTrendRate.java
@@ -49,11 +49,31 @@ public final class BroadcastTrendRate {
     public static float computed(String sensorId, float nativeRate) {
         try {
             final boolean isMmol = Applic.unit == 1;
-            final java.util.List<GlucosePoint> points = NotificationHistorySource.getDisplayHistory(
-                    System.currentTimeMillis() - DisplayTrendSource.TREND_WINDOW_MS,
+            // Load twice the trend window: the canonical cut below anchors at the newest
+            // point, which lags the wall clock, so a window-sized load could miss the tail.
+            final long startT = System.currentTimeMillis() - 2 * DisplayTrendSource.TREND_WINDOW_MS;
+            java.util.List<GlucosePoint> points = NotificationHistorySource.getDisplayHistory(
+                    startT,
                     isMmol,
                     sensorId);
+            // Append the live reading before regressing, exactly like the notification and the
+            // dashboard do. Room persistence lags the current value, so without this the outgoing
+            // rate is computed over a point list one reading shorter than the one the app's own
+            // arrow uses -- the two then disagree on precisely the fast moves this option exists
+            // for. resolveCurrent (not ...ForExchange) on purpose: the promise here is to carry
+            // the trend the app's arrows show, which is the locally smoothed series.
+            CurrentDisplaySource.Snapshot current = null;
+            try {
+                current = CurrentDisplaySource.resolveCurrent(Notify.glucosetimeout, sensorId);
+            } catch (Throwable th) {
+                if (Log.doLog)
+                    Log.i("BroadcastTrendRate", "resolveCurrent failed: " + th);
+            }
+            points = DisplayTrendSource.resolveTrendPoints(points, current, sensorId);
             final int viewMode = Notify.resolveSensorViewMode(sensorId);
+            // current is deliberately not handed to resolveArrowRate: when the history is too thin
+            // to say anything this must fall back to the caller's native rate, as documented above,
+            // rather than to the display snapshot's own rate.
             final float computed = DisplayTrendSource.resolveArrowRate(points, null, viewMode, isMmol, Float.NaN);
             return Float.isFinite(computed) ? computed : nativeRate;
         } catch (Throwable th) {

--- a/Common/src/test/java/tk/glucodata/TrendConsumerPointListTests.kt
+++ b/Common/src/test/java/tk/glucodata/TrendConsumerPointListTests.kt
@@ -142,8 +142,15 @@ class TrendConsumerPointListTests {
         val alarmVelocity =
             DisplayTrendSource.resolveArrowRate(alarmList(base, snap), snap, 0, false, Float.NaN)
 
+        // Broadcast (BroadcastTrendRate.java): the same canonical list; the snapshot is
+        // deliberately not handed to resolveArrowRate so a too-thin history falls back
+        // to the caller's native rate instead of the snapshot's own.
+        val broadcastVelocity =
+            DisplayTrendSource.resolveArrowRate(alarmList(base, snap), null, 0, false, Float.NaN)
+
         assertEquals(dashboardResult.velocity, notificationVelocity, 1e-6f)
         assertEquals(dashboardResult.velocity, alarmVelocity, 1e-6f)
+        assertEquals(dashboardResult.velocity, broadcastVelocity, 1e-6f)
 
         // Identical velocity means one glyph decision: every consumer sits on the
         // same side of the ±0.5 dead zone, whatever the estimator reads for the
@@ -156,6 +163,7 @@ class TrendConsumerPointListTests {
         }
         assertEquals(deadZoneSide(dashboardResult.velocity), deadZoneSide(notificationVelocity))
         assertEquals(deadZoneSide(dashboardResult.velocity), deadZoneSide(alarmVelocity))
+        assertEquals(deadZoneSide(dashboardResult.velocity), deadZoneSide(broadcastVelocity))
     }
 
     @Test


### PR DESCRIPTION
Completes #105 for the one arrow consumer it left out: the outgoing broadcast rate. I had offered this in a #87 comment while that PR was open; #87 merged without it, so here it is on its own.

`BroadcastTrendRate.computed()` still regresses over a bare Room load cut at the wall clock. Since #105, every arrow the app itself draws resolves its points through `DisplayTrendSource.resolveTrendPoints`: history plus the live reading, cut to the trend window anchored at the newest point. Room persistence lags the current value, so the broadcast's list runs one reading short of the app's own exactly on fast moves, which is the situation the computed-trend option exists for. Receivers then rotate their arrow by a rate the phone's own arrows disagree with; sitting next to the delta readout (#86), the mismatch is visible on screen.

The change mirrors the notification path. Load twice the trend window, because the canonical cut anchors at the newest point, which lags the wall clock, so a window-sized load could miss the tail row. Append the live reading via `resolveCurrent`, the locally smoothed series, since the documented promise of this option is to carry the trend the app's arrows show. Then hand the list to `resolveArrowRate`. The snapshot deliberately stays out of `resolveArrowRate` itself, so a too-thin history still falls back to the caller's native rate, as before.

`TrendConsumerPointListTests` gains the broadcast consumer: same canonical list, same velocity as the dashboard and both notifications, same side of the flat dead zone.

Unit suite: 832 tests, with the two pre-existing failures (ManagedSensorStatusPolicy wall-clock test, DefaultParamCatalog org.json) unchanged.
