### PR TITLE
Journal quick-add seeds wall-clock now instead of the last known reading

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
@@ -137,10 +137,7 @@ fun JournalScreen(
         buildJournalChartMarkers(filteredEntries, presetsById, unit, sortedHistory, foodsById)
     }
     val entriesById = remember(filteredEntries) { filteredEntries.associateBy { it.id } }
-    val selectedTimestamp = viewportSnapshot?.selectedPoint?.timestamp
-        ?: sortedHistory.lastOrNull()?.timestamp
-        ?: journalEntries.maxOfOrNull { it.timestamp }
-        ?: System.currentTimeMillis()
+    val selectedPointTimestamp = viewportSnapshot?.selectedPoint?.timestamp
     val selectedDisplayGlucose = viewportSnapshot?.selectedPoint?.value
 
     fun clearChartAction() {
@@ -376,7 +373,7 @@ fun JournalScreen(
             },
             onTypeSelected = { type ->
                 onAddJournalEntry(
-                    selectedTimestamp,
+                    journalQuickAddTimestamp(selectedPointTimestamp, System.currentTimeMillis()),
                     type,
                     selectedDisplayGlucose.takeIf { type == JournalEntryType.FINGERSTICK },
                     null
@@ -388,6 +385,16 @@ fun JournalScreen(
         )
     }
 }
+
+/**
+ * Timestamp seed for quick-add entries created without an explicit chart selection.
+ * Tapping "+" means "log something happening now"; the last known reading or journal
+ * entry can lag minutes behind wall clock (e.g. right after resume, before the data
+ * flows re-emit) and must never seed the entry. Backdating stays an explicit act:
+ * selecting a chart point or using the timeline/long-press menus.
+ */
+internal fun journalQuickAddTimestamp(selectedPointTimestamp: Long?, nowMillis: Long): Long =
+    selectedPointTimestamp ?: nowMillis
 
 @Composable
 private fun JournalHeader(

--- a/Common/src/testMobile/java/tk/glucodata/ui/journal/JournalQuickAddTimestampTests.kt
+++ b/Common/src/testMobile/java/tk/glucodata/ui/journal/JournalQuickAddTimestampTests.kt
@@ -1,0 +1,25 @@
+package tk.glucodata.ui.journal
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class JournalQuickAddTimestampTests {
+
+    private val now = 1_700_000_000_000L
+
+    @Test
+    fun quickAddWithoutSelectionSeedsWallClockNow() {
+        // Regression: a stale history tail (e.g. T-6 min after resume, before the
+        // data flows re-emit) must never seed the entry; only "now" may.
+        assertEquals(now, journalQuickAddTimestamp(selectedPointTimestamp = null, nowMillis = now))
+    }
+
+    @Test
+    fun quickAddWithSelectionSeedsSelectedPoint() {
+        val selected = now - 45L * 60L * 1000L
+        assertEquals(
+            selected,
+            journalQuickAddTimestamp(selectedPointTimestamp = selected, nowMillis = now)
+        )
+    }
+}


### PR DESCRIPTION
A new entry from the journal "+" button inherited the timestamp of the last glucose point the UI knew about, then fell back to the newest journal entry, before ever reaching wall-clock now. With a live sensor the chain looks harmless: the tail is under a minute old. Right after the app returns from the background it is not: the Room flows re-emit late, the tail sits minutes behind, and an insulin entry logged "now" lands in the past. Reproduced live several times before tracking it down.

The fallback is also semantically wrong. Tapping "+" means "log something happening right now"; only an explicit chart selection is a statement about a different time. The seed is now the selected chart point if there is one, else `System.currentTimeMillis()`, resolved in the tap handler rather than during composition, so a screen that sat idle without recomposing cannot serve a stale "now" either.

The explicit backdating flows are untouched: a selected chart point still wins over the clock, and the timeline tap menu and the dashboard long-press continue to use their own tapped timestamp. The companion PR #111 makes sure a selection cannot silently survive backgrounding and win when the user no longer means it.

`JournalQuickAddTimestampTests` pins the two cases: no selection seeds now, a selection seeds the selected point.

Unit suite: 841 tests, with the two pre-existing failures (ManagedSensorStatusPolicy wall-clock test, DefaultParamCatalog org.json) unchanged.
