### PR TITLE
Sensor end-date calendar event: include the Libre 3 account ID

### DIFF
--- a/Common/src/main/java/tk/glucodata/MainActivity.java
+++ b/Common/src/main/java/tk/glucodata/MainActivity.java
@@ -850,7 +850,7 @@ public class MainActivity extends AppCompatActivity implements NfcAdapter.Reader
                 if (tocalendarapp) {
                     final String name = Natives.getUsedSensorName();
                     if (name != null) {
-                        ScanNfcV.calendar(this, 0, name);
+                        ScanNfcV.calendar(this, 0, name, 0L);
                         tocalendarapp = false;
                     }
                 }

--- a/Common/src/main/java/tk/glucodata/ScanNfcV.java
+++ b/Common/src/main/java/tk/glucodata/ScanNfcV.java
@@ -252,7 +252,7 @@ public class ScanNfcV {
                             ret = 0xFC;
                             value = 1;
                             askcalendar = true;
-                            curve.render.badscan = calendar(main, ret, name);
+                            curve.render.badscan = calendar(main, ret, name, getlibreAccountIDnumber());
                         }
                     }
                 } else {
@@ -451,7 +451,7 @@ public class ScanNfcV {
                                     else
                                         vibrator.vibrate(VibrationEffect.createWaveform(newsensorwait, -1));
                                     String sensorident = Natives.getserial(uid, info);
-                                    curve.render.badscan = calendar(main, ret, sensorident);
+                                    curve.render.badscan = calendar(main, ret, sensorident, 0L);
                                 }
                                     ;
                                     break;
@@ -465,7 +465,7 @@ public class ScanNfcV {
                                     else
                                         vibrator.vibrate(VibrationEffect.createWaveform(newsensorVib, -1));
                                     String sensorident = Natives.getserial(uid, info);
-                                    curve.render.badscan = calendar(main, ret, sensorident);
+                                    curve.render.badscan = calendar(main, ret, sensorident, 0L);
                                     // ret=0;
                                     break;
                             }
@@ -528,7 +528,7 @@ public class ScanNfcV {
         return glucoseValue > 0 || (resultCode & 0x7F) <= 9;
     }
 
-    static private void newsensor(Activity act, String text, String name) {
+    static private void newsensor(Activity act, String text, String name, long accountid) {
         if (!isWearable) {
             XInfuus.sendSensorActivateBroadcast(act, name, Natives.laststarttime());
         }
@@ -568,7 +568,7 @@ public class ScanNfcV {
             ok.setOnClickListener(v -> {
                 removeContentView(lay);
                 if (stillused && calBox.isChecked()) {
-                    insertcalendar(act, name, endtime);
+                    insertcalendar(act, name, endtime, accountid);
                 } else
                     askcalendar = false;
             });
@@ -593,20 +593,20 @@ public class ScanNfcV {
 
     static boolean askcalendar = true;
 
-    static int calendar(Activity act, int ret, String name) {
+    static int calendar(Activity act, int ret, String name, long accountid) {
         if (askcalendar) {
             int waitmin = (ret & 0xff) == 5 ? ret >> 8 : 0;
             String mess = (waitmin > 0)
                     ? (act.getString(R.string.sensor) + " " + name + act.getString(R.string.ready_in) + waitmin + " "
                             + act.getString(R.string.minutes))
                     : act.getString(R.string.ready_for_use);
-            newsensor(act, mess, name);
+            newsensor(act, mess, name, accountid);
             return 0;
         } else
             return ret;
     }
 
-    private static void insertcalendar(Activity act, String name, long endtime) {
+    private static void insertcalendar(Activity act, String name, long endtime, long accountid) {
         /*
          * long endtime=Natives.sensorends()*1000L;
          * if(endtime<= System.currentTimeMillis())
@@ -617,7 +617,10 @@ public class ScanNfcV {
             Intent intent = new Intent(Intent.ACTION_INSERT)
                     .putExtra(CalendarContract.Events.TITLE, act.getString(R.string.enddatesensor) + name)
                     .putExtra(CalendarContract.Events.DESCRIPTION,
-                            act.getString(R.string.sensor) + " " + name + act.getString(R.string.endstime))
+                            act.getString(R.string.sensor) + " " + name + act.getString(R.string.endstime)
+                                    + (accountid > 0L
+                                            ? "\n" + act.getString(R.string.libreview_account_id) + ": " + accountid
+                                            : ""))
                     .setData(CalendarContract.Events.CONTENT_URI)
                     .putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, endtime)
                     .putExtra(CalendarContract.EXTRA_EVENT_END_TIME, endtime + 1000L);


### PR DESCRIPTION
When a Libre 3 registration succeeds and the user accepts the "add sensor end date" prompt, the calendar event description now includes the account ID the sensor was activated with:

```
Sensor <serial> ends at this time
Account ID: 1234567890
```

Motivation: if the phone is lost or breaks mid-sensor, the account ID is usually gone with it, and the sensor can't be taken over by a replacement device. The end-date calendar event syncs off the phone for most people, so this puts the one number you need somewhere you can still read it. The numeric form is exactly what the setup wizard and the LibreView settings accept as manual entry.

Implementation: `libre3scan()` passes `getlibreAccountIDnumber()` down the existing `calendar()` / `newsensor()` / `insertcalendar()` chain. The Libre 1/2 NFC paths, the SiBionics resume path, and the wear build pass 0 and produce the same event as before. The account ID can't be 0 on this path since registration already refuses to start without one. Reuses the `libreview_account_id` string, so no new translations are needed.

Verified with `compileMobileLibre3SiDexGoogleDebugJavaWithJavac` and the full `testMobileLibre3SiDexGoogleDebugUnitTest` suite on top of 1.0.6 (1007 tests, only the known DefaultParamCatalog and Sibionics Exact failures). Not yet checked on a device.
