### PR TITLE
History quick-add seeds now; option to always log at the current time

### DIFF
--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1619,6 +1619,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="journal_metric_eiob">eIOB %1$s E</string>
     <string name="journal_eiob_display_title">Effektives IOB (eIOB) anzeigen</string>
     <string name="journal_eiob_display_desc">Aktivitätsbasiertes Insulin an Bord zusätzlich zum klassischen IOB anzeigen</string>
+    <string name="journal_quickadd_always_now_title">Schnelleintrag immer zur aktuellen Zeit</string>
+    <string name="journal_quickadd_always_now_desc">Die Plus-Taste legt neue Einträge auch bei ausgewähltem Diagrammpunkt zur aktuellen Zeit an. Nachtragen über das Zeitfeld des Eintrags, das Diagramm-Menü oder eine Messwertzeile</string>
     <string name="notification_show_iob_title">Insulin an Bord anzeigen</string>
     <string name="notification_show_iob_desc">IOB/eIOB aus dem Journal in der Statuszeile</string>
     <string name="notification_show_cob_title">Kohlenhydrate an Bord anzeigen</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1874,6 +1874,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_metric_eiob">eIOB %1$s U</string>
     <string name="journal_eiob_display_title">Show effective IOB (eIOB)</string>
     <string name="journal_eiob_display_desc">Also display activity-based insulin on board next to classic IOB</string>
+    <string name="journal_quickadd_always_now_title">Quick add always uses the current time</string>
+    <string name="journal_quickadd_always_now_desc">The + button starts new entries at the current time even while a chart point is selected. Backdate via the entry\'s time field, the chart menu, or a reading row</string>
     <string name="notification_show_iob_title">Show insulin on board</string>
     <string name="notification_show_iob_desc">IOB/eIOB from the journal in the status line</string>
     <string name="notification_show_cob_title">Show carbs on board</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/HistoryBrowseScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/HistoryBrowseScreen.kt
@@ -71,6 +71,7 @@ import tk.glucodata.data.journal.JournalEntryType
 import tk.glucodata.data.journal.JournalFood
 import tk.glucodata.data.journal.JournalInsulinPreset
 import tk.glucodata.ui.journal.buildJournalChartMarkers
+import tk.glucodata.ui.journal.journalQuickAddTimestamp
 import tk.glucodata.ui.journal.journalTypeColor
 import tk.glucodata.ui.journal.journalTypeSelectedContainerColor
 import tk.glucodata.ui.util.ConnectedButtonGroup
@@ -377,7 +378,8 @@ fun HistoryBrowseScreen(
     onDeleteReading: ((GlucosePoint) -> Unit)? = null,
     onJournalEntryClick: ((JournalEntry) -> Unit)? = null,
     onAddJournalEntry: ((Long, JournalEntryType?, Float?) -> Unit)? = null,
-    showTransferActions: Boolean = true
+    showTransferActions: Boolean = true,
+    quickAddAlwaysNow: Boolean = false
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -519,11 +521,14 @@ fun HistoryBrowseScreen(
                             IconButton(
                                 onClick = {
                                     onAddJournalEntry(
-                                        viewportSnapshot?.selectedPoint?.timestamp
-                                            ?: viewportEnd
-                                            ?: System.currentTimeMillis(),
+                                        journalQuickAddTimestamp(
+                                            viewportSnapshot?.selectedPoint?.timestamp,
+                                            System.currentTimeMillis(),
+                                            quickAddAlwaysNow
+                                        ),
                                         selectedJournalTypes.singleOrNull(),
                                         viewportSnapshot?.selectedPoint?.value
+                                            ?.takeIf { !quickAddAlwaysNow }
                                     )
                                 }
                             ) {

--- a/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
@@ -147,6 +147,7 @@ private fun HistoryRoute(
     val journalEntries by dashboardViewModel.journalEntries.collectAsStateWithLifecycle()
     val journalInsulinPresets by dashboardViewModel.journalInsulinPresets.collectAsStateWithLifecycle()
     val journalFoods by dashboardViewModel.journalFoods.collectAsStateWithLifecycle()
+    val journalQuickAddAlwaysNow by dashboardViewModel.journalQuickAddAlwaysNow.collectAsStateWithLifecycle()
     val appChartRangeColorsEnabled by dashboardViewModel.glucoseAppChartRangeColorsEnabled.collectAsStateWithLifecycle()
     val predictionCarbRatioGramsPerUnit by dashboardViewModel.predictionCarbRatioGramsPerUnit.collectAsStateWithLifecycle()
     val predictionInsulinSensitivityMgDlPerUnit by dashboardViewModel.predictionInsulinSensitivityMgDlPerUnit.collectAsStateWithLifecycle()
@@ -181,6 +182,7 @@ private fun HistoryRoute(
         journalEntries = scopedJournalEntries,
         journalInsulinPresets = journalInsulinPresets,
         journalFoods = journalFoods,
+        quickAddAlwaysNow = journalQuickAddAlwaysNow,
         onBack = onBack,
         onPointClick = { point ->
             onTriggerCalibration(
@@ -296,6 +298,7 @@ private fun JournalRoute(
     val journalInsulinPresets by dashboardViewModel.journalInsulinPresets.collectAsStateWithLifecycle()
     val journalFoods by dashboardViewModel.journalFoods.collectAsStateWithLifecycle()
     val journalEiobDisplayEnabled by dashboardViewModel.journalEiobDisplayEnabled.collectAsStateWithLifecycle()
+    val journalQuickAddAlwaysNow by dashboardViewModel.journalQuickAddAlwaysNow.collectAsStateWithLifecycle()
     val appChartRangeColorsEnabled by dashboardViewModel.glucoseAppChartRangeColorsEnabled.collectAsStateWithLifecycle()
     val predictionCarbRatioGramsPerUnit by dashboardViewModel.predictionCarbRatioGramsPerUnit.collectAsStateWithLifecycle()
     val predictionInsulinSensitivityMgDlPerUnit by dashboardViewModel.predictionInsulinSensitivityMgDlPerUnit.collectAsStateWithLifecycle()
@@ -368,7 +371,8 @@ private fun JournalRoute(
         useStatusBarsPadding = useStatusBarsPadding,
         bottomContentPadding = bottomContentPadding,
         showEiob = journalEiobDisplayEnabled,
-        chartRangeColors = appChartRangeColorsEnabled
+        chartRangeColors = appChartRangeColorsEnabled,
+        quickAddAlwaysNow = journalQuickAddAlwaysNow
     )
 
     journalEditorRequest?.let { request ->

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
@@ -108,7 +108,8 @@ fun JournalScreen(
     useStatusBarsPadding: Boolean = true,
     bottomContentPadding: Dp = 104.dp,
     showEiob: Boolean = true,
-    chartRangeColors: Boolean = false
+    chartRangeColors: Boolean = false,
+    quickAddAlwaysNow: Boolean = false
 ) {
     val view = LocalView.current
     val sortedHistory = remember(glucoseHistory) { glucoseHistory.sortedBy { it.timestamp } }
@@ -373,9 +374,9 @@ fun JournalScreen(
             },
             onTypeSelected = { type ->
                 onAddJournalEntry(
-                    journalQuickAddTimestamp(selectedPointTimestamp, System.currentTimeMillis()),
+                    journalQuickAddTimestamp(selectedPointTimestamp, System.currentTimeMillis(), quickAddAlwaysNow),
                     type,
-                    selectedDisplayGlucose.takeIf { type == JournalEntryType.FINGERSTICK },
+                    selectedDisplayGlucose.takeIf { type == JournalEntryType.FINGERSTICK && !quickAddAlwaysNow },
                     null
                 )
             },
@@ -392,9 +393,18 @@ fun JournalScreen(
  * entry can lag minutes behind wall clock (e.g. right after resume, before the data
  * flows re-emit) and must never seed the entry. Backdating stays an explicit act:
  * selecting a chart point or using the timeline/long-press menus.
+ *
+ * [alwaysNow] is the opt-in journal setting: the "+" button seeds wall-clock now
+ * even while a chart point is selected — a selection can silently outlive a resume
+ * or tab switch, and users who only ever log in the moment never want it as a seed.
+ * Backdating then goes through the editor's time field or the chart/timeline menus.
  */
-internal fun journalQuickAddTimestamp(selectedPointTimestamp: Long?, nowMillis: Long): Long =
-    selectedPointTimestamp ?: nowMillis
+internal fun journalQuickAddTimestamp(
+    selectedPointTimestamp: Long?,
+    nowMillis: Long,
+    alwaysNow: Boolean = false
+): Long =
+    if (alwaysNow) nowMillis else selectedPointTimestamp ?: nowMillis
 
 @Composable
 private fun JournalHeader(

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
@@ -174,6 +174,7 @@ fun JournalSettingsScreen(
     val journalFoodMacrosEnabled by viewModel.journalFoodMacrosEnabled.collectAsState()
     val journalFoodLibraryEnabled by viewModel.journalFoodLibraryEnabled.collectAsState()
     val journalEiobDisplayEnabled by viewModel.journalEiobDisplayEnabled.collectAsState()
+    val journalQuickAddAlwaysNow by viewModel.journalQuickAddAlwaysNow.collectAsState()
     val journalHealthConnectActivityEnabled by viewModel.journalHealthConnectActivityEnabled.collectAsState()
     val aapsJournalImportEnabled by viewModel.aapsJournalImportEnabled.collectAsState()
     val allPresets by viewModel.journalInsulinPresets.collectAsState()
@@ -234,6 +235,18 @@ fun JournalSettingsScreen(
                             if (journalNavigationTabEnabled) "journal" else "settings/journal/history"
                         )
                     }
+                )
+            }
+            item(key = "journal_quickadd_always_now") {
+                SettingsSwitchItem(
+                    title = stringResource(R.string.journal_quickadd_always_now_title),
+                    subtitle = stringResource(R.string.journal_quickadd_always_now_desc),
+                    checked = journalQuickAddAlwaysNow,
+                    onCheckedChange = { viewModel.setJournalQuickAddAlwaysNow(it) },
+                    icon = Icons.Default.History,
+                    iconTint = MaterialTheme.colorScheme.secondary,
+                    position = CardPosition.SINGLE,
+                    enabled = journalEnabled
                 )
             }
             item(key = "journal_intelligence") {

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
@@ -113,6 +113,7 @@ class DashboardViewModel(
         const val JOURNAL_FOOD_MACROS_KEY = "dashboard_journal_food_macros_enabled"
         const val JOURNAL_FOOD_LIBRARY_KEY = "dashboard_journal_food_library_enabled"
         const val JOURNAL_EIOB_DISPLAY_KEY = "dashboard_journal_eiob_display_enabled"
+        const val JOURNAL_QUICKADD_ALWAYS_NOW_KEY = "dashboard_journal_quickadd_always_now"
         const val GLUCOSE_RANGE_COLORS_KEY = "glucose_value_range_colors_enabled"
         const val ARROW_FORECAST_COLORS_KEY = "glucose_arrow_forecast_colors_enabled"
         const val CHART_RANGE_COLORS_KEY = "glucose_chart_range_colors_enabled"
@@ -305,6 +306,9 @@ class DashboardViewModel(
 
     private val _journalEiobDisplayEnabled = MutableStateFlow(true)
     val journalEiobDisplayEnabled = _journalEiobDisplayEnabled.asStateFlow()
+
+    private val _journalQuickAddAlwaysNow = MutableStateFlow(false)
+    val journalQuickAddAlwaysNow = _journalQuickAddAlwaysNow.asStateFlow()
 
     private val _glucoseValueRangeColorsEnabled = MutableStateFlow(false)
     val glucoseValueRangeColorsEnabled = _glucoseValueRangeColorsEnabled.asStateFlow()
@@ -602,6 +606,7 @@ class DashboardViewModel(
         _journalFoodMacrosEnabled.value = prefs.getBoolean(JOURNAL_FOOD_MACROS_KEY, false)
         _journalFoodLibraryEnabled.value = prefs.getBoolean(JOURNAL_FOOD_LIBRARY_KEY, true)
         _journalEiobDisplayEnabled.value = prefs.getBoolean(JOURNAL_EIOB_DISPLAY_KEY, true)
+        _journalQuickAddAlwaysNow.value = prefs.getBoolean(JOURNAL_QUICKADD_ALWAYS_NOW_KEY, false)
         _glucoseValueRangeColorsEnabled.value = prefs.getBoolean(GLUCOSE_RANGE_COLORS_KEY, false)
         _glucoseArrowForecastColorsEnabled.value = prefs.getBoolean(ARROW_FORECAST_COLORS_KEY, false)
         _glucoseChartRangeColorsEnabled.value = prefs.getBoolean(CHART_RANGE_COLORS_KEY, false)
@@ -1366,6 +1371,13 @@ class DashboardViewModel(
         val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
         prefs.edit().putBoolean(JOURNAL_EIOB_DISPLAY_KEY, enabled).apply()
         _journalEiobDisplayEnabled.value = enabled
+    }
+
+    fun setJournalQuickAddAlwaysNow(enabled: Boolean) {
+        val context = tk.glucodata.Applic.app
+        val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(JOURNAL_QUICKADD_ALWAYS_NOW_KEY, enabled).apply()
+        _journalQuickAddAlwaysNow.value = enabled
     }
 
     fun setGlucoseValueRangeColorsEnabled(enabled: Boolean) {

--- a/Common/src/testMobile/java/tk/glucodata/ui/journal/JournalQuickAddTimestampTests.kt
+++ b/Common/src/testMobile/java/tk/glucodata/ui/journal/JournalQuickAddTimestampTests.kt
@@ -22,4 +22,21 @@ class JournalQuickAddTimestampTests {
             journalQuickAddTimestamp(selectedPointTimestamp = selected, nowMillis = now)
         )
     }
+
+    @Test
+    fun quickAddAlwaysNowIgnoresSelection() {
+        val selected = now - 45L * 60L * 1000L
+        assertEquals(
+            now,
+            journalQuickAddTimestamp(selectedPointTimestamp = selected, nowMillis = now, alwaysNow = true)
+        )
+    }
+
+    @Test
+    fun quickAddAlwaysNowWithoutSelectionSeedsWallClockNow() {
+        assertEquals(
+            now,
+            journalQuickAddTimestamp(selectedPointTimestamp = null, nowMillis = now, alwaysNow = true)
+        )
+    }
 }


### PR DESCRIPTION
Follow-up to #110 and #111. A user report showed that "+"-created journal entries still sometimes landed on an old timestamp after re-entering the app or switching tabs. #110 only covered the Journal screen's FAB. The History screen's toolbar "+" was a third quick-add path with its own, older fallback chain:

```kotlin
viewportSnapshot?.selectedPoint?.timestamp
    ?: viewportEnd                          // frozen viewport end, minutes behind wall clock
    ?: System.currentTimeMillis()
```

`viewportEnd` is the right edge of this screen's chart viewport; after a resume or tab return it lags wall clock with no visual cue at all. The toolbar "+" now goes through `journalQuickAddTimestamp` like the Journal FAB: explicit chart selection wins, everything else means "log something happening now". The `viewportEnd` link is gone.

### Audit of every journal-editor entry point

I checked all call sites of `onAddJournalEntry` / `openJournalEditor` / `JournalEditorRequest(...)` against one criterion: an explicit reference point (row, chart selection, long-press, existing entry) seeds its own timestamp; everything else seeds wall-clock now.

| Site | Reference point | Verdict |
|---|---|---|
| `HistoryBrowseScreen` toolbar "+" | `selectedPoint ?: viewportEnd ?: now` | **fixed here** |
| `HistoryBrowseScreen` reading-row "+" | `readingPoint.timestamp` | ok |
| `HistoryBrowseScreen` journal-row "+" | `item.timestamp` | ok |
| `JournalScreen` FAB | `journalQuickAddTimestamp` | ok (#110) |
| `JournalScreen` row actions | `item.timestamp` | ok |
| `JournalScreen` chart action menu | long-press/tap timestamp | ok |
| `DashboardScreen` entry clicks | `entry.timestamp` | ok |
| `DashboardScreen` row "+" | `item.timestamp` | ok |
| `DashboardScreen` timeline-tap menu | tapped timestamp | ok |
| `MainNavigation` entry clicks / pass-throughs | `entry.timestamp` / callers above | ok |

No fourth path exists.

### New option: quick add always uses the current time (default off)

A selected chart point can silently outlive a resume or tab switch and then seed the next quick-add. 4f0dcd21 attacked this with an unconditional viewport reset, which 307da540 reverted. Instead of resetting state behind the user's back, this makes it a choice: with the new journal setting enabled, the "+" button always seeds wall-clock now (and drops the stale suggested-glucose value), even while a point is selected. Backdating then goes through the editor's time field, the chart menus, or a reading row. Off (default) keeps today's behavior exactly.

### Tests

- `JournalQuickAddTimestampTests` extended: `alwaysNow` ignores a selection, and seeds now without one; the two existing cases are untouched and green.
- Full `testMobileLibre3SiDexGoogleDebug` run: 966 tests, the only failures are the 13 that already fail on a clean upstream/main tip (`DefaultParamCatalogCompareTests`, `ManagedSensorStatusPolicyTests`, and the `SibionicsExactV115G/V116ACoreTest` classes; identical list with and without this change).
