### PR TITLE
Add Bluetooth glucose meters to the journal

### DIFF
--- a/Common/src/main/cpp/meter/java.cpp
+++ b/Common/src/main/cpp/meter/java.cpp
@@ -2,6 +2,7 @@
 #include "jniclass.hpp"
 #include "settings/settings.hpp"
 #include "share/hexstr.hpp"
+#include <cmath>
 #include <jni.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -64,29 +65,35 @@ extern Numdata *getherenums();
 extern void addCalibration(uint32_t tim, int type, Num *num,
                            const Numdata *numdata);
 extern void setnumchanged(uint32_t tim);
-extern "C" JNIEXPORT jboolean JNICALL fromjava(GlucoseMeterSave)(
-    JNIEnv *env, jclass cl, jint meterIndex, jbyteArray value) {
-  const auto bloodvar = settings->data()->bloodvar;
-  if (bloodvar >= maxvarnr) {
-    LOGAR("GlucoseMeterSave: no bloodvar set");
-    return false;
-  }
+struct MeterSaveResult {
+  uint32_t timestamp{};
+  int mgdlTenths{};
+  bool stored{};
+  bool recentLegacyValue{};
+};
+
+static MeterSaveResult saveGlucoseMeter(JNIEnv *env, jint meterIndex,
+                                        jbyteArray value) {
   const auto arlen = env->GetArrayLength(value);
   if (arlen < 14) {
     LOGGER("GlucoseMeterSave length (%d) <14\n", arlen);
-    return false;
+    return {};
   }
   const CritAr bluedata(env, value);
   const MeterData *glu = reinterpret_cast<const MeterData *>(bluedata.data());
   GlucoseMeter *meter = settings->data()->getGlucoseMeter(meterIndex);
   if (!meter) {
     LOGGER("GlucoseMeterSave no meter at %d\n", meterIndex);
-    return false;
+    return {};
   }
   const auto timeoffset = glu->getTimeoffset();
   const uint32_t timeorig = glu->time.getLocaltime();
   const uint32_t timcorrected = timeorig + meter->timeoffset + timeoffset * 60;
   auto mgdL = glu->getmgdL();
+  if (!std::isfinite(mgdL) || mgdL <= 0.0f) {
+    LOGGER("GlucoseMeterSave invalid glucose %.2f\n", mgdL);
+    return {};
+  }
 #ifndef NOLOG
   char timebuf1[27], timebuf2[27];
   time_t ort = timeorig, cort = timcorrected;
@@ -99,29 +106,58 @@ extern "C" JNIEXPORT jboolean JNICALL fromjava(GlucoseMeterSave)(
          ctime_r(&ort, timebuf1), meter->timeoffset, timeoffset,
          ctime_r(&cort, timebuf2));
 #endif
-  bool ret = false;
+  MeterSaveResult result;
   if (timcorrected > meter->lastTime) {
-    float value;
-    if (settings->data()->unit == 1) {
-      value = std::round(convertmultmmol * 100.0f * mgdL) * .1f;
-    } else
-      value = std::roundf(mgdL);
-    Numdata *numda = getherenums();
-    if (Num *num = numda->numsaveonly(timcorrected, value, bloodvar, 0)) {
-      uint32_t now = time(nullptr);
-      if (abs((int)(now - timcorrected)) < 60) {
-        addCalibration(timcorrected, bloodvar, num, numda);
-        if (backup)
-          backup->wakebackup(Backup::wakenums);
-        setnumchanged(now);
-        ret = true;
+    result.timestamp = timcorrected;
+    result.mgdlTenths = std::lround(mgdL * 10.0f);
+    result.stored = true;
+
+    const auto bloodvar = settings->data()->bloodvar;
+    if (bloodvar < maxvarnr) {
+      float displayValue;
+      if (settings->data()->unit == 1) {
+        displayValue = std::round(convertmultmmol * 100.0f * mgdL) * .1f;
+      } else {
+        displayValue = std::roundf(mgdL);
       }
+      Numdata *numda = getherenums();
+      if (Num *num =
+              numda->numsaveonly(timcorrected, displayValue, bloodvar, 0)) {
+        uint32_t now = time(nullptr);
+        if (abs((int)(now - timcorrected)) < 60) {
+          addCalibration(timcorrected, bloodvar, num, numda);
+          if (backup)
+            backup->wakebackup(Backup::wakenums);
+          setnumchanged(now);
+          result.recentLegacyValue = true;
+        }
+      }
+    } else {
+      LOGAR("GlucoseMeterSave: no legacy blood glucose label set; journal only");
     }
+    meter->lastTime = timcorrected;
   }
   meter->nextIndex = glu->index + 1;
-  meter->lastTime = timcorrected;
+  return result;
+}
 
-  return ret;
+extern "C" JNIEXPORT jboolean JNICALL fromjava(GlucoseMeterSave)(
+    JNIEnv *env, jclass cl, jint meterIndex, jbyteArray value) {
+  return saveGlucoseMeter(env, meterIndex, value).recentLegacyValue;
+}
+
+extern "C" JNIEXPORT jlongArray JNICALL fromjava(GlucoseMeterSaveResult)(
+    JNIEnv *env, jclass cl, jint meterIndex, jbyteArray value) {
+  const auto result = saveGlucoseMeter(env, meterIndex, value);
+  if (!result.stored)
+    return nullptr;
+  const jlong data[]{static_cast<jlong>(result.timestamp) * 1000LL,
+                     static_cast<jlong>(result.mgdlTenths),
+                     result.recentLegacyValue ? 1LL : 0LL};
+  jlongArray out = env->NewLongArray(3);
+  if (out)
+    env->SetLongArrayRegion(out, 0, 3, data);
+  return out;
 }
 #include "Context.hpp"
 extern "C" JNIEXPORT jboolean JNICALL fromjava(GlucoseMeterProcessContext)(

--- a/Common/src/main/java/tk/glucodata/Natives.java
+++ b/Common/src/main/java/tk/glucodata/Natives.java
@@ -1539,6 +1539,9 @@ public class Natives {
 
         public static native boolean GlucoseMeterSave(int meterIndex, byte[] value);
 
+        /** Returns timestamp millis, mg/dL tenths, and recent-legacy flag for a newly accepted reading. */
+        public static native long[] GlucoseMeterSaveResult(int meterIndex, byte[] value);
+
         public static native boolean GlucoseMeterProcessContext(int meterIndex, byte[] value);
 
         public static native boolean GlucoseMeterSaveTime(int meterIndex, byte[] value);

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -790,6 +790,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="max_glucose">Макс</string>
     <string name="median">Медыяна</string>
     <string name="meterlist">"Glucose Meters"</string>
+    <string name="glucose_meters_desc">Падключэнне Bluetooth-глюкометраў</string>
+    <string name="glucose_meters_journal_desc">Вынікі захоўваюцца як запісы глюкозы крыві ў дзённіку і могуць адпраўляцца ў Nightscout.</string>
+    <string name="glucose_meters_configured">Наладжаныя глюкометры</string>
+    <string name="glucose_meters_none">Глюкометры не наладжаны</string>
+    <string name="glucose_meters_none_desc">Знайдзіце глюкометр паблізу, каб пачаць імпарт вынікаў.</string>
+    <string name="glucose_meters_nearby">Глюкометры паблізу</string>
+    <string name="glucose_meter_last_reading">Апошні вынік: %1$s</string>
+    <string name="glucose_meter_no_readings">Вынікі яшчэ не імпартаваны</string>
     <string name="min">Мін</string>
     <string name="min_glucose">Мін</string>
     <string name="newdata">"New data"</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -402,6 +402,14 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
  <string name="bloodafter">"Nur Glukosewerte hinzufügen ab:"</string>
 <string name="specifyblood">Zuerst das Etikett für Blutzucker angeben</string>
 <string name="meterlist">"Blutzuckermessgeräte"</string>
+<string name="glucose_meters_desc">Bluetooth-Blutzuckermessgeräte verbinden</string>
+<string name="glucose_meters_journal_desc">Messwerte werden als Blutzuckereinträge im Tagebuch gespeichert und können an Nightscout gesendet werden.</string>
+<string name="glucose_meters_configured">Eingerichtete Messgeräte</string>
+<string name="glucose_meters_none">Keine Messgeräte eingerichtet</string>
+<string name="glucose_meters_none_desc">Ein Messgerät in der Nähe suchen, um Messwerte zu importieren.</string>
+<string name="glucose_meters_nearby">Messgeräte in der Nähe</string>
+<string name="glucose_meter_last_reading">Letzter Messwert: %1$s</string>
+<string name="glucose_meter_no_readings">Noch keine Messwerte importiert</string>
 <string name="finddevices">"Geräte suchen"</string>
 <string name="nonewdata">"Keine neuen Daten"</string>
 <string name="newdata">"Neue Daten"</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -765,6 +765,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="max_glucose">Max.</string>
     <string name="median">Médiane</string>
     <string name="meterlist">"Glucose Meters"</string>
+    <string name="glucose_meters_desc">Connecter des lecteurs de glycémie Bluetooth</string>
+    <string name="glucose_meters_journal_desc">Les mesures sont enregistrées comme glycémies dans le journal et peuvent être envoyées à Nightscout.</string>
+    <string name="glucose_meters_configured">Lecteurs configurés</string>
+    <string name="glucose_meters_none">Aucun lecteur configuré</string>
+    <string name="glucose_meters_none_desc">Recherchez un lecteur à proximité pour importer des mesures.</string>
+    <string name="glucose_meters_nearby">Lecteurs à proximité</string>
+    <string name="glucose_meter_last_reading">Dernière mesure : %1$s</string>
+    <string name="glucose_meter_no_readings">Aucune mesure importée</string>
     <string name="mgdL">mg/dL</string>
     <string name="min">Min.</string>
     <string name="min_glucose">Min.</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -715,6 +715,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="max_glucose">Massimo</string>
     <string name="median">Mediano</string>
     <string name="meterlist">"Glucose Meters"</string>
+    <string name="glucose_meters_desc">Collega glucometri Bluetooth</string>
+    <string name="glucose_meters_journal_desc">Le misurazioni vengono salvate come glicemie nel diario e possono essere inviate a Nightscout.</string>
+    <string name="glucose_meters_configured">Glucometri configurati</string>
+    <string name="glucose_meters_none">Nessun glucometro configurato</string>
+    <string name="glucose_meters_none_desc">Trova un glucometro nelle vicinanze per iniziare a importare le misurazioni.</string>
+    <string name="glucose_meters_nearby">Glucometri nelle vicinanze</string>
+    <string name="glucose_meter_last_reading">Ultima misurazione: %1$s</string>
+    <string name="glucose_meter_no_readings">Nessuna misurazione ancora importata</string>
     <string name="mgdL">mg/dL</string>
     <string name="min">minimo</string>
     <string name="min_glucose">minimo</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -425,6 +425,14 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="bloodafter">"Зөвхөн дараах хугацаанаас хойших глюкозын уншилтуудыг нэмэх: "</string>
     <string name="specifyblood">"Эхлээд цусны глюкозын шошгыг сонгоно уу"</string>
     <string name="meterlist">"Глюкоз хэмжигч төхөөрөмжүүд"</string>
+    <string name="glucose_meters_desc">Bluetooth глюкоз хэмжигч холбоно уу</string>
+    <string name="glucose_meters_journal_desc">Хэмжилтүүд өдрийн тэмдэглэлд цусан дахь глюкозын бичлэгээр хадгалагдаж, Nightscout руу илгээгдэх боломжтой.</string>
+    <string name="glucose_meters_configured">Тохируулсан хэмжигчүүд</string>
+    <string name="glucose_meters_none">Хэмжигч тохируулаагүй</string>
+    <string name="glucose_meters_none_desc">Хэмжилт импортлохын тулд ойролцоох хэмжигчийг олно уу.</string>
+    <string name="glucose_meters_nearby">Ойролцоох хэмжигчүүд</string>
+    <string name="glucose_meter_last_reading">Сүүлийн хэмжилт: %1$s</string>
+    <string name="glucose_meter_no_readings">Хэмжилт хараахан импортлоогүй</string>
     <string name="finddevices">"Төхөөрөмж хайх"</string>
     <string name="nonewdata">"Шинэ өгөгдөл алга"</string>
     <string name="newdata">"Шинэ өгөгдөл"</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -395,6 +395,14 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
 <string name="bloodafter">"Voeg alleen glucosemetingen toe van na: "</string>
 <string name="specifyblood">"Selecteer eerst het bloedglucose label"</string>
 <string name="meterlist">"Glucosemeters"</string>
+<string name="glucose_meters_desc">Bluetooth-glucosemeters verbinden</string>
+<string name="glucose_meters_journal_desc">Metingen worden als bloedglucose in het dagboek opgeslagen en kunnen naar Nightscout worden verzonden.</string>
+<string name="glucose_meters_configured">Ingestelde meters</string>
+<string name="glucose_meters_none">Geen meters ingesteld</string>
+<string name="glucose_meters_none_desc">Zoek een meter in de buurt om metingen te importeren.</string>
+<string name="glucose_meters_nearby">Meters in de buurt</string>
+<string name="glucose_meter_last_reading">Laatste meting: %1$s</string>
+<string name="glucose_meter_no_readings">Nog geen metingen geïmporteerd</string>
 <string name="finddevices">"Apparaten zoeken"</string>
 <string name="nonewdata">"Geen nieuwe gegevens"</string>
 <string name="newdata">"Nieuwe gegevens"</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -848,6 +848,14 @@
     <string name="max_glucose">Maks</string>
     <string name="median">Mediana</string>
     <string name="meterlist">"Glukometry"</string>
+    <string name="glucose_meters_desc">Połącz glukometry Bluetooth</string>
+    <string name="glucose_meters_journal_desc">Pomiary są zapisywane jako wpisy glikemii w dzienniku i mogą być wysyłane do Nightscout.</string>
+    <string name="glucose_meters_configured">Skonfigurowane glukometry</string>
+    <string name="glucose_meters_none">Brak skonfigurowanych glukometrów</string>
+    <string name="glucose_meters_none_desc">Znajdź pobliski glukometr, aby rozpocząć import pomiarów.</string>
+    <string name="glucose_meters_nearby">Glukometry w pobliżu</string>
+    <string name="glucose_meter_last_reading">Ostatni pomiar: %1$s</string>
+    <string name="glucose_meter_no_readings">Nie zaimportowano jeszcze pomiarów</string>
     <string name="min">Min</string>
     <string name="min_glucose">Min</string>
     <string name="newdata">"Nowe dane"</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -735,6 +735,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="max_glucose">Máx.</string>
     <string name="median">Mediana</string>
     <string name="meterlist">"Glucose Meters"</string>
+    <string name="glucose_meters_desc">Ligar medidores de glicose Bluetooth</string>
+    <string name="glucose_meters_journal_desc">As medições são guardadas como glicemia no diário e podem ser enviadas para o Nightscout.</string>
+    <string name="glucose_meters_configured">Medidores configurados</string>
+    <string name="glucose_meters_none">Nenhum medidor configurado</string>
+    <string name="glucose_meters_none_desc">Procure um medidor próximo para começar a importar medições.</string>
+    <string name="glucose_meters_nearby">Medidores próximos</string>
+    <string name="glucose_meter_last_reading">Última medição: %1$s</string>
+    <string name="glucose_meter_no_readings">Ainda não foram importadas medições</string>
     <string name="mgdL">mg/dL</string>
     <string name="min">Mínimo</string>
     <string name="min_glucose">Mínimo</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -852,6 +852,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="max_glucose">Макс</string>
     <string name="median">Медиана</string>
     <string name="meterlist">"Glucose Meters"</string>
+    <string name="glucose_meters_desc">Подключение Bluetooth-глюкометров</string>
+    <string name="glucose_meters_journal_desc">Измерения сохраняются в журнале как значения глюкозы крови и могут отправляться в Nightscout.</string>
+    <string name="glucose_meters_configured">Настроенные глюкометры</string>
+    <string name="glucose_meters_none">Нет настроенных глюкометров</string>
+    <string name="glucose_meters_none_desc">Найдите глюкометр поблизости, чтобы импортировать измерения.</string>
+    <string name="glucose_meters_nearby">Глюкометры поблизости</string>
+    <string name="glucose_meter_last_reading">Последнее измерение: %1$s</string>
+    <string name="glucose_meter_no_readings">Измерения ещё не импортированы</string>
     <string name="min">Мин</string>
     <string name="min_glucose">Мин</string>
     <string name="newdata">"New data"</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -447,6 +447,14 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
  <string name="bloodafter">"Kaliya ku dar akhrinta gulukooska kadib:"</string>
  <string name="specifyblood">"Marka hore dooro calaamadda gulukooska dhiigga"</string>
  <string name="meterlist">"Glucose mitir"</string>
+ <string name="glucose_meters_desc">Ku xir mitirrada gulukoosta Bluetooth</string>
+ <string name="glucose_meters_journal_desc">Cabbirrada waxaa loogu kaydiyaa gulukoosta dhiigga ee diiwaanka waxaana loo diri karaa Nightscout.</string>
+ <string name="glucose_meters_configured">Mitirrada la habeeyey</string>
+ <string name="glucose_meters_none">Mitir lama habayn</string>
+ <string name="glucose_meters_none_desc">Raadi mitir kuu dhow si aad u soo dejiso cabbirrada.</string>
+ <string name="glucose_meters_nearby">Mitirrada kuu dhow</string>
+ <string name="glucose_meter_last_reading">Cabbirkii ugu dambeeyay: %1$s</string>
+ <string name="glucose_meter_no_readings">Weli cabbir lama soo dejin</string>
  <string name="finddevices">"Raad qalab"</string>
  <string name="nonewdata">"Ma jirto xog cusub"</string>
  <string name="newdata">"xog cusub"</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -795,6 +795,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="max_glucose">Max</string>
     <string name="median">Median</string>
     <string name="meterlist">"Glucose Meters"</string>
+    <string name="glucose_meters_desc">Anslut Bluetooth-blodsockermätare</string>
+    <string name="glucose_meters_journal_desc">Mätvärden sparas som blodsockerposter i journalen och kan skickas till Nightscout.</string>
+    <string name="glucose_meters_configured">Konfigurerade mätare</string>
+    <string name="glucose_meters_none">Inga mätare konfigurerade</string>
+    <string name="glucose_meters_none_desc">Hitta en mätare i närheten för att börja importera mätvärden.</string>
+    <string name="glucose_meters_nearby">Mätare i närheten</string>
+    <string name="glucose_meter_last_reading">Senaste mätning: %1$s</string>
+    <string name="glucose_meter_no_readings">Inga mätvärden har importerats ännu</string>
     <string name="min">Min</string>
     <string name="min_glucose">Min</string>
     <string name="newdata">"New data"</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -830,6 +830,14 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="max_glucose">Maksimum</string>
     <string name="median">Medyan</string>
     <string name="meterlist">"Glucose Meters"</string>
+    <string name="glucose_meters_desc">Bluetooth glikoz ölçerleri bağlayın</string>
+    <string name="glucose_meters_journal_desc">Ölçümler günlükte kan şekeri kaydı olarak saklanır ve Nightscout\'a gönderilebilir.</string>
+    <string name="glucose_meters_configured">Yapılandırılmış ölçerler</string>
+    <string name="glucose_meters_none">Yapılandırılmış ölçer yok</string>
+    <string name="glucose_meters_none_desc">Ölçümleri içe aktarmak için yakındaki bir ölçeri bulun.</string>
+    <string name="glucose_meters_nearby">Yakındaki ölçerler</string>
+    <string name="glucose_meter_last_reading">Son ölçüm: %1$s</string>
+    <string name="glucose_meter_no_readings">Henüz ölçüm içe aktarılmadı</string>
     <string name="min">Min.</string>
     <string name="min_glucose">Min.</string>
     <string name="newdata">"New data"</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -807,6 +807,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="max_glucose">Макс</string>
     <string name="median">Медіана</string>
     <string name="meterlist">"Glucose Meters"</string>
+    <string name="glucose_meters_desc">Підключення Bluetooth-глюкометрів</string>
+    <string name="glucose_meters_journal_desc">Вимірювання зберігаються в журналі як значення глюкози крові та можуть надсилатися до Nightscout.</string>
+    <string name="glucose_meters_configured">Налаштовані глюкометри</string>
+    <string name="glucose_meters_none">Немає налаштованих глюкометрів</string>
+    <string name="glucose_meters_none_desc">Знайдіть глюкометр поблизу, щоб імпортувати вимірювання.</string>
+    <string name="glucose_meters_nearby">Глюкометри поблизу</string>
+    <string name="glucose_meter_last_reading">Останнє вимірювання: %1$s</string>
+    <string name="glucose_meter_no_readings">Вимірювання ще не імпортовано</string>
     <string name="min">Мін</string>
     <string name="min_glucose">Мін</string>
     <string name="newdata">"New data"</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -807,6 +807,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="max_glucose">最大</string>
     <string name="median">中位数</string>
     <string name="meterlist">"Glucose Meters"</string>
+    <string name="glucose_meters_desc">连接蓝牙血糖仪</string>
+    <string name="glucose_meters_journal_desc">读数会作为血糖记录保存到日志中，并可发送到 Nightscout。</string>
+    <string name="glucose_meters_configured">已配置的血糖仪</string>
+    <string name="glucose_meters_none">尚未配置血糖仪</string>
+    <string name="glucose_meters_none_desc">查找附近的血糖仪以开始导入读数。</string>
+    <string name="glucose_meters_nearby">附近的血糖仪</string>
+    <string name="glucose_meter_last_reading">最近读数：%1$s</string>
+    <string name="glucose_meter_no_readings">尚未导入读数</string>
     <string name="mgdL">mg/dL</string>
     <string name="min">最小</string>
     <string name="min_glucose">最小</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -450,6 +450,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
  <string name="bloodafter">"Only add glucose readings from after: "</string>
  <string name="specifyblood">"First select the label for blood glucose"</string>
  <string name="meterlist">"Glucose Meters"</string>
+ <string name="glucose_meters_desc">Connect Bluetooth glucose meters</string>
+ <string name="glucose_meters_journal_desc">Readings are saved as blood glucose entries in the Journal and can be sent to Nightscout.</string>
+ <string name="glucose_meters_configured">Configured meters</string>
+ <string name="glucose_meters_none">No meters configured</string>
+ <string name="glucose_meters_none_desc">Find a nearby meter to start importing readings.</string>
+ <string name="glucose_meters_nearby">Nearby meters</string>
+ <string name="glucose_meter_last_reading">Last reading: %1$s</string>
+ <string name="glucose_meter_no_readings">No readings imported yet</string>
  <string name="finddevices">"Find devices"</string>
  <string name="nonewdata">"No new data"</string>
  <string name="newdata">"New data"</string>

--- a/Common/src/mobile/java/tk/glucodata/GlucoseMeterGatt.java
+++ b/Common/src/mobile/java/tk/glucodata/GlucoseMeterGatt.java
@@ -157,7 +157,11 @@ boolean newvalues=false;
             Log.showbytes("Meter: onCharacteristicChanged "+uuid,value);
         switch(uuid) {
             case GlucoseCharUUID:
-                if(Natives.GlucoseMeterSave(meterIndex,value)) {
+                final long[] saved = Natives.GlucoseMeterSaveResult(meterIndex,value);
+                if(saved != null && saved.length >= 2) {
+                    GlucoseMeterJournalBridge.record(meterIndex, saved[0], saved[1]);
+                }
+                if(saved != null && saved.length >= 3 && saved[2] != 0L) {
                     newvalues=true;
                     receivedTime=System.currentTimeMillis();
                     updateview();

--- a/Common/src/mobile/java/tk/glucodata/GlucoseMeterManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/GlucoseMeterManager.kt
@@ -1,0 +1,132 @@
+package tk.glucodata
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import androidx.annotation.Keep
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import tk.glucodata.data.journal.JournalEntryInput
+import tk.glucodata.data.journal.JournalEntrySource
+import tk.glucodata.data.journal.JournalEntryType
+import tk.glucodata.data.journal.JournalRepository
+
+data class GlucoseMeterSnapshot(
+    val index: Int,
+    val name: String,
+    val address: String?,
+    val active: Boolean,
+    val connected: Boolean,
+    val lastReadingAt: Long,
+)
+
+/** Compose-facing facade over the legacy, protocol-capable glucose meter runtime. */
+object GlucoseMeterManager {
+    fun configuredMeters(): List<GlucoseMeterSnapshot> =
+        (0 until Natives.GlucoseMeterCount()).mapNotNull(::snapshot)
+
+    fun setEnabled(index: Int, enabled: Boolean) {
+        if (enabled) {
+            Natives.GlucoseMeterSetActive(index, true)
+            BluetoothGlucoseMeter.addDevice(index, null)
+        } else {
+            BluetoothGlucoseMeter.removeDevice(index)
+            Natives.GlucoseMeterSetActive(index, false)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    fun add(device: BluetoothDevice, displayName: String): Int {
+        val existingIndex = Natives.GlucoseMeterHasIndex(displayName)
+        val index = if (existingIndex >= 0) existingIndex else Natives.GlucoseMeterGetIndex(displayName)
+        if (index < 0) return -1
+        val address = runCatching { device.address }.getOrNull() ?: return -1
+        if (!Natives.GlucoseMeterSetDeviceAddress(index, address)) return -1
+        if (existingIndex < 0) {
+            // A new meter may safely offer its stored history. Native timestamp gating prevents replay.
+            Natives.GlucoseMeterSetLastTime(index, 0L)
+        } else {
+            Natives.GlucoseMeterSetActive(index, true)
+        }
+        BluetoothGlucoseMeter.addDevice(index, device)
+        return index
+    }
+
+    private fun snapshot(index: Int): GlucoseMeterSnapshot? {
+        val name = Natives.GlucoseMeterDeviceName(index)?.takeIf(String::isNotBlank) ?: return null
+        val gatt = BluetoothGlucoseMeter.getExistingGatt(index)
+        return GlucoseMeterSnapshot(
+            index = index,
+            name = name,
+            address = Natives.GlucoseMeterDeviceAddress(index),
+            active = Natives.GlucoseMeterGetActive(index),
+            connected = gatt?.connected == true,
+            lastReadingAt = Natives.GlucoseMeterGetLastTime(index),
+        )
+    }
+}
+
+/** Persists only the value and timestamp produced by the native meter decoder. */
+@Keep
+object GlucoseMeterJournalBridge {
+    private const val LOG_ID = "GlucoseMeterJournal"
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @JvmStatic
+    fun record(meterIndex: Int, timestampMillis: Long, mgdlTenths: Long) {
+        val now = System.currentTimeMillis()
+        val decoded = MeterJournalPolicy.decode(meterIndex, timestampMillis, mgdlTenths, now)
+        if (decoded == null) {
+            Log.e(LOG_ID, "Rejected invalid decoded meter reading")
+            return
+        }
+        val meterName = Natives.GlucoseMeterDeviceName(meterIndex)?.takeIf(String::isNotBlank)
+        scope.launch {
+            runCatching {
+                JournalRepository().upsertEntry(
+                    JournalEntryInput(
+                        timestamp = decoded.timestampMillis,
+                        type = JournalEntryType.FINGERSTICK,
+                        title = Applic.app.getString(R.string.journal_type_fingerstick),
+                        note = meterName,
+                        glucoseValueMgDl = decoded.glucoseMgDl,
+                        source = JournalEntrySource.METER,
+                        sourceRecordId = decoded.sourceRecordId,
+                    )
+                )
+                UiRefreshBus.requestDataRefresh()
+                if (Natives.getpostTreatments()) Natives.wakeuploader()
+            }.onFailure { error ->
+                Log.e(LOG_ID, "Failed to journal meter reading: ${Log.stackline(error)}")
+            }
+        }
+    }
+}
+
+internal data class DecodedMeterJournalRecord(
+    val timestampMillis: Long,
+    val glucoseMgDl: Float,
+    val sourceRecordId: String,
+)
+
+internal object MeterJournalPolicy {
+    private const val MAX_FUTURE_MILLIS = 24 * 60 * 60 * 1000L
+
+    fun decode(
+        meterIndex: Int,
+        timestampMillis: Long,
+        mgdlTenths: Long,
+        nowMillis: Long,
+    ): DecodedMeterJournalRecord? {
+        if (meterIndex < 0 || timestampMillis <= 0L || timestampMillis > nowMillis + MAX_FUTURE_MILLIS) {
+            return null
+        }
+        if (mgdlTenths !in 1L..20_000L) return null
+        return DecodedMeterJournalRecord(
+            timestampMillis = timestampMillis,
+            glucoseMgDl = mgdlTenths.toFloat() / 10f,
+            sourceRecordId = "meter:$meterIndex:$timestampMillis",
+        )
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalModels.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalModels.kt
@@ -32,6 +32,7 @@ enum class JournalIntensity(val storageValue: String) {
 enum class JournalEntrySource(val storageValue: String) {
     MANUAL("manual"),
     HEALTH_CONNECT("health_connect"),
+    METER("meter"),
     AAPS("aaps"),
     NIGHTSCOUT("nightscout"),
     API("api");

--- a/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
@@ -459,6 +459,15 @@ fun ExpressiveSettingsScreen(
                     )
                 }
                 SettingsItem(
+                    title = stringResource(R.string.meterlist),
+                    subtitle = stringResource(R.string.glucose_meters_desc),
+                    showArrow = true,
+                    icon = Icons.Default.Bloodtype,
+                    iconTint = exchangeColor,
+                    position = CardPosition.MIDDLE,
+                    onClick = { navController.navigate("settings/glucose-meters") }
+                )
+                SettingsItem(
                     title = stringResource(R.string.watches),
                     subtitle = "WearOS, Watchdrip, GadgetBridge, Kerfstok",
                     showArrow = true,

--- a/Common/src/mobile/java/tk/glucodata/ui/GlucoseMeterSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/GlucoseMeterSettingsScreen.kt
@@ -1,0 +1,287 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package tk.glucodata.ui
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.BluetoothSearching
+import androidx.compose.material.icons.filled.Bloodtype
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.navigation.NavController
+import kotlinx.coroutines.delay
+import tk.glucodata.GlucoseMeterManager
+import tk.glucodata.GlucoseMeterSnapshot
+import tk.glucodata.R
+import tk.glucodata.ui.components.CardPosition
+import tk.glucodata.ui.components.SectionLabel
+import tk.glucodata.ui.components.SettingsItem
+import tk.glucodata.ui.components.SettingsSwitchItem
+import tk.glucodata.ui.util.BleDeviceScanner
+import tk.glucodata.ui.util.rememberBleScanner
+import java.text.DateFormat
+import java.util.Date
+import java.util.UUID
+
+private data class NearbyGlucoseMeter(
+    val device: BluetoothDevice,
+    val name: String,
+    val address: String,
+)
+
+private val glucoseMeterServiceUuids = listOf(
+    UUID.fromString("00001808-0000-1000-8000-00805f9b34fb"),
+    UUID.fromString("af9df7a1-e595-11e3-96b4-0002a5d5c51b"),
+)
+
+@SuppressLint("MissingPermission")
+@Composable
+fun GlucoseMeterSettingsScreen(navController: NavController) {
+    val context = LocalContext.current
+    val scanner = rememberBleScanner()
+    var meters by remember { mutableStateOf(GlucoseMeterManager.configuredMeters()) }
+    var nearby by remember { mutableStateOf<List<NearbyGlucoseMeter>>(emptyList()) }
+    var scanning by remember { mutableStateOf(false) }
+    var scanRequest by remember { mutableIntStateOf(0) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        if (grants.values.all { it }) scanRequest += 1
+        else Toast.makeText(context, R.string.turn_on_nearby_devices_permission, Toast.LENGTH_LONG).show()
+    }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            meters = GlucoseMeterManager.configuredMeters()
+            delay(2_000L)
+        }
+    }
+
+    LaunchedEffect(scanRequest) {
+        if (scanRequest == 0) return@LaunchedEffect
+        nearby = emptyList()
+        scanning = true
+        scanner.startScan(
+            serviceUuids = glucoseMeterServiceUuids,
+            onResult = { result ->
+                val device = result.device
+                val address = runCatching { device.address }.getOrNull() ?: return@startScan
+                val name = runCatching { device.name }.getOrNull()
+                    ?: result.scanRecord?.deviceName
+                    ?: return@startScan
+                if (nearby.none { it.address == address }) {
+                    nearby = nearby + NearbyGlucoseMeter(device, name, address)
+                }
+            },
+            onError = { error ->
+                scanning = false
+                val message = if (error is BleDeviceScanner.ScanStartError.BluetoothDisabled) {
+                    R.string.bluetooth_is_turned_off
+                } else {
+                    R.string.wentwrong
+                }
+                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+            }
+        )
+        delay(15_000L)
+        scanner.stopScan()
+        scanning = false
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { scanner.stopScan() }
+    }
+
+    Scaffold(
+        contentWindowInsets = WindowInsets(0.dp),
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.meterlist)) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            item("meter_intro") {
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    shape = RoundedCornerShape(24.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(
+                        modifier = Modifier.padding(20.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Surface(
+                            color = MaterialTheme.colorScheme.primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary,
+                            shape = RoundedCornerShape(18.dp),
+                        ) {
+                            Icon(
+                                Icons.Filled.Bloodtype,
+                                contentDescription = null,
+                                modifier = Modifier.padding(14.dp).size(28.dp),
+                            )
+                        }
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(
+                                stringResource(R.string.glucose_meters_desc),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Text(
+                                stringResource(R.string.glucose_meters_journal_desc),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
+                }
+            }
+
+            item("configured_label") {
+                SectionLabel(stringResource(R.string.glucose_meters_configured))
+            }
+            if (meters.isEmpty()) {
+                item("configured_empty") {
+                    SettingsItem(
+                        title = stringResource(R.string.glucose_meters_none),
+                        subtitle = stringResource(R.string.glucose_meters_none_desc),
+                        icon = Icons.Filled.History,
+                        iconTint = MaterialTheme.colorScheme.secondary,
+                    )
+                }
+            } else {
+                items(meters, key = GlucoseMeterSnapshot::index) { meter ->
+                    val status = when {
+                        meter.connected -> stringResource(R.string.connected)
+                        meter.active -> stringResource(R.string.active)
+                        else -> stringResource(R.string.off)
+                    }
+                    val lastReading = if (meter.lastReadingAt > 0L) {
+                        stringResource(
+                            R.string.glucose_meter_last_reading,
+                            DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
+                                .format(Date(meter.lastReadingAt))
+                        )
+                    } else {
+                        stringResource(R.string.glucose_meter_no_readings)
+                    }
+                    SettingsSwitchItem(
+                        title = meter.name,
+                        subtitle = "$status · $lastReading",
+                        checked = meter.active,
+                        icon = Icons.Filled.Bloodtype,
+                        iconTint = MaterialTheme.colorScheme.primary,
+                        onCheckedChange = { enabled ->
+                            GlucoseMeterManager.setEnabled(meter.index, enabled)
+                            meters = GlucoseMeterManager.configuredMeters()
+                        },
+                    )
+                }
+            }
+
+            item("nearby_label") {
+                SectionLabel(stringResource(R.string.glucose_meters_nearby))
+            }
+            item("scan_action") {
+                Button(
+                    onClick = {
+                        val missing = requiredMeterPermissions().filter {
+                            ContextCompat.checkSelfPermission(context, it) !=
+                                android.content.pm.PackageManager.PERMISSION_GRANTED
+                        }
+                        if (missing.isEmpty()) scanRequest += 1
+                        else permissionLauncher.launch(missing.toTypedArray())
+                    },
+                    enabled = !scanning,
+                    modifier = Modifier.fillMaxWidth().height(56.dp),
+                ) {
+                    Icon(Icons.AutoMirrored.Filled.BluetoothSearching, contentDescription = null)
+                    Spacer(Modifier.size(10.dp))
+                    Text(stringResource(if (scanning) R.string.scanning_devices else R.string.finddevices))
+                }
+                if (scanning) LinearProgressIndicator(Modifier.fillMaxWidth().padding(top = 8.dp))
+            }
+            items(nearby, key = NearbyGlucoseMeter::address) { candidate ->
+                SettingsItem(
+                    title = candidate.name,
+                    subtitle = candidate.address,
+                    icon = Icons.AutoMirrored.Filled.BluetoothSearching,
+                    iconTint = MaterialTheme.colorScheme.tertiary,
+                    position = CardPosition.SINGLE,
+                    onClick = {
+                        val index = GlucoseMeterManager.add(candidate.device, candidate.name)
+                        if (index >= 0) {
+                            meters = GlucoseMeterManager.configuredMeters()
+                            nearby = nearby.filterNot { it.address == candidate.address }
+                        } else {
+                            Toast.makeText(context, R.string.wentwrong, Toast.LENGTH_LONG).show()
+                        }
+                    },
+                    trailingContent = { Text(stringResource(R.string.pair)) },
+                )
+            }
+        }
+    }
+}
+
+private fun requiredMeterPermissions(): List<String> = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
+        listOf(Manifest.permission.BLUETOOTH_SCAN, Manifest.permission.BLUETOOTH_CONNECT)
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> listOf(Manifest.permission.ACCESS_FINE_LOCATION)
+    else -> emptyList()
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
@@ -775,6 +775,7 @@ fun MainApp(themeMode: ThemeMode, onThemeChanged: (ThemeMode) -> Unit) {
                     composable("settings/mirror") { MirrorSettingsScreen(navController) }
                     composable("settings/outbound-api") { OutboundApiSettingsScreen(navController) }
                     composable("settings/api-source") { ApiSourceSettingsScreen(navController) }
+                    composable("settings/glucose-meters") { GlucoseMeterSettingsScreen(navController) }
                     composable("settings/watch") { WatchSettingsScreen(navController) }
                     // Keep legacy route for backward compatibility.
                     composable("settings/weartransport") { WatchSettingsScreen(navController) }
@@ -918,6 +919,7 @@ fun MainApp(themeMode: ThemeMode, onThemeChanged: (ThemeMode) -> Unit) {
                 composable("settings/mirror") { MirrorSettingsScreen(navController) }
                 composable("settings/outbound-api") { OutboundApiSettingsScreen(navController) }
                 composable("settings/api-source") { ApiSourceSettingsScreen(navController) }
+                composable("settings/glucose-meters") { GlucoseMeterSettingsScreen(navController) }
                 composable("settings/watch") { WatchSettingsScreen(navController) }
                 // Keep legacy route for backward compatibility.
                 composable("settings/weartransport") { WatchSettingsScreen(navController) }

--- a/Common/src/test/java/tk/glucodata/MeterJournalPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/MeterJournalPolicyTests.kt
@@ -1,0 +1,34 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class MeterJournalPolicyTests {
+    @Test
+    fun decodedReadingKeepsNativeTimestampAndMgdlTenths() {
+        val decoded = MeterJournalPolicy.decode(
+            meterIndex = 3,
+            timestampMillis = 1_700_000_000_000L,
+            mgdlTenths = 1_237L,
+            nowMillis = 1_700_000_000_000L,
+        )
+
+        assertNotNull(decoded)
+        assertEquals(1_700_000_000_000L, decoded!!.timestampMillis)
+        assertEquals(123.7f, decoded.glucoseMgDl, 0.001f)
+        assertEquals("meter:3:1700000000000", decoded.sourceRecordId)
+    }
+
+    @Test
+    fun invalidNativeValuesAreNotJournaled() {
+        val now = 1_700_000_000_000L
+
+        assertNull(MeterJournalPolicy.decode(0, 0L, 1_000L, now))
+        assertNull(MeterJournalPolicy.decode(0, now, 0L, now))
+        assertNull(MeterJournalPolicy.decode(0, now, 20_001L, now))
+        assertNull(MeterJournalPolicy.decode(-1, now, 1_000L, now))
+        assertNull(MeterJournalPolicy.decode(0, now + 24 * 60 * 60 * 1000L + 1L, 1_000L, now))
+    }
+}


### PR DESCRIPTION
## Summary
- add an M3 Expressive Glucose Meters screen under Exchange Data, directly above Watches
- discover Bluetooth meters through the standard Glucose Service and the existing supported vendor service, then manage configured meter status without returning to the legacy view UI
- carry the exact native-decoded timestamp and mg/dL reading across JNI into a deduplicated Journal fingerstick entry
- let the existing Journal treatment uploader send meter readings to Nightscout as BG Check treatments
- translate the new interface across every supported locale

The issue also requested uploader battery reporting. That is already present on main from ffcc5ed7, so this PR keeps its scope to the missing meter setup and reading path.

## Safety
- no glucose is synthesized or re-parsed in Compose/Kotlin
- invalid decoded timestamps/values are rejected
- journal source IDs are stable per meter and timestamp to prevent duplicate entries
- mg/dL remains the canonical Journal value even when the legacy numeric store displays mmol/L

## Verification
- ./gradlew --no-daemon :Common:testMobileLibre3SiDexGoogleDebugUnitTest --tests tk.glucodata.MeterJournalPolicyTests
- ./gradlew --no-daemon :Common:compileMobileLibre3SiDexGoogleDebugKotlin
- ./gradlew --no-daemon :Common:assembleMobileLibre3SiDexGoogleDebug
- xmllint on all values*/strings.xml files
- locale key coverage: 15/15
- git diff --check

Fixes #67