### PR TITLE
Ottai: fix Nightscout uploads

### DIFF
--- a/Common/src/main/cpp/SensorGlucoseData.hpp
+++ b/Common/src/main/cpp/SensorGlucoseData.hpp
@@ -50,6 +50,7 @@ inline int getpagesize(void) {
 } */
 #include "config.h"
 
+#include "directstreammaintenance.hpp"
 #include "inout.hpp"
 
 #include "net/backup.hpp"
@@ -717,6 +718,22 @@ public:
     if (!polls.data() || !rawpolls.data() || !temppolls.data())
       return 0;
     return std::min({polls.size(), rawpolls.size(), temppolls.size()});
+  }
+  bool ensurePollStorageCapacity(size_t minimumRecords) {
+    auto *info = getinfo();
+    const int recordsPerDay = 24 * streamperhour();
+    if (!info || recordsPerDay <= 0)
+      return false;
+    const size_t requiredDays =
+        (minimumRecords + recordsPerDay - 1) / recordsPerDay;
+    if (requiredDays > std::numeric_limits<uint8_t>::max())
+      return false;
+    if (!directstream::ensurePollStorageCapacity(
+            polls, rawpolls, temppolls, getsensordir(), minimumRecords))
+      return false;
+    info->days =
+        std::max<uint8_t>(info->days, static_cast<uint8_t>(requiredDays));
+    return true;
   }
   bool validPollIndex(int64_t index) const {
     return index >= 0 &&

--- a/Common/src/main/cpp/directstreammaintenance.hpp
+++ b/Common/src/main/cpp/directstreammaintenance.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <string_view>
+#include <utility>
+
+namespace directstream {
+
+template <typename PollMap, typename RawMap, typename TemperatureMap>
+bool ensurePollStorageCapacity(
+    PollMap &polls,
+    RawMap &rawpolls,
+    TemperatureMap &temppolls,
+    std::string_view sensorDir,
+    size_t minimumRecords) {
+  const size_t current =
+      std::min({polls.size(), rawpolls.size(), temppolls.size()});
+  if (current >= minimumRecords)
+    return true;
+  if (minimumRecords > static_cast<size_t>(std::numeric_limits<int>::max()))
+    return false;
+
+  const int requested = static_cast<int>(minimumRecords);
+  PollMap expandedPolls(sensorDir, "polls.dat", requested);
+  RawMap expandedRaw(sensorDir, "rawpolls.dat", requested);
+  TemperatureMap expandedTemperatures(sensorDir, "temppolls.dat", requested);
+  if (!expandedPolls.data() || !expandedRaw.data() ||
+      !expandedTemperatures.data() ||
+      expandedPolls.size() < minimumRecords ||
+      expandedRaw.size() < minimumRecords ||
+      expandedTemperatures.size() < minimumRecords) {
+    return false;
+  }
+
+  polls = std::move(expandedPolls);
+  rawpolls = std::move(expandedRaw);
+  temppolls = std::move(expandedTemperatures);
+  return true;
+}
+
+inline int nightSensorAfterRewind(int currentSensor, int targetSensor) {
+  if (currentSensor <= 0)
+    return currentSensor;
+  return std::min(currentSensor, targetSensor);
+}
+
+} // namespace directstream

--- a/Common/src/main/cpp/g.cpp
+++ b/Common/src/main/cpp/g.cpp
@@ -1543,6 +1543,21 @@ extern "C" JNIEXPORT jboolean JNICALL fromjava(hasSensorStreamCapacity)(
   return ready ? JNI_TRUE : JNI_FALSE;
 }
 
+extern "C" JNIEXPORT jboolean JNICALL fromjava(ensureSensorStreamCapacity)(
+    JNIEnv *env, jclass cl, jstring sensorId, jint minimumRecords) {
+  if (!sensors || !sensorId || minimumRecords <= 0)
+    return JNI_FALSE;
+  const char *str = env->GetStringUTFChars(sensorId, nullptr);
+  if (!str)
+    return JNI_FALSE;
+  SensorGlucoseData *hist = ensureDirectStreamShellForId(str, 0);
+  const bool ready =
+      hist && !hist->error() &&
+      hist->ensurePollStorageCapacity(static_cast<size_t>(minimumRecords));
+  env->ReleaseStringUTFChars(sensorId, str);
+  return ready ? JNI_TRUE : JNI_FALSE;
+}
+
 extern "C" JNIEXPORT void JNICALL fromjava(rebaseDirectStreamWindow)(
     JNIEnv *env, jclass cl, jstring sensorId, jlong startTimeSec) {
   if (!sensors || !sensorId || startTimeSec <= 0)

--- a/Common/src/main/cpp/net/watchserver/uploader.cpp
+++ b/Common/src/main/cpp/net/watchserver/uploader.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include "directstreammaintenance.hpp"
 #include "settings/settings.hpp"
 #include "share/logs.hpp"
 #include "sensoren.hpp"
@@ -977,6 +978,25 @@ extern "C" JNIEXPORT jboolean JNICALL fromjava(wakeNightscoutForLiveReading)
     if(source)
         env->ReleaseStringUTFChars(jsource,source);
     return ready?JNI_TRUE:JNI_FALSE;
+    }
+extern "C" JNIEXPORT jboolean JNICALL fromjava(rewindNightscoutForSensor)
+    (JNIEnv *env,jclass clazz,jstring sensorId) {
+    if(!sensors || !settings || !sensorId)
+        return JNI_FALSE;
+    const char *name=env->GetStringUTFChars(sensorId,nullptr);
+    if(!name)
+        return JNI_FALSE;
+    SensorGlucoseData *sens=sensors->gethistshort(name);
+    env->ReleaseStringUTFChars(sensorId,name);
+    if(!sens || sens->error())
+        return JNI_FALSE;
+    const int target=sens->sensorIndex;
+    sens->getinfo()->nightiter=0;
+    settings->data()->nightsensor=directstream::nightSensorAfterRewind(
+        settings->data()->nightsensor,target);
+    if(target>=0 && target<maxRecentNightUploadSensors)
+        recentNightUploads[target]={};
+    return JNI_TRUE;
     }
 extern "C" JNIEXPORT void JNICALL fromjava(resetuploader) (JNIEnv *env, jclass clazz) {
     reset();

--- a/Common/src/main/java/tk/glucodata/Natives.java
+++ b/Common/src/main/java/tk/glucodata/Natives.java
@@ -742,6 +742,8 @@ public class Natives {
 
         public static native boolean hasSensorStreamCapacity(String sensorId, int minimumRecords);
 
+        public static native boolean ensureSensorStreamCapacity(String sensorId, int minimumRecords);
+
         public static native void rebaseDirectStreamWindow(String sensorId, long startTimeSec);
 
         public static native void addRawGlucoseStream(long time, float rawGlucose, String sensorId);
@@ -1038,6 +1040,8 @@ public class Natives {
         public static native void wakeuploader();
 
         public static native boolean wakeNightscoutForLiveReading(String source, long timestampMillis);
+
+        public static native boolean rewindNightscoutForSensor(String sensorId);
 
         public static native void resetuploader();
 

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -34,6 +34,7 @@ import tk.glucodata.HistorySyncAccess
 import tk.glucodata.Log
 import tk.glucodata.logd
 import tk.glucodata.logi
+import tk.glucodata.NightscoutUploadWake
 import tk.glucodata.Natives
 import tk.glucodata.R
 import tk.glucodata.SensorBluetooth
@@ -344,6 +345,14 @@ class OttaiBleManager(
 
     private val handlerThread = HandlerThread("Ottai-$serial").also { it.start() }
     private val handler = Handler(handlerThread.looper)
+    private val nativeGlucoseMirror = OttaiNativeGlucoseMirror(
+        writeNative = { timestampSec, glucose, temperatureC, sensorId ->
+            Natives.addGlucoseStreamWithTemp(timestampSec, glucose, temperatureC, sensorId)
+        },
+        wakeNightscout = { source, timestampMs ->
+            NightscoutUploadWake.afterLiveNativeWrite(source, timestampMs)
+        },
+    )
 
     // Recent abnormal-disconnect timestamps (status!=0), pruned to UNSTABLE_LINK_WINDOW_MS;
     // feeds the fast-params hold and is only touched under its own lock (binder threads).
@@ -2336,6 +2345,7 @@ class OttaiBleManager(
         if (live && toPersist.size == 1) {
             val reading = toPersist.single()
             HistorySyncAccess.storeCurrentReadingAsync(reading.sampleMs, reading.mgdl, 0f, 0f, id)
+            mirrorDecodedReadingsIntoNative(id, toPersist, live = true)
             return
         }
         val timestamps = LongArray(toPersist.size) { index -> toPersist[index].sampleMs }
@@ -2343,6 +2353,31 @@ class OttaiBleManager(
         // Ottai rawCurrent is an electrode/current diagnostic, not raw glucose mg/dL.
         val rawValues = FloatArray(toPersist.size) { 0f }
         HistorySyncAccess.storeSensorHistoryBatchAsync(id, timestamps, values, rawValues)
+        mirrorDecodedReadingsIntoNative(id, toPersist, live)
+    }
+
+    private fun mirrorDecodedReadingsIntoNative(
+        id: String,
+        readings: List<EmittedReading>,
+        live: Boolean,
+    ) {
+        runCatching {
+            ensureNativePresenceShell("glucose-mirror")
+            val timestampsMs = LongArray(readings.size) { readings[it].sampleMs }
+            val glucoseMgdl = FloatArray(readings.size) { readings[it].mgdl }
+            val temperaturesC = FloatArray(readings.size) { readings[it].temperatureC }
+            val storedCount = nativeGlucoseMirror.mirror(
+                id,
+                timestampsMs,
+                glucoseMgdl,
+                temperaturesC,
+                live,
+            )
+            if (storedCount > 0) {
+                applyActivatedWearToNative(id)
+                Natives.wakebackup()
+            }
+        }.onFailure { Log.stack(TAG, "mirrorDecodedReadingsIntoNative", it) }
     }
 
     /** Keeps the per-sample skin temperature so the stats screen can chart it. */

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -132,6 +132,7 @@ class OttaiBleManager(
         // enough to cover an NFC wake plus a couple of advertisement bursts.
         private const val FRESH_ACTIVATION_ADVERTISEMENT_TIMEOUT_MS = 120_000L
         private const val RECORD_INTERVAL_MS = 60_000L
+        private const val DAY_MS = 24L * 60L * RECORD_INTERVAL_MS
         // How close two independently-derived activation starts must be to corroborate each
         // other. Both are (wall clock - dataNo * interval); the wall clocks differ by the poll
         // gap and each is floored to the record minute, so a genuine pair agrees within a couple
@@ -321,6 +322,19 @@ class OttaiBleManager(
             pendingDurationMs.takeIf {
                 commandStatus == 3 && activationCommandAcknowledged && it > 0L
             } ?: 0L
+
+        internal fun nativeStreamCapacityMinutesFor(acceptedMaxActiveMs: Long): Int {
+            val acceptedDays = if (acceptedMaxActiveMs <= 0L) {
+                OttaiConstants.DEFAULT_RATED_LIFETIME_DAYS.toLong()
+            } else {
+                (acceptedMaxActiveMs + DAY_MS - 1L) / DAY_MS
+            }
+            val capacityDays = acceptedDays.coerceIn(
+                OttaiConstants.DEFAULT_RATED_LIFETIME_DAYS.toLong(),
+                OttaiConstants.EXTENDED_LIFETIME_DAYS.toLong(),
+            )
+            return (capacityDays * 24L * 60L).toInt()
+        }
     }
 
     enum class Phase { IDLE, CONNECTING, DISCOVERING, ENABLING_NOTIFY, AUTH, STREAMING }
@@ -346,9 +360,11 @@ class OttaiBleManager(
     private val handlerThread = HandlerThread("Ottai-$serial").also { it.start() }
     private val handler = Handler(handlerThread.looper)
     private val nativeGlucoseMirror = OttaiNativeGlucoseMirror(
+        prepareNative = ::prepareNativeGlucoseMirror,
         writeNative = { timestampSec, glucose, temperatureC, sensorId ->
             Natives.addGlucoseStreamWithTemp(timestampSec, glucose, temperatureC, sensorId)
         },
+        rewindNightscout = Natives::rewindNightscoutForSensor,
         wakeNightscout = { source, timestampMs ->
             NightscoutUploadWake.afterLiveNativeWrite(source, timestampMs)
         },
@@ -2362,19 +2378,27 @@ class OttaiBleManager(
         live: Boolean,
     ) {
         runCatching {
-            ensureNativePresenceShell("glucose-mirror")
-            val timestampsMs = LongArray(readings.size) { readings[it].sampleMs }
             val glucoseMgdl = FloatArray(readings.size) { readings[it].mgdl }
             val temperaturesC = FloatArray(readings.size) { readings[it].temperatureC }
-            val storedCount = nativeGlucoseMirror.mirror(
-                id,
-                timestampsMs,
-                glucoseMgdl,
-                temperaturesC,
-                live,
-            )
+            val reliableStartMs = nativePresenceStartTimeMs()
+            val storedCount = if (live) {
+                nativeGlucoseMirror.mirrorLive(
+                    sensorId = id,
+                    reliableStartMs = reliableStartMs,
+                    timestampsMs = LongArray(readings.size) { readings[it].sampleMs },
+                    glucoseMgdl = glucoseMgdl,
+                    temperaturesC = temperaturesC,
+                )
+            } else {
+                nativeGlucoseMirror.mirrorHistory(
+                    sensorId = id,
+                    reliableStartMs = reliableStartMs,
+                    dataNos = IntArray(readings.size) { readings[it].dataNo },
+                    glucoseMgdl = glucoseMgdl,
+                    temperaturesC = temperaturesC,
+                )
+            }
             if (storedCount > 0) {
-                applyActivatedWearToNative(id)
                 Natives.wakebackup()
             }
         }.onFailure { Log.stack(TAG, "mirrorDecodedReadingsIntoNative", it) }
@@ -2486,6 +2510,33 @@ class OttaiBleManager(
             Natives.ensureSensorShell(id, (startMs / 1000L).coerceAtLeast(1L))
             applyActivatedWearToNative(id)
         }.onFailure { Log.stack(TAG, "ensureNativePresenceShell($reason)", it) }
+    }
+
+    private fun prepareNativeGlucoseMirror(
+        id: String,
+        reliableStartMs: Long,
+    ): Boolean {
+        if (id.isBlank() || reliableStartMs <= 0L) return false
+        return runCatching {
+            val sensorPtr = Natives.ensureSensorShell(
+                id,
+                (reliableStartMs / 1000L).coerceAtLeast(1L),
+            )
+            if (sensorPtr == 0L) {
+                false
+            } else {
+                applyActivatedWearToNative(id)
+                val minimumRecords = nativeStreamCapacityMinutesFor(activatedMaxActiveMs)
+                if (!Natives.ensureSensorStreamCapacity(id, minimumRecords)) {
+                    Log.e(TAG, "native glucose mirror capacity failed id=$id records=$minimumRecords")
+                    false
+                } else {
+                    true
+                }
+            }
+        }.onFailure {
+            Log.stack(TAG, "prepareNativeGlucoseMirror", it)
+        }.getOrDefault(false)
     }
 
     /** Real activated lifetime in whole days (rounded), or 0 if unknown. */

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiNativeGlucoseMirror.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiNativeGlucoseMirror.kt
@@ -1,0 +1,39 @@
+package tk.glucodata.drivers.ottai
+
+internal class OttaiNativeGlucoseMirror(
+    private val writeNative: (Long, Float, Float, String) -> Boolean,
+    private val wakeNightscout: (String, Long) -> Unit,
+) {
+    fun mirror(
+        sensorId: String,
+        timestampsMs: LongArray,
+        glucoseMgdl: FloatArray,
+        temperaturesC: FloatArray,
+        live: Boolean,
+    ): Int {
+        require(timestampsMs.size == glucoseMgdl.size)
+        require(timestampsMs.size == temperaturesC.size)
+
+        var storedCount = 0
+        var newestStoredLiveTimestampMs = 0L
+        timestampsMs.indices.forEach { index ->
+            val timestampMs = timestampsMs[index]
+            val stored = writeNative(
+                timestampMs / 1000L,
+                glucoseMgdl[index] / 10f,
+                temperaturesC[index],
+                sensorId,
+            )
+            if (stored) {
+                storedCount++
+                if (live && timestampMs > newestStoredLiveTimestampMs) {
+                    newestStoredLiveTimestampMs = timestampMs
+                }
+            }
+        }
+        if (newestStoredLiveTimestampMs > 0L) {
+            wakeNightscout("ottai", newestStoredLiveTimestampMs)
+        }
+        return storedCount
+    }
+}

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiNativeGlucoseMirror.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiNativeGlucoseMirror.kt
@@ -1,18 +1,60 @@
 package tk.glucodata.drivers.ottai
 
+import java.util.TreeMap
+
 internal class OttaiNativeGlucoseMirror(
+    private val prepareNative: (String, Long) -> Boolean,
     private val writeNative: (Long, Float, Float, String) -> Boolean,
+    private val rewindNightscout: (String) -> Boolean,
     private val wakeNightscout: (String, Long) -> Unit,
 ) {
-    fun mirror(
+    companion object {
+        private const val RECORD_INTERVAL_MS = 60_000L
+        private const val MAX_PENDING_HISTORY = 30 * 24 * 60
+    }
+
+    private val pendingHistory = TreeMap<Int, Pair<Float, Float>>()
+
+    fun mirrorHistory(
         sensorId: String,
+        reliableStartMs: Long,
+        dataNos: IntArray,
+        glucoseMgdl: FloatArray,
+        temperaturesC: FloatArray,
+    ): Int {
+        require(dataNos.size == glucoseMgdl.size)
+        require(dataNos.size == temperaturesC.size)
+
+        dataNos.indices.forEach { index ->
+            val dataNo = dataNos[index]
+            if (dataNo >= 0) {
+                pendingHistory[dataNo] = glucoseMgdl[index] to temperaturesC[index]
+            }
+        }
+        while (pendingHistory.size > MAX_PENDING_HISTORY) {
+            pendingHistory.pollFirstEntry()
+        }
+
+        if (sensorId.isBlank() || reliableStartMs <= 0L) return 0
+        if (!prepareNative(sensorId, reliableStartMs)) return 0
+        return replayPendingHistory(sensorId, reliableStartMs).storedCount
+    }
+
+    fun mirrorLive(
+        sensorId: String,
+        reliableStartMs: Long,
         timestampsMs: LongArray,
         glucoseMgdl: FloatArray,
         temperaturesC: FloatArray,
-        live: Boolean,
     ): Int {
         require(timestampsMs.size == glucoseMgdl.size)
         require(timestampsMs.size == temperaturesC.size)
+
+        if (sensorId.isBlank() || reliableStartMs <= 0L) return 0
+        if (!prepareNative(sensorId, reliableStartMs)) return 0
+
+        val historyReplay = replayPendingHistory(sensorId, reliableStartMs)
+        if (!historyReplay.cursorReady) return historyReplay.storedCount
 
         var storedCount = 0
         var newestStoredLiveTimestampMs = 0L
@@ -26,7 +68,7 @@ internal class OttaiNativeGlucoseMirror(
             )
             if (stored) {
                 storedCount++
-                if (live && timestampMs > newestStoredLiveTimestampMs) {
+                if (timestampMs > newestStoredLiveTimestampMs) {
                     newestStoredLiveTimestampMs = timestampMs
                 }
             }
@@ -34,6 +76,39 @@ internal class OttaiNativeGlucoseMirror(
         if (newestStoredLiveTimestampMs > 0L) {
             wakeNightscout("ottai", newestStoredLiveTimestampMs)
         }
-        return storedCount
+        return historyReplay.storedCount + storedCount
     }
+
+    private fun replayPendingHistory(
+        sensorId: String,
+        reliableStartMs: Long,
+    ): HistoryReplay {
+        if (pendingHistory.isEmpty()) return HistoryReplay(storedCount = 0, cursorReady = true)
+
+        val storedDataNos = mutableListOf<Int>()
+        pendingHistory.forEach { (dataNo, reading) ->
+            val timestampMs = reliableStartMs + dataNo.toLong() * RECORD_INTERVAL_MS
+            val stored = writeNative(
+                timestampMs / 1000L,
+                reading.first / 10f,
+                reading.second,
+                sensorId,
+            )
+            if (stored) storedDataNos += dataNo
+        }
+        if (storedDataNos.isEmpty()) {
+            return HistoryReplay(storedCount = 0, cursorReady = true)
+        }
+
+        val cursorReady = rewindNightscout(sensorId)
+        if (cursorReady) {
+            storedDataNos.forEach(pendingHistory::remove)
+        }
+        return HistoryReplay(storedCount = storedDataNos.size, cursorReady = cursorReady)
+    }
+
+    private data class HistoryReplay(
+        val storedCount: Int,
+        val cursorReady: Boolean,
+    )
 }

--- a/Common/src/test/cpp/DirectStreamMaintenanceTests.cpp
+++ b/Common/src/test/cpp/DirectStreamMaintenanceTests.cpp
@@ -1,0 +1,51 @@
+#define NOLOGS_H
+#include "inout.hpp"
+#include "directstreammaintenance.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+
+struct TestPoll {
+  uint32_t timestamp;
+  int value;
+};
+
+int main() {
+  char path[] = "/tmp/juggluco-direct-stream-XXXXXX";
+  const char *dir = mkdtemp(path);
+  assert(dir);
+
+  {
+    Mmap<TestPoll> polls(dir, "polls.dat", 15 * 24 * 60);
+    Mmap<uint16_t> raw(dir, "rawpolls.dat", 15 * 24 * 60);
+    Mmap<uint16_t> temperatures(dir, "temppolls.dat", 15 * 24 * 60);
+    polls.data()[120] = {1234u, 99};
+    raw.data()[120] = 77;
+    temperatures.data()[120] = 88;
+
+    assert(directstream::ensurePollStorageCapacity(
+        polls, raw, temperatures, dir, 30 * 24 * 60));
+    assert(polls.size() >= 30 * 24 * 60);
+    assert(raw.size() >= 30 * 24 * 60);
+    assert(temperatures.size() >= 30 * 24 * 60);
+    assert(polls.data()[120].timestamp == 1234u);
+    assert(polls.data()[120].value == 99);
+    assert(raw.data()[120] == 77);
+    assert(temperatures.data()[120] == 88);
+  }
+
+  {
+    Mmap<TestPoll> polls(dir, "polls.dat", 30 * 24 * 60);
+    assert(polls.size() >= 30 * 24 * 60);
+    assert(polls.data()[120].value == 99);
+  }
+
+  assert(directstream::nightSensorAfterRewind(7, 3) == 3);
+  assert(directstream::nightSensorAfterRewind(2, 3) == 2);
+  assert(directstream::nightSensorAfterRewind(0, 3) == 0);
+
+  std::filesystem::remove_all(dir);
+  return 0;
+}

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiLifetimeTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiLifetimeTests.kt
@@ -93,6 +93,15 @@ class OttaiLifetimeTests {
     }
 
     @Test
+    fun nativeStreamCapacityCoversAcceptedLifetimeWithinSupportedBounds() {
+        assertEquals(21_600, OttaiBleManager.nativeStreamCapacityMinutesFor(0L))
+        assertEquals(21_600, OttaiBleManager.nativeStreamCapacityMinutesFor(14L * DAY_MS))
+        assertEquals(36_000, OttaiBleManager.nativeStreamCapacityMinutesFor(25L * DAY_MS))
+        assertEquals(43_200, OttaiBleManager.nativeStreamCapacityMinutesFor(30L * DAY_MS))
+        assertEquals(43_200, OttaiBleManager.nativeStreamCapacityMinutesFor(40L * DAY_MS))
+    }
+
+    @Test
     fun endedSensorRecoveryIsLimitedToStatusFourInsideManagedLifetime() {
         val start = 1_000_000L
 

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiNativeGlucoseMirrorTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiNativeGlucoseMirrorTests.kt
@@ -1,0 +1,82 @@
+package tk.glucodata.drivers.ottai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OttaiNativeGlucoseMirrorTests {
+
+    @Test
+    fun historyReadingsUseNativeUnitsAndDoNotWakeNightscout() {
+        val timestampsSec = mutableListOf<Long>()
+        val nativeGlucose = mutableListOf<Float>()
+        val temperatures = mutableListOf<Float>()
+        val sensorIds = mutableListOf<String>()
+        val wakes = mutableListOf<Pair<String, Long>>()
+        val mirror = OttaiNativeGlucoseMirror(
+            writeNative = { timestampSec, glucose, temperature, sensorId ->
+                timestampsSec += timestampSec
+                nativeGlucose += glucose
+                temperatures += temperature
+                sensorIds += sensorId
+                true
+            },
+            wakeNightscout = { source, timestampMs -> wakes += source to timestampMs },
+        )
+
+        val stored = mirror.mirror(
+            sensorId = "AABBCCDDEEFF",
+            timestampsMs = longArrayOf(120_000L, 180_000L),
+            glucoseMgdl = floatArrayOf(108f, 126f),
+            temperaturesC = floatArrayOf(31.5f, 32f),
+            live = false,
+        )
+
+        assertEquals(2, stored)
+        assertEquals(listOf(120L, 180L), timestampsSec)
+        assertEquals(listOf(10.8f, 12.6f), nativeGlucose)
+        assertEquals(listOf(31.5f, 32f), temperatures)
+        assertEquals(listOf("AABBCCDDEEFF", "AABBCCDDEEFF"), sensorIds)
+        assertTrue(wakes.isEmpty())
+    }
+
+    @Test
+    fun successfulLiveWriteWakesNightscoutOnceAtNewestStoredTimestamp() {
+        val wakes = mutableListOf<Pair<String, Long>>()
+        val mirror = OttaiNativeGlucoseMirror(
+            writeNative = { timestampSec, _, _, _ -> timestampSec >= 180L },
+            wakeNightscout = { source, timestampMs -> wakes += source to timestampMs },
+        )
+
+        val stored = mirror.mirror(
+            sensorId = "AABBCCDDEEFF",
+            timestampsMs = longArrayOf(120_000L, 180_000L),
+            glucoseMgdl = floatArrayOf(108f, 126f),
+            temperaturesC = floatArrayOf(31.5f, 32f),
+            live = true,
+        )
+
+        assertEquals(1, stored)
+        assertEquals(listOf("ottai" to 180_000L), wakes)
+    }
+
+    @Test
+    fun failedLiveWriteDoesNotWakeNightscout() {
+        val wakes = mutableListOf<Pair<String, Long>>()
+        val mirror = OttaiNativeGlucoseMirror(
+            writeNative = { _, _, _, _ -> false },
+            wakeNightscout = { source, timestampMs -> wakes += source to timestampMs },
+        )
+
+        val stored = mirror.mirror(
+            sensorId = "AABBCCDDEEFF",
+            timestampsMs = longArrayOf(180_000L),
+            glucoseMgdl = floatArrayOf(126f),
+            temperaturesC = floatArrayOf(32f),
+            live = true,
+        )
+
+        assertEquals(0, stored)
+        assertTrue(wakes.isEmpty())
+    }
+}

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiNativeGlucoseMirrorTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiNativeGlucoseMirrorTests.kt
@@ -7,13 +7,19 @@ import org.junit.Test
 class OttaiNativeGlucoseMirrorTests {
 
     @Test
-    fun historyReadingsUseNativeUnitsAndDoNotWakeNightscout() {
+    fun unanchoredHistoryIsDeferredThenReplayedFromDataNo() {
+        val prepared = mutableListOf<Pair<String, Long>>()
         val timestampsSec = mutableListOf<Long>()
         val nativeGlucose = mutableListOf<Float>()
         val temperatures = mutableListOf<Float>()
         val sensorIds = mutableListOf<String>()
+        val rewinds = mutableListOf<String>()
         val wakes = mutableListOf<Pair<String, Long>>()
         val mirror = OttaiNativeGlucoseMirror(
+            prepareNative = { sensorId, startMs ->
+                prepared += sensorId to startMs
+                true
+            },
             writeNative = { timestampSec, glucose, temperature, sensorId ->
                 timestampsSec += timestampSec
                 nativeGlucose += glucose
@@ -21,39 +27,227 @@ class OttaiNativeGlucoseMirrorTests {
                 sensorIds += sensorId
                 true
             },
+            rewindNightscout = { sensorId ->
+                rewinds += sensorId
+                true
+            },
             wakeNightscout = { source, timestampMs -> wakes += source to timestampMs },
         )
 
-        val stored = mirror.mirror(
+        val deferred = mirror.mirrorHistory(
             sensorId = "AABBCCDDEEFF",
-            timestampsMs = longArrayOf(120_000L, 180_000L),
+            reliableStartMs = 0L,
+            dataNos = intArrayOf(19_000, 19_001),
             glucoseMgdl = floatArrayOf(108f, 126f),
             temperaturesC = floatArrayOf(31.5f, 32f),
-            live = false,
+        )
+
+        assertEquals(0, deferred)
+        assertTrue(prepared.isEmpty())
+        assertTrue(timestampsSec.isEmpty())
+        assertTrue(rewinds.isEmpty())
+
+        val stored = mirror.mirrorHistory(
+            sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 1_700_000_000_000L,
+            dataNos = intArrayOf(),
+            glucoseMgdl = floatArrayOf(),
+            temperaturesC = floatArrayOf(),
         )
 
         assertEquals(2, stored)
-        assertEquals(listOf(120L, 180L), timestampsSec)
+        assertEquals(listOf("AABBCCDDEEFF" to 1_700_000_000_000L), prepared)
+        assertEquals(listOf(1_701_140_000L, 1_701_140_060L), timestampsSec)
         assertEquals(listOf(10.8f, 12.6f), nativeGlucose)
         assertEquals(listOf(31.5f, 32f), temperatures)
         assertEquals(listOf("AABBCCDDEEFF", "AABBCCDDEEFF"), sensorIds)
+        assertEquals(listOf("AABBCCDDEEFF"), rewinds)
         assertTrue(wakes.isEmpty())
+    }
+
+    @Test
+    fun preparationFailureKeepsHistoryPendingAndDoesNotWrite() {
+        var preparationAllowed = false
+        var writerCalls = 0
+        val rewinds = mutableListOf<String>()
+        val mirror = OttaiNativeGlucoseMirror(
+            prepareNative = { _, _ -> preparationAllowed },
+            writeNative = { _, _, _, _ ->
+                writerCalls++
+                true
+            },
+            rewindNightscout = { sensorId ->
+                rewinds += sensorId
+                true
+            },
+            wakeNightscout = { _, _ -> },
+        )
+
+        val blocked = mirror.mirrorHistory(
+            sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 1_700_000_000_000L,
+            dataNos = intArrayOf(100),
+            glucoseMgdl = floatArrayOf(108f),
+            temperaturesC = floatArrayOf(31.5f),
+        )
+
+        assertEquals(0, blocked)
+        assertEquals(0, writerCalls)
+        assertTrue(rewinds.isEmpty())
+
+        preparationAllowed = true
+        val stored = mirror.mirrorHistory(
+            sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 1_700_000_000_000L,
+            dataNos = intArrayOf(),
+            glucoseMgdl = floatArrayOf(),
+            temperaturesC = floatArrayOf(),
+        )
+
+        assertEquals(1, stored)
+        assertEquals(1, writerCalls)
+        assertEquals(listOf("AABBCCDDEEFF"), rewinds)
+    }
+
+    @Test
+    fun successfulHistoryBatchRewindsOnceAndNeverUsesLiveWake() {
+        val rewinds = mutableListOf<String>()
+        val wakes = mutableListOf<Pair<String, Long>>()
+        val mirror = OttaiNativeGlucoseMirror(
+            prepareNative = { _, _ -> true },
+            writeNative = { _, _, _, _ -> true },
+            rewindNightscout = { sensorId ->
+                rewinds += sensorId
+                true
+            },
+            wakeNightscout = { source, timestampMs -> wakes += source to timestampMs },
+        )
+
+        val stored = mirror.mirrorHistory(
+            sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 1_700_000_000_000L,
+            dataNos = intArrayOf(100, 101, 102),
+            glucoseMgdl = floatArrayOf(108f, 126f, 144f),
+            temperaturesC = floatArrayOf(31.5f, 32f, 32.5f),
+        )
+
+        assertEquals(3, stored)
+        assertEquals(listOf("AABBCCDDEEFF"), rewinds)
+        assertTrue(wakes.isEmpty())
+    }
+
+    @Test
+    fun failedHistoryWriteRemainsPendingForLaterReplay() {
+        var writerAllowed = false
+        var writerCalls = 0
+        val rewinds = mutableListOf<String>()
+        val mirror = OttaiNativeGlucoseMirror(
+            prepareNative = { _, _ -> true },
+            writeNative = { _, _, _, _ ->
+                writerCalls++
+                writerAllowed
+            },
+            rewindNightscout = { sensorId ->
+                rewinds += sensorId
+                true
+            },
+            wakeNightscout = { _, _ -> },
+        )
+
+        val failed = mirror.mirrorHistory(
+            sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 1_700_000_000_000L,
+            dataNos = intArrayOf(100),
+            glucoseMgdl = floatArrayOf(108f),
+            temperaturesC = floatArrayOf(31.5f),
+        )
+
+        assertEquals(0, failed)
+        assertEquals(1, writerCalls)
+        assertTrue(rewinds.isEmpty())
+
+        writerAllowed = true
+        val stored = mirror.mirrorHistory(
+            sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 1_700_000_000_000L,
+            dataNos = intArrayOf(),
+            glucoseMgdl = floatArrayOf(),
+            temperaturesC = floatArrayOf(),
+        )
+
+        assertEquals(1, stored)
+        assertEquals(2, writerCalls)
+        assertEquals(listOf("AABBCCDDEEFF"), rewinds)
+    }
+
+    @Test
+    fun failedHistoryRewindBlocksLiveWriteAndWakeUntilRetrySucceeds() {
+        var rewindAllowed = false
+        val timestampsSec = mutableListOf<Long>()
+        val wakes = mutableListOf<Pair<String, Long>>()
+        val mirror = OttaiNativeGlucoseMirror(
+            prepareNative = { _, _ -> true },
+            writeNative = { timestampSec, _, _, _ ->
+                timestampsSec += timestampSec
+                true
+            },
+            rewindNightscout = { rewindAllowed },
+            wakeNightscout = { source, timestampMs -> wakes += source to timestampMs },
+        )
+
+        mirror.mirrorHistory(
+            sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 1_700_000_000_000L,
+            dataNos = intArrayOf(100),
+            glucoseMgdl = floatArrayOf(108f),
+            temperaturesC = floatArrayOf(31.5f),
+        )
+
+        val blocked = mirror.mirrorLive(
+            sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 1_700_000_000_000L,
+            timestampsMs = longArrayOf(1_700_010_000_000L),
+            glucoseMgdl = floatArrayOf(126f),
+            temperaturesC = floatArrayOf(32f),
+        )
+
+        assertEquals(1, blocked)
+        assertEquals(listOf(1_700_006_000L, 1_700_006_000L), timestampsSec)
+        assertTrue(wakes.isEmpty())
+
+        rewindAllowed = true
+        val stored = mirror.mirrorLive(
+            sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 1_700_000_000_000L,
+            timestampsMs = longArrayOf(1_700_010_000_000L),
+            glucoseMgdl = floatArrayOf(126f),
+            temperaturesC = floatArrayOf(32f),
+        )
+
+        assertEquals(2, stored)
+        assertEquals(
+            listOf(1_700_006_000L, 1_700_006_000L, 1_700_006_000L, 1_700_010_000L),
+            timestampsSec,
+        )
+        assertEquals(listOf("ottai" to 1_700_010_000_000L), wakes)
     }
 
     @Test
     fun successfulLiveWriteWakesNightscoutOnceAtNewestStoredTimestamp() {
         val wakes = mutableListOf<Pair<String, Long>>()
         val mirror = OttaiNativeGlucoseMirror(
+            prepareNative = { _, _ -> true },
             writeNative = { timestampSec, _, _, _ -> timestampSec >= 180L },
+            rewindNightscout = { true },
             wakeNightscout = { source, timestampMs -> wakes += source to timestampMs },
         )
 
-        val stored = mirror.mirror(
+        val stored = mirror.mirrorLive(
             sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 60_000L,
             timestampsMs = longArrayOf(120_000L, 180_000L),
             glucoseMgdl = floatArrayOf(108f, 126f),
             temperaturesC = floatArrayOf(31.5f, 32f),
-            live = true,
         )
 
         assertEquals(1, stored)
@@ -64,16 +258,18 @@ class OttaiNativeGlucoseMirrorTests {
     fun failedLiveWriteDoesNotWakeNightscout() {
         val wakes = mutableListOf<Pair<String, Long>>()
         val mirror = OttaiNativeGlucoseMirror(
+            prepareNative = { _, _ -> true },
             writeNative = { _, _, _, _ -> false },
+            rewindNightscout = { true },
             wakeNightscout = { source, timestampMs -> wakes += source to timestampMs },
         )
 
-        val stored = mirror.mirror(
+        val stored = mirror.mirrorLive(
             sensorId = "AABBCCDDEEFF",
+            reliableStartMs = 60_000L,
             timestampsMs = longArrayOf(180_000L),
             glucoseMgdl = floatArrayOf(126f),
             temperaturesC = floatArrayOf(32f),
-            live = true,
         )
 
         assertEquals(0, stored)


### PR DESCRIPTION
Коротко: именно с Ottai не работала выгрузка данных в Nightscout

TLDR: the Nightscout uploads didn't work, because the Ottai readings weren't mirrored into the native stream

---

Ottai readings were only stored in the managed Room history, while Nightscout reads from the native glucose stream. Accepted Ottai readings are now mirrored into that stream, matching other managed CGM integrations, with successful live readings triggering an upload wake.

Historical readings are mirrored without triggering per-reading uploads

coauthor + rereview by: gpt-5.6-sol xhigh