### PR TITLE
Sensor-expiry warnings never fired: end time was sourced from the chart clamp

### DIFF
--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -82,6 +82,7 @@ import java.text.DateFormat;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import tk.glucodata.alerts.AlertDisplayText;
 import tk.glucodata.alerts.AlertType;
 import tk.glucodata.alerts.SnoozeManager;
 import tk.glucodata.alerts.AlertConfig;
@@ -3022,12 +3023,12 @@ public class Notify {
                 RemoteViews remoteViewsHeadsUp = new RemoteViews(Applic.app.getPackageName(),
                         R.layout.notification_material_heads_up);
 
-                // Clean message: "Forecast Low 4.0 mmol/L" -> "Forecast Low"
-                String cleanMessage = customAlertId != null && !customAlertId.isEmpty()
-                        ? message
-                        : message.replaceAll("[0-9.,]+", "").replaceAll("mmol/L", "")
-                                .replaceAll("mg/dL", "").trim();
-                final String badgeText = cleanMessage.isEmpty() ? message : cleanMessage;
+                // "Forecast Low 4.0 mmol/L" -> "Forecast Low"; duration-carrying
+                // messages (sensor expiry, missed reading) keep their numbers.
+                final String badgeText = AlertDisplayText.notificationBadge(
+                        AlertType.Companion.fromId(alertTypeId),
+                        customAlertId != null && !customAlertId.isEmpty(),
+                        message);
                 final String alertMeta = timef.format(glucose.time);
                 final String plainValueText = valueText.toString();
 

--- a/Common/src/main/java/tk/glucodata/alerts/AlertDisplayText.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertDisplayText.kt
@@ -1,0 +1,80 @@
+package tk.glucodata.alerts
+
+/**
+ * Pure text rules for how a triggered alert is worded on the notification and
+ * the full-screen alarm. Kept free of Android dependencies so the rules are
+ * unit-testable; the callers ([tk.glucodata.Notify], AlarmActivity) supply the
+ * localized strings.
+ */
+object AlertDisplayText {
+
+    // These alerts embed a duration/lead time in their message ("Sensor expires
+    // in 12 hours", "Missed reading - 30 min"); the numbers ARE the payload.
+    private fun carriesDurationNumbers(type: AlertType?): Boolean =
+        type == AlertType.SENSOR_EXPIRY || type == AlertType.MISSED_READING
+
+    /**
+     * Badge/title of the separate alert notification. Glucose-carrying messages
+     * ("Forecast Low 4.0 mmol/L") lose the value because the notification shows
+     * it in its own row; duration-carrying messages keep their numbers -
+     * stripping them produced "Sensor expires in hours".
+     */
+    @JvmStatic
+    fun notificationBadge(type: AlertType?, isCustomAlert: Boolean, message: String): String {
+        if (isCustomAlert || carriesDurationNumbers(type)) {
+            return message
+        }
+        val cleaned = message
+            .replace(Regex("[0-9.,]+"), "")
+            .replace("mmol/L", "", ignoreCase = true)
+            .replace("mg/dL", "", ignoreCase = true)
+            .trim()
+        return cleaned.ifEmpty { message }
+    }
+
+    /**
+     * Secondary line on the full-screen alarm. Keeps whatever the alert message
+     * adds over the big label and the glucose hero (expiry lead time,
+     * missed-reading duration, forecast horizon) and drops messages that merely
+     * repeat "<label> <value>".
+     */
+    @JvmStatic
+    fun alarmSupportingText(
+        parsedValueMessage: String,
+        rawMessage: String,
+        rawValue: String,
+        parsedValueRaw: String,
+        alertLabel: String,
+        unitLabels: List<String>
+    ): String {
+        val fromParsed = parsedValueMessage.takeIf {
+            it.isNotBlank() &&
+                !it.equals(alertLabel, ignoreCase = true) &&
+                !it.equals("low", ignoreCase = true) &&
+                !it.equals("high", ignoreCase = true) &&
+                !it.equals("alarm", ignoreCase = true)
+        }
+        if (fromParsed != null) {
+            return fromParsed
+        }
+
+        val withoutValues = unitLabels
+            .fold(rawMessage.replace(Regex("[0-9.,:()]+"), " ")) { acc, unit ->
+                if (unit.isEmpty()) acc else acc.replace(unit, " ", ignoreCase = true)
+            }
+            .replace(Regex("\\s+"), " ")
+            .trim()
+        val fromMessage = rawMessage.takeIf {
+            it.isNotBlank() &&
+                !it.equals(alertLabel, ignoreCase = true) &&
+                !it.equals(rawValue, ignoreCase = true) &&
+                // "<label> <glucose>" repeats what the hero already shows.
+                !withoutValues.equals(alertLabel, ignoreCase = true)
+        }
+        if (fromMessage != null) {
+            return fromMessage
+        }
+
+        return rawValue.takeIf { it.isNotBlank() && it != parsedValueRaw } ?: ""
+    }
+}

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -72,6 +72,61 @@ object AlertRepository {
     // Sensor-expiry pre-warning thresholds (minutes), stored as a StringSet.
     private fun keyExpiryWarnings(type: AlertType) = "alert_${type.id}_expiryWarnings"
 
+    // Thresholds already warned for, entries "endTimeMs:minutes". Saving keeps
+    // only the current sensor's entries, so the set stays bounded.
+    private fun keyExpiryWarned(type: AlertType) = "alert_${type.id}_expiryWarned"
+
+    internal val sensorExpiryWarnedStore: ExpiryWarnedStore = object : ExpiryWarnedStore {
+        override fun load(endTimeMs: Long): Set<Int> {
+            val raw = prefs.getStringSet(keyExpiryWarned(AlertType.SENSOR_EXPIRY), null)
+                ?: return emptySet()
+            val prefix = "$endTimeMs:"
+            return raw.mapNotNull { entry ->
+                entry.takeIf { it.startsWith(prefix) }?.removePrefix(prefix)?.toIntOrNull()
+            }.toSet()
+        }
+
+        override fun save(endTimeMs: Long, thresholds: Set<Int>) {
+            prefs.edit {
+                putStringSet(
+                    keyExpiryWarned(AlertType.SENSOR_EXPIRY),
+                    thresholds.map { "$endTimeMs:$it" }.toSet()
+                )
+            }
+        }
+    }
+
+    /**
+     * A threshold enabled mid-episode whose warning window is already open must
+     * not fire retroactively - not even after a process restart. Persist the
+     * adoption at save time; the runtime baseline then treats it like any
+     * already-warned window. Thresholds that were already configured keep their
+     * state: one that is due but was never warned (process was down at window
+     * entry) stays eligible for the catch-up warning.
+     */
+    private fun adoptOpenWindowsForNewExpiryThresholds(config: AlertConfig) {
+        if (!config.enabled) {
+            return
+        }
+        val nowMs = System.currentTimeMillis()
+        val endTimeMs = resolveSensorExpiryEndMs(preferredSensorId = null, nowMs = nowMs)
+        if (endTimeMs <= 0L) {
+            return
+        }
+        val previous = loadConfig(config.type)
+        val previouslyActive = if (previous.enabled) previous.expiryWarningMinutes else emptySet()
+        val newlyOpen = sanitizeExpiryWarningMinutes(config.expiryWarningMinutes).filter {
+            it !in previouslyActive && endTimeMs - nowMs <= it.toLong() * 60_000L
+        }
+        if (newlyOpen.isEmpty()) {
+            return
+        }
+        sensorExpiryWarnedStore.save(
+            endTimeMs,
+            sensorExpiryWarnedStore.load(endTimeMs) + newlyOpen
+        )
+    }
+
     /** Missing key -> default (24h migration); present-but-empty -> no pre-warning. */
     private fun readExpiryWarnings(type: AlertType, default: Set<Int>): Set<Int> {
         if (!prefs.contains(keyExpiryWarnings(type))) {
@@ -302,6 +357,9 @@ object AlertRepository {
     }
     
     private fun saveToPrefs(config: AlertConfig) {
+        if (config.type == AlertType.SENSOR_EXPIRY) {
+            adoptOpenWindowsForNewExpiryThresholds(config)
+        }
         prefs.edit {
             putBoolean(keyEnabled(config.type), config.enabled)
             if (config.threshold != null) putFloat(keyThreshold(config.type), config.threshold) else remove(keyThreshold(config.type))

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -7,7 +7,6 @@ import tk.glucodata.Applic
 import tk.glucodata.CurrentDisplaySource
 import tk.glucodata.GlucoseDelta
 import tk.glucodata.Log
-import tk.glucodata.Natives
 import tk.glucodata.Notify
 import tk.glucodata.R
 import tk.glucodata.SuperGattCallback
@@ -31,6 +30,7 @@ object AlertRuntimeManager {
     private var lastRate: Float = Float.NaN
     private var lastDisplaySnapshot: CurrentDisplaySource.Snapshot? = null
     private var persistentHighStartedAtMs: Long = 0L
+    private var lastLoggedExpiryEndMs: Long = Long.MIN_VALUE
     private val standardEpisodes = AlertEpisodeState<AlertType>()
     private val sensorExpiryState = SensorExpiryAlertState()
     private val fallingDeltaState = DeltaAlarmState(falling = true)
@@ -374,10 +374,19 @@ object AlertRuntimeManager {
             return
         }
 
-        val endTimeMs = try {
-            Natives.getendtime()
-        } catch (t: Throwable) {
-            0L
+        val endTimeMs = resolveSensorExpiryEndMs(lastDisplaySnapshot?.sensorId, nowMs)
+        if (endTimeMs != lastLoggedExpiryEndMs) {
+            // A sane source logs once per sensor; a bad one (0, past, or moving
+            // every tick like the old Natives.getendtime()) becomes visible log
+            // churn instead of silently swallowed warnings.
+            Log.i(LOG_ID, "Sensor expiry end resolved: $endTimeMs (now=$nowMs)")
+            lastLoggedExpiryEndMs = endTimeMs
+        }
+        if (endTimeMs <= 0L) {
+            // No plausible end: keep the latch untouched so a transient gatt
+            // dropout cannot re-baseline the episode.
+            clearRuntimeAlert(type, "sensor-expiry-no-endtime")
+            return
         }
 
         val thresholds = config.expiryWarningMinutes
@@ -394,7 +403,7 @@ object AlertRuntimeManager {
 
         // Not yet within even the longest configured lead time -> nothing pending.
         val largestThresholdMs = (thresholds.maxOrNull() ?: 0).toLong() * 60_000L
-        if (endTimeMs <= 0L || thresholds.isEmpty() || endTimeMs - nowMs > largestThresholdMs) {
+        if (thresholds.isEmpty() || endTimeMs - nowMs > largestThresholdMs) {
             clearRuntimeAlert(type, "sensor-expiry-not-due")
             return
         }

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -32,7 +32,7 @@ object AlertRuntimeManager {
     private var persistentHighStartedAtMs: Long = 0L
     private var lastLoggedExpiryEndMs: Long = Long.MIN_VALUE
     private val standardEpisodes = AlertEpisodeState<AlertType>()
-    private val sensorExpiryState = SensorExpiryAlertState()
+    private val sensorExpiryState = SensorExpiryAlertState(AlertRepository.sensorExpiryWarnedStore)
     private val fallingDeltaState = DeltaAlarmState(falling = true)
     private val risingDeltaState = DeltaAlarmState(falling = false)
     private val calibrationReadingBarrier = ReadingTimestampBarrier()

--- a/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
@@ -1,5 +1,58 @@
 package tk.glucodata.alerts
 
+import tk.glucodata.Natives
+import tk.glucodata.SensorBluetooth
+import tk.glucodata.drivers.ManagedBluetoothSensorDriver
+
+/**
+ * Pick the expiry-relevant sensor end among per-sensor candidates
+ * (serial -> official end, ms). The sensor currently on the display wins;
+ * otherwise the farthest end, since the running sensor outlives finished ones.
+ *
+ * Ends not in the future are rejected: 0 means unknown, a past end means the
+ * sensor is already expired. This also keeps a clamped source out of the latch —
+ * Natives.getendtime() returns the chart's data range end, capped at "now"
+ * while the sensor runs, which made every window look open on every tick and
+ * silenced all expiry warnings.
+ */
+internal fun selectSensorExpiryEndMs(
+    candidates: List<Pair<String?, Long>>,
+    preferredSensorId: String?,
+    nowMs: Long
+): Long {
+    val plausible = candidates.filter { it.second > nowMs }
+    if (plausible.isEmpty()) return 0L
+    if (preferredSensorId != null) {
+        plausible.firstOrNull { it.first == preferredSensorId }?.let { return it.second }
+    }
+    return plausible.maxOf { it.second }
+}
+
+/**
+ * Resolve the official end (start + wear duration) of the relevant sensor from
+ * the live gatt registry. Kotlin-managed drivers without native backing fall
+ * back to their UI snapshot.
+ */
+internal fun resolveSensorExpiryEndMs(preferredSensorId: String?, nowMs: Long): Long {
+    val gatts = try {
+        SensorBluetooth.mygatts()
+    } catch (t: Throwable) {
+        null
+    } ?: return 0L
+    val candidates = gatts.map { gatt ->
+        val nativeEnd = runCatching { Natives.getSensorEndTime(gatt.dataptr, true) }.getOrDefault(0L)
+        val end = if (nativeEnd > 0L) {
+            nativeEnd
+        } else {
+            runCatching {
+                (gatt as? ManagedBluetoothSensorDriver)?.getManagedUiSnapshot()?.officialEndMs ?: 0L
+            }.getOrDefault(0L)
+        }
+        gatt.SerialNumber to end
+    }
+    return selectSensorExpiryEndMs(candidates, preferredSensorId, nowMs)
+}
+
 /**
  * Edge-triggered latch for the sensor-expiry pre-warnings, one latch per
  * configured threshold. Each threshold fires exactly once per sensor when the

--- a/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
@@ -54,6 +54,19 @@ internal fun resolveSensorExpiryEndMs(preferredSensorId: String?, nowMs: Long): 
 }
 
 /**
+ * Durable memory of which expiry thresholds already warned, keyed by the
+ * sensor's end time. Production backs this with SharedPreferences
+ * ([AlertRepository.sensorExpiryWarnedStore]); tests inject a fake.
+ */
+internal interface ExpiryWarnedStore {
+    /** Thresholds (minutes) already warned for the sensor ending at [endTimeMs]. */
+    fun load(endTimeMs: Long): Set<Int>
+
+    /** Replace the stored set with [thresholds] for [endTimeMs], dropping other sensors' entries. */
+    fun save(endTimeMs: Long, thresholds: Set<Int>)
+}
+
+/**
  * Edge-triggered latch for the sensor-expiry pre-warnings, one latch per
  * configured threshold. Each threshold fires exactly once per sensor when the
  * clock first crosses into its warning window (`endTimeMs - now <= threshold`).
@@ -62,16 +75,20 @@ internal fun resolveSensorExpiryEndMs(preferredSensorId: String?, nowMs: Long): 
  * threshold:
  *  - **Edge-triggered:** fire on window entry, not on every 15s tick.
  *  - **New sensor** (`endTimeMs` changes): rearm every threshold.
- *  - **Baseline:** the first active pass only records current window membership
- *    and fires nothing, so starting the app already inside several windows does
- *    not produce a burst of alerts.
- *  - **Newly enabled thresholds** whose window is already past are adopted like
- *    the baseline (marked warned, never fired retroactively).
+ *  - **Baseline:** the first active pass reloads the persisted warned-set for
+ *    the current sensor. Already-warned windows (from this or an earlier
+ *    process run) stay silent; open windows that were never warned are due
+ *    now, so a restart between window entry and the next tick cannot swallow
+ *    a warning. The cascade guard caps the catch-up at one alert.
+ *  - **Newly enabled thresholds** whose window is already open are adopted
+ *    (marked warned, never fired retroactively). Mid-process that happens
+ *    here; across a restart [AlertRepository.saveConfig] persists the
+ *    adoption at save time.
  *  - **Cascade guard:** if several thresholds come due in the same tick (e.g. the
  *    app resumes deep inside multiple windows), fire only the smallest (most
  *    urgent) and silently mark the rest as warned.
  */
-internal class SensorExpiryAlertState {
+internal class SensorExpiryAlertState(private val store: ExpiryWarnedStore) {
     private var baselineReady = false
     private var lastEndTimeMs = 0L
     private val wasInWindow = mutableMapOf<Int, Boolean>()   // threshold -> inside window last tick
@@ -101,12 +118,16 @@ internal class SensorExpiryAlertState {
             return emptySet()
         }
 
-        // New sensor -> new episode: rearm everything.
+        // New sensor -> new episode: rearm everything, then adopt what an
+        // earlier process run already warned for this end time.
         if (endTimeMs != lastEndTimeMs) {
             baselineReady = false
             lastEndTimeMs = endTimeMs
             wasInWindow.clear()
             alertedForEnd.clear()
+            for (t in store.load(endTimeMs)) {
+                alertedForEnd[t] = endTimeMs
+            }
         }
 
         // Forget thresholds the user has removed so the maps stay bounded.
@@ -120,31 +141,36 @@ internal class SensorExpiryAlertState {
         fun inWindow(minutes: Int): Boolean =
             endTimeMs - nowMs <= minutes.toLong() * 60_000L
 
-        // First active pass: adopt current membership, fire nothing.
+        val newlyDue = mutableListOf<Int>()
         if (!baselineReady) {
+            // First active pass: open windows that were never warned - not in
+            // this process, not in an earlier one - are due now.
             baselineReady = true
             for (t in thresholdsMinutes) {
                 val inside = inWindow(t)
                 wasInWindow[t] = inside
-                if (inside) alertedForEnd[t] = endTimeMs
+                if (inside && alertedForEnd[t] != endTimeMs) {
+                    newlyDue.add(t)
+                }
             }
-            return emptySet()
-        }
-
-        val newlyDue = mutableListOf<Int>()
-        for (t in thresholdsMinutes) {
-            val inside = inWindow(t)
-            val known = wasInWindow.containsKey(t)
-            val prev = wasInWindow[t] ?: false
-            wasInWindow[t] = inside
-            if (!known) {
-                // Threshold enabled mid-episode: adopt like the baseline, never
-                // fire retroactively for a window that is already open.
-                if (inside) alertedForEnd[t] = endTimeMs
-                continue
-            }
-            if (inside && !prev && alertedForEnd[t] != endTimeMs) {
-                newlyDue.add(t)
+        } else {
+            for (t in thresholdsMinutes) {
+                val inside = inWindow(t)
+                val known = wasInWindow.containsKey(t)
+                val prev = wasInWindow[t] ?: false
+                wasInWindow[t] = inside
+                if (!known) {
+                    // Threshold enabled mid-episode: adopt like the baseline, never
+                    // fire retroactively for a window that is already open.
+                    if (inside && alertedForEnd[t] != endTimeMs) {
+                        alertedForEnd[t] = endTimeMs
+                        persistWarned()
+                    }
+                    continue
+                }
+                if (inside && !prev && alertedForEnd[t] != endTimeMs) {
+                    newlyDue.add(t)
+                }
             }
         }
 
@@ -158,6 +184,13 @@ internal class SensorExpiryAlertState {
         for (t in newlyDue) {
             alertedForEnd[t] = endTimeMs
         }
+        persistWarned()
         return setOf(fire)
+    }
+
+    /** Union with the stored set so a concurrent settings-save adoption is not lost. */
+    private fun persistWarned() {
+        val warned = alertedForEnd.filterValues { it == lastEndTimeMs }.keys
+        store.save(lastEndTimeMs, store.load(lastEndTimeMs) + warned)
     }
 }

--- a/Common/src/mobile/java/tk/glucodata/ui/AlarmActivity.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/AlarmActivity.kt
@@ -19,6 +19,7 @@ import tk.glucodata.GlucosePoint
 import tk.glucodata.Natives
 import tk.glucodata.Notify
 import tk.glucodata.SensorBluetooth
+import tk.glucodata.alerts.AlertDisplayText
 import tk.glucodata.alerts.AlertRepository
 import tk.glucodata.alerts.AlertStateTracker
 import tk.glucodata.alerts.AlertType
@@ -170,18 +171,14 @@ class AlarmActivity : ComponentActivity() {
                     .ifBlank { getString(tk.glucodata.R.string.alarms) }
         }
 
-        val supportingText = parsedValueMessage.takeIf {
-            it.isNotBlank() &&
-                !it.equals(alertLabel, ignoreCase = true) &&
-                !it.equals("low", ignoreCase = true) &&
-                !it.equals("high", ignoreCase = true) &&
-                !it.equals("alarm", ignoreCase = true)
-        }
-            ?: rawMessage.takeIf {
-                it.isNotBlank() && !it.equals(alertLabel, ignoreCase = true) && !it.equals(rawValue, ignoreCase = true)
-            }
-            ?: rawValue.takeIf { it.isNotBlank() && it != parsedValueRaw }
-            ?: ""
+        val supportingText = AlertDisplayText.alarmSupportingText(
+            parsedValueMessage = parsedValueMessage,
+            rawMessage = rawMessage,
+            rawValue = rawValue,
+            parsedValueRaw = parsedValueRaw,
+            alertLabel = alertLabel,
+            unitLabels = listOf(Notify.unitlabel, "mmol/L", "mg/dL")
+        )
 
         val severity = when (alertType) {
             AlertType.LOW, AlertType.VERY_LOW, AlertType.PRE_LOW -> AlarmSeverity.LOW

--- a/Common/src/mobile/java/tk/glucodata/ui/AlarmScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/AlarmScreen.kt
@@ -109,6 +109,7 @@ fun AlarmScreen(
         PixelAlarmContent(
             primaryGlucose = primaryGlucose,
             alarmLabel = alarmLabel,
+            supportingText = supportingText,
             trend = trend,
             trendResult = trendResult,
             typographyChoice = typographyChoice,
@@ -122,6 +123,7 @@ fun AlarmScreen(
 private fun PixelAlarmContent(
     primaryGlucose: String,
     alarmLabel: String,
+    supportingText: String,
     trend: Trend,
     trendResult: TrendEngine.TrendResult,
     typographyChoice: AlarmTypographyChoice,
@@ -189,6 +191,7 @@ private fun PixelAlarmContent(
             ) {
                 AlarmHeader(
                     alarmLabel = alarmLabel,
+                    supportingText = supportingText,
                     compact = compact,
                     fontFamily = typographyChoice.fontFamily,
                     modifier = Modifier.padding(top = if (compact) 28.dp else 40.dp)
@@ -235,6 +238,7 @@ private fun PixelAlarmContent(
 @Composable
 private fun AlarmHeader(
     alarmLabel: String,
+    supportingText: String,
     compact: Boolean,
     fontFamily: FontFamily,
     modifier: Modifier = Modifier
@@ -266,6 +270,21 @@ private fun AlarmHeader(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
+            // What the alert actually says beyond its type name: expiry lead
+            // time, missed-reading duration, forecast horizon.
+            if (supportingText.isNotBlank()) {
+                Text(
+                    text = supportingText,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontFamily = fontFamily,
+                        fontWeight = FontWeight.W300,
+                        letterSpacing = 0.sp
+                    ),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
 }

--- a/Common/src/test/java/tk/glucodata/alerts/AlertDisplayTextTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/AlertDisplayTextTests.kt
@@ -1,0 +1,126 @@
+package tk.glucodata.alerts
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AlertDisplayTextTests {
+
+    private val units = listOf("mmol/L", "mg/dL")
+
+    // --- notificationBadge ---
+
+    @Test
+    fun badgeKeepsNumbersForDurationCarryingAlerts() {
+        assertEquals(
+            "Sensor expires in 12 hours",
+            AlertDisplayText.notificationBadge(AlertType.SENSOR_EXPIRY, false, "Sensor expires in 12 hours")
+        )
+        assertEquals(
+            "Missed reading - 30 min",
+            AlertDisplayText.notificationBadge(AlertType.MISSED_READING, false, "Missed reading - 30 min")
+        )
+    }
+
+    @Test
+    fun badgeStripsGlucoseValueFromGlucoseAlerts() {
+        assertEquals(
+            "Low",
+            AlertDisplayText.notificationBadge(AlertType.LOW, false, "Low 4.0 mmol/L")
+        )
+        assertEquals(
+            "High",
+            AlertDisplayText.notificationBadge(AlertType.HIGH, false, "High 220 mg/dL")
+        )
+    }
+
+    @Test
+    fun badgeLeavesCustomAlertMessagesAlone() {
+        assertEquals(
+            "My rule 5.5",
+            AlertDisplayText.notificationBadge(AlertType.LOW, true, "My rule 5.5")
+        )
+    }
+
+    @Test
+    fun badgeFallsBackToMessageWhenStrippingEmptiesIt() {
+        assertEquals("4.0", AlertDisplayText.notificationBadge(AlertType.LOW, false, "4.0"))
+    }
+
+    // --- alarmSupportingText ---
+
+    @Test
+    fun alarmKeepsExpiryLeadTime() {
+        assertEquals(
+            "Sensor expires in 12 hours",
+            AlertDisplayText.alarmSupportingText(
+                parsedValueMessage = "",
+                rawMessage = "Sensor expires in 12 hours",
+                rawValue = "5.6",
+                parsedValueRaw = "5.6",
+                alertLabel = "Sensor Expiry",
+                unitLabels = units
+            )
+        )
+    }
+
+    @Test
+    fun alarmKeepsMissedReadingDuration() {
+        assertEquals(
+            "Missed reading - 30 min",
+            AlertDisplayText.alarmSupportingText(
+                parsedValueMessage = "",
+                rawMessage = "Missed reading - 30 min",
+                rawValue = "5.6",
+                parsedValueRaw = "5.6",
+                alertLabel = "Missed reading",
+                unitLabels = units
+            )
+        )
+    }
+
+    @Test
+    fun alarmDropsLabelPlusValueRepetition() {
+        // "Low 4.0" adds nothing over the "Low" header and the 4.0 hero.
+        assertEquals(
+            "",
+            AlertDisplayText.alarmSupportingText(
+                parsedValueMessage = "",
+                rawMessage = "Low 4.0",
+                rawValue = "4.0",
+                parsedValueRaw = "4.0",
+                alertLabel = "Low",
+                unitLabels = units
+            )
+        )
+    }
+
+    @Test
+    fun alarmKeepsForecastHorizon() {
+        assertEquals(
+            "Forecast Low: 4.7 (30 min)",
+            AlertDisplayText.alarmSupportingText(
+                parsedValueMessage = "",
+                rawMessage = "Forecast Low: 4.7 (30 min)",
+                rawValue = "5.6",
+                parsedValueRaw = "5.6",
+                alertLabel = "Forecast Low",
+                unitLabels = units
+            )
+        )
+    }
+
+    @Test
+    fun alarmPrefersParsedMessageWhenMeaningful() {
+        assertEquals(
+            "Sensor expires in hours",
+            AlertDisplayText.alarmSupportingText(
+                parsedValueMessage = "Sensor expires in hours",
+                rawMessage = "Sensor expires in 12 hours",
+                rawValue = "",
+                parsedValueRaw = "12",
+                alertLabel = "Sensor Expiry",
+                unitLabels = units
+            )
+        )
+    }
+}

--- a/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
@@ -122,6 +122,29 @@ class SensorExpiryAlertStateTests {
     }
 
     @Test
+    fun clampedOrPastEndTimeSourceIsRejected() {
+        val now = end - min(1000)
+        // A Natives.getendtime()-style source returns "now" while the sensor runs.
+        assertEquals(0L, selectSensorExpiryEndMs(listOf("A" to now), "A", now))
+        assertEquals(0L, selectSensorExpiryEndMs(listOf("A" to (now - 5_000L)), "A", now))
+        assertEquals(0L, selectSensorExpiryEndMs(emptyList(), null, now))
+    }
+
+    @Test
+    fun endSelectionPrefersDisplayedSensorElseFarthestEnd() {
+        val now = 1_000_000L
+        val candidates = listOf("A" to now + 100_000L, "B" to now + 900_000L)
+        assertEquals(now + 100_000L, selectSensorExpiryEndMs(candidates, "A", now))
+        assertEquals(now + 900_000L, selectSensorExpiryEndMs(candidates, null, now))
+        assertEquals(now + 900_000L, selectSensorExpiryEndMs(candidates, "unknown", now))
+        // A displayed sensor without a plausible end must not shadow the running one.
+        assertEquals(
+            now + 900_000L,
+            selectSensorExpiryEndMs(listOf("A" to 0L, "B" to now + 900_000L), "A", now)
+        )
+    }
+
+    @Test
     fun defaultSensorExpiryConfigKeeps24hThreshold() {
         val cfg = AlertDefaults.defaultConfig(AlertType.SENSOR_EXPIRY, isMmol = false)
         assertEquals(setOf(1440), cfg.expiryWarningMinutes)

--- a/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
@@ -10,6 +10,21 @@ class SensorExpiryAlertStateTests {
 
     private fun min(m: Int) = m.toLong() * 60_000L
 
+    /** Mirrors the SharedPreferences StringSet backing: flat "endTimeMs:minutes" entries. */
+    private class FakeWarnedStore : ExpiryWarnedStore {
+        var entries = setOf<String>()
+
+        override fun load(endTimeMs: Long): Set<Int> = entries.mapNotNull { entry ->
+            entry.takeIf { it.startsWith("$endTimeMs:") }?.substringAfter(':')?.toIntOrNull()
+        }.toSet()
+
+        override fun save(endTimeMs: Long, thresholds: Set<Int>) {
+            entries = thresholds.map { "$endTimeMs:$it" }.toSet()
+        }
+    }
+
+    private fun newState(store: ExpiryWarnedStore = FakeWarnedStore()) = SensorExpiryAlertState(store)
+
     /** Evaluate a tick "minutesBefore" minutes before [endMs]. */
     private fun SensorExpiryAlertState.fire(
         minutesBefore: Int,
@@ -32,7 +47,7 @@ class SensorExpiryAlertStateTests {
 
     @Test
     fun singleThresholdFiresOnceOnEntry() {
-        val s = SensorExpiryAlertState()
+        val s = newState()
         val t = setOf(T1D)
         assertEquals(emptySet<Int>(), s.fire(1800, t))     // 30h before: baseline, outside window
         assertEquals(emptySet<Int>(), s.fire(1500, t))     // 25h before: still outside
@@ -42,15 +57,15 @@ class SensorExpiryAlertStateTests {
     }
 
     @Test
-    fun firstObservationInsideWindowDoesNotFire() {
-        val s = SensorExpiryAlertState()
-        assertEquals(emptySet<Int>(), s.fire(60, setOf(T1D)))   // baseline already inside
-        assertEquals(emptySet<Int>(), s.fire(30, setOf(T1D)))
+    fun firstObservationInsideUnwarnedWindowFiresCatchUpOnce() {
+        val s = newState()
+        assertEquals(setOf(T1D), s.fire(60, setOf(T1D)))        // due, never warned anywhere
+        assertEquals(emptySet<Int>(), s.fire(30, setOf(T1D)))   // once only
     }
 
     @Test
     fun multipleThresholdsEachFireOnceInOrder() {
-        val s = SensorExpiryAlertState()
+        val s = newState()
         val t = setOf(T3D, T1D, T6H)
         assertEquals(emptySet<Int>(), s.fire(5760, t))     // 4d before: baseline, outside all
         assertEquals(setOf(T3D), s.fire(4320, t))          // enter 3d
@@ -61,16 +76,16 @@ class SensorExpiryAlertStateTests {
     }
 
     @Test
-    fun baselineInsideSeveralWindowsFiresNothing() {
-        val s = SensorExpiryAlertState()
+    fun baselineInsideSeveralUnwarnedWindowsFiresOnlyMostUrgent() {
+        val s = newState()
         val t = setOf(T3D, T1D, T6H)
-        assertEquals(emptySet<Int>(), s.fire(300, t))      // 5h before: inside all three -> baseline
-        assertEquals(emptySet<Int>(), s.fire(120, t))      // still nothing
+        assertEquals(setOf(T6H), s.fire(300, t))           // 5h before, inside all three: cascade guard
+        assertEquals(emptySet<Int>(), s.fire(120, t))      // rest silently adopted
     }
 
     @Test
     fun newSensorRearmsAllThresholds() {
-        val s = SensorExpiryAlertState()
+        val s = newState()
         val t = setOf(T1D)
         s.fire(1800, t)
         assertEquals(setOf(T1D), s.fire(1440, t))
@@ -82,7 +97,7 @@ class SensorExpiryAlertStateTests {
 
     @Test
     fun addingThresholdInsideItsWindowDoesNotFireRetroactively() {
-        val s = SensorExpiryAlertState()
+        val s = newState()
         s.fire(4320, setOf(T6H))                           // baseline outside the 6h window (with 6h only)
         // Now 3h before end, user adds the 1d threshold whose window opened long ago.
         val res = s.fire(180, setOf(T6H, T1D))
@@ -91,7 +106,7 @@ class SensorExpiryAlertStateTests {
 
     @Test
     fun cascadeFiresOnlySmallestWhenSeveralComeDueAtOnce() {
-        val s = SensorExpiryAlertState()
+        val s = newState()
         val t = setOf(T3D, T1D, T6H)
         s.fire(5760, t)                                    // baseline outside all
         // Big jump (e.g. app resumed) straight to 30 min before end.
@@ -101,7 +116,7 @@ class SensorExpiryAlertStateTests {
 
     @Test
     fun snoozeDefersButDoesNotSwallowThreshold() {
-        val s = SensorExpiryAlertState()
+        val s = newState()
         val t = setOf(T3D, T1D)
         s.fire(5760, t)                                    // baseline outside
         assertEquals(setOf(T3D), s.fire(4320, t))          // 3d fires
@@ -113,12 +128,83 @@ class SensorExpiryAlertStateTests {
 
     @Test
     fun emptyOrDisabledFiresNothing() {
-        val s = SensorExpiryAlertState()
+        val s = newState()
         assertEquals(emptySet<Int>(), s.fire(60, emptySet()))
         assertEquals(
             emptySet<Int>(),
             s.triggeredThresholds(false, true, false, end, end - min(60), setOf(T1D))
         )
+    }
+
+    @Test
+    fun windowEntryDuringProcessDowntimeFiresCatchUpAfterRestart() {
+        val store = FakeWarnedStore()
+        val t = setOf(T3D)
+        val s1 = SensorExpiryAlertState(store)
+        assertEquals(emptySet<Int>(), s1.fire(5760, t))    // baseline outside; process dies here
+        val s2 = SensorExpiryAlertState(store)             // restart after the 3d window opened
+        assertEquals(setOf(T3D), s2.fire(4000, t))         // due but never warned -> catch-up
+        assertEquals(emptySet<Int>(), s2.fire(3990, t))
+        val s3 = SensorExpiryAlertState(store)             // yet another restart
+        assertEquals(emptySet<Int>(), s3.fire(3980, t))    // persisted: no re-fire
+    }
+
+    @Test
+    fun restartWithSeveralUnwarnedOpenWindowsFiresOnlyMostUrgent() {
+        val store = FakeWarnedStore()
+        val t = setOf(T3D, T1D)
+        SensorExpiryAlertState(store).fire(5760, t)        // baseline outside both; process dies
+        val s2 = SensorExpiryAlertState(store)
+        assertEquals(setOf(T1D), s2.fire(1000, t))         // both open: cascade guard picks 1d
+        val s3 = SensorExpiryAlertState(store)
+        assertEquals(emptySet<Int>(), s3.fire(990, t))     // 3d was persisted-adopted, no late fire
+    }
+
+    @Test
+    fun restartWhileSnoozedStillFiresCatchUpAfterSnoozeEnds() {
+        val store = FakeWarnedStore()
+        SensorExpiryAlertState(store).fire(5760, setOf(T3D))
+        val s2 = SensorExpiryAlertState(store)
+        assertEquals(emptySet<Int>(), s2.fire(4000, setOf(T3D), snoozed = true))
+        assertEquals(setOf(T3D), s2.fire(3990, setOf(T3D)))
+    }
+
+    @Test
+    fun midEpisodeActivationIsAdoptedAndSurvivesRestart() {
+        val store = FakeWarnedStore()
+        val s1 = SensorExpiryAlertState(store)
+        s1.fire(5760, setOf(T6H))                                       // baseline with 6h only
+        assertEquals(emptySet<Int>(), s1.fire(4000, setOf(T6H, T3D)))   // 3d added inside its window: adopted
+        val s2 = SensorExpiryAlertState(store)                          // restart
+        assertEquals(emptySet<Int>(), s2.fire(3990, setOf(T6H, T3D)))   // adoption persisted, still silent
+        assertEquals(setOf(T6H), s2.fire(360, setOf(T6H, T3D)))         // 6h edge unaffected
+    }
+
+    @Test
+    fun newSensorRearmsAndPrunesOldPersistedEntries() {
+        val store = FakeWarnedStore()
+        val t = setOf(T1D)
+        val s = SensorExpiryAlertState(store)
+        s.fire(1800, t)
+        assertEquals(setOf(T1D), s.fire(1440, t))                      // warned + persisted
+        val end2 = end + 14L * 24 * 60 * 60 * 1000
+        assertEquals(emptySet<Int>(), s.fire(1800, t, endMs = end2))   // baseline outside for new sensor
+        assertEquals(setOf(T1D), s.fire(1440, t, endMs = end2))        // fires again for new sensor
+        assertEquals(setOf("$end2:$T1D"), store.entries)               // old sensor's entry pruned
+    }
+
+    @Test
+    fun stableEndTimeAcrossManyTicksKeepsLatchArmed() {
+        // Regression for the getendtime() clamp: an end time that stays constant
+        // must not re-baseline, and each edge fires exactly once.
+        val s = newState()
+        val t = setOf(T3D, T1D)
+        assertEquals(emptySet<Int>(), s.fire(5760, t))
+        for (m in 5700 downTo 4330 step 15) assertEquals(emptySet<Int>(), s.fire(m, t))
+        assertEquals(setOf(T3D), s.fire(4320, t))
+        for (m in 4305 downTo 1441 step 15) assertEquals(emptySet<Int>(), s.fire(m, t))
+        assertEquals(setOf(T1D), s.fire(1440, t))
+        for (m in 1425 downTo 15 step 15) assertEquals(emptySet<Int>(), s.fire(m, t))
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #97, and a fix for the original 24h warning as well.

Testing #97 over a full 14-day sensor with five thresholds configured (3d/2d/1d/12h/1h) produced zero warnings, deterministically. Two commits.

**Commit 1, the actual bug.** The evaluator sourced the sensor end from `Natives.getendtime()`, which is a chart function (javacurve.cpp): `min(curve start + duration, time(nullptr))`, the end of the drawable data range, clamped to the wall clock so the curve doesn't draw into the future. While a sensor runs it always returns "now". That kills the alert twice over: every threshold window looks open since forever, so the startup baseline adopts them all as already-warned, and the value moves every tick, so the new-sensor detection resets the latch on every pass. The latch itself was fine, it was fed garbage. This predates #97: the original fixed 24h warning used the same source, so it can never have fired either.

The fix resolves the official sensor end (start + wear duration) from the gatt registry via `Natives.getSensorEndTime(dataptr, official=true)`, falling back to the Kotlin-managed drivers' snapshot `officialEndMs` when native backing is absent. The displayed sensor wins, otherwise the farthest end. A plausibility guard drops ends that are not in the future before they reach the latch, and the resolved end is logged on change, so a bad source now shows up as log churn instead of silence. No native rebuild needed.

**Commit 2, persistence to make commit 1 stick.** The warned-latch lived in memory only, so a warning fired only if the process witnessed the exact tick of window entry; any restart in between (app update, process death) swallowed it via the startup baseline. And with commit 1 alone, the first start on an already-running sensor would silently adopt all open windows. The warned-set is now persisted per sensor end time behind a small `ExpiryWarnedStore` interface over SharedPreferences. On restart, thresholds that are due but were never warned fire a catch-up: smallest lead time first through the existing cascade guard, so it's one alert, not a burst. Thresholds enabled mid-episode whose window is already open still don't fire retroactively; that adoption is persisted at config-save time.

Tests: 19 unit tests in `SensorExpiryAlertStateTests`, including regressions for the clamped source, restart catch-up, cascade on restart, mid-episode enablement across restart, and sensor-change pruning.

Known and separate: the trigger path still bails without a current glucose reading (`currentGlucoseValueLocked() ?: return`, see #98). Harmless with a nearly-expired but still-sending sensor, but a conceptual wart. Unchanged here.


**Commit 3, display follow-up.** Once the warnings fired, they turned out to be unreadable. The separate alert notification builds its badge by stripping all digits from the message, meant to turn "Low 4.0 mmol/L" into "Low" since the value has its own row, but that also produced "Sensor expires in hours" (and "Missed reading - min"). And the full-screen alarm computed a supporting text with the full message but never rendered it, so a sensor-expiry alarm showed nothing beyond the type name and the current glucose. The wording rules now live in a small unit-tested helper (`AlertDisplayText`): duration-carrying alerts keep their numbers in the badge, and the alarm screen shows the message line under the header (still dropping plain "label + value" repetitions that would duplicate the hero).
