### PR TITLE
fix(iCan): drop post-connection identity rejection to restore i6 support

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
@@ -28,7 +28,6 @@ import java.util.ArrayDeque
 import java.util.LinkedHashMap
 import java.util.Locale
 import java.util.UUID
-import java.util.concurrent.CopyOnWriteArraySet
 import kotlin.math.abs
 import kotlin.math.round
 import tk.glucodata.Applic
@@ -207,7 +206,6 @@ class ICanHealthBleManager(
     @Volatile private var vendorSoftwareVersion: String = ""
     private val pendingHistoryBatch = LinkedHashMap<Int, PendingHistoryReading>()
     private val recentLiveGlucoseMgdl = ArrayDeque<Float>(RECENT_GLUCOSE_WINDOW_SIZE)
-    private val rejectedOnboardingAddresses = CopyOnWriteArraySet<String>()
 
     private var provisionalSensorIdForAdoption: String? =
         serial.takeIf { ICanHealthConstants.isProvisionalSensorId(it) }
@@ -814,12 +812,8 @@ class ICanHealthBleManager(
     }
 
     fun setOnboardingDeviceSn(deviceSnOrCode: String?) {
-        val normalized = ICanHealthConstants.normalizeOnboardingDeviceSn(deviceSnOrCode)
+        onboardingDeviceSn = ICanHealthConstants.normalizeOnboardingDeviceSn(deviceSnOrCode)
             .takeIf { it.isNotBlank() }
-        if (normalized != onboardingDeviceSn) {
-            rejectedOnboardingAddresses.clear()
-        }
-        onboardingDeviceSn = normalized
     }
 
     fun setConfiguredAuthUserId(userId: String?) {
@@ -1079,10 +1073,6 @@ class ICanHealthBleManager(
 
     override fun matchDeviceName(deviceName: String?, address: String?): Boolean {
         val trimmedName = deviceName?.trim()?.takeIf { it.isNotEmpty() } ?: return false
-        val candidateAddress = address?.trim()?.uppercase(Locale.US)
-        if (candidateAddress != null && candidateAddress in rejectedOnboardingAddresses) {
-            return false
-        }
         val knownAddress = mActiveDeviceAddress?.takeIf { it.isNotBlank() }
         if (knownAddress != null) {
             return address != null && address.equals(knownAddress, ignoreCase = true)
@@ -1122,16 +1112,6 @@ class ICanHealthBleManager(
 
     override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
         if (stop) return
-        val stateAddress = gatt.device?.address?.trim()?.uppercase(Locale.US)
-        if (stateAddress != null && stateAddress in rejectedOnboardingAddresses) {
-            Log.d(TAG, "Ignoring GATT state=$newState from rejected onboarding candidate $stateAddress")
-            if (newState == BluetoothProfile.STATE_CONNECTED) {
-                runCatching { gatt.disconnect() }
-            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
-                runCatching { gatt.close() }
-            }
-            return
-        }
         val currentGatt = mBluetoothGatt
         if (currentGatt != null && currentGatt !== gatt) {
             Log.d(TAG, "Ignoring stale GATT state=$newState status=$status for $SerialNumber")
@@ -1353,9 +1333,6 @@ class ICanHealthBleManager(
                 val rawSerial = ICanHealthParser.parseRawDeviceSerial(data)
                 val resolvedSerial = ICanHealthParser.parseDeviceSerial(data)
                 if (resolvedSerial.isNotEmpty()) {
-                    if (rejectMismatchedOnboardingCandidate(gatt, rawSerial, resolvedSerial)) {
-                        return
-                    }
                     rawSerialFromDevice = rawSerial.takeIf { it.isNotBlank() }
                     applyBundledGlucoseKey(rawSerialFromDevice, vendorSoftwareVersion)
                     Log.i(TAG, "Device serial: $resolvedSerial")
@@ -1427,51 +1404,6 @@ class ICanHealthBleManager(
         }
 
         finishGattOp()
-    }
-
-    private fun rejectMismatchedOnboardingCandidate(
-        gatt: BluetoothGatt,
-        rawSerial: String,
-        resolvedSerial: String,
-    ): Boolean {
-        val expectedOnboardingSn = onboardingDeviceSn ?: return false
-        val isAwaitingIdentity = provisionalSensorIdForAdoption != null ||
-            ICanHealthConstants.isProvisionalSensorId(SerialNumber)
-        if (!isAwaitingIdentity) {
-            return false
-        }
-        val identityMatches =
-            ICanHealthConstants.matchesOnboardingIdentity(expectedOnboardingSn, rawSerial) ||
-                ICanHealthConstants.matchesOnboardingIdentity(expectedOnboardingSn, resolvedSerial)
-        if (identityMatches) {
-            rejectedOnboardingAddresses.clear()
-            return false
-        }
-
-        val address = gatt.device?.address?.trim()?.uppercase(Locale.US)
-        if (address != null) {
-            rejectedOnboardingAddresses.add(address)
-        }
-        Log.w(
-            TAG,
-            "Rejected iCan candidate address=${address ?: "unknown"}: " +
-                "onboarding=${ICanHealthConstants.onboardingIdentityPrefix(expectedOnboardingSn)} " +
-                "device=$resolvedSerial"
-        )
-
-        rawSerialFromDevice = null
-        serialFromDevice = null
-        close()
-        setDevice(null)
-        searchforDeviceAddress()
-        setUiStatus(UiStatusKind.PREPARING)
-        UiRefreshBus.requestStatusRefresh()
-        handler.postDelayed({
-            if (!stop && !uiPaused && ICanHealthConstants.isProvisionalSensorId(SerialNumber)) {
-                SensorBluetooth.startscan()
-            }
-        }, 250L)
-        return true
     }
 
     override fun onDescriptorWrite(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int) {

--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthConstants.kt
@@ -11,6 +11,7 @@ package tk.glucodata.drivers.icanhealth
 
 import java.util.UUID
 import java.util.Locale
+import tk.glucodata.Log
 
 object ICanHealthConstants {
     private val FULL_CANONICAL_HEX_SENSOR_ID_REGEX = Regex("^[0-9A-Z]{16}$", RegexOption.IGNORE_CASE)
@@ -205,7 +206,11 @@ object ICanHealthConstants {
 
     @JvmStatic
     fun normalizeOnboardingDeviceSn(source: String?): String {
-        val sanitized = sanitizeSensorIdentity(source)
+        val sanitized = source
+            ?.trim()
+            ?.uppercase(Locale.US)
+            ?.filter { it.isLetterOrDigit() }
+            .orEmpty()
         if (sanitized.isEmpty()) {
             return ""
         }
@@ -214,41 +219,6 @@ object ICanHealthConstants {
         }
         return sanitized
     }
-
-    /**
-     * The launcher QR and DIS serial are different representations of the same
-     * physical sensor identity. The vendor launcher uses the leading 8 or 9
-     * characters as its short serial, depending on the active-code family.
-     */
-    @JvmStatic
-    fun onboardingIdentityPrefix(source: String?): String {
-        val normalized = normalizeOnboardingDeviceSn(source)
-        return deriveShortSnFromActiveCode(normalized)
-    }
-
-    @JvmStatic
-    fun matchesOnboardingIdentity(onboardingDeviceSn: String?, deviceSerial: String?): Boolean {
-        val expected = normalizeOnboardingDeviceSn(onboardingDeviceSn)
-        val observed = sanitizeSensorIdentity(deviceSerial)
-        if (expected.isEmpty() || observed.isEmpty()) {
-            return false
-        }
-        val prefix = deriveShortSnFromActiveCode(expected)
-        if (prefix.length < 8) {
-            return false
-        }
-        if (expected == observed) {
-            return true
-        }
-        return observed.startsWith(prefix)
-    }
-
-    private fun sanitizeSensorIdentity(source: String?): String =
-        source
-            ?.trim()
-            ?.uppercase(Locale.US)
-            ?.filter { it.isLetterOrDigit() }
-            .orEmpty()
 
     private fun deriveShortSnFromActiveCode(activeCode: String): String {
         if (activeCode.length < 12) {

--- a/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthConstantsTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthConstantsTests.kt
@@ -44,59 +44,6 @@ class ICanHealthConstantsTests {
     }
 
     @Test
-    fun matchesOnboardingIdentity_acceptsLauncherCodeForObservedDisSerial() {
-        assertEquals("8760080A", ICanHealthConstants.onboardingIdentityPrefix("8760080A2604"))
-        assertTrue(
-            ICanHealthConstants.matchesOnboardingIdentity(
-                "8760080A2604",
-                "8760080a0007000000000000"
-            )
-        )
-        assertTrue(
-            ICanHealthConstants.matchesOnboardingIdentity(
-                "8760080A2604",
-                "8760080A00070000"
-            )
-        )
-    }
-
-    @Test
-    fun matchesOnboardingIdentity_acceptsExactShortSerialFamily() {
-        assertTrue(
-            ICanHealthConstants.matchesOnboardingIdentity(
-                "726022F50005",
-                "726022f50005"
-            )
-        )
-    }
-
-    @Test
-    fun matchesOnboardingIdentity_rejectsAnotherNearbySensor() {
-        assertFalse(
-            ICanHealthConstants.matchesOnboardingIdentity(
-                "8760080A2604",
-                "8760080B00070000"
-            )
-        )
-    }
-
-    @Test
-    fun matchesOnboardingIdentity_rejectsWeakPartialIdentity() {
-        assertFalse(ICanHealthConstants.matchesOnboardingIdentity("8760", "8760080A00070000"))
-    }
-
-    @Test
-    fun onboardingIdentityPrefix_usesExtendedVendorPrefixRule() {
-        assertEquals("G760080A2", ICanHealthConstants.onboardingIdentityPrefix("G760080A2604"))
-        assertTrue(
-            ICanHealthConstants.matchesOnboardingIdentity(
-                "G760080A2604",
-                "G760080A200070000"
-            )
-        )
-    }
-
-    @Test
     fun isEndedStatusSequenceCap_onlyMatchesEndedStateAtVendorCap() {
         assertFalse(
             ICanHealthConstants.isEndedStatusSequenceCap(


### PR DESCRIPTION
## Problem

Commit cbd5847d7 ("iCan identity fix") introduced a strict post-connection identity check in the iCan BLE manager. After reading the DIS Serial Number characteristic (0x2A25), the manager calls `matchesOnboardingIdentity` which enforces an 8/9-char common-prefix rule between the wizard-supplied onboarding SN / active code and the device's advertised serial. Mismatches blacklist the BLE MAC and close the GATT.

This breaks the i6 firmware variant observed in production:

- Wizard onboarding code: `ZA1OR03MSE50` (12-char vendor "active code")
- Device DIS serial: `01OR03MS00070101` (16-char canonical)

These share zero characters at the head, so the prefix rule rejects the candidate forever. Trace logs show:

```
I/ICanHealth Rejected iCan candidate address=...: onboarding=ZA1OR03MS device=01OR03MS00070101
```

in a tight loop on every reconnect.

Pre-cbd5847d7 iCan drivers (e.g. 87574e093 "iCan i6 fix") had no such rejection — any iCan the BLE scanner found was accepted, and `handleResolvedSerial` promoted the DIS serial into `SerialNumber`. The `isICanHealthDevice` prefix check on the advertised name (`iCGM-`, `Sinocare CGM`, `ICN-`) was sufficient to keep non-iCan peripherals out.

## Fix

Drop the rejection call from the SERIAL_NUMBER characteristic handler and remove the now-unreachable helpers:

- `ICanHealthBleManager.rejectMismatchedOnboardingCandidate` (the rejection flow itself)
- `ICanHealthConstants.matchesOnboardingIdentity` (no callers after the rejection is gone)
- `ICanHealthConstants.onboardingIdentityPrefix` (no callers)
- `sanitizeSensorIdentity` inlined back into `normalizeOnboardingDeviceSn` (only remaining caller)
- `ICanHealthBleManager.rejectedOnboardingAddresses` field + all read/clear sites
- `java.util.concurrent.CopyOnWriteArraySet` import (only use was removed)
- 6 now-orphaned tests in `ICanHealthConstantsTests`

Net: 3 files changed, 7 insertions(+), 158 deletions(-).

## Verification

A downstream fork (GlucoDroid/app PR #47, merged as commit 60742b797) ran this same diff and verified it on a physical Sinocare iCan i6 (firmware v4.2.3, model `iCGM-t6`):

```
D/ICanHealth Vendor response: 06 F3 01 48 DF 82 B9   ← F3 challenge
D/ICanHealth Vendor response: 1C F4 01                  ← F4 auth success
D/ICanHealth Vendor response: 1C F6 01 FF FF            ← F6 sensor info
I/ICanHealth Session start epochMs=1784363274000
```

UI confirmed: serial `01OR03MS00070101` (promoted from provisional `ICN-ZA1OR03MSE50`), Connected.

Bundled OLD auth key family is correct for v4.2.3 (chars[10..11] of serial = "70" → 0x70, outside the 0x04..0x07 NEW-key selector range, so OLD keys are used and auth succeeds).

## Notes

- This branch is byte-identical in intent to GlucoDroid/app PR #47 (which was merged and shipped as v0.3.0.6-alpha). The diff applies cleanly against `upstream/main` HEAD (`57acd956f`) — same source files, same line ranges — because the iCan identity code on upstream main is identical to what was in the GlucoDroid pre-fix tree.
- Removing `rejectedOnboardingAddresses` does not weaken any other safety net — `matchDeviceName` already filters non-iCan peripherals via `isICanHealthDevice` (advertised-name prefix check), and the wizard flow still requires a real Bluetooth pairing for the device to be `mActiveBluetoothDevice != null`.