### PR TITLE
Optional long-shaft trend arrow glyph

### DIFF
--- a/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
+++ b/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
@@ -945,14 +945,20 @@ public class NotificationChartDrawer {
 
         // Total Length Calculation. The arrow rotates around the bitmap
         // center, so a shaft of up to ~95% of the box never clips at any
-        // angle; the old 50% factor left a stubby glyph next to what other
-        // apps render for the same rate.
-        float arrowLenFactor = showDouble ? 0.42f : 0.62f;
+        // angle. Opt-in setting: the long-shaft variant matches what other
+        // apps render for the same rate; the default keeps the compact glyph.
+        boolean largeArrow = context.getSharedPreferences("tk.glucodata_preferences", Context.MODE_PRIVATE)
+                .getBoolean("notification_large_trend_arrow", false);
+        float arrowLenFactor = largeArrow
+                ? (showDouble ? 0.62f : 0.82f)
+                : (showDouble ? 0.42f : 0.62f);
 
         // Slight growth with speed, capped so the double-head variant still
         // fits inside the bitmap.
         float speed = Math.abs(rate);
-        float totalScale = 1.0f + Math.min(speed * 0.04f, 0.18f);
+        float totalScale = largeArrow
+                ? 1.0f + Math.min(speed * 0.05f, 0.12f)
+                : 1.0f + Math.min(speed * 0.04f, 0.18f);
 
         float arrowLen = drawSize * arrowLenFactor * totalScale;
         float totalVisualLen = arrowLen;

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1309,6 +1309,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="settings_changed_press_to_apply">Einstellungen geändert – zum Übernehmen drücken</string>
     <string name="shortcuthelp">Hilfe zu Verknüpfungen</string>
     <string name="show_trend_arrow">Trendpfeil anzeigen</string>
+    <string name="notification_large_arrow_title">Größerer Trendpfeil</string>
+    <string name="notification_large_arrow_desc">Trendpfeil überall mit längerem Schaft zeichnen (Benachrichtigungen, Widgets, AOD)</string>
     <string name="slope">Steigung</string>
     <string name="stathelp">Stat-Hilfe</string>
     <string name="staticnum">Staticnum</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1570,6 +1570,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="settings_changed_press_to_apply">Settings changed — press to apply</string>
     <string name="shortcuthelp">Shortcut Help</string>
     <string name="show_trend_arrow">Show trend arrow</string>
+    <string name="notification_large_arrow_title">Larger trend arrow</string>
+    <string name="notification_large_arrow_desc">Draw the trend arrow with a longer shaft wherever it appears (notifications, widgets, AOD)</string>
     <string name="slope">Slope</string>
     <string name="start_time_with_value">Start: %1$s</string>
     <string name="stathelp">Stat Help</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
@@ -103,6 +103,7 @@ fun NotificationSettingsScreen(
     var fontType by rememberSaveable { mutableIntStateOf(prefs.getInt("notification_font_family", 0)) }
     var fontWeight by rememberSaveable { mutableIntStateOf(prefs.getInt("notification_font_weight", 400)) }
     var showArrow by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_show_arrow", true)) }
+    var largeArrow by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_large_trend_arrow", false)) }
     var arrowSize by rememberSaveable { mutableFloatStateOf(prefs.getFloat("notification_arrow_size", 1.0f)) }
     var collapsedChart by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_chart_collapsed", false)) }
     var showTargetRange by rememberSaveable { mutableStateOf(prefs.getBoolean("notification_chart_target_range", true)) }
@@ -119,6 +120,7 @@ fun NotificationSettingsScreen(
             .putInt("notification_font_family", fontType)
             .putInt("notification_font_weight", fontWeight)
             .putBoolean("notification_show_arrow", showArrow)
+            .putBoolean("notification_large_trend_arrow", largeArrow)
             .putFloat("notification_arrow_size", arrowSize)
             .putBoolean("notification_chart_collapsed", collapsedChart)
             .putBoolean("notification_chart_target_range", showTargetRange)
@@ -215,6 +217,14 @@ fun NotificationSettingsScreen(
                 onCheckedChange = { showArrow = it; save() },
                 icon = null,
                 position = CardPosition.TOP
+            )
+            SettingsSwitchItem(
+                title = stringResource(R.string.notification_large_arrow_title),
+                subtitle = stringResource(R.string.notification_large_arrow_desc),
+                checked = largeArrow,
+                onCheckedChange = { largeArrow = it; save() },
+                icon = null,
+                position = CardPosition.MIDDLE
             )
             SettingsSwitchItem(
                 title = stringResource(R.string.show_chart_expanded),


### PR DESCRIPTION
5c865000 shrank the drawn trend arrow back to a compact glyph (shaft factor 0.62→0.42 / 0.82→0.62, flatter speed growth), undoing the longer shaft from 1f631dcd. Fair enough, but both sizes have an audience, so this makes it a choice instead of a coin flip.

A new switch in the notification settings ("Larger trend arrow", default off) restores the long-shaft geometry. Off keeps the current compact glyph byte-for-byte. The flag is read in `NotificationChartDrawer.drawArrow`, so it applies to every surface that glyph reaches: notifications, the status line, widgets, and the AOD overlay.

Verified with a full `testMobileLibre3SiDexGoogleDebug` run: compiles clean, only the 13 pre-existing upstream test failures.
