### PR TITLE
Show Libre NFC readings and history on the dashboard

### DIFF
--- a/Common/src/main/cpp/g.cpp
+++ b/Common/src/main/cpp/g.cpp
@@ -29,6 +29,7 @@
 #include <cinttypes>
 #include <future>
 #include <jni.h>
+#include <map>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1583,12 +1584,26 @@ fromjava(addRawGlucoseStream)(JNIEnv *env, jclass cl, jlong timestamp,
 extern double calibrateNow(const SensorGlucoseData *sens,
                            const ScanData &value);
 
-// HistorySync currently consumes native history from polls[]. For NFC-only Libre
-// flows (no BLE stream yet), values can exist only in scans[]. If polls are empty,
-// expose scans as a fallback so Room/dashboard stay populated.
-static void appendScanFallbackHistory(const SensorGlucoseData *hist,
-                                      jlong starttime,
-                                      std::vector<jlong> &result) {
+using HistorySamples = std::map<jlong, std::pair<jlong, jlong>>;
+
+// Compose reads Room, while Libre NFC history is stored in historydata rather
+// than polls. Export that 15-minute history so an NFC scan can populate the
+// dashboard instead of only reaching native followers/LibreView.
+static void appendStoredHistory(const SensorGlucoseData *hist, jlong starttime,
+                                HistorySamples &samples) {
+  const int start = std::max(0, hist->getstarthistory());
+  const int end = std::min(hist->getAllendhistory(), hist->maxpos());
+  for (int pos = start; pos < end; ++pos) {
+    const Glucose *item = hist->getglucose(pos);
+    if (!item->valid() || item->gettime() <= starttime)
+      continue;
+
+    samples[item->gettime()] = {(jlong)item->getsputnik(), 0};
+  }
+}
+
+static void appendScanHistory(const SensorGlucoseData *hist, jlong starttime,
+                              HistorySamples &samples) {
   const auto scans = hist->getScandata();
   for (const auto &item : scans) {
     if (!item.valid() || item.t <= starttime)
@@ -1597,9 +1612,9 @@ static void appendScanFallbackHistory(const SensorGlucoseData *hist,
     const double cali = calibrateNow(hist, item);
     const jlong valAuto = !isnan(cali) ? (jlong)(cali * 10) : (jlong)item.g * 10;
 
-    result.push_back((jlong)item.t);
-    result.push_back(valAuto);
-    result.push_back(0); // scans have no dedicated raw lane like rawpolls.dat
+    // Scans have no dedicated raw lane like rawpolls.dat. Assignment is
+    // intentional: a scan is a newer source than the periodic history point.
+    samples[item.t] = {valAuto, 0};
   }
 }
 
@@ -1610,7 +1625,7 @@ static bool rawOnlyPollValid(const ScanData &item, uint16_t rawVal,
 }
 
 static void appendPollHistory(const SensorGlucoseData *hist, jlong starttime,
-                              std::vector<jlong> &result) {
+                              HistorySamples &samples) {
   auto polls = hist->getPolldata();
   static const double convfactordL = 18.0182;
 
@@ -1630,10 +1645,28 @@ static void appendPollHistory(const SensorGlucoseData *hist, jlong starttime,
 
     const jlong valRaw = rawVal > 0 ? (jlong)(rawVal * convfactordL) : 0;
 
-    result.push_back((jlong)item.t);
-    result.push_back(valAuto);
-    result.push_back(valRaw);
+    // BLE polls are the highest-resolution source and win exact timestamp
+    // collisions with NFC history or scans.
+    samples[item.t] = {valAuto, valRaw};
   }
+}
+
+static jlongArray historySamplesToJava(JNIEnv *env,
+                                       const HistorySamples &samples) {
+  if (samples.empty())
+    return nullptr;
+
+  std::vector<jlong> result;
+  result.reserve(samples.size() * 3);
+  for (const auto &[time, values] : samples) {
+    result.push_back(time);
+    result.push_back(values.first);
+    result.push_back(values.second);
+  }
+
+  jlongArray jresult = env->NewLongArray(result.size());
+  env->SetLongArrayRegion(jresult, 0, result.size(), result.data());
+  return jresult;
 }
 
 extern "C" JNIEXPORT jlongArray JNICALL
@@ -1648,21 +1681,11 @@ fromjava(getGlucoseHistory)(JNIEnv *env, jclass cl, jlong starttime) {
   if (!hist)
     return nullptr;
 
-  std::vector<jlong> result;
-  result.reserve(900);
-
-  appendPollHistory(hist, starttime, result);
-
-  if (result.empty()) {
-    appendScanFallbackHistory(hist, starttime, result);
-  }
-
-  if (result.empty())
-    return nullptr;
-
-  jlongArray jresult = env->NewLongArray(result.size());
-  env->SetLongArrayRegion(jresult, 0, result.size(), result.data());
-  return jresult;
+  HistorySamples samples;
+  appendStoredHistory(hist, starttime, samples);
+  appendScanHistory(hist, starttime, samples);
+  appendPollHistory(hist, starttime, samples);
+  return historySamplesToJava(env, samples);
 }
 
 /**
@@ -1692,21 +1715,11 @@ extern "C" JNIEXPORT jlongArray JNICALL fromjava(getGlucoseHistoryForSensor)(
   if (!hist)
     return nullptr;
 
-  std::vector<jlong> result;
-  result.reserve(900);
-
-  appendPollHistory(hist, starttime, result);
-
-  if (result.empty()) {
-    appendScanFallbackHistory(hist, starttime, result);
-  }
-
-  if (result.empty())
-    return nullptr;
-
-  jlongArray jresult = env->NewLongArray(result.size());
-  env->SetLongArrayRegion(jresult, 0, result.size(), result.data());
-  return jresult;
+  HistorySamples samples;
+  appendStoredHistory(hist, starttime, samples);
+  appendScanHistory(hist, starttime, samples);
+  appendPollHistory(hist, starttime, samples);
+  return historySamplesToJava(env, samples);
 }
 
 jlong glucoseback(uint32_t nu, uint32_t glval, float drate,

--- a/Common/src/main/java/tk/glucodata/ScanNfcV.java
+++ b/Common/src/main/java/tk/glucodata/ScanNfcV.java
@@ -368,9 +368,13 @@ public class ScanNfcV {
                             value = uit & 0xFFFF;
                             Log.format("glucose=%.1f\n", (float) value / mgdLmult);
                             ret = uit >> 16;
+                            String scannedSensorIdent = Natives.getserial(uid, info);
+                            if (shouldSyncDecodedHistory(ret, value)) {
+                                HistorySyncAccess.mergeFullSyncForSensor(scannedSensorIdent);
+                            }
                             if (newdevice != null && Arrays.equals(newdevice, uid) && Applic.app.canusebluetooth()) {
                                 if (value != 0 || (ret & 0xFF) == 5 || (ret & 0xFF) == 7) {
-                                    if (SensorBluetooth.resetDevice(Natives.getserial(uid, info)))
+                                    if (SensorBluetooth.resetDevice(scannedSensorIdent))
                                         askpermission = true;
                                     newdevice = null;
                                 }
@@ -518,6 +522,10 @@ public class ScanNfcV {
             if (askpermission)
                 main.finepermission();
         });
+    }
+
+    static boolean shouldSyncDecodedHistory(int resultCode, int glucoseValue) {
+        return glucoseValue > 0 || (resultCode & 0x7F) <= 9;
     }
 
     static private void newsensor(Activity act, String text, String name) {

--- a/Common/src/test/java/tk/glucodata/ScanNfcVTests.java
+++ b/Common/src/test/java/tk/glucodata/ScanNfcVTests.java
@@ -1,0 +1,21 @@
+package tk.glucodata;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ScanNfcVTests {
+    @Test
+    public void decodedLibreScanRequestsHistorySync() {
+        assertTrue(ScanNfcV.shouldSyncDecodedHistory(0, 123));
+        assertTrue(ScanNfcV.shouldSyncDecodedHistory(5, 0));
+        assertTrue(ScanNfcV.shouldSyncDecodedHistory(0x85, 0));
+    }
+
+    @Test
+    public void nativeDecodeErrorsDoNotRequestHistorySync() {
+        assertFalse(ScanNfcV.shouldSyncDecodedHistory(10, 0));
+        assertFalse(ScanNfcV.shouldSyncDecodedHistory(12, 0));
+    }
+}


### PR DESCRIPTION
Fixes #73.

## What changed
- export Libre's native 15-minute NFC history into the Room history sync path
- merge NFC history, scan points, and higher-resolution BLE polls chronologically, with BLE data winning exact timestamp collisions
- request a full non-destructive Room sync immediately after a decoded Libre NFC scan
- add regression coverage for successful and failed native scan result codes

## Root cause
The NFC decoder stored the current scan and eight-hour history in native scan/history storage, which followers and LibreView could consume. The Compose dashboard reads Room, but its native bridge exported BLE polls and only used the current scan as an empty-history fallback. It also did not resync Room after NFC processing.

## Validation
- `:Common:testMobileLibre3SiDexGoogleDebugUnitTest --tests 'tk.glucodata.ScanNfcVTests'`
- `:Common:assembleMobileLibre3SiDexGoogleDebug`
- `git diff --check`