### PR TITLE
FAB menu rows swallow taps in the gap between label and icon

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalActionMenus.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalActionMenus.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -289,7 +290,17 @@ private fun JournalActionMenuRow(
                 scaleX = 0.78f + (0.22f * itemProgress)
                 scaleY = 0.78f + (0.22f * itemProgress)
                 rotationZ = (if (placeIconAfterLabel) -7f else 7f) * (1f - itemProgress)
-            },
+            }
+            // The whole row is one touch target: without this, the 10dp gap
+            // between the label pill and the icon belongs to nothing, and a
+            // tap there falls through to the content behind the menu (journal
+            // rows, or the dashboard chart's calibration tap). No indication:
+            // the pills keep their own ripples.
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick
+            ),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {


### PR DESCRIPTION
Each expanded journal-FAB menu row is a label pill plus an icon pill with a 10dp spacer between them. Only the two pills were clickable, so a tap in the spacer fell through to whatever sits behind the menu: a journal row on the Journal tab, or the chart and reading rows (including their calibration tap) on any screen hosting the FAB. Easy to hit by accident, and confusing when it opens a calibration sheet instead of logging insulin.

The row is now a single click target (no indication of its own, so the pills keep their ripples), meaning a tap anywhere on a row activates that row's type.

Known remainder, left alone on purpose: the 10dp vertical gaps between rows still pass through. Much smaller surface, and whether an outside tap should close the menu (scrim) is a design question rather than a bug fix.

Compiles clean. The bug was reproduced on device; the fix still needs the same on-device tap check.
