### PR TITLE
Ottai: reliable history, real activation lifetime, and safe reconnect

### DIFF
--- a/Common/proguard-rules.log
+++ b/Common/proguard-rules.log
@@ -6,6 +6,15 @@
      public static String getStackTraceString(...);
 }
 -whyareyoukeeping class android.util.Log 
+# NOTE: this block is INERT and has been for as long as it has existed. R8 matches the
+# modifiers in a class specification as required flags, and tk.glucodata.Log (Log.java:39) is
+# `public class Log` — not final — so nothing below is stripped. That is why trace.log is still
+# written by release builds while the android.util.Log block above (that class IS final) really
+# does take effect: a shipped APK has 272 android.util.Log.e call sites left but only 10 .w.
+# Deleting `final` here would silence the on-device trace log that CGM diagnosis depends on, so
+# the discrepancy is left as it is. Do not read this block as evidence that a tk.glucodata.Log
+# line cannot reach a release build — the reverse is true, and it is android.util.Log warnings
+# that vanish.
 -assumenosideeffects public final class tk.glucodata.Log {
    private static void log(...);
     public static void v(...);

--- a/Common/proguard-rules.my
+++ b/Common/proguard-rules.my
@@ -35,15 +35,24 @@
 
 # Keep HistorySync/HistoryRepository names and reflected members stable.
 # HistorySyncAccess in src/main resolves these mobile-only classes by name.
+# This list is a duplicate of the getMethod() names in HistorySyncAccess, and nothing checks
+# that the two agree. They did not: getHistoryTimestampsForSensorBlocking was missing here, so
+# in every minified build the lookup threw, the bridge answered "no rows", and the Ottai driver
+# read that as "nothing stored" and re-pulled the sensor's whole history on every reconnect --
+# silently, because tk.glucodata.Log is stripped by proguard-rules.log. The members below now
+# also carry @Keep at their declaration, which cannot drift; keep both in sync when adding one.
 -keepnames class tk.glucodata.data.HistoryRepository
 -keepclassmembers class tk.glucodata.data.HistoryRepository {
     public static void resetBackfillFlag();
     public static java.util.List getHistoryForNotificationForSensor(java.lang.String,long,boolean);
     public static long getLatestTimestampForSensorBlocking(java.lang.String);
+    public static long[] getHistoryTimestampsForSensorBlocking(java.lang.String,long,long);
+    public static int deleteReadingsForSensorAfterBlocking(java.lang.String,long);
     public static void storeReadingAsync(long,float,int);
     public static void storeReadingAsync(long,float,float,float);
     public static void storeReadingAsync(long,float,float,float,java.lang.String);
     public static void storeHistoryBatchAsync(java.lang.String,long[],float[],float[]);
+    public static boolean storeHistoryBatchBlocking(java.lang.String,long[],float[],float[]);
 }
 
 -keepnames class tk.glucodata.data.HistorySync
@@ -53,6 +62,7 @@
     public final void syncRecentSensorFromNative(java.lang.String,long);
     public final void forceFullSyncForSensor(java.lang.String);
     public final void mergeFullSyncForSensor(java.lang.String);
+    public final void markSensorReset(java.lang.String);
 }
 
 # Keep CalibrationManager names and reflected members stable.

--- a/Common/src/main/java/tk/glucodata/HistorySyncAccess.kt
+++ b/Common/src/main/java/tk/glucodata/HistorySyncAccess.kt
@@ -325,24 +325,46 @@ object HistorySyncAccess {
         }.getOrDefault(0L)
     }
 
+    /**
+     * Timestamps already stored for [sensorSerial], or null when the question could not be
+     * asked at all (bridge method missing, or the query threw).
+     *
+     * The distinction matters: callers diff this against what a sensor claims to hold, and an
+     * empty array means "that sensor has nothing stored" — a conclusion that costs a full
+     * history download. Collapsing "could not ask" into the same empty array is what made the
+     * Ottai driver re-pull thousands of records on every reconnect, for months, in silence.
+     *
+     * Failures are reported at error level on purpose: proguard-rules.log strips
+     * android.util.Log.w/i/d/v via -assumenosideeffects, so a warning here does not exist in a
+     * release build — which is exactly why the original breakage left no trace.
+     */
     @JvmStatic
-    fun getHistoryTimestampsForSensor(sensorSerial: String?, startTime: Long, endTime: Long): LongArray {
+    fun getHistoryTimestampsForSensorOrNull(
+        sensorSerial: String?,
+        startTime: Long,
+        endTime: Long
+    ): LongArray? {
         if (sensorSerial.isNullOrBlank() || endTime < startTime) return LongArray(0)
         val method = getHistoryTimestampsMethod
         if (method == null) {
-            Log.w(TAG, "getHistoryTimestampsForSensor unavailable for serial=$sensorSerial")
-            return LongArray(0)
+            Log.e(TAG, "getHistoryTimestampsForSensor unavailable for serial=$sensorSerial")
+            return null
         }
         return runCatching {
-            method.invoke(null, sensorSerial, startTime, endTime) as? LongArray ?: LongArray(0)
+            method.invoke(null, sensorSerial, startTime, endTime) as? LongArray
         }.onFailure {
-            Log.w(
+            Log.e(
                 TAG,
                 "getHistoryTimestampsForSensor failed for serial=$sensorSerial range=$startTime..$endTime",
                 it
             )
-        }.getOrDefault(LongArray(0))
+        }.getOrNull()
     }
+
+    /** As [getHistoryTimestampsForSensorOrNull], but reports "could not ask" as an empty array. */
+    @JvmStatic
+    fun getHistoryTimestampsForSensor(sensorSerial: String?, startTime: Long, endTime: Long): LongArray =
+        getHistoryTimestampsForSensorOrNull(sensorSerial, startTime, endTime) ?: LongArray(0)
 
     @JvmStatic
     fun deleteReadingsForSensorAfter(sensorSerial: String?, timestampExclusive: Long): Int {

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -83,8 +83,17 @@ class OttaiBleManager(
         private const val HISTORY_MAX_RETRIES = 3
         // Hole ledger: requested-but-undelivered history windows, persisted per sensor (see
         // historyHoles). Attempts are cross-session; the size cap bounds the pref for a
-        // runaway overshoot.
-        private const val MAX_HISTORY_HOLES = 16
+        // runaway overshoot. Overflow drops the OLDEST window and loses those records, so the
+        // cap has to stay clear of what a normal session produces: up to
+        // MAX_HISTORY_GAP_RANGES diff windows plus whatever the chunk watchdog records.
+        private const val MAX_HISTORY_HOLES = 32
+        // Diffing the sensor's records against the local store yields the windows that are
+        // genuinely missing. Two windows separated by fewer than this many stored records are
+        // merged: one slightly redundant request costs less air time than a second round trip.
+        // At most MAX_HISTORY_GAP_RANGES windows are produced, so a fragmented history cannot
+        // flood the ledger. Both rules only ever widen a window — coverage is never traded away.
+        private const val HISTORY_GAP_COALESCE_RECORDS = 5
+        private const val MAX_HISTORY_GAP_RANGES = 8
         private const val HISTORY_HOLE_MAX_ATTEMPTS = 5
         private const val HISTORY_HOLE_RETRY_DELAY_MS = 5_000L
         private const val MAX_LIVE_POLL_INTERVAL_MS = 60_000L
@@ -144,6 +153,55 @@ class OttaiBleManager(
 
         internal fun previousDataNoForHistory(previousDataNo: Int, liveDataNo: Int): Int =
             if (isPersistedDataNoAheadOfLive(previousDataNo, liveDataNo)) -1 else previousDataNo
+
+        /**
+         * The `false` windows of [present], coalesced and capped — i.e. exactly the records the
+         * local store is missing, expressed as the fewest requests that still cover all of them.
+         *
+         * Callers previously asked for one contiguous span from the first gap to the newest
+         * record. A single permanently-missing early record (the continuity filter rejects some,
+         * and rejected records are never stored) therefore re-requested the entire history on
+         * every reconnect.
+         *
+         * Merging is deliberately one-directional: a window only ever grows, and every missing
+         * index stays inside some returned window. Hitting [maxRanges] costs redundant records,
+         * never coverage.
+         */
+        internal fun missingRanges(
+            present: BooleanArray,
+            coalesceGap: Int = HISTORY_GAP_COALESCE_RECORDS,
+            maxRanges: Int = MAX_HISTORY_GAP_RANGES,
+        ): List<MissingRange> {
+            if (maxRanges <= 0) return emptyList()
+            val ranges = ArrayList<MissingRange>()
+            var index = 0
+            while (index < present.size) {
+                if (present[index]) {
+                    index++
+                    continue
+                }
+                val start = index
+                while (index < present.size && !present[index]) index++
+                ranges += MissingRange(start, index)
+            }
+            while (ranges.size > 1) {
+                var mergeAt = -1
+                var smallestSeparation = Int.MAX_VALUE
+                for (i in 0 until ranges.size - 1) {
+                    val separation = ranges[i + 1].start - ranges[i].endExclusive
+                    if (separation < smallestSeparation) {
+                        smallestSeparation = separation
+                        mergeAt = i
+                    }
+                }
+                // Stop once the closest pair is far apart AND the count already fits: past that
+                // point merging would only add redundancy for nothing.
+                if (mergeAt < 0 || (smallestSeparation > coalesceGap && ranges.size <= maxRanges)) break
+                ranges[mergeAt] = MissingRange(ranges[mergeAt].start, ranges[mergeAt + 1].endExclusive)
+                ranges.removeAt(mergeAt + 1)
+            }
+            return ranges
+        }
 
         internal fun isLinkUnstable(dropTimesMs: List<Long>, nowMs: Long): Boolean =
             dropTimesMs.count { nowMs - it <= UNSTABLE_LINK_WINDOW_MS } >= UNSTABLE_LINK_MIN_DROPS
@@ -367,6 +425,9 @@ class OttaiBleManager(
     // while iterating, read-modify-write of attempts), so a lock is required rather than a
     // concurrent collection.
     private data class HistoryHole(var start: Int, var endExclusive: Int, var attempts: Int)
+
+    /** A `[start, endExclusive)` window of records the local store does not have. */
+    internal data class MissingRange(val start: Int, val endExclusive: Int)
     private val historyHolesLock = Any()
     private val historyHoles = mutableListOf<HistoryHole>()
     // Set while we re-run service discovery AFTER auth (the sensor exposes a Service
@@ -2801,11 +2862,19 @@ class OttaiBleManager(
         }
         val startMs = streamStartTimeMs.takeIf { it > 0L } ?: return false
         val endMs = (System.currentTimeMillis() + RECORD_INTERVAL_MS).coerceAtLeast(startMs)
-        val existing = HistorySyncAccess.getHistoryTimestampsForSensor(
+        val existing = HistorySyncAccess.getHistoryTimestampsForSensorOrNull(
             id,
             (startMs - RECORD_INTERVAL_MS / 2L).coerceAtLeast(0L),
             endMs,
         )
+        if (existing == null) {
+            // The local store could not be asked. "Don't know" must not collapse into "have
+            // nothing": that answer costs a full re-download of the whole sensor history, and
+            // it repeats on every reconnect because nothing about it self-heals. Leave the
+            // one-shot clear so the live path retries off a real lastDataNo once a sample lands.
+            Log.e(TAG, "history diff unavailable — deferring backfill live=$liveDataNo")
+            return false
+        }
         if (existing.isEmpty()) {
             return requestHistoryRange("room-backfill", 0, liveDataNo)
                 .also { if (it) roomBackfillChecked = true }
@@ -2815,13 +2884,27 @@ class OttaiBleManager(
             val dataNo = ((timestamp - startMs + RECORD_INTERVAL_MS / 2L) / RECORD_INTERVAL_MS).toInt()
             if (dataNo in present.indices) present[dataNo] = true
         }
-        val firstMissing = present.indices.firstOrNull { !present[it] }
-            ?: run {
-                roomBackfillChecked = true // verified complete against Room = trusted
-                return false
-            }
-        return requestHistoryRange("room-backfill", firstMissing, liveDataNo - firstMissing)
-            .also { if (it) roomBackfillChecked = true }
+        val gaps = missingRanges(present)
+        if (gaps.isEmpty()) {
+            roomBackfillChecked = true // verified complete against Room = trusted
+            return false
+        }
+        // Run the newest gap as the live chain — that is the data the chart is waiting for —
+        // and put the older ones on the books first. The ledger's retry driver picks those up
+        // once the chain drains (advanceHistoryChunkChain/continueHistoryAfterPayload call
+        // scheduleHoleRetry), and because they are ledgered before anything is issued, a
+        // disconnect mid-chain cannot lose them.
+        val head = gaps.last()
+        for (gap in gaps.dropLast(1)) addHistoryHole(gap.start, gap.endExclusive)
+        val issued = requestHistoryRange("room-backfill", head.start, head.endExclusive - head.start)
+        if (issued) roomBackfillChecked = true else scheduleHoleRetry()
+        Log.i(
+            TAG,
+            "history diff live=$liveDataNo stored=${existing.size} gaps=${gaps.size} " +
+                "missing=${gaps.sumOf { it.endExclusive - it.start }} " +
+                "head=[${head.start},${head.endExclusive}) issued=$issued"
+        )
+        return issued
     }
 
     private fun requestRecentHistory(reason: String): Boolean {

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -172,7 +172,10 @@ class OttaiBleManager(
             coalesceGap: Int = HISTORY_GAP_COALESCE_RECORDS,
             maxRanges: Int = MAX_HISTORY_GAP_RANGES,
         ): List<MissingRange> {
-            if (maxRanges <= 0) return emptyList()
+            // An empty result is the caller's proof that nothing is missing, and it latches
+            // "history complete" for the connection. A nonsensical cap must therefore still
+            // return a covering window rather than that answer.
+            val cap = maxRanges.coerceAtLeast(1)
             val ranges = ArrayList<MissingRange>()
             var index = 0
             while (index < present.size) {
@@ -196,7 +199,7 @@ class OttaiBleManager(
                 }
                 // Stop once the closest pair is far apart AND the count already fits: past that
                 // point merging would only add redundancy for nothing.
-                if (mergeAt < 0 || (smallestSeparation > coalesceGap && ranges.size <= maxRanges)) break
+                if (mergeAt < 0 || (smallestSeparation > coalesceGap && ranges.size <= cap)) break
                 ranges[mergeAt] = MissingRange(ranges[mergeAt].start, ranges[mergeAt + 1].endExclusive)
                 ranges.removeAt(mergeAt + 1)
             }
@@ -428,6 +431,20 @@ class OttaiBleManager(
 
     /** A `[start, endExclusive)` window of records the local store does not have. */
     internal data class MissingRange(val start: Int, val endExclusive: Int)
+
+    // Set by requestRoomBackfillAfterLive once it enters the local-store diff, which is the
+    // branch taken when the previous dataNo is unusable.
+    //
+    // The live path answers a negative backfill result by calling requestHistoryAfterLive, and
+    // that function's behaviour for an unusable previous dataNo is to ask for [0, live) — the
+    // exact full pull the diff exists to eliminate, reached by a second route. It fires not
+    // only when the diff cannot run but also when it runs fine and merely fails to get its
+    // first GATT write out, which under RF trouble is routine.
+    //
+    // Suppressing it there is safe: the diff ledgers every window before issuing anything, the
+    // ledger's retry driver owns recovery, and this payload has just advanced lastDataNo, so
+    // the next live sample takes the cheap incremental branch instead.
+    @Volatile private var historyDiffOwnsRecovery = false
     private val historyHolesLock = Any()
     private val historyHoles = mutableListOf<HistoryHole>()
     // Set while we re-run service discovery AFTER auth (the sensor exposes a Service
@@ -1983,7 +2000,10 @@ class OttaiBleManager(
                 // independent backstop so the two don't both issue (which would wipe and restart
                 // the in-flight chunk chain via clearPendingHistoryRange).
                 handler.removeCallbacks(initialHistoryRunnable)
-                if (!requestRoomBackfillAfterLive(liveDataNo, previousForHistory) && !roomBackfillChecked) {
+                if (!requestRoomBackfillAfterLive(liveDataNo, previousForHistory) &&
+                    !roomBackfillChecked &&
+                    !historyDiffOwnsRecovery
+                ) {
                     val missingBeforeLive = liveDataNo - previousForHistory - 1
                     if (previousForHistory < 0 || missingBeforeLive > 0) {
                         handler.postDelayed({ requestHistoryAfterLive(previousForHistory, liveDataNo) }, 1_500L)
@@ -2845,6 +2865,7 @@ class OttaiBleManager(
         previousDataNo: Int,
         observedNewest: Boolean = true,
     ): Boolean {
+        historyDiffOwnsRecovery = false
         if (roomBackfillChecked || liveDataNo <= 0) return false
         val id = SerialNumber ?: return false
         // The one-shot is consumed only by an actually-issued request or a trusted "nothing
@@ -2860,6 +2881,8 @@ class OttaiBleManager(
             return requestHistoryRange("room-backfill", previousDataNo + 1, missingBeforeLive)
                 .also { if (it) roomBackfillChecked = true }
         }
+        // From here on the diff owns recovery for this payload — see historyDiffOwnsRecovery.
+        historyDiffOwnsRecovery = true
         val startMs = streamStartTimeMs.takeIf { it > 0L } ?: return false
         val endMs = (System.currentTimeMillis() + RECORD_INTERVAL_MS).coerceAtLeast(startMs)
         val existing = HistorySyncAccess.getHistoryTimestampsForSensorOrNull(
@@ -3206,7 +3229,11 @@ class OttaiBleManager(
     }
 
     private fun retryNextHistoryHole() {
-        if (stop || phase != Phase.STREAMING || sessionKeyHex.isBlank() || commandStatus != 3) return
+        // commandStatus >= 4 is an ended sensor, and its final backfill (runEndedHistoryBackfill)
+        // goes through the same diff, which ledgers every window but the newest. Gating this on
+        // == 3 meant those windows had no driver at all on the sensor's last connection: the
+        // records existed, were known to be missing, and were never asked for.
+        if (stop || phase != Phase.STREAMING || sessionKeyHex.isBlank() || commandStatus < 3) return
         if (activeHistoryEndExclusive > 0 || pendingHistoryReason != null) return // never preempt a live chain
         // Snapshot under the lock: the request below can re-enter the ledger, and the binder
         // thread may be mutating it concurrently from a history notification.

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
@@ -2,6 +2,7 @@ package tk.glucodata.data
 
 import android.content.Context
 import android.util.Log
+import androidx.annotation.Keep
 import androidx.room.withTransaction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -143,6 +144,14 @@ class HistoryRepository(context: Context = Applic.app) {
             }
         }
 
+        /**
+         * Resolved by name from [tk.glucodata.HistorySyncAccess], so the name must survive R8.
+         * The manual keep list in proguard-rules.my did not cover this one: in every minified
+         * build the lookup threw, the bridge answered "no rows", and the Ottai driver read that
+         * as "nothing stored" and re-pulled the sensor's entire history on every reconnect.
+         * @Keep pins it at the declaration, where it cannot drift away from the caller.
+         */
+        @Keep
         @JvmStatic
         fun getHistoryTimestampsForSensorBlocking(
             sensorSerial: String,
@@ -159,6 +168,8 @@ class HistoryRepository(context: Context = Applic.app) {
             }
         }
 
+        /** Resolved by name from [tk.glucodata.HistorySyncAccess] — see [getHistoryTimestampsForSensorBlocking]. */
+        @Keep
         @JvmStatic
         fun deleteReadingsForSensorAfterBlocking(sensorSerial: String, timestampExclusive: Long): Int {
             val resolvedSerial = sensorSerial.takeIf { it.isNotBlank() }
@@ -307,6 +318,8 @@ class HistoryRepository(context: Context = Applic.app) {
             }
         }
 
+        /** Resolved by name from [tk.glucodata.HistorySyncAccess] — see [getHistoryTimestampsForSensorBlocking]. */
+        @Keep
         @JvmStatic
         fun storeHistoryBatchBlocking(
             sensorSerial: String,

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
@@ -157,14 +157,16 @@ class HistoryRepository(context: Context = Applic.app) {
             sensorSerial: String,
             startTime: Long,
             endTime: Long
-        ): LongArray {
+        ): LongArray? {
             val resolvedSerial = sensorSerial.takeIf { it.isNotBlank() }
                 ?: return LongArray(0)
             if (endTime < startTime) return LongArray(0)
+            // null propagates "the query failed" all the way to the caller; an empty array here
+            // means the store really holds nothing for this window.
             return kotlinx.coroutines.runBlocking {
                 HistoryRepository()
-                    .getHistoryTimestampsForSensor(resolvedSerial, startTime, endTime)
-                    .toLongArray()
+                    .getHistoryTimestampsForSensorOrNull(resolvedSerial, startTime, endTime)
+                    ?.toLongArray()
             }
         }
 
@@ -814,7 +816,20 @@ class HistoryRepository(context: Context = Applic.app) {
         serial: String,
         startTime: Long,
         endTime: Long
-    ): List<Long> {
+    ): List<Long> = getHistoryTimestampsForSensorOrNull(serial, startTime, endTime) ?: emptyList()
+
+    /**
+     * Stored timestamps in the window, or null when the query could not be answered.
+     *
+     * Callers diff this against what a sensor reports and treat an empty list as "nothing is
+     * stored" — a conclusion that costs a full history re-download. A failed query must not
+     * masquerade as that answer, so it is reported as null and the caller decides.
+     */
+    suspend fun getHistoryTimestampsForSensorOrNull(
+        serial: String,
+        startTime: Long,
+        endTime: Long
+    ): List<Long>? {
         val serials = resolveQuerySensorSerials(serial)
         if (serials.isEmpty() || endTime < startTime) return emptyList()
         return withContext(Dispatchers.IO) {
@@ -822,7 +837,7 @@ class HistoryRepository(context: Context = Applic.app) {
                 dao.getTimestampsForSensors(serials, startTime, endTime)
             } catch (e: Exception) {
                 Log.e(TAG, "Error getting history timestamps for sensor $serial", e)
-                emptyList()
+                null
             }
         }
     }

--- a/Common/src/mobile/java/tk/glucodata/data/HistorySync.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistorySync.kt
@@ -1,6 +1,7 @@
 package tk.glucodata.data
 
 import android.util.Log
+import androidx.annotation.Keep
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -544,6 +545,8 @@ object HistorySync {
         }
     }
 
+    /** Resolved by name from [tk.glucodata.HistorySyncAccess], so the name must survive R8. */
+    @Keep
     fun markSensorReset(serial: String) {
         if (serial.isBlank()) return
         val deadline = System.currentTimeMillis() + RESET_PRESERVE_WINDOW_MS

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiHistoryDiffTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiHistoryDiffTests.kt
@@ -92,9 +92,29 @@ class OttaiHistoryDiffTests {
     fun handlesTheDegenerateInputs() {
         assertEquals(emptyList<OttaiBleManager.MissingRange>(), OttaiBleManager.missingRanges(BooleanArray(0)))
         assertEquals(ranges(0 to 3), OttaiBleManager.missingRanges(BooleanArray(3)))
-        assertEquals(
-            emptyList<OttaiBleManager.MissingRange>(),
-            OttaiBleManager.missingRanges(present(100, 5..5), maxRanges = 0)
-        )
+    }
+
+    @Test
+    fun anImpossibleCapStillReportsTheMissingRecord() {
+        // Empty is the caller's proof that nothing is missing, and it latches "history complete"
+        // for the connection. A cap that cannot be satisfied must never borrow that answer.
+        assertEquals(ranges(5 to 6), OttaiBleManager.missingRanges(present(100, 5..5), maxRanges = 0))
+        assertEquals(ranges(5 to 6), OttaiBleManager.missingRanges(present(100, 5..5), maxRanges = -3))
+    }
+
+    @Test
+    fun emptyOnlyEverMeansNothingIsMissing() {
+        // The one input that may produce an empty result.
+        assertTrue(OttaiBleManager.missingRanges(present(200)).isEmpty())
+        // Any genuinely-missing record must survive every combination of the tuning knobs.
+        for (cap in intArrayOf(-1, 0, 1, 2, 8, 1000)) {
+            for (coalesce in intArrayOf(-1, 0, 1, 5, 10_000)) {
+                val gaps = OttaiBleManager.missingRanges(present(200, 7..7, 150..151), coalesce, cap)
+                val covered = gaps.flatMap { it.start until it.endExclusive }.toSet()
+                assertTrue("cap=$cap coalesce=$coalesce lost record 7", 7 in covered)
+                assertTrue("cap=$cap coalesce=$coalesce lost record 150", 150 in covered)
+                assertTrue("cap=$cap coalesce=$coalesce lost record 151", 151 in covered)
+            }
+        }
     }
 }

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiHistoryDiffTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiHistoryDiffTests.kt
@@ -1,0 +1,100 @@
+package tk.glucodata.drivers.ottai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The reconnect backfill diffs what the sensor holds against what is already stored and asks
+ * only for the difference. Before this, one permanently-missing early record re-requested the
+ * sensor's entire history on every reconnect — on device that was 4171 records and ~24s of
+ * uninterrupted GATT traffic, repeatedly, during the very link trouble that caused the reconnect.
+ */
+class OttaiHistoryDiffTests {
+
+    private fun present(size: Int, vararg missing: IntRange): BooleanArray {
+        val flags = BooleanArray(size) { true }
+        missing.forEach { range -> range.forEach { flags[it] = false } }
+        return flags
+    }
+
+    private fun ranges(vararg pairs: Pair<Int, Int>) =
+        pairs.map { OttaiBleManager.MissingRange(it.first, it.second) }
+
+    @Test
+    fun noGapsWhenEverythingIsStored() {
+        assertEquals(emptyList<OttaiBleManager.MissingRange>(), OttaiBleManager.missingRanges(present(500)))
+    }
+
+    @Test
+    fun findsEachGapSeparately() {
+        assertEquals(
+            ranges(10 to 13, 400 to 402),
+            OttaiBleManager.missingRanges(present(500, 10..12, 400..401))
+        )
+    }
+
+    @Test
+    fun anEarlyGapDoesNotDragInEverythingAfterIt() {
+        // The regression: dataNo 1 and 2 were rejected by the continuity filter at activation and
+        // are never stored, so they are missing forever. Asking for "first gap .. newest" turned
+        // that into a full-history download on every single reconnect.
+        val gaps = OttaiBleManager.missingRanges(present(4171, 1..2))
+        assertEquals(ranges(1 to 3), gaps)
+        assertEquals(2, gaps.sumOf { it.endExclusive - it.start })
+    }
+
+    @Test
+    fun onlyTheTailIsFetchedAfterAnOfflineStretch() {
+        assertEquals(ranges(4100 to 4171), OttaiBleManager.missingRanges(present(4171, 4100..4170)))
+    }
+
+    @Test
+    fun mergesGapsSeparatedByOnlyAFewStoredRecords() {
+        // [10,13) and [16,19) are 3 records apart: one request for [10,19) beats two round trips.
+        assertEquals(ranges(10 to 19), OttaiBleManager.missingRanges(present(500, 10..12, 16..18)))
+    }
+
+    @Test
+    fun keepsDistantGapsApart() {
+        assertEquals(
+            ranges(10 to 13, 300 to 303),
+            OttaiBleManager.missingRanges(present(500, 10..12, 300..302))
+        )
+    }
+
+    @Test
+    fun capsTheWindowCountByMergingTheClosestPairsFirst() {
+        // Ten scattered gaps, capped at three windows.
+        val missing = (0 until 10).map { (it * 40)..(it * 40) }.toTypedArray()
+        val gaps = OttaiBleManager.missingRanges(present(500, *missing), maxRanges = 3)
+        assertEquals(3, gaps.size)
+        // Capping trades redundancy for window count; it must never drop a missing record.
+        val covered = gaps.flatMap { it.start until it.endExclusive }.toSet()
+        (0 until 10).forEach { assertTrue("record ${it * 40} uncovered", (it * 40) in covered) }
+    }
+
+    @Test
+    fun mergingOnlyEverWidensWindows() {
+        // Whatever the coalescing does, every missing index stays inside some returned window
+        // and the windows stay ordered and disjoint.
+        val flags = present(1000, 3..5, 7..7, 200..260, 262..262, 900..999)
+        val gaps = OttaiBleManager.missingRanges(flags)
+        flags.indices.filter { !flags[it] }.forEach { index ->
+            assertTrue("index $index uncovered", gaps.any { index >= it.start && index < it.endExclusive })
+        }
+        gaps.zipWithNext().forEach { (left, right) ->
+            assertTrue("windows overlap or are unordered", left.endExclusive < right.start)
+        }
+    }
+
+    @Test
+    fun handlesTheDegenerateInputs() {
+        assertEquals(emptyList<OttaiBleManager.MissingRange>(), OttaiBleManager.missingRanges(BooleanArray(0)))
+        assertEquals(ranges(0 to 3), OttaiBleManager.missingRanges(BooleanArray(3)))
+        assertEquals(
+            emptyList<OttaiBleManager.MissingRange>(),
+            OttaiBleManager.missingRanges(present(100, 5..5), maxRanges = 0)
+        )
+    }
+}


### PR DESCRIPTION
Twelve commits on top of 1.0.8 (`d1a6fc64`), 26 files, +2029/−108. Almost all of it is the
Ottai driver; the first commit is shared sensor-lifetime and identity code.

| Commit | Subject | Covered in |
|---|---|---|
| `1f06a964` | sensor: fix lifetime totals and memoize identity/driver resolution | Sensor lifetime and identity |
| `771be5b1` | Ottai: history backfill, real activation lifetime, and reconnect hardening | History · Activation lifetime · Reconnect · Cloud sign-in |
| `7b0db42b` | Ottai: stop activation discovery from chasing neighbouring sensors | Reconnect and candidate selection |
| `a7577eb1` | Ottai: never bound dataNo by an unconfirmed activation start | Activation lifetime |
| `cd9b5a80` | Ottai: never install an unverified candidate as the transport address | Reconnect and candidate selection |
| `922c410c` | Ottai: stop unconfirmed activation state owning the session | Activation lifetime |
| `5e2af08f` | Ottai: guard the history-hole ledger against its two writer threads | History |
| `20749a71` | Ottai: let the corroboration gate actually complete | Activation lifetime |
| `504b8a7a` | Ottai: show history backfill progress | History |
| `738428ea` | Ottai: retire the backfill chain explicitly when its last chunk lands | History |
| `74bbb4ac` | Ottai: fetch the history that is missing, not all of it | History: fetch what is missing |
| `da75e26e` | Ottai: close the four defects the review found in the backfill diff | History: fetch what is missing |

## Shared: sensor lifetime and identity (`1f06a964`)

`ManagedSensorStatusPolicy` derived the lifetime window from the driver-reported
age+remaining span even when the sensor carried an explicit expected/official end, so a
21-day sensor collapsed to the reported span instead of reading "20 / 21". The same routine
rounded the total **up**: Ottai's `maxActive` is 15d+30min, so the ceiling turned a genuine
15-day sensor into "16" on the dashboard. It now prefers the explicit end and rounds to
nearest — 15d30min reads 15, a real 15.6d still reads 16, exact-day sensors are unchanged.

`SensorIdentity.resolveAppSensorId` iterates every driver's identity adapter, each hitting
SharedPreferences and a regex, and the calibrated-chart draw path calls it per glucose point
per frame. It and `ManagedSensorRuntime`'s driver lookups are memoized behind
`ConcurrentHashMap`. Memoizing is only safe if the caches die when the record set changes,
so `invalidateCaches()` runs at every mutation site — the Anytime and Ottai registries, the
Sibionics manager, and the `aidex_sensors` edits in `SensorBluetooth`/`SensorViewModel`.
Without that a stale entry resolves to the wrong sensor or applies a calibration twice, so
the invalidation is part of the fix rather than housekeeping.

## Ottai history (`771be5b1`, `5e2af08f`, `504b8a7a`, `738428ea`)

Backfill no longer depends on a live reading arriving first: an initial pass runs
independently of the live stream, a watchdog resumes a stalled chunk instead of hanging on
it, and a persisted, attempt-capped hole ledger retries gaps across app restarts. Corrupt
frames are rejected rather than stored.

The ledger is guarded by a lock. `onCharacteristicChanged` runs on the BLE binder thread and
reaches the trim/failure paths directly, with no handler hop, while the watchdog and the
retry run on the driver's own HandlerThread. The operations are compound — sort, remove
while iterating, read-modify-write of the attempt counter — so a concurrent collection would
not have made the sequences atomic. The failure modes were a ConcurrentModificationException
on a glucose notification and, worse, a silently lost ledger update turning a transient miss
into a permanent gap.

A sensor re-added after a sign-out refetches its entire history — roughly 19000 records in
270-record chunks, several minutes — during which the status read only "Connected" and the
graph filled in from behind, so the older readings appeared to be missing. The status now
shows "Loading history N%", measured from the chain's own start so a gap refetch in the
middle of history does not read as nearly complete from its first chunk, and capped at 99
while the chain is live.

That cap only held because a finished chain happened to leave bounds that made the percentage
answer −1. The chain is now retired explicitly when its last chunk lands, so the status
cannot pin itself on a percentage that never moves again after one edit to those bounds.

## Ottai history: fetch what is missing, not all of it (`74bbb4ac`, `da75e26e`)

On device, three reconnects during a radio-interference storm each re-requested the sensor's
**entire** history from record 0 — 1660, 2228 and 4171 records. The last was 16 chunk
requests and 466 BLE payloads over ~24s of solid GATT traffic, and re-delivered 4176 records
of which one was new. It happened during the exact link trouble that caused the reconnect,
and it scales with sensor age: a 15-day sensor ends at ~21600 records per reconnect.

The chain of causes ends in a proguard rule. `HistorySyncAccess` resolves `HistoryRepository`
members by name, and the keep list in `proguard-rules.my` is a hand-maintained duplicate of
the names it looks up. `getHistoryTimestampsForSensorBlocking` was missing from that list, so
R8 renamed it and every lookup threw. The bridge caught that, logged a warning and answered
"no rows" — and `proguard-rules.log` strips `android.util.Log.w` via `-assumenosideeffects`,
so the warning does not exist in a release build. `requestRoomBackfillAfterLive` read the
empty answer as "nothing is stored" and asked for everything.

Confirmed against the shipped APK rather than inferred: `dexdump` of the installed release
shows `HistoryRepository` retaining exactly the members named in the keep list
(`resetBackfillFlag`, `getLatestTimestampForSensorBlocking`, `storeReadingAsync`,
`storeHistoryBatchAsync`, `getHistoryForNotificationForSensor`) with everything else renamed
to `a`…`o`. Two more reflected members were renamed with it and were silently broken the same
way: `storeHistoryBatchBlocking`, which degraded to its async fallback, and
`deleteReadingsForSensorAfterBlocking`, which meant `pruneFutureHistory` never pruned
anything. `HistorySync.markSensorReset` was equally unprotected.

Those members now carry `@Keep` at the declaration, which cannot drift away from the caller
the way a duplicated list did, and the list is updated to match. Beyond the keep rules:

- `getHistoryTimestampsForSensorOrNull` separates "could not ask" from "no rows", all the way
  down to the DAO call, which caught its own exceptions and returned an empty list. Conflating
  those is what let a populated store read as empty. On "could not ask" the driver defers
  rather than re-downloading; the next live sample has a usable `lastDataNo` and diffs
  incrementally.
- The diff requests the windows that are genuinely missing rather than one span from the first
  gap to the newest record. Records rejected by the continuity filter are never stored, so a
  single rejected record near activation made that span the whole history, every reconnect.
  Nearby windows coalesce and the count is capped; both rules only ever widen a window, so the
  cap costs redundant records and never coverage.
- Every window but the newest goes on the hole ledger before anything is issued, so a
  disconnect mid-chain cannot lose them, and `MAX_HISTORY_HOLES` rises 16 → 32 because
  overflow drops the oldest window. The ledger's retry driver was gated on `commandStatus == 3`
  and so never ran for an ended sensor; relaxed to `>= 3`, since the final backfill of an
  expired sensor goes through the same diff.
- The live path's fallback answers an unusable previous `dataNo` by asking for `[0, live)` —
  the same full pull by a second route. It fires not only when the diff cannot run but also
  when the diff runs fine and merely fails to get its first GATT write out, which under RF
  trouble is routine. The diff now claims ownership of recovery once entered.

Records the continuity filter rejects keep their second chance: the diff re-offers them on
each reconnect for the price of a two-record request, which is how the two rejected at
activation were eventually accepted.

## Ottai activation lifetime (`771be5b1`, `a7577eb1`, `922c410c`, `20749a71`)

The accepted `maxActive` is persisted at activation and recovered by reading it back off the
sensor; a new `Natives.setSensorWearDays` writes it into `info->wearduration2` so the graph's
sensor-end reflects the real activated life rather than a default span.

A reconnected, vendor-activated sensor used to show "warmup" with blank dates because a
provisional cgm-info start beat the real activation anchor. Only live and monitor-live frames
count as reliable anchors now, and anchors carry that reliability so an unreliable one — one
whose own hint is derived from the provisional — cannot own the session.

The corrupt-frame `dataNo` ceiling is derived **only** from a confirmed activation start. A
provisional start is approximately "now", which would bound `dataNo` near the tolerance while
the real value is in the thousands: every record dropped, and unrecoverably, because the
anchor that learns the true start is seeded downstream of that filter. The confirmed start in
turn requires two independently-derived anchors that agree within two records, so a single
corrupt frame cannot commit a wrong one. And if the filter ever rejects three whole payloads
in a row it stops trusting itself for the session — every input that could widen the bound is
only updated by a record that already passed it, so a bound that is once too tight would
otherwise stay too tight forever.

That corroboration gate then had to be able to close, and as first written it could not
(`20749a71`). The anchor short-circuit in `resolveSampleTimeMs` was keyed on
`streamStartReliable`, which the *first* reliable anchor sets — but `seedStreamTimeAnchor` is
the only place a candidate is ever offered to `offerConfirmedActiveTime`, so that first anchor
closed the only door the corroborating second could arrive through. The gate was unsatisfiable
for the life of the driver, the confirmed start was never written, and with
`materials.activeTimeMs` stuck at 0 the ceiling returned `Int.MAX_VALUE` — leaving the
corrupt-frame filter disabled for exactly the vendor-activated sensors the rewrite was meant
to protect. It is keyed on the start being *confirmed* instead, so live records keep flowing
through the anchor path until corroboration completes and the shortcut then engages
permanently.

## Ottai reconnect and candidate selection (`771be5b1`, `7b0db42b`, `cd9b5a80`)

Connection parameters are re-gripped via the hidden `onConnectionUpdated` callback, the
connect-stall watchdog backs off 90 → 180 → 360s rather than hammering a jammed link, live
reads retry, and user reconnects are debounced.

Activation-candidate discovery admits any advertisement whose name contains "ottai". That
fallback is needed when a sensor's BLE address changes across an activation, but it also
admits a neighbour's sensor, and the driver would then chase strangers in turn while its own
address was displaced. An unverified candidate is now never installed as the transport
address. The test is "did this address prove possession of *this* sensor's auth material",
not "did we manage to disprove it" — a probe that dies before the signature read (GATT 133, a
discovery timeout, a remote drop) never reaches the rejection path. This matters because
`SensorBluetooth.getCallback()` dispatches on address before any admission check, so an
installed stranger is reconnected unchecked and a completed auth would persist its address
into this sensor's registry record. The wait is also bounded, falling back to a direct
connect rather than scanning indefinitely.

## Ottai cloud sign-in (`771be5b1`)

The client forged CN client-IP headers on every backend. `api.ottai.com` is geoblocked to
China and requires them, but on `seas.ottai.com` and `ru.syai.com` the request then looked
cross-region and the backend rejected the session with `AuthFailed_TokenInvalid`. They now go
only to `api.ottai.com`, which is what the official global app does. Confirmed on-device: a
GLOBAL account signs in from Russia without a VPN.

## Verification

- `compileMobileLibre3SiDexGoogleDebug` and its unit-test variant build clean.
- 100 Ottai unit tests pass across 13 suites, run on this branch. The pre-existing
  `ManagedSensorStatusPolicyTests` passes unchanged despite the rounding change — it never
  pinned the old ceiling behaviour.
- The PR adds 467 lines of test: `OttaiReconnectPolicyTests` (281, across `771be5b1`,
  `a7577eb1`, `cd9b5a80`, `922c410c`), `OttaiHistoryDiffTests` (120), `OttaiLifetimeTests`
  (40) and `OttaiHistoryProgressTests` (26).
- The gap-diff helper's tests include a sweep over both tuning knobs asserting that no missing
  record is ever dropped for any combination, and that an empty result means exactly one thing
  — nothing is missing — since the caller latches that as "history complete".
- Native `libg.so` builds for arm64-v8a with `Java_tk_glucodata_Natives_setSensorWearDays`
  exported alongside the existing `hasSensorStreamCapacity`.
- Installed and run on a Realme RMX3840 (Android 15): the sensor connects, authenticates,
  publishes live readings and completes a full ~19000-record history backfill. The Ottai
  driver work has been running on-device since 2026-07-23.

## Notes for review

`SuperGattCallback.onConnectionUpdated` is a hidden framework callback — present since
Android O but absent from the SDK stubs, hence no `@Override`. Its signature must stay exactly
as written or runtime dispatch will not bind to it.

The reflection seam between `src/main` and the mobile-only Room classes is worth a look
beyond this change. The keep list in `proguard-rules.my` duplicates the `getMethod` names in
`HistorySyncAccess` and nothing checks that the two agree; when they drift, the failure is
silent, release-only, and indistinguishable from a legitimate empty result. `CustomAlertAccess`
carries a class comment describing the same bug class taking out custom alerts earlier, which
is why the members here are pinned with `@Keep` at the declaration instead of by name in a
list. `GLUCODATA_SOURCE_AIDEX` is still resolved by `getField` with no keep rule; it is
currently unreachable (`storeAidexReadingAsync` has no callers) so it is left alone rather
than pinned speculatively.

One related discrepancy is documented in place rather than changed: the `-assumenosideeffects`
block for `tk.glucodata.Log` in `proguard-rules.log` is inert, because R8 matches class-spec
modifiers as required flags and `Log.java` is not `final`. That is why release builds still
write the on-device trace log while `android.util.Log` warnings really do vanish — the shipped
APK has 272 surviving `.e` call sites against 10 `.w`. Adding `final` would silence the trace
log that on-device diagnosis depends on, so the block is left inert and now says so.

Two known limits, deliberately not addressed here. The start corroboration is partly
self-referential: the `monitor-live` path can reproduce the first anchor rather than deriving
an independent one, so it stops a single corrupt frame but not a systematically skewed stream.
And the progress percentage restarts when a failed chunk is retried as a fresh chain, because
the driver genuinely refetches that range.
