### PR TITLE
Add a Nightscout long-insulin upload control

### DIFF
--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1176,6 +1176,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightnumhelp">Даведка Nightnum</string>
     <string name="nightscout_enable_upload">Уключыць загрузку Nightscout</string>
     <string name="nightscout_send_amounts_desc">Загрузіць інсулін/вугляводы (лячэнне)</string>
+    <string name="nightscout_send_long_insulin">Адпраўляць інсулін працяглага дзеяння</string>
+    <string name="nightscout_send_long_insulin_desc">Уключаць базальны і звышдоўгі інсулін у загрузкі Nightscout</string>
     <string name="nightscout_receive_amounts">Атрымліваць сумы</string>
     <string name="nightscout_receive_amounts_desc">Імпартаваць інсулін/вугляводы з Nightscout у журнал</string>
     <string name="nightscout_settings_title">Налады Nightscout</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1247,6 +1247,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightnumhelp">Nightnum-Hilfe</string>
     <string name="nightscout_enable_upload">Nightscout-Upload aktivieren</string>
     <string name="nightscout_send_amounts_desc">Insulin/Kohlenhydrate hochladen (Behandlungen)</string>
+    <string name="nightscout_send_long_insulin">Langzeitinsulin senden</string>
+    <string name="nightscout_send_long_insulin_desc">Basal- und ultralang wirkendes Insulin zu Nightscout hochladen</string>
     <string name="nightscout_receive_amounts">Mengen empfangen</string>
     <string name="nightscout_receive_amounts_desc">Nightscout-Insulin/Kohlenhydrate ins Journal importieren</string>
     <string name="nightscout_settings_title">Nightscout-Einstellungen</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1183,6 +1183,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightnumhelp">Aide Nightnum</string>
     <string name="nightscout_enable_upload">Activer le téléchargement Nightscout</string>
     <string name="nightscout_send_amounts_desc">Télécharger de l\'insuline/des glucides (traitements)</string>
+    <string name="nightscout_send_long_insulin">Envoyer l’insuline à action prolongée</string>
+    <string name="nightscout_send_long_insulin_desc">Inclure l’insuline basale et à action ultra-longue dans les envois Nightscout</string>
     <string name="nightscout_receive_amounts">Recevoir les quantités</string>
     <string name="nightscout_receive_amounts_desc">Importer l\'insuline/les glucides Nightscout dans le journal</string>
     <string name="nightscout_settings_title">Paramètres de Nightscout</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1167,6 +1167,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightnumhelp">Aiuto Nightnum</string>
     <string name="nightscout_enable_upload">Abilita il caricamento di Nightscout</string>
     <string name="nightscout_send_amounts_desc">Carica insulina/carboidrati (trattamenti)</string>
+    <string name="nightscout_send_long_insulin">Invia insulina a lunga durata</string>
+    <string name="nightscout_send_long_insulin_desc">Includi l’insulina basale e ultralenta nei caricamenti Nightscout</string>
     <string name="nightscout_receive_amounts">Ricevi quantità</string>
     <string name="nightscout_receive_amounts_desc">Importa insulina/carboidrati di Nightscout nel diario</string>
     <string name="nightscout_settings_title">Impostazioni Nightscout</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1205,6 +1205,8 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="nightscout_status_last_attempt">Сүүлийн оролдлого: %1$s</string>
     <string name="nightscout_status_last_success">Сүүлийн амжилт: %1$s</string>
     <string name="nightscout_send_amounts_desc">Инсулин/Нүүрс ус ачаалах (Treatments)</string>
+    <string name="nightscout_send_long_insulin">Удаан үйлдэлтэй инсулин илгээх</string>
+    <string name="nightscout_send_long_insulin_desc">Nightscout руу суурь болон хэт удаан инсулиныг хамт илгээх</string>
     <string name="nightscout_settings_title">Nightscout тохиргоо</string>
     <string name="nightscout_sync_actions_title">Синк үйлдлүүд</string>
     <string name="nightscout_url_label">Nightscout URL</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1220,6 +1220,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="nightnumhelp">Nachtelijke hulp</string>
     <string name="nightscout_enable_upload">Schakel Nightscout-upload in</string>
     <string name="nightscout_send_amounts_desc">Upload insuline/koolhydraten (behandelingen)</string>
+    <string name="nightscout_send_long_insulin">Langwerkende insuline verzenden</string>
+    <string name="nightscout_send_long_insulin_desc">Basale en ultralangwerkende insuline naar Nightscout uploaden</string>
     <string name="nightscout_receive_amounts">Hoeveelheden ontvangen</string>
     <string name="nightscout_receive_amounts_desc">Nightscout-insuline/koolhydraten in het dagboek importeren</string>
     <string name="nightscout_settings_title">Nightscout-instellingen</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1212,6 +1212,8 @@
     <string name="nightnumhelp">Pomoc Nightnum</string>
     <string name="nightscout_enable_upload">Włącz przesyłanie Nightscout</string>
     <string name="nightscout_send_amounts_desc">Prześlij insulinę/węglowodany (leczenia)</string>
+    <string name="nightscout_send_long_insulin">Wysyłaj insulinę długodziałającą</string>
+    <string name="nightscout_send_long_insulin_desc">Uwzględniaj insulinę bazową i ultradługodziałającą w wysyłaniu do Nightscout</string>
     <string name="nightscout_receive_amounts">Odbieraj wartości</string>
     <string name="nightscout_receive_amounts_desc">Importuj insulinę/węglowodany z Nightscout do dziennika</string>
     <string name="nightscout_settings_title">Ustawienia Nightscouta</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1178,6 +1178,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightnumhelp">Ajuda do Nightnum</string>
     <string name="nightscout_enable_upload">Ativar upload do Nightscout</string>
     <string name="nightscout_send_amounts_desc">Carregar insulina/carboidratos (tratamentos)</string>
+    <string name="nightscout_send_long_insulin">Enviar insulina de ação prolongada</string>
+    <string name="nightscout_send_long_insulin_desc">Incluir insulina basal e de ação ultralonga nos envios para o Nightscout</string>
     <string name="nightscout_receive_amounts">Receber valores</string>
     <string name="nightscout_receive_amounts_desc">Importar insulina/carboidratos do Nightscout para o diário</string>
     <string name="nightscout_settings_title">Configurações do Nightscout</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1213,6 +1213,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightnumhelp">Помощь Найтнума</string>
     <string name="nightscout_enable_upload">Включить загрузку Nightscout</string>
     <string name="nightscout_send_amounts_desc">Загрузите инсулин/углеводы (лечение)</string>
+    <string name="nightscout_send_long_insulin">Отправлять длинный инсулин</string>
+    <string name="nightscout_send_long_insulin_desc">Включать базальный и ультрадлительный инсулин при загрузке в Nightscout</string>
     <string name="nightscout_receive_amounts">Получать результаты</string>
     <string name="nightscout_receive_amounts_desc">Импортировать инсулин/углеводы Nightscout в журнал</string>
     <string name="nightscout_settings_title">Настройки ночного скаута</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1467,6 +1467,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="nightscout_status_last_attempt">Isku daygii ugu dambeeyay: %1$s</string>
     <string name="nightscout_status_last_success">Guushii u dambaysay: %1$s</string>
     <string name="nightscout_send_amounts_desc">Soo rar Insulin/Carbs (Daawaynta)</string>
+    <string name="nightscout_send_long_insulin">Dir insuliinta muddada dheer</string>
+    <string name="nightscout_send_long_insulin_desc">Ku dar insuliinta basal iyo tan aadka u dheer gelinta Nightscout</string>
     <string name="nightscout_receive_amounts">Hesho qaddaro</string>
     <string name="nightscout_receive_amounts_desc">Soo rar Nightscout insulin/carbs joornaalka</string>
     <string name="nightscout_settings_title">Goobaha Nightscoout</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1177,6 +1177,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightnumhelp">Nightnum Hjälp</string>
     <string name="nightscout_enable_upload">Aktivera uppladdning av Nightscout</string>
     <string name="nightscout_send_amounts_desc">Ladda upp insulin/kolhydrater (behandlingar)</string>
+    <string name="nightscout_send_long_insulin">Skicka långverkande insulin</string>
+    <string name="nightscout_send_long_insulin_desc">Inkludera basinsulin och ultralångverkande insulin i Nightscout-uppladdningar</string>
     <string name="nightscout_receive_amounts">Ta emot mängder</string>
     <string name="nightscout_receive_amounts_desc">Importera Nightscout-insulin/kolhydrater till journalen</string>
     <string name="nightscout_settings_title">Nightscout-inställningar</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1205,6 +1205,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="nightnumhelp">Nightnum Yardımı</string>
     <string name="nightscout_enable_upload">Nightscout yüklemesini etkinleştir</string>
     <string name="nightscout_send_amounts_desc">İnsülin/Karbonhidrat Yükle (Tedaviler)</string>
+    <string name="nightscout_send_long_insulin">Uzun etkili insülini gönder</string>
+    <string name="nightscout_send_long_insulin_desc">Nightscout yüklemelerine bazal ve ultra uzun etkili insülini dahil et</string>
     <string name="nightscout_receive_amounts">Miktarları al</string>
     <string name="nightscout_receive_amounts_desc">Nightscout insülin/karbonhidrat kayıtlarını günlüğe içe aktar</string>
     <string name="nightscout_settings_title">Gece İzci Ayarları</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1191,6 +1191,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightnumhelp">Допомога Nightnum</string>
     <string name="nightscout_enable_upload">Увімкнути завантаження Nightscout</string>
     <string name="nightscout_send_amounts_desc">Завантажити інсулін/вуглеводи (лікування)</string>
+    <string name="nightscout_send_long_insulin">Надсилати інсулін тривалої дії</string>
+    <string name="nightscout_send_long_insulin_desc">Додавати базальний та ультратривалий інсулін до завантажень Nightscout</string>
     <string name="nightscout_receive_amounts">Отримувати суми</string>
     <string name="nightscout_receive_amounts_desc">Імпортувати інсулін/вуглеводи з Nightscout до журналу</string>
     <string name="nightscout_settings_title">Налаштування Nightscout</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1193,6 +1193,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightnumhelp">Nightnum 帮助</string>
     <string name="nightscout_enable_upload">启用 Nightscout 上传</string>
     <string name="nightscout_send_amounts_desc">上传胰岛素/碳水化合物（治疗）</string>
+    <string name="nightscout_send_long_insulin">发送长效胰岛素</string>
+    <string name="nightscout_send_long_insulin_desc">在 Nightscout 上传中包含基础和超长效胰岛素治疗</string>
     <string name="nightscout_receive_amounts">接收用量</string>
     <string name="nightscout_receive_amounts_desc">将 Nightscout 胰岛素/碳水导入日志</string>
     <string name="nightscout_settings_title">夜巡设置</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1504,6 +1504,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_last_attempt">Last attempt: %1$s</string>
     <string name="nightscout_status_last_success">Last success: %1$s</string>
     <string name="nightscout_send_amounts_desc">Upload Insulin/Carbs (Treatments)</string>
+    <string name="nightscout_send_long_insulin">Send long-acting insulin</string>
+    <string name="nightscout_send_long_insulin_desc">Include basal and ultra-long insulin treatments in Nightscout uploads</string>
     <string name="nightscout_receive_amounts">Receive amounts</string>
     <string name="nightscout_receive_amounts_desc">Import Nightscout insulin/carbs into journal</string>
     <string name="nightscout_settings_title">Nightscout Settings</string>

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
@@ -31,6 +31,7 @@ object JournalTreatmentUploader {
     private const val LOOKBACK_MILLIS = 30L * 24 * 60 * 60 * 1000  // mirrors C++ nighttimeback (30 days)
     private const val PREFS_NAME = "tk.glucodata_preferences"
     private const val PREF_RECEIVE_TREATMENTS = "nightscout_receive_treatments"
+    private const val PREF_SEND_LONG_INSULIN = "nightscout_send_long_insulin"
     private const val TREATMENT_FETCH_COUNT = 240
     private const val ERROR_INVALID_URL = -2
 
@@ -72,9 +73,25 @@ object JournalTreatmentUploader {
             .apply()
     }
 
+    @JvmStatic
+    @Keep
+    fun getSendLongInsulin(): Boolean =
+        Applic.app.getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE)
+            .getBoolean(PREF_SEND_LONG_INSULIN, true)
+
+    @JvmStatic
+    @Keep
+    fun setSendLongInsulin(enabled: Boolean) {
+        Applic.app.getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(PREF_SEND_LONG_INSULIN, enabled)
+            .apply()
+    }
+
     private suspend fun uploadInternal(useV3: Boolean): Boolean {
         val sendEnabled = Natives.getpostTreatments()
         val receiveEnabled = getReceiveTreatments()
+        val sendLongInsulin = getSendLongInsulin()
         if (!sendEnabled && !receiveEnabled) return true
         val baseUrl = Natives.getnightuploadurl()?.takeIf { it.isNotBlank() } ?: return true
         val secretHashed = if (useV3) null else hashedSecret(Natives.getnightuploadsecret())
@@ -105,6 +122,11 @@ object JournalTreatmentUploader {
                 if (!isSendableType(entry.entryType)) continue
                 if (isExternalMirrorSource(entry.source)) continue
 
+                val preset = entry.insulinPresetId?.let { id ->
+                    presetCache.getOrPut(id) { dao.getInsulinPresetById(id) }
+                }
+                if (!shouldUploadTreatment(entry.entryType, preset, sendLongInsulin)) continue
+
                 val localIdentifier = ID_PREFIX + entry.id.toString(16)
                 val remoteId = if (useV3) {
                     entry.nsRemoteId ?: localIdentifier
@@ -116,9 +138,6 @@ object JournalTreatmentUploader {
                     NightPost.deleteUrl(treatmentDeleteUrl(baseUrl, entry.nsRemoteId, useV3), secretHashed)
                 }
 
-                val preset = entry.insulinPresetId?.let { id ->
-                    presetCache.getOrPut(id) { dao.getInsulinPresetById(id) }
-                }
                 val food = entry.foodId?.let { id ->
                     foodCache.getOrPut(id) { dao.getFoodById(id) }
                 }
@@ -166,6 +185,20 @@ object JournalTreatmentUploader {
             type == JournalEntryType.FINGERSTICK ||
             type == JournalEntryType.ACTIVITY ||
             type == JournalEntryType.NOTE
+    }
+
+    internal fun shouldUploadTreatment(
+        entryType: String,
+        preset: JournalInsulinPresetEntity?,
+        sendLongInsulin: Boolean
+    ): Boolean {
+        if (sendLongInsulin || JournalEntryType.fromStorage(entryType) != JournalEntryType.INSULIN) {
+            return true
+        }
+        // Basal presets deliberately do not count toward IOB. Unknown/deleted
+        // presets remain sendable so this preference never silently drops an
+        // insulin entry whose classification cannot be recovered.
+        return preset?.countsTowardIob != false
     }
 
     private fun isExternalMirrorSource(source: String): Boolean {

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -137,6 +137,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
     val followerConfig = remember { NightscoutFollowerRegistry.loadConfig(context) }
     var isActive by rememberSaveable { mutableStateOf(initialUploaderActive || followerConfig.enabled) }
     var sendTreatments by rememberSaveable { mutableStateOf(Natives.getpostTreatments()) }
+    var sendLongInsulin by rememberSaveable { mutableStateOf(JournalTreatmentUploader.getSendLongInsulin()) }
     var receiveTreatments by rememberSaveable { mutableStateOf(JournalTreatmentUploader.getReceiveTreatments()) }
     var isV3 by rememberSaveable { mutableStateOf(Natives.getnightscoutV3()) }
     var showSecret by rememberSaveable { mutableStateOf(false) }
@@ -164,6 +165,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
 
         Natives.setNightUploader(url.trim(), secret.trim(), uploadActive, isV3)
         Natives.setpostTreatments(sendTreatments)
+        JournalTreatmentUploader.setSendLongInsulin(sendLongInsulin)
         JournalTreatmentUploader.setReceiveTreatments(receiveTreatments)
         if (followActive) {
             if (normalizedUrl.isBlank()) {
@@ -489,6 +491,20 @@ fun NightscoutSettingsScreen(navController: NavController) {
                             icon = Icons.Default.Link,
                             iconTint = MaterialTheme.colorScheme.secondary,
                             enabled = isActive,
+                            position = CardPosition.MIDDLE
+                        )
+                        SettingsSwitchItem(
+                            title = stringResource(R.string.nightscout_send_long_insulin),
+                            subtitle = stringResource(R.string.nightscout_send_long_insulin_desc),
+                            checked = sendLongInsulin,
+                            onCheckedChange = {
+                                sendLongInsulin = it
+                                JournalTreatmentUploader.setSendLongInsulin(it)
+                                if (it) Natives.wakeuploader()
+                            },
+                            icon = Icons.Default.Medication,
+                            iconTint = MaterialTheme.colorScheme.tertiary,
+                            enabled = isActive && sendTreatments,
                             position = CardPosition.MIDDLE
                         )
                         SettingsSwitchItem(

--- a/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
@@ -1,0 +1,56 @@
+package tk.glucodata.data.journal
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JournalTreatmentUploaderTests {
+    private fun preset(countsTowardIob: Boolean) = JournalInsulinPresetEntity(
+        id = 1,
+        displayName = "Test insulin",
+        onsetMinutes = 30,
+        durationMinutes = 720,
+        accentColor = 0,
+        curveJson = "",
+        isBuiltIn = false,
+        isArchived = false,
+        countsTowardIob = countsTowardIob,
+        sortOrder = 0
+    )
+
+    @Test
+    fun longInsulinCanBeExcludedWithoutSuppressingOtherTreatments() {
+        assertFalse(
+            JournalTreatmentUploader.shouldUploadTreatment(
+                JournalEntryType.INSULIN.storageValue,
+                preset(countsTowardIob = false),
+                sendLongInsulin = false
+            )
+        )
+        assertTrue(
+            JournalTreatmentUploader.shouldUploadTreatment(
+                JournalEntryType.INSULIN.storageValue,
+                preset(countsTowardIob = true),
+                sendLongInsulin = false
+            )
+        )
+        assertTrue(
+            JournalTreatmentUploader.shouldUploadTreatment(
+                JournalEntryType.CARBS.storageValue,
+                null,
+                sendLongInsulin = false
+            )
+        )
+    }
+
+    @Test
+    fun longInsulinRemainsEnabledByTheUploadPolicyWhenRequested() {
+        assertTrue(
+            JournalTreatmentUploader.shouldUploadTreatment(
+                JournalEntryType.INSULIN.storageValue,
+                preset(countsTowardIob = false),
+                sendLongInsulin = true
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fixes #72.

## What changed
- add a subordinate **Send long-acting insulin** switch to Nightscout upload settings
- classify journal basal/ultra-long presets through their existing `countsTowardIob = false` behavior instead of insulin names
- suppress only those insulin entries when disabled; rapid insulin, carbs, fingersticks, activity, and notes remain uploadable
- retain unknown/deleted-preset insulin entries to avoid unclassifiable silent data loss
- default the preference to enabled for backward compatibility and translate it across all 15 locales

## User impact
Families can keep recording basal insulin in the journal while preventing it from appearing as indistinguishable insulin treatments for Nightscout followers.

## Validation
- `:Common:testMobileLibre3SiDexGoogleDebugUnitTest --tests 'tk.glucodata.data.journal.JournalTreatmentUploaderTests'`
- `xmllint --noout` for every `values*/strings.xml`
- locale key coverage: 15/15 for both strings
- `git diff --check`