### PR TITLE
Dashboard readings list: optional per-row delta column

### DIFF
--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1633,6 +1633,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="notification_show_delta_desc">Gemessene Änderung über das Delta-Intervall, neben dem Pfeil</string>
     <string name="dashboard_show_delta_title">Delta (Δ) auf dem Dashboard</string>
     <string name="dashboard_show_delta_desc">Gemessene Änderung über das Delta-Intervall, unter dem Trendpfeil</string>
+    <string name="dashboard_rows_show_delta_title">Delta (Δ) in der Messwert-Liste</string>
+    <string name="dashboard_rows_show_delta_desc">Gemessene Änderung je Messwert über das Delta-Intervall, neben dem Wert</string>
     <string name="delta_interval_title">Delta-Intervall (Δ)</string>
     <string name="delta_interval_desc">Zeitfenster für die Δ-Anzeige; die Schnell-fallend/steigend-Alarme folgen ihm, solange kein eigenes Fenster gesetzt ist</string>
     <string name="delta_interval_1min">1 Min</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1888,6 +1888,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_delta_desc">Measured change over the delta interval, next to the arrow</string>
     <string name="dashboard_show_delta_title">Delta (Δ) on the dashboard</string>
     <string name="dashboard_show_delta_desc">Measured change over the delta interval, below the trend arrow</string>
+    <string name="dashboard_rows_show_delta_title">Delta (Δ) in the readings list</string>
+    <string name="dashboard_rows_show_delta_desc">Each reading\'s measured change over the delta interval, next to its value</string>
     <string name="delta_interval_title">Delta (Δ) interval</string>
     <string name="delta_interval_desc">Time window for the Δ readout; the falling/rising alarms follow it unless given their own window</string>
     <string name="delta_interval_1min">1 min</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
@@ -250,3 +250,54 @@ internal const val TREND_HISTORY_LIMIT = 30
  */
 internal fun buildTrendHistory(consumerHistory: List<GlucosePoint>): List<GlucosePoint> =
     buildDisplayReadings(consumerHistory, limit = TREND_HISTORY_LIMIT)
+
+/**
+ * The "Δ" readout of the hero card, anchored at arbitrary points in time: for each
+ * anchor timestamp, the delta the hero would have shown when that reading was the
+ * newest one. The hero's own readout is the single-anchor case (the newest point),
+ * so there is exactly one walk-back and one formatting rule — a row can never
+ * disagree with the hero about the same reading.
+ *
+ * Anchors must be newest-first (the order the dashboard rows are drawn in) and
+ * [history] is the hero's input list, oldest-first — the *unsmoothed* one: visual
+ * smoothing reshapes recent values, and the Δ is a raw measurement by design.
+ * Both cursors only ever move toward older points, so the whole visible list is
+ * one pass over the history regardless of how many rows are shown.
+ *
+ * An anchor with no old-enough partner (start of the data, or a gap wider than
+ * the pairing rules allow) yields null, never a NaN text.
+ */
+internal fun readingDeltaTexts(
+    anchorTimestamps: List<Long>,
+    history: List<GlucosePoint>,
+    isMmol: Boolean,
+    deltaIntervalMinutes: Int
+): List<String?> {
+    if (anchorTimestamps.isEmpty()) return emptyList()
+    val newestFirst = history.asReversed()
+    val minGap = tk.glucodata.GlucoseDelta.minGapMillis(deltaIntervalMinutes)
+    var anchorIndex = 0
+    var previousIndex = 0
+    return anchorTimestamps.map { anchorTimestamp ->
+        while (anchorIndex < newestFirst.size && newestFirst[anchorIndex].timestamp > anchorTimestamp) {
+            anchorIndex++
+        }
+        val anchor = newestFirst.getOrNull(anchorIndex) ?: return@map null
+        // Same predicate as the hero's walk-back: the first point old enough for
+        // the interval's window, skipping empty/sentinel values. Skips are safe to
+        // keep across anchors: a value failure is permanent, and a too-small gap
+        // only shrinks further for the older anchors that follow.
+        while (previousIndex < newestFirst.size) {
+            val candidate = newestFirst[previousIndex]
+            if (candidate.value > 0.1f && anchor.timestamp - candidate.timestamp >= minGap) break
+            previousIndex++
+        }
+        val previous = newestFirst.getOrNull(previousIndex) ?: return@map null
+        val delta = tk.glucodata.GlucoseDelta.delta(
+            anchor.timestamp, anchor.value,
+            previous.timestamp, previous.value,
+            deltaIntervalMinutes
+        )
+        tk.glucodata.GlucoseDelta.format(delta, isMmol).takeIf { it.isNotEmpty() }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -315,27 +315,14 @@ fun DashboardCombinedHeader(
         }
     }
     // "Δ" readout: the measured change over the last ~5 minutes — a raw
-    // number to sanity-check the estimated arrow against. Walks back to the
-    // first point old enough for the window instead of taking blind indices.
+    // number to sanity-check the estimated arrow against. Same computation as
+    // the per-row deltas in the readings list, anchored at the newest point.
     val heroDeltaText = if (showDelta) {
         remember(history, isMmol, deltaIntervalMinutes) {
-            val newest = history.lastOrNull()
-            val previous = newest?.let { n ->
-                history.asReversed().firstOrNull { p ->
-                    p.value > 0.1f && n.timestamp - p.timestamp >= tk.glucodata.GlucoseDelta.minGapMillis(deltaIntervalMinutes)
-                }
-            }
-            if (newest != null && previous != null) {
-                val delta = tk.glucodata.GlucoseDelta.delta(
-                    newest.timestamp, newest.value,
-                    previous.timestamp, previous.value,
-                    deltaIntervalMinutes
-                )
-                tk.glucodata.GlucoseDelta.format(delta, isMmol)
-                    .takeIf { it.isNotEmpty() }
+            history.lastOrNull()?.let { newest ->
+                readingDeltaTexts(listOf(newest.timestamp), history, isMmol, deltaIntervalMinutes)
+                    .first()
                     ?.let { "Δ $it" }
-            } else {
-                null
             }
         }
     } else {

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -318,6 +318,7 @@ fun DashboardScreen(
     val glucoseArrowForecastEnabled by viewModel.glucoseArrowForecastColorsEnabled.collectAsState()
     val appChartRangeColorsEnabled by viewModel.glucoseAppChartRangeColorsEnabled.collectAsState()
     val dashboardShowDelta by viewModel.dashboardShowDelta.collectAsState()
+    val dashboardRowsShowDelta by viewModel.dashboardRowsShowDelta.collectAsState()
     val deltaIntervalMinutes by viewModel.deltaIntervalMinutes.collectAsState()
     val journalDoseCalculatorEnabled by viewModel.journalDoseCalculatorEnabled.collectAsState()
     val journalFoodMacrosEnabled by viewModel.journalFoodMacrosEnabled.collectAsState()
@@ -1091,6 +1092,23 @@ fun DashboardScreen(
             val recentReadingPeers = remember(recentReadings, multiSensorDisplay) {
                 recentReadings.map { reading -> multiSensorDisplay.peersAt(reading.timestamp) }
             }
+            // Per-row Δ: the hero's delta computation anchored at each row's
+            // timestamp — over the same unsmoothed history the hero reads, so the
+            // newest row and the hero can never disagree.
+            val recentReadingDeltaTexts = remember(
+                dashboardRowsShowDelta, recentReadings, glucoseHistory, unit, deltaIntervalMinutes
+            ) {
+                if (dashboardRowsShowDelta) {
+                    readingDeltaTexts(
+                        recentReadings.map { it.timestamp },
+                        glucoseHistory,
+                        tk.glucodata.ui.util.GlucoseFormatter.isMmol(unit),
+                        deltaIntervalMinutes
+                    )
+                } else {
+                    emptyList()
+                }
+            }
             val peerSeriesById = remember(multiSensorDisplay) {
                 multiSensorDisplay.series.associateBy { it.sensorId }
             }
@@ -1255,6 +1273,7 @@ fun DashboardScreen(
                                 index = index,
                                 totalCount = recentReadings.size,
                                 history = recentReadingsTrendHistory,
+                                deltaText = recentReadingDeltaTexts.getOrNull(index),
                                 peerReadings = recentReadingPeers.getOrNull(index).orEmpty(),
                                 peerSeries = peerSeriesById,
                                 multiSensorActive = multiSensorActive,
@@ -1627,6 +1646,7 @@ fun DashboardScreen(
                                 index = index,
                                 totalCount = recentReadings.size,
                                 history = recentReadingsTrendHistory,
+                                deltaText = recentReadingDeltaTexts.getOrNull(index),
                                 peerReadings = recentReadingPeers.getOrNull(index).orEmpty(),
                                 peerSeries = peerSeriesById,
                                 multiSensorActive = multiSensorActive,

--- a/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
@@ -97,6 +97,7 @@ fun NotificationSettingsScreen(
     val chartRangeColorsEnabled by viewModel.glucoseChartRangeColorsEnabled.collectAsState()
     val appChartRangeColorsEnabled by viewModel.glucoseAppChartRangeColorsEnabled.collectAsState()
     val dashboardDeltaEnabled by viewModel.dashboardShowDelta.collectAsState()
+    val dashboardRowsDeltaEnabled by viewModel.dashboardRowsShowDelta.collectAsState()
     val deltaIntervalMinutes by viewModel.deltaIntervalMinutes.collectAsState()
 
     var fontSize by rememberSaveable { mutableFloatStateOf(prefs.getFloat("notification_font_size", 1.0f)) }
@@ -288,6 +289,14 @@ fun NotificationSettingsScreen(
                 subtitle = stringResource(R.string.dashboard_show_delta_desc),
                 checked = dashboardDeltaEnabled,
                 onCheckedChange = { viewModel.setDashboardShowDelta(it) },
+                icon = null,
+                position = CardPosition.MIDDLE
+            )
+            SettingsSwitchItem(
+                title = stringResource(R.string.dashboard_rows_show_delta_title),
+                subtitle = stringResource(R.string.dashboard_rows_show_delta_desc),
+                checked = dashboardRowsDeltaEnabled,
+                onCheckedChange = { viewModel.setDashboardRowsShowDelta(it) },
                 icon = null,
                 position = CardPosition.MIDDLE
             )

--- a/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
@@ -68,6 +68,8 @@ fun ReadingRow(
     index: Int = 0,
     totalCount: Int = 1,
     history: List<GlucosePoint> = emptyList(), // Advanced Trend: Need history
+    // The row's historical "Δ" (see readingDeltaTexts); null hides the slot entirely.
+    deltaText: String? = null,
     peerReadings: List<GlucosePoint> = emptyList(),
     peerSeries: Map<String, PeerSensorSeries> = emptyMap(),
     // True whenever the dashboard is in multi-sensor mode, even if THIS row has
@@ -301,6 +303,15 @@ fun ReadingRow(
                     modifier = modifier,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
+                    if (!deltaText.isNullOrEmpty()) {
+                        Text(
+                            text = deltaText,
+                            style = timeStyle.copy(fontFeatureSettings = "tnum"),
+                            color = tertiaryColor
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                    }
+
                     if (tk.glucodata.data.calibration.CalibrationManager.hasCalibrationAt(point.timestamp, isRawModeRR)) {
                         Icon(
                             imageVector = Icons.Filled.WaterDrop,

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
@@ -120,6 +120,7 @@ class DashboardViewModel(
         const val CHART_RANGE_COLORS_KEY = "glucose_chart_range_colors_enabled"
         const val APP_CHART_RANGE_COLORS_KEY = "glucose_app_chart_range_colors_enabled"
         const val DASHBOARD_SHOW_DELTA_KEY = "dashboard_show_delta"
+        const val DASHBOARD_ROWS_SHOW_DELTA_KEY = "dashboard_rows_show_delta"
         const val DELTA_INTERVAL_KEY = "delta_interval_minutes"
         const val JOURNAL_HEALTH_CONNECT_ACTIVITY_KEY = "dashboard_journal_health_connect_activity_enabled"
         const val PREDICTION_CARB_RATIO_KEY = "dashboard_prediction_carb_ratio_g_per_u"
@@ -328,6 +329,9 @@ class DashboardViewModel(
 
     private val _dashboardShowDelta = MutableStateFlow(false)
     val dashboardShowDelta = _dashboardShowDelta.asStateFlow()
+
+    private val _dashboardRowsShowDelta = MutableStateFlow(false)
+    val dashboardRowsShowDelta = _dashboardRowsShowDelta.asStateFlow()
 
     private val _deltaIntervalMinutes = MutableStateFlow(tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES)
     val deltaIntervalMinutes = _deltaIntervalMinutes.asStateFlow()
@@ -617,6 +621,7 @@ class DashboardViewModel(
         _glucoseChartRangeColorsEnabled.value = prefs.getBoolean(CHART_RANGE_COLORS_KEY, false)
         _glucoseAppChartRangeColorsEnabled.value = prefs.getBoolean(APP_CHART_RANGE_COLORS_KEY, false)
         _dashboardShowDelta.value = prefs.getBoolean(DASHBOARD_SHOW_DELTA_KEY, false)
+        _dashboardRowsShowDelta.value = prefs.getBoolean(DASHBOARD_ROWS_SHOW_DELTA_KEY, false)
         _deltaIntervalMinutes.value = tk.glucodata.GlucoseDelta.sanitizeIntervalMinutes(
             prefs.getInt(DELTA_INTERVAL_KEY, tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES)
         )
@@ -1405,6 +1410,13 @@ class DashboardViewModel(
         val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
         prefs.edit().putBoolean(DASHBOARD_SHOW_DELTA_KEY, enabled).apply()
         _dashboardShowDelta.value = enabled
+    }
+
+    fun setDashboardRowsShowDelta(enabled: Boolean) {
+        val context = tk.glucodata.Applic.app
+        val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(DASHBOARD_ROWS_SHOW_DELTA_KEY, enabled).apply()
+        _dashboardRowsShowDelta.value = enabled
     }
 
     /**

--- a/Common/src/test/java/tk/glucodata/ui/DashboardReadingDeltaTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/DashboardReadingDeltaTests.kt
@@ -1,0 +1,185 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import tk.glucodata.GlucoseDelta
+
+/**
+ * The per-row "Δ" column of the dashboard readings list is the hero readout
+ * anchored in the past: [readingDeltaTexts] is the one function both call, so a
+ * row and the hero can never show different deltas for the same reading.
+ *
+ * These tests pin that identity three ways: the newest row against the hero's
+ * own call shape, every row against a literal per-row walk-back (the pre-change
+ * hero algorithm), and the arithmetic against [GlucoseDelta] directly.
+ */
+class DashboardReadingDeltaTests {
+
+    private val nowMillis = 1_700_000_000_000L
+    private val minute = 60_000L
+
+    /** Oldest-first, like the hero's history input. */
+    private fun oneMinuteCadence(count: Int, valueAt: (minutesAgo: Int) -> Float): List<GlucosePoint> =
+        (count - 1 downTo 0).map { minutesAgo ->
+            GlucosePoint(
+                value = valueAt(minutesAgo),
+                time = "",
+                timestamp = nowMillis - minutesAgo * minute
+            )
+        }
+
+    /** Newest-first, like buildDisplayReadings hands the rows to the card. */
+    private fun rowsOf(history: List<GlucosePoint>, limit: Int = 10): List<GlucosePoint> =
+        buildDisplayReadings(history, limit = limit)
+
+    /**
+     * The hero's original inline walk-back, kept verbatim as the reference: the
+     * first point old enough for the window, then GlucoseDelta over the pair.
+     */
+    private fun heroReference(
+        history: List<GlucosePoint>,
+        anchor: GlucosePoint,
+        isMmol: Boolean,
+        intervalMinutes: Int
+    ): String? {
+        val previous = history.asReversed().firstOrNull { p ->
+            p.value > 0.1f && anchor.timestamp - p.timestamp >= GlucoseDelta.minGapMillis(intervalMinutes)
+        } ?: return null
+        val delta = GlucoseDelta.delta(
+            anchor.timestamp, anchor.value,
+            previous.timestamp, previous.value,
+            intervalMinutes
+        )
+        return GlucoseDelta.format(delta, isMmol).takeIf { it.isNotEmpty() }
+    }
+
+    @Test
+    fun newestRowIsBitIdenticalToTheHeroReadout() {
+        val history = oneMinuteCadence(count = 30) { minutesAgo -> 100f + minutesAgo * 2f }
+        val rows = rowsOf(history)
+
+        // The hero's exact call shape (DashboardComponents.kt) for the newest point.
+        val hero = readingDeltaTexts(
+            listOf(history.last().timestamp), history, false, 5
+        ).first()
+        val newestRow = readingDeltaTexts(
+            rows.map { it.timestamp }, history, false, 5
+        ).first()
+
+        assertEquals(hero, newestRow)
+        assertEquals(heroReference(history, history.last(), false, 5), newestRow)
+    }
+
+    @Test
+    fun everyRowMatchesAPerRowWalkBack() {
+        // Mixed shape: a climb, a plateau of repeats, a sensor dropout value.
+        val values = listOf(90f, 92f, 92f, 0f, 95f, 99f, 104f, 104f, 110f, 118f, 121f, 119f, 122f, 130f, 133f)
+        val history = (0 until values.size).map { i ->
+            GlucosePoint(value = values[i], time = "", timestamp = nowMillis - (values.size - 1 - i) * minute)
+        }
+        val rows = rowsOf(history)
+
+        for (intervalMinutes in listOf(1, 5)) {
+            val onePass = readingDeltaTexts(rows.map { it.timestamp }, history, false, intervalMinutes)
+            rows.forEachIndexed { index, row ->
+                assertEquals(
+                    "row $index (interval $intervalMinutes) must match the hero's walk-back",
+                    heroReference(history, row, false, intervalMinutes),
+                    onePass[index]
+                )
+            }
+        }
+    }
+
+    @Test
+    fun fiveMinuteWindowOnOneMinuteCadenceIsThePlainDifference() {
+        // 2 mg/dL per minute: value(t) - value(t - 5 min) = 10, gap exactly the
+        // window, so no rescaling — the column shows the raw difference.
+        val history = oneMinuteCadence(count = 30) { minutesAgo -> 100f + (30 - minutesAgo) * 2f }
+        val rows = rowsOf(history)
+        val texts = readingDeltaTexts(rows.map { it.timestamp }, history, false, 5)
+
+        assertEquals("+10", texts.first())
+        val expected = GlucoseDelta.format(
+            GlucoseDelta.delta(
+                history.last().timestamp, history.last().value,
+                history[history.size - 6].timestamp, history[history.size - 6].value,
+                5
+            ),
+            false
+        )
+        assertEquals(expected, texts.first())
+    }
+
+    @Test
+    fun columnFollowsTheIntervalSetting() {
+        val history = oneMinuteCadence(count = 30) { minutesAgo -> 100f + (30 - minutesAgo) * 2f }
+        val rows = rowsOf(history)
+
+        val oneMinute = readingDeltaTexts(rows.map { it.timestamp }, history, false, 1)
+        val fiveMinute = readingDeltaTexts(rows.map { it.timestamp }, history, false, 5)
+
+        assertEquals("+2", oneMinute.first())
+        assertEquals("+10", fiveMinute.first())
+        // And each stays the hero's own value for that interval.
+        assertEquals(
+            readingDeltaTexts(listOf(history.last().timestamp), history, false, 1).first(),
+            oneMinute.first()
+        )
+        assertEquals(
+            readingDeltaTexts(listOf(history.last().timestamp), history, false, 5).first(),
+            fiveMinute.first()
+        )
+    }
+
+    @Test
+    fun rowsWithoutAnOldEnoughPartnerStayEmpty() {
+        // Only 4 minutes of data: no pair satisfies the 5-minute walk-back, for
+        // any row — empty column, no NaN text.
+        val history = oneMinuteCadence(count = 4) { minutesAgo -> 100f + minutesAgo * 2f }
+        val rows = rowsOf(history)
+        val texts = readingDeltaTexts(rows.map { it.timestamp }, history, false, 5)
+
+        assertEquals(rows.size, texts.size)
+        texts.forEach { assertNull(it) }
+    }
+
+    @Test
+    fun aDataGapWiderThanThePairingRuleYieldsEmptyNotNan() {
+        // 25-minute hole: the walk-back lands on a point too old to pair with
+        // (GlucoseDelta caps at 20 minutes), so the rows right after the gap
+        // stay empty instead of showing a stretched number.
+        val afterGap = (4 downTo 0).map { minutesAgo ->
+            GlucosePoint(value = 120f + minutesAgo, time = "", timestamp = nowMillis - minutesAgo * minute)
+        }
+        val beforeGap = (3 downTo 0).map { i ->
+            GlucosePoint(value = 100f + i, time = "", timestamp = nowMillis - 25 * minute - i * minute)
+        }
+        val history = beforeGap + afterGap
+        val rows = rowsOf(history)
+        val texts = readingDeltaTexts(rows.map { it.timestamp }, history, false, 5)
+
+        rows.forEachIndexed { index, row ->
+            assertEquals(heroReference(history, row, false, 5), texts[index])
+        }
+        assertNull("newest row sits 25+ min after its walk-back target", texts.first())
+    }
+
+    @Test
+    fun mmolKeepsOneDecimalAndItsSign() {
+        val history = oneMinuteCadence(count = 30) { minutesAgo -> 5.0f + (30 - minutesAgo) * 0.1f }
+        val rows = rowsOf(history)
+        val texts = readingDeltaTexts(rows.map { it.timestamp }, history, true, 5)
+
+        assertEquals("+0.5", texts.first())
+        assertEquals(heroReference(history, history.last(), true, 5), texts.first())
+    }
+
+    @Test
+    fun emptyInputsProduceEmptyColumns() {
+        assertEquals(emptyList<String?>(), readingDeltaTexts(emptyList(), emptyList(), false, 5))
+        val texts = readingDeltaTexts(listOf(nowMillis), emptyList(), false, 5)
+        assertEquals(listOf(null as String?), texts)
+    }
+}


### PR DESCRIPTION
## What

The readings list under the home chart can now optionally show each reading's delta, e.g. `22:58  -9  207 (falling arrow)`. Off by default, with its own switch right below the existing "Delta (Δ) on the dashboard" setting, and independent of it.

## How

`readingDeltaTexts()` (DashboardChartPipeline) is the hero's delta walk-back and formatting, anchored at arbitrary timestamps. For each row it yields the delta the hero readout would have shown when that reading was the newest one. The hero now calls the same function with a single anchor, so the newest row and the hero can never disagree.

Deltas are computed over the same unsmoothed history the hero reads, since visual smoothing must not reshape a raw measurement. The whole visible list is one pass: both cursors only move toward older points.

Rows without an old-enough partner (start of the data, or a gap wider than the pairing rules) leave the slot empty instead of showing a stretched or NaN value.

## Tests

`DashboardReadingDeltaTests` pins the newest row to the hero's exact call shape and every row to a literal per-row walk-back (the pre-change hero algorithm, kept as the reference). It also covers the plain-difference case on 1-minute cadence with the 5-minute window, interval switching between 1 and 5 minutes, empty slots on gaps, and mmol formatting.

## Possible follow-ups (not included)

The history screen and journal rows use the same `ReadingRow`. They could inherit the setting later by just passing the new optional `deltaText` parameter.
