### PR TITLE
Vibration must span the sound-delay phase, not just the alarm duration

### DIFF
--- a/Common/src/main/java/tk/glucodata/AlertVibrationPattern.java
+++ b/Common/src/main/java/tk/glucodata/AlertVibrationPattern.java
@@ -1,12 +1,15 @@
 package tk.glucodata;
 
+import static tk.glucodata.alerts.AlertConfigKt.MAX_SOUND_DELAY_SECONDS;
 import static tk.glucodata.alerts.AlertConfigKt.sanitizeAlertDurationSeconds;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 final class AlertVibrationPattern {
-    private static final int MAX_SEGMENTS = 512;
+    // Sized for the densest base pattern (9 segments per 1.2s loop) looped
+    // across the maximum sound delay plus the maximum alarm duration (360s).
+    private static final int MAX_SEGMENTS = 4096;
 
     final long[] timings;
     final int[] amplitudes;
@@ -17,8 +20,18 @@ final class AlertVibrationPattern {
     }
 
     static AlertVibrationPattern buildFinite(long[] baseTimings, int[] baseAmplitudes, int durationSeconds) {
+        return buildFinite(baseTimings, baseAmplitudes, durationSeconds, 0);
+    }
+
+    // leadInSeconds extends the pattern across the silent sound-delay phase
+    // ("vibrate first"), so it is bounded by the sound-delay cap rather than
+    // folded into the alarm-duration sanitizer, which would reject the sum.
+    static AlertVibrationPattern buildFinite(long[] baseTimings, int[] baseAmplitudes, int durationSeconds,
+            int leadInSeconds) {
         // Never hand Android an infinite alert vibration; scheduled stop is only an early cleanup path.
-        final long maxDurationMs = TimeUnit.SECONDS.toMillis(sanitizeAlertDurationSeconds(durationSeconds));
+        final int boundedLeadIn = Math.max(0, Math.min(leadInSeconds, MAX_SOUND_DELAY_SECONDS));
+        final long maxDurationMs = TimeUnit.SECONDS
+                .toMillis(sanitizeAlertDurationSeconds(durationSeconds) + (long) boundedLeadIn);
         final ArrayList<Long> timingList = new ArrayList<>();
         final ArrayList<Integer> amplitudeList = new ArrayList<>();
         long elapsedMs = 0L;

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -1664,6 +1664,10 @@ public class Notify {
     }
 
     private void vibratealarm(int kind, String hapticProfileName, int durationSeconds) {
+        vibratealarm(kind, hapticProfileName, durationSeconds, 0);
+    }
+
+    private void vibratealarm(int kind, String hapticProfileName, int durationSeconds, int soundDelayLeadInSeconds) {
         var context = Applic.app;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
             vibrator = ((VibratorManager) (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE)))
@@ -1752,16 +1756,19 @@ public class Notify {
                         amplitudes[i] = 1; // Ensure non-zero if it was meant to be on
                 }
             }
-            final AlertVibrationPattern finitePattern = AlertVibrationPattern.buildFinite(timings, amplitudes, durationSeconds);
+            final AlertVibrationPattern finitePattern = AlertVibrationPattern.buildFinite(timings, amplitudes,
+                    durationSeconds, soundDelayLeadInSeconds);
             vibrateWaveform(vibrator, finitePattern.timings, finitePattern.amplitudes, -1);
         } else {
-            final AlertVibrationPattern finitePattern = AlertVibrationPattern.buildFinite(timings, amplitudes, durationSeconds);
+            final AlertVibrationPattern finitePattern = AlertVibrationPattern.buildFinite(timings, amplitudes,
+                    durationSeconds, soundDelayLeadInSeconds);
             vibrator.vibrate(finitePattern.timings, -1);
         }
 
         if (doLog) {
             Log.i(LOG_ID, "vibratealarm " + kind + " hapticProfile=" + hapticProfileName
-                    + " duration=" + sanitizeAlarmDurationSeconds(durationSeconds));
+                    + " duration=" + sanitizeAlarmDurationSeconds(durationSeconds)
+                    + (soundDelayLeadInSeconds > 0 ? " soundDelayLeadIn=" + soundDelayLeadInSeconds : ""));
         }
     }
 
@@ -2011,7 +2018,9 @@ public class Notify {
             }
         }
         if (vibrate) {
-            vibratealarm(kind, resolvedHapticProfile, duration);
+            // The finite pattern must also span the silent delay phase
+            // ("vibrate first"), else it runs out before the sound starts.
+            vibratealarm(kind, resolvedHapticProfile, duration, soundDelaySeconds);
         }
 
         if (canPlaySound) {

--- a/Common/src/test/java/tk/glucodata/AlertVibrationPatternTests.kt
+++ b/Common/src/test/java/tk/glucodata/AlertVibrationPatternTests.kt
@@ -1,5 +1,6 @@
 package tk.glucodata
 
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -41,6 +42,88 @@ class AlertVibrationPatternTests {
         assertEquals(4_000L, pattern.totalDurationMs())
         assertEquals(1, pattern.timings.size)
         assertEquals(0, pattern.amplitudes[0])
+    }
+
+    @Test
+    fun leadInExtendsPatternAcrossSoundDelay() {
+        // Sound delay 45s + duration 25s: the pattern must span all 70s so the
+        // vibration does not run out before the delayed sound starts.
+        val pattern = AlertVibrationPattern.buildFinite(
+            longArrayOf(0, 200, 100),
+            intArrayOf(0, 255, 0),
+            25,
+            45
+        )
+
+        assertEquals(70_000L, pattern.totalDurationMs())
+    }
+
+    @Test
+    fun zeroLeadInMatchesPlainBuild() {
+        val plain = AlertVibrationPattern.buildFinite(
+            longArrayOf(0, 200, 100),
+            intArrayOf(0, 255, 0),
+            25
+        )
+        val withLeadIn = AlertVibrationPattern.buildFinite(
+            longArrayOf(0, 200, 100),
+            intArrayOf(0, 255, 0),
+            25,
+            0
+        )
+
+        assertArrayEquals(plain.timings, withLeadIn.timings)
+        assertArrayEquals(plain.amplitudes, withLeadIn.amplitudes)
+    }
+
+    @Test
+    fun maxDelayPlusMaxDurationIsCoveredByDensestPattern() {
+        // HIGH base pattern, the densest looped one; 300s delay + 60s duration
+        // must fit within the segment budget without truncation.
+        val pattern = AlertVibrationPattern.buildFinite(
+            longArrayOf(0, 150, 100, 150, 100, 150, 100, 150, 300),
+            intArrayOf(0, 255, 0, 255, 0, 255, 0, 255, 0),
+            60,
+            300
+        )
+
+        assertEquals(360_000L, pattern.totalDurationMs())
+    }
+
+    @Test
+    fun leadInIsBoundedBySoundDelayCap() {
+        val pattern = AlertVibrationPattern.buildFinite(
+            longArrayOf(0, 200, 100),
+            intArrayOf(0, 255, 0),
+            5,
+            999
+        )
+
+        assertEquals(305_000L, pattern.totalDurationMs())
+    }
+
+    @Test
+    fun negativeLeadInIsIgnored() {
+        val pattern = AlertVibrationPattern.buildFinite(
+            longArrayOf(0, 200, 100),
+            intArrayOf(0, 255, 0),
+            25,
+            -10
+        )
+
+        assertEquals(25_000L, pattern.totalDurationMs())
+    }
+
+    @Test
+    fun invalidDurationWithLeadInFallsBackToDefaultPlusLeadIn() {
+        val pattern = AlertVibrationPattern.buildFinite(
+            longArrayOf(0, 200, 100),
+            intArrayOf(0, 255, 0),
+            65_535,
+            45
+        )
+
+        assertEquals(50_000L, pattern.totalDurationMs())
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #96. The delayed alarm sound shifts the audible alarm and the auto-stop by the configured delay, but the finite vibration pattern was still cut to the alarm duration alone and started at trigger time. With a delay longer than the duration, the vibration ran out before the sound began: delay 45s + duration 25s gave 25s of vibration, 20s of dead silence, then 25s of sound. That silent window is exactly what "vibrate first" was supposed to prevent.

The fix passes the sound delay into `vibratealarm` as a lead-in, so the finite pattern is built for `soundDelaySeconds + duration`. The vibration now runs through the delay phase and keeps going in parallel with the sound until the scheduled stop. I picked that over stopping the vibration at sound onset because without a delay, vibration and sound already run in parallel for the whole alarm window; this keeps the same invariant, just shifted.

Two things in the pattern builder had to change:

- The lead-in is bounded by `MAX_SOUND_DELAY_SECONDS` and added on top of the sanitized duration. Folding the sum into `sanitizeAlertDurationSeconds` would not work: that sanitizer resets anything over 60s to the 5s default, so delay 45 + duration 25 would have produced a 5s pattern.
- `MAX_SEGMENTS` grows from 512 to 4096. The old cap was sized for a 60s pattern; the densest base pattern (HIGH, 9 segments per 1.2s loop) needs ~2400 segments to cover the worst case of 300s delay + 60s duration.

With no delay configured the built pattern is unchanged (pinned by test), and dismiss/snooze during the delay still cancels the vibration through `stopvibratealarm()`. Flash was already fine: it runs unbounded until the shifted stop.

Tests: lead-in extends the pattern (45+25 gives 70s), zero lead-in matches the plain build, 300s+60s fits the segment budget without truncation, lead-in is capped and negative lead-ins ignored, invalid duration still falls back to default+lead-in. Full Common unit suite shows only the two known pre-existing failures (wall-clock-dependent sensor test, org.json-dependent catalog test).

Not verified on device: the actual 70s waveform playback. The pattern math is unit-tested, but if a vendor HAL caps waveform length somewhere below ~2500 segments, long delays could still truncate on that device.
