### PR TITLE
fix(ui/settings): Fix glucose display unit resetting to mmol/L on app restart

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
@@ -1720,7 +1720,7 @@ private fun UnitPickerDialog(isMmol: Boolean, onSelect: (Int) -> Unit, onDismiss
                     style = MaterialTheme.typography.headlineSmall,
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
                 )
-                listOf(stringResource(R.string.unit_mg) to 0, stringResource(R.string.unit_mmol) to 1).forEach { (label, value) ->
+                listOf(stringResource(R.string.unit_mg) to 2, stringResource(R.string.unit_mmol) to 1).forEach { (label, value) ->
                     Row(
                         Modifier
                             .fillMaxWidth()
@@ -1729,7 +1729,7 @@ private fun UnitPickerDialog(isMmol: Boolean, onSelect: (Int) -> Unit, onDismiss
                             .padding(horizontal = 24.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        RadioButton(selected = (if (isMmol) 1 else 0) == value, onClick = null)
+                        RadioButton(selected = (if (isMmol) 1 else 2) == value, onClick = null)
                         Spacer(Modifier.width(16.dp))
                         Text(label, style = MaterialTheme.typography.bodyLarge)
                     }


### PR DESCRIPTION
Summary: Fixes an issue where selecting `mg/dL` in the unit picker dialog passed `0` instead of `2` to native settings storage. Because `0` represents an uninitialized unit state, native initialization re-triggered country auto-detection on every full app restart and reset the display unit back to `mmol/L`.

Changes

Updated `UnitPickerDialog` in `ExpressiveSettingsScreen.kt` to correctly map `mg/dL`  to integer `2` (`listOf(unit_mg to 2, unit_mmol to 1)`).