### PR TITLE
Charts always re-anchor to the latest value on resume

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
@@ -1117,43 +1117,6 @@ fun InteractiveGlucoseChart(
         }
     }
 
-    // TRACKING INACTIVITY FOR GRAPH RESET
-    var lastActiveTime by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
-    val currentLatestDataTimestamp by rememberUpdatedState(latestDataTimestamp)
-    val currentSelectedTimeRange by rememberUpdatedState(selectedTimeRange)
-
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                isResumed = true
-
-                val currentTime = System.currentTimeMillis()
-                val latestTimestamp = currentLatestDataTimestamp
-                // Bound how long the chart may keep a frozen viewport. After 5 min away,
-                // anchor the view to "now" even if the data flow has not re-emitted yet
-                // (cold start / process death restore). Clearing lastAutoScrolledTimestamp
-                // lets the dataSeriesSignature path re-snap on the next emission.
-                if (currentTime - lastActiveTime > 5 * 60 * 1000L) {
-                    visibleDuration = (currentSelectedTimeRange?.hours?.toLong() ?: 3L) * 60 * 60 * 1000
-                    val targetCenter = if (latestTimestamp > 0L) {
-                        liveCenterTimeFor(latestTimestamp, visibleDuration)
-                    } else {
-                        currentTime - visibleDuration / 2
-                    }
-                    centerTime = targetCenter
-                    previewCenterTime = previewCenterTimeForWindowEnd(targetCenter + visibleDuration / 2L)
-                    lastAutoScrolledTimestamp = 0L
-                }
-            }
-            else if (event == Lifecycle.Event.ON_PAUSE) {
-                isResumed = false
-                lastActiveTime = System.currentTimeMillis() // Save time on pause
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
-
     // React to parent range state only when it represents a new range button choice.
     // Range changes alter the visible duration inside the current frame; tapping the
     // already-active range button is the explicit "back to now" action.
@@ -1308,6 +1271,42 @@ fun InteractiveGlucoseChart(
     fun cancelPendingTimelineTap() {
         pendingTimelineTapJob?.cancel()
         pendingTimelineTapJob = null
+    }
+
+    // GRAPH RESET ON RESUME
+    val currentLatestDataTimestamp by rememberUpdatedState(latestDataTimestamp)
+    val currentSelectedTimeRange by rememberUpdatedState(selectedTimeRange)
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                isResumed = true
+
+                // Returning to the chart is a "what's my glucose now" moment: always
+                // re-anchor to the live edge and drop any stale point selection, no
+                // matter how short the absence. Lifecycle observers receive ON_RESUME
+                // on registration too, so re-entering composition (tab return,
+                // orientation switch) lands on the latest value as well. Clearing
+                // lastAutoScrolledTimestamp lets the dataSeriesSignature path re-snap
+                // on the next emission.
+                val latestTimestamp = currentLatestDataTimestamp
+                visibleDuration = (currentSelectedTimeRange?.hours?.toLong() ?: 3L) * 60 * 60 * 1000
+                val targetCenter = if (latestTimestamp > 0L) {
+                    liveCenterTimeFor(latestTimestamp, visibleDuration)
+                } else {
+                    System.currentTimeMillis() - visibleDuration / 2
+                }
+                centerTime = targetCenter
+                previewCenterTime = previewCenterTimeForWindowEnd(targetCenter + visibleDuration / 2L)
+                lastAutoScrolledTimestamp = 0L
+                selectedPoint = null
+            }
+            else if (event == Lifecycle.Event.ON_PAUSE) {
+                isResumed = false
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     // Auto-dismiss selection if off-screen (User Request)

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -48,6 +49,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import tk.glucodata.R
 import kotlinx.coroutines.delay
 import tk.glucodata.data.journal.JournalEntry
@@ -116,6 +120,20 @@ fun JournalScreen(
     val foodsById = remember(journalFoods) { journalFoods.associateBy { it.id } }
     var selectedChartRange by rememberSaveable { mutableStateOf(TimeRange.H3) }
     var viewportSnapshot by remember { mutableStateOf<ChartViewportSnapshot?>(null) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                // A snapshot captured before the app went to background describes a
+                // stale viewport and possibly an hour-old point selection; drop it so
+                // quick-add seeds "now" and the chart re-anchors to the latest reading.
+                viewportSnapshot = null
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
     var selectedTypeFilters by rememberSaveable {
         mutableStateOf(JournalEntryType.entries.map { it.name })
     }


### PR DESCRIPTION
Companion to #110; both came out of the same live debugging session.

The dashboard chart's ON_RESUME observer only snapped back to the live edge after more than five minutes away, and it never cleared the point selection. The journal chart had no lifecycle handling at all, so a selection made before backgrounding survived indefinitely and silently seeded the next quick-add entry.

The decision this PR encodes: a CGM app brought back to the foreground is a "what's my glucose now" moment. Deliberate history browsing restarts cheaply; a stale viewport that looks current does not. So the observer now re-anchors unconditionally and drops the selection, and `lastActiveTime` goes away with the grace period. If you'd rather keep a threshold it is a single constant, but I think zero is the right value.

On coverage: the observer lives in `InteractiveGlucoseChart`, so every instance composes it. That is the portrait dashboard chart (the compact/expanded toggle animates within this one instance), the landscape right-pane chart, the journal chart, and the history screen's chart. Each holds its own viewport state and used to freeze independently; fixing the shared composable fixes all of them, which is why I kept per-instance observers instead of hoisting viewport state up to the screens. For the history screen this means a short interruption while browsing an old day now also restarts at the live edge; it already did after five minutes, and I'd rather have all charts behave the same than special-case it.

Tab switches turn out to be covered by the same mechanism. Bottom-tab navigation restores state (`saveState`/`restoreState` in MainNavigation), so a chart comes back with its old saveable viewport. But androidx lifecycle delivers ON_RESUME to an observer registered on an already-resumed lifecycle, so re-entering composition re-anchors immediately; the same applies when rotation switches between the portrait and landscape instances. The journal's viewport snapshot is plain `remember` and dies with the composition; it is additionally cleared on ON_RESUME so a background/resume cycle within a live composition cannot keep it alive either.

No JVM test for this one: it is lifecycle wiring inside a composable, and the unit test setup has no Robolectric or compose-ui-test harness. Verification is an on-device pass of the resume and tab-return paths.

Unit suite: 841 tests, with the two pre-existing failures (ManagedSensorStatusPolicy wall-clock test, DefaultParamCatalog org.json) unchanged.
