### PR TITLE
Trend arrow: ramp out of the dead zone instead of jumping to 22.5°

### DIFF
--- a/Common/src/main/java/tk/glucodata/TrendArrowAngle.java
+++ b/Common/src/main/java/tk/glucodata/TrendArrowAngle.java
@@ -21,7 +21,11 @@ package tk.glucodata;
  * vertical at +/-2 (the CGM arrow convention), rendered flat below the Flat
  * trend state threshold. Under 0.5 mg/dL per minute the sign of the rate is
  * noise — two honest estimators regularly disagree on it for the same data —
- * so a slow drift must not tilt the arrow in either direction.
+ * so a slow drift must not tilt the arrow in either direction. Between 0.5
+ * and 1 the tilt ramps linearly from 0 to 45 degrees instead of jumping to
+ * 22.5 at the dead-zone edge, so a rate creeping past 0.5 eases the arrow
+ * out of flat rather than snapping it; from 1 upward the plain 45-per-unit
+ * line applies unchanged.
  */
 public final class TrendArrowAngle {
     public static final float DEGREES_PER_UNIT = 45f;
@@ -36,8 +40,17 @@ public final class TrendArrowAngle {
      * rotation both renderers apply.
      */
     public static float rotationDegrees(float rateMgdlPerMin) {
-        if (!Float.isFinite(rateMgdlPerMin) || Math.abs(rateMgdlPerMin) < FLAT_BELOW_RATE)
+        if (!Float.isFinite(rateMgdlPerMin))
             return 0f;
+        float magnitude = Math.abs(rateMgdlPerMin);
+        if (magnitude <= FLAT_BELOW_RATE)
+            return 0f;
+        if (magnitude < 1f) {
+            // Ramp 0..45 degrees over the 0.5..1 band: 45 at 1 keeps the
+            // CGM anchor, 0 at 0.5 meets the dead zone without a jump.
+            float ramp = 2f * DEGREES_PER_UNIT * (magnitude - FLAT_BELOW_RATE);
+            return rateMgdlPerMin > 0f ? -ramp : ramp;
+        }
         float rotation = -rateMgdlPerMin * DEGREES_PER_UNIT;
         if (rotation < -90f)
             return -90f;

--- a/Common/src/test/java/tk/glucodata/TrendArrowAngleTests.kt
+++ b/Common/src/test/java/tk/glucodata/TrendArrowAngleTests.kt
@@ -22,7 +22,35 @@ class TrendArrowAngleTests {
         // rotation in screen coordinates handled by callers via the sign).
         assertEquals(-45f, TrendArrowAngle.rotationDegrees(1f), 0.001f)
         assertEquals(45f, TrendArrowAngle.rotationDegrees(-1f), 0.001f)
-        assertEquals(-22.5f, TrendArrowAngle.rotationDegrees(0.5f), 0.001f)
+    }
+
+    @Test
+    fun rampEasesOutOfTheDeadZone() {
+        // Between 0.5 and 1 the tilt ramps linearly 0..45 degrees instead of
+        // jumping to 22.5 at the edge: a rate creeping past the dead zone
+        // must not snap the arrow from flat to a visible tilt.
+        assertEquals(-9f, TrendArrowAngle.rotationDegrees(0.6f), 0.001f)
+        assertEquals(9f, TrendArrowAngle.rotationDegrees(-0.6f), 0.001f)
+        assertEquals(-27f, TrendArrowAngle.rotationDegrees(0.8f), 0.001f)
+        assertEquals(27f, TrendArrowAngle.rotationDegrees(-0.8f), 0.001f)
+    }
+
+    @Test
+    fun continuousAtTheBandEdges() {
+        // No jump at either end of the ramp: ~0 just past 0.5, ~45 just
+        // under 1, exactly the 45-per-unit line from 1 on.
+        assertEquals(0f, TrendArrowAngle.rotationDegrees(0.5f), 0.001f)
+        assertEquals(0f, TrendArrowAngle.rotationDegrees(-0.5f), 0.001f)
+        assertEquals(0f, TrendArrowAngle.rotationDegrees(0.501f), 0.1f)
+        assertEquals(-45f, TrendArrowAngle.rotationDegrees(0.999f), 0.1f)
+        assertEquals(45f, TrendArrowAngle.rotationDegrees(-0.999f), 0.1f)
+    }
+
+    @Test
+    fun unchangedAboveOne() {
+        // The plain 45-per-unit line above 1 is untouched by the ramp.
+        assertEquals(-67.5f, TrendArrowAngle.rotationDegrees(1.5f), 0.001f)
+        assertEquals(67.5f, TrendArrowAngle.rotationDegrees(-1.5f), 0.001f)
     }
 
     @Test


### PR DESCRIPTION
The arrow currently jumps from 0° straight to 22.5° the moment the rate crosses the 0.5 dead zone. A velocity creeping from 0.49 to 0.51 flips the arrow from flat to a clearly visible tilt, which reads more dramatic than the data behind it.

This replaces the jump with a linear ramp: 0° at 0.5, 45° exactly at 1.0, then the existing 45°/unit line from #79 unchanged. The curve is continuous at both band edges, so there is no flicker at the dead-zone boundary and no need for hysteresis. The CGM anchors stay put (45° at the FortyFive boundary, vertical at 2), everything at or above 1.0 is bit-identical to today, and the dead zone itself is untouched. Both renderers (dashboard TrendIndicator, notification glyph) pick this up through the shared TrendArrowAngle class, so no renderer changes.

| velocity (mg/dL/min) | before | after |
|---|---|---|
| ≤ 0.5 | 0° | 0° |
| 0.6 | 25° | 9° |
| 0.8 | 36° | 27° |
| 1.0 | 45° | 45° |
| 1.5 | 67.5° | 67.5° |
| ≥ 2.0 | 90° | 90° |

A side effect worth naming: in the 0.5 to 1.0 band NG now shows a subtle tilt where Dexcom-calibrated renderers (GDH for example) still show flat until 1.0. Before this change NG already stood at 22.5° and more in that band, a whole category more alarmed than those displays. Now the two read as the same story at different resolutions instead of contradicting each other.

Tests cover the ramp support points in both signs, continuity at 0.5 and 1.0, unchanged values above 1.0, and the unchanged dead zone/NaN handling.
