### PR TITLE
Add optional automatic sensor handover at expiry

### DIFF
--- a/Common/src/main/java/tk/glucodata/SensorHandoverNotifier.kt
+++ b/Common/src/main/java/tk/glucodata/SensorHandoverNotifier.kt
@@ -1,0 +1,94 @@
+package tk.glucodata
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+
+/**
+ * One-off informational notifications for the automatic sensor handover:
+ * the receipt after a switch (also the warming-up variant) and the warning
+ * when several successor candidates exist. Deliberately plain notifications,
+ * not alarms - the user should see the state change (even in the morning
+ * after sleeping through it), not be woken by it.
+ */
+internal object SensorHandoverNotifier {
+    private const val CHANNEL_ID = "SENSOR_HANDOVER"
+    private const val NOTIFICATION_ID_SWITCHED = 0x5348
+    private const val NOTIFICATION_ID_WARNING = 0x5349
+
+    fun notifySwitched(context: Context, oldSerial: String, newSerial: String) {
+        show(
+            context,
+            context.getString(R.string.sensor_handover_switched_text, oldSerial, newSerial),
+            NOTIFICATION_ID_SWITCHED
+        )
+    }
+
+    fun notifySwitchedWarming(context: Context, newSerial: String, warmupMinutes: Int) {
+        show(
+            context,
+            context.getString(R.string.sensor_handover_warming_text, newSerial, warmupMinutes),
+            NOTIFICATION_ID_SWITCHED
+        )
+    }
+
+    fun notifyMultipleCandidates(context: Context) {
+        show(context, context.getString(R.string.sensor_handover_multiple_text), NOTIFICATION_ID_WARNING)
+    }
+
+    private fun show(context: Context, text: String, notificationId: Int) {
+        val manager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager ?: return
+        createChannel(context, manager)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            notificationId,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.novalue)
+            .setContentTitle(context.getString(R.string.sensor_handover_title))
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setContentIntent(contentIntent)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(true)
+            .build()
+        manager.notify(notificationId, notification)
+    }
+
+    private fun createChannel(context: Context, manager: NotificationManager) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
+            manager.getNotificationChannel(CHANNEL_ID) != null
+        ) {
+            return
+        }
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.sensor_handover_title),
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                setShowBadge(false)
+            },
+        )
+    }
+}

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -113,6 +113,7 @@ object AlertRuntimeManager {
         }
         synchronized(lock) {
             lastReadingTimeMs = maxOf(lastReadingTimeMs, readingTimeMs)
+            SensorHandoverRuntime.onReading(sensorId)
             if (snapshot != null && snapshot.primaryValue.isFinite()) {
                 lastGlucoseValue = snapshot.primaryValue
                 lastRate = snapshot.rate
@@ -162,6 +163,7 @@ object AlertRuntimeManager {
             evaluateDeltaAlarmsLocked()
         }
         evaluateSensorExpiryLocked(nowMs)
+        SensorHandoverRuntime.evaluate(nowMs)
         return standardAlertEvaluation
     }
 
@@ -311,6 +313,12 @@ object AlertRuntimeManager {
         if (SnoozeManager.isSnoozed(type)) {
             return
         }
+        if (SensorHandoverRuntime.missedReadingSuppressed(nowMs)) {
+            // Post-handover window: the successor is still warming up; a short
+            // data gap during the switch must not alarm as an outage.
+            clearRuntimeAlert(type, "sensor-handover-window")
+            return
+        }
 
         val missed = nowMs - lastReadingTimeMs >= durationMs
         if (!missed) {
@@ -417,7 +425,7 @@ object AlertRuntimeManager {
         }
 
         val glucoseValue = currentGlucoseValueLocked() ?: return
-        val message = sensorExpiryMessage(triggered.first())
+        val message = SensorHandoverRuntime.decorateExpiryMessage(sensorExpiryMessage(triggered.first()), nowMs)
 
         triggerAlert(type, glucoseValue, currentRateLocked(), message)
     }

--- a/Common/src/main/java/tk/glucodata/alerts/SensorHandoverRuntime.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/SensorHandoverRuntime.kt
@@ -1,0 +1,379 @@
+package tk.glucodata.alerts
+
+import android.content.Context
+import androidx.core.content.edit
+import java.util.concurrent.Executors
+import tk.glucodata.Applic
+import tk.glucodata.CurrentDisplaySource
+import tk.glucodata.Log
+import tk.glucodata.MultiSensorSelection
+import tk.glucodata.Natives
+import tk.glucodata.R
+import tk.glucodata.SensorBluetooth
+import tk.glucodata.SensorHandoverNotifier
+import tk.glucodata.SensorIdentity
+import tk.glucodata.SuperGattCallback
+import tk.glucodata.UiRefreshBus
+import tk.glucodata.drivers.ManagedBluetoothSensorDriver
+
+/**
+ * Automatic sensor handover: when the primary sensor reaches its official end
+ * time and exactly one successor is active, the successor becomes primary and
+ * the expired sensor is deselected (optionally removed). Opt-in via
+ * [PREF_ENABLED]; with the switch off, [evaluate] returns before touching
+ * anything, so default behaviour is identical to before.
+ *
+ * [evaluate] runs on the [AlertRuntimeManager] tick (the same 15s cadence and
+ * end-time source as the sensor-expiry alarm) and only decides and latches
+ * there; the actual switch work (selection writes, BLE teardown on REMOVE,
+ * notifications) runs on a dedicated single thread so the alert lock is not
+ * held across it and incoming readings are never blocked.
+ */
+internal object SensorHandoverRuntime {
+    private const val LOG_ID = "SensorHandover"
+
+    const val PREF_ENABLED = "sensor_handover_enabled"
+    const val PREF_OLD_ACTION = "sensor_handover_old_action"
+    const val OLD_ACTION_DEACTIVATE = 0
+    const val OLD_ACTION_REMOVE = 1
+
+    private const val PREF_HANDLED = "sensor_handover_handled"
+    private const val PREF_WARNED = "sensor_handover_warned"
+    private const val PREF_SUPPRESS_UNTIL_MS = "sensor_handover_suppress_until_ms"
+    private const val PREF_SUPPRESS_SUCCESSOR = "sensor_handover_suppress_successor"
+
+    private const val PREFS_NAME = "tk.glucodata_preferences"
+
+    /** A successor counts as delivering when it has a reading at most this old. */
+    private const val RECENT_READING_MAX_AGE_MS = 15L * 60_000L
+
+    /** Side-effect thread; the alert lock is never held while a handover executes. */
+    private val executor = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "SensorHandover").apply { isDaemon = true }
+    }
+
+    private fun prefs() =
+        Applic.app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private fun latchKey(serial: String, endMs: Long) = "$serial|$endMs"
+
+    private val store = object : SensorHandoverStore {
+        override fun isHandled(serial: String, endMs: Long): Boolean =
+            runCatching { prefs().getString(PREF_HANDLED, null) == latchKey(serial, endMs) }
+                .getOrDefault(false)
+
+        override fun markHandled(serial: String, endMs: Long) {
+            runCatching { prefs().edit { putString(PREF_HANDLED, latchKey(serial, endMs)) } }
+        }
+
+        override fun isWarned(serial: String, endMs: Long): Boolean =
+            runCatching { prefs().getString(PREF_WARNED, null) == latchKey(serial, endMs) }
+                .getOrDefault(false)
+
+        override fun markWarned(serial: String, endMs: Long) {
+            runCatching { prefs().edit { putString(PREF_WARNED, latchKey(serial, endMs)) } }
+        }
+
+        override fun suppressionUntilMs(): Long =
+            runCatching { prefs().getLong(PREF_SUPPRESS_UNTIL_MS, 0L) }.getOrDefault(0L)
+
+        override fun suppressionSuccessor(): String? =
+            runCatching { prefs().getString(PREF_SUPPRESS_SUCCESSOR, null) }.getOrNull()
+
+        override fun openSuppression(untilMs: Long, successorSerial: String) {
+            runCatching {
+                prefs().edit {
+                    putLong(PREF_SUPPRESS_UNTIL_MS, untilMs)
+                    putString(PREF_SUPPRESS_SUCCESSOR, successorSerial)
+                }
+            }
+        }
+
+        override fun clearSuppression() {
+            runCatching {
+                prefs().edit {
+                    remove(PREF_SUPPRESS_UNTIL_MS)
+                    remove(PREF_SUPPRESS_SUCCESSOR)
+                }
+            }
+        }
+    }
+
+    private val state = SensorHandoverState(store, SensorIdentity::matches)
+
+    fun isEnabled(): Boolean =
+        runCatching { prefs().getBoolean(PREF_ENABLED, false) }.getOrDefault(false)
+
+    private fun oldSensorAction(): Int =
+        runCatching { prefs().getInt(PREF_OLD_ACTION, OLD_ACTION_DEACTIVATE) }
+            .getOrDefault(OLD_ACTION_DEACTIVATE)
+
+    /** Snapshot of the live sensor registry, split into primary and the rest. */
+    private class Roster(
+        val primary: HandoverSensor?,
+        val others: List<HandoverSensor>,
+        val allSerials: List<String>
+    )
+
+    private fun buildRoster(): Roster? {
+        val gatts = runCatching { SensorBluetooth.mygatts() }.getOrNull() ?: return null
+        if (gatts.isEmpty()) return null
+        val primarySerial = runCatching { SensorIdentity.resolveMainSensor() }.getOrNull()
+        if (primarySerial.isNullOrEmpty()) return null
+        val activeSet = (runCatching { Natives.activeSensors() }.getOrNull() ?: emptyArray())
+            .filterNotNull()
+            .toHashSet()
+
+        var primary: HandoverSensor? = null
+        val others = mutableListOf<HandoverSensor>()
+        val allSerials = mutableListOf<String>()
+        for (gatt in gatts) {
+            val serial = gatt.SerialNumber ?: continue
+            if (!SensorIdentity.isUsableSensorId(serial)) continue
+            val managedOutsideNative = gatt is ManagedBluetoothSensorDriver &&
+                gatt.isManagedOutsideNativeActiveSet()
+            if (!managedOutsideNative && !activeSet.contains(serial)) continue
+
+            val snapshot = if (gatt is ManagedBluetoothSensorDriver) {
+                runCatching { gatt.getManagedUiSnapshot(primarySerial) }.getOrNull()
+            } else {
+                null
+            }
+            val nativeEnd = if (gatt.dataptr != 0L) {
+                runCatching { Natives.getSensorEndTime(gatt.dataptr, true) }.getOrDefault(0L)
+            } else {
+                0L
+            }
+            val endMs = if (nativeEnd > 0L) nativeEnd else snapshot?.officialEndMs ?: 0L
+            val nativeStart = if (gatt.dataptr != 0L) {
+                runCatching { Natives.getSensorStartmsec(gatt.dataptr) }.getOrDefault(0L)
+            } else {
+                0L
+            }
+            val startMs = if (nativeStart > 0L) nativeStart else snapshot?.startTimeMs ?: 0L
+
+            allSerials.add(serial)
+            val sensor = HandoverSensor(serial, startMs, endMs) { hasRecentReading(serial) }
+            if (SensorIdentity.matches(serial, primarySerial)) {
+                if (primary == null) primary = sensor
+            } else if (others.none { SensorIdentity.matches(it.serial, serial) }) {
+                // One physical sensor can sit in the registry under several
+                // serial forms (ICN- alias, short tail, vendor-padded); collapse
+                // them so an alias twin cannot fake a second candidate.
+                others.add(sensor)
+            }
+        }
+        return Roster(primary, others, allSerials)
+    }
+
+    private fun hasRecentReading(serial: String): Boolean {
+        val snapshot = runCatching {
+            CurrentDisplaySource.resolveCurrent(RECENT_READING_MAX_AGE_MS, serial)
+        }.getOrNull() ?: return false
+        if (!snapshot.primaryValue.isFinite() || snapshot.timeMillis <= 0L) return false
+        return System.currentTimeMillis() - snapshot.timeMillis <= RECENT_READING_MAX_AGE_MS
+    }
+
+    /** Called from the alert tick; decides and latches only, never throws. */
+    fun evaluate(nowMs: Long) {
+        try {
+            if (!isEnabled()) return
+            val roster = buildRoster() ?: return
+            val primary = roster.primary ?: return
+            when (val decision = state.evaluate(true, primary, roster.others, nowMs)) {
+                is HandoverDecision.None -> {}
+                is HandoverDecision.WarnMultiple -> {
+                    store.markWarned(primary.serial, primary.endMs)
+                    Log.i(
+                        LOG_ID,
+                        "Multiple successor candidates ${decision.candidateSerials} for expired " +
+                            "${decision.expiredSerial}; not switching automatically"
+                    )
+                    executor.execute {
+                        runCatching { SensorHandoverNotifier.notifyMultipleCandidates(Applic.app) }
+                    }
+                }
+                is HandoverDecision.Switch -> {
+                    // Latch before acting: a crash mid-switch must not retrigger
+                    // the handover on the next tick (at-most-once per expiry).
+                    store.markHandled(primary.serial, primary.endMs)
+                    val warmupMinutes = warmupMinutesEstimate(roster, decision.newSerial, nowMs)
+                    if (decision.successorWarming) {
+                        // Open the window before the switch so a missed-reading
+                        // check between switch and notification cannot fire.
+                        state.openMissedReadingSuppression(nowMs, decision.newSerial)
+                    }
+                    executor.execute { performHandover(roster, decision, warmupMinutes) }
+                }
+            }
+        } catch (t: Throwable) {
+            Log.stack(LOG_ID, "evaluate", t)
+        }
+    }
+
+    private fun performHandover(
+        roster: Roster,
+        decision: HandoverDecision.Switch,
+        warmupMinutes: Int
+    ) {
+        Log.i(
+            LOG_ID,
+            "Handover: ${decision.oldSerial} expired -> promoting ${decision.newSerial}" +
+                if (decision.successorWarming) " (successor still warming up)" else ""
+        )
+
+        // Promote the successor through the existing selection machinery and
+        // deselect the expired sensor (the equivalent of unchecking it on its
+        // card) in a single write. The expired sensor stays in the sensor list
+        // until removed or aged out. Note: unlike a manual promotion this does
+        // not run HistorySync.mergeFullSyncForSensor (mobile-only); the
+        // successor's history is already in Room from its time as a peer.
+        runCatching {
+            val selected = MultiSensorSelection.selectedAvailable(roster.allSerials, decision.newSerial)
+            val next = listOf(decision.newSerial) + selected.filterNot {
+                SensorIdentity.matches(it, decision.newSerial) ||
+                    SensorIdentity.matches(it, decision.oldSerial)
+            }
+            MultiSensorSelection.setSelectedOrder(next)
+        }
+        runCatching { SensorBluetooth.setCurrentSensorSelection(decision.newSerial) }
+
+        val promoted = runCatching {
+            SensorIdentity.matches(SensorIdentity.resolveMainSensor(), decision.newSerial)
+        }.getOrDefault(false)
+        if (!promoted) {
+            // Latched already, so this expiry will not be retried - surface it
+            // loudly in the log instead of sending a false success receipt.
+            Log.e(LOG_ID, "Handover promotion did not take: ${decision.newSerial} is not primary")
+            store.clearSuppression()
+            return
+        }
+
+        if (oldSensorAction() == OLD_ACTION_REMOVE) {
+            removeOldSensor(decision.oldSerial)
+        }
+
+        runCatching {
+            if (decision.successorWarming) {
+                SensorHandoverNotifier.notifySwitchedWarming(
+                    Applic.app, decision.newSerial, warmupMinutes
+                )
+            } else {
+                SensorHandoverNotifier.notifySwitched(
+                    Applic.app, decision.oldSerial, decision.newSerial
+                )
+            }
+        }
+
+        runCatching { UiRefreshBus.requestDataRefresh() }
+    }
+
+    private fun warmupMinutesEstimate(roster: Roster, successorSerial: String, nowMs: Long): Int {
+        val startMs = roster.others.firstOrNull { it.serial == successorSerial }?.startMs ?: 0L
+        val warmupMinutes = SensorHandoverState.WARMUP_DURATION_MS / 60_000L
+        if (startMs <= 0L) return warmupMinutes.toInt()
+        val remaining = (startMs + SensorHandoverState.WARMUP_DURATION_MS - nowMs) / 60_000L
+        return remaining.coerceIn(1L, warmupMinutes).toInt()
+    }
+
+    /**
+     * The REMOVE option: the full forget path of the existing remove dialog
+     * (mirrors SensorViewModel.forgetSensor, which is UI-scoped and therefore
+     * not callable from here). Wipes pairing keys and removes the sensor from
+     * list and prefs; measurement history is untouched (there is no history
+     * delete in this path).
+     */
+    private fun removeOldSensor(serial: String) {
+        Log.i(LOG_ID, "Removing expired sensor $serial after handover")
+        val gatt = findGatt(serial)
+        if (gatt != null) {
+            if (gatt is ManagedBluetoothSensorDriver) {
+                // Managed drivers own their teardown (AiDex wipes vendor keys here).
+                runCatching {
+                    gatt.terminateManagedSensor(wipeData = false)
+                    gatt.removeManagedPersistence(Applic.app)
+                }.onFailure { Log.e(LOG_ID, "managed teardown failed: ${it.message}") }
+                runCatching { SensorBluetooth.sensorEnded(serial) }
+                runCatching { SensorBluetooth.startscan() }
+                return
+            }
+            // Legacy native path: stop BLE processing and mark finished before
+            // removing from the Java list (same order as the remove dialog).
+            runCatching {
+                gatt.setPause(true)
+                gatt.disconnect()
+                if (gatt.dataptr != 0L) gatt.finishSensor()
+            }.onFailure { Log.e(LOG_ID, "finishSensor failed: ${it.message}") }
+            runCatching {
+                if (gatt.dataptr != 0L && Natives.isSibionics(gatt.dataptr)) {
+                    Natives.siClearTransmitterBinding(gatt.dataptr)
+                    runCatching { gatt.setDeviceAddress(null) }
+                }
+            }.onFailure { Log.e(LOG_ID, "clear transmitter binding failed: ${it.message}") }
+            runCatching { gatt.close() }
+        }
+        removeAiDexFromPrefs(serial)
+        runCatching { SensorBluetooth.sensorEnded(serial) }
+        runCatching { SensorBluetooth.startscan() }
+    }
+
+    private fun findGatt(serial: String): SuperGattCallback? {
+        val gatts = runCatching { SensorBluetooth.mygatts() }.getOrNull() ?: return null
+        return gatts.firstOrNull { it.SerialNumber == serial }
+            ?: gatts.firstOrNull { SensorIdentity.matches(it.SerialNumber, serial) }
+            ?: gatts.firstOrNull {
+                (it as? ManagedBluetoothSensorDriver)?.matchesManagedSensorId(serial) == true
+            }
+    }
+
+    /** Mirror of SensorViewModel.removeAiDexFromPrefs (UI-scoped there). */
+    private fun removeAiDexFromPrefs(serial: String) {
+        runCatching {
+            val prefs = prefs()
+            val sensors = prefs.getStringSet("aidex_sensors", null) ?: return
+            val updated = HashSet(sensors)
+            val removed = updated.removeAll { it.startsWith("$serial|") || it == serial }
+            if (removed) {
+                prefs.edit().putStringSet("aidex_sensors", updated).commit()
+                SensorIdentity.invalidateCaches()
+            }
+        }.onFailure { Log.e(LOG_ID, "removeAiDexFromPrefs failed: ${it.message}") }
+    }
+
+    /** Missed-reading gate for [AlertRuntimeManager]: true while the post-handover window is open. */
+    fun missedReadingSuppressed(nowMs: Long): Boolean {
+        return runCatching {
+            if (!isEnabled()) {
+                // Turning the feature off must not leave a suppression behind.
+                if (store.suppressionUntilMs() > 0L) store.clearSuppression()
+                return@runCatching false
+            }
+            state.missedReadingSuppressed(nowMs)
+        }.getOrDefault(false)
+    }
+
+    /** Reading tap-in from [AlertRuntimeManager.onNewReading]; closes the window on the successor's first data. */
+    fun onReading(sensorId: String?) {
+        runCatching { state.onReading(sensorId) }
+    }
+
+    /**
+     * Sensor-expiry alarm interlock: when the handover is armed and a unique,
+     * already-delivering successor exists, the expiry warning is reworded as
+     * "successor ready" instead of a bare problem report - the app is about to
+     * solve this itself. The expiry latch and its persistence stay untouched.
+     */
+    fun decorateExpiryMessage(message: String, nowMs: Long): String {
+        return try {
+            if (!isEnabled()) return message
+            val roster = buildRoster() ?: return message
+            if (roster.primary == null) return message
+            val candidates = roster.others.filter { it.endMs <= 0L || it.endMs > nowMs }
+            val successor = candidates.singleOrNull() ?: return message
+            if (!successor.hasRecentReading()) return message
+            message + " - " + Applic.app.getString(R.string.sensor_handover_successor_ready)
+        } catch (t: Throwable) {
+            message
+        }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/alerts/SensorHandoverState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/SensorHandoverState.kt
@@ -1,0 +1,163 @@
+package tk.glucodata.alerts
+
+/**
+ * One sensor as the handover evaluation sees it. [endMs] is the official end
+ * (start + wear duration, the same source the expiry alarm uses); 0 means
+ * unknown. [hasRecentReading] is evaluated lazily because it needs a history
+ * lookup - the decision only asks for it on the chosen successor.
+ */
+internal data class HandoverSensor(
+    val serial: String,
+    val startMs: Long,
+    val endMs: Long,
+    val hasRecentReading: () -> Boolean = { false }
+)
+
+internal sealed class HandoverDecision {
+    object None : HandoverDecision()
+
+    /** Switch primary from [oldSerial] to [newSerial]. [successorWarming] when the successor is inside its warmup phase with no reading yet. */
+    data class Switch(
+        val oldSerial: String,
+        val newSerial: String,
+        val successorWarming: Boolean
+    ) : HandoverDecision()
+
+    /** More than one possible successor - no automation, the user decides. */
+    data class WarnMultiple(
+        val expiredSerial: String,
+        val candidateSerials: List<String>
+    ) : HandoverDecision()
+}
+
+/**
+ * Durable handover state. Production backs this with SharedPreferences
+ * ([SensorHandoverRuntime.store]); tests inject a fake. Latches are keyed on
+ * the expiring sensor's serial plus its end time so two sensors sharing an
+ * end timestamp cannot swallow each other's handover.
+ */
+internal interface SensorHandoverStore {
+    /** True when the handover for this expiry was already performed (or attempted). */
+    fun isHandled(serial: String, endMs: Long): Boolean
+
+    fun markHandled(serial: String, endMs: Long)
+
+    /** True when the multiple-candidates warning for this expiry already fired. */
+    fun isWarned(serial: String, endMs: Long): Boolean
+
+    fun markWarned(serial: String, endMs: Long)
+
+    /** Missed-reading suppression window end (ms); 0 when no window is open. */
+    fun suppressionUntilMs(): Long
+
+    /** Serial of the successor whose first reading closes the window. */
+    fun suppressionSuccessor(): String?
+
+    fun openSuppression(untilMs: Long, successorSerial: String)
+
+    fun clearSuppression()
+}
+
+/**
+ * Decision logic for the automatic sensor handover, kept free of Android and
+ * native dependencies so it is unit-testable.
+ *
+ * Trigger: the primary sensor's official end time has passed and a successor
+ * exists. There is nothing to wait for beyond that - past its end the old
+ * sensor no longer counts as the source of truth. A successor that is still
+ * warming up is switched to regardless (it is the only source); the caller
+ * shows an informational notification for that case.
+ *
+ * Exactly-once: the caller persists the handled key via
+ * [SensorHandoverStore.markHandled] *before* performing the switch, so a
+ * process restart cannot repeat a handover (at-most-once semantics). The
+ * multiple-candidates warning has its own latch ([SensorHandoverStore.markWarned])
+ * so it fires once per expiry - but the switch itself stays armed: if the
+ * ambiguity is resolved (one candidate removed) the handover still happens.
+ */
+internal class SensorHandoverState(
+    private val store: SensorHandoverStore,
+    private val matches: (String?, String?) -> Boolean = { a, b -> a == b }
+) {
+
+    fun evaluate(
+        enabled: Boolean,
+        primary: HandoverSensor?,
+        others: List<HandoverSensor>,
+        nowMs: Long
+    ): HandoverDecision {
+        if (!enabled || primary == null) return HandoverDecision.None
+        // Unknown end (0) never triggers; the expiry has to be positively known.
+        if (primary.endMs <= 0L || primary.endMs > nowMs) return HandoverDecision.None
+        if (store.isHandled(primary.serial, primary.endMs)) return HandoverDecision.None
+
+        // A successor must not itself be expired; sensors with unknown ends stay
+        // candidates (they are in the active list, so they are running).
+        val candidates = others.filter { it.endMs <= 0L || it.endMs > nowMs }
+        // No successor: nothing happens, behaviour as today. Deliberately not
+        // latched - a successor scanned after the expiry still gets the handover.
+        if (candidates.isEmpty()) return HandoverDecision.None
+        if (candidates.size > 1) {
+            // Warn once per expiry, but keep the switch armed: dropping back to
+            // a single candidate resumes the automation.
+            return if (store.isWarned(primary.serial, primary.endMs)) {
+                HandoverDecision.None
+            } else {
+                HandoverDecision.WarnMultiple(primary.serial, candidates.map { it.serial })
+            }
+        }
+        val successor = candidates.single()
+        // "Warming" strictly means inside the warmup phase after activation. A
+        // successor that is merely disconnected (old start, no readings) is NOT
+        // warming - it gets no suppression window, so a real outage still alarms.
+        val warming = successor.startMs > 0L &&
+            nowMs - successor.startMs < WARMUP_DURATION_MS &&
+            !successor.hasRecentReading()
+        return HandoverDecision.Switch(
+            oldSerial = primary.serial,
+            newSerial = successor.serial,
+            successorWarming = warming
+        )
+    }
+
+    /**
+     * Open the missed-reading suppression window after a handover to a
+     * still-warming successor. A brief data gap while the successor warms up
+     * must not alarm as an outage; the window closes on the successor's first
+     * reading or after [MISSED_READING_GRACE_MS] (then missed-reading resumes
+     * normally, which is the fallback warning).
+     */
+    fun openMissedReadingSuppression(nowMs: Long, successorSerial: String) {
+        store.openSuppression(nowMs + MISSED_READING_GRACE_MS, successorSerial)
+    }
+
+    fun missedReadingSuppressed(nowMs: Long): Boolean {
+        val until = store.suppressionUntilMs()
+        if (until <= 0L) return false
+        if (nowMs >= until) {
+            store.clearSuppression()
+            return false
+        }
+        return true
+    }
+
+    /** A reading from the awaited successor ends the suppression window. */
+    fun onReading(sensorId: String?) {
+        if (store.suppressionUntilMs() <= 0L) return
+        val successor = store.suppressionSuccessor()
+        if (successor.isNullOrEmpty() || matches(sensorId, successor)) {
+            store.clearSuppression()
+        }
+    }
+
+    companion object {
+        /**
+         * Warmup phase of a freshly activated sensor (Libre 3: ~1h). Bounds
+         * both the "warming" classification and the suppression window; if no
+         * reading arrives by the end of it, the missed-reading alarm resumes
+         * as the fallback.
+         */
+        const val WARMUP_DURATION_MS = 60L * 60_000L
+        const val MISSED_READING_GRACE_MS = WARMUP_DURATION_MS
+    }
+}

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2301,4 +2301,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="stats_pinned_remove">Прыбраць з галоўнага</string>
     <string name="stats_pinned_already">замацавана</string>
     <string name="stats_pinned_remove_short">Прыбраць</string>
+    <string name="sensor_handover_title">Аўтаматычная перадача сенсара</string>
+    <string name="sensor_handover_desc">Актывуйце наступны сенсар загадзя; калі стары сенсар скончыцца, праграма аўтаматычна пераключыцца на пераемніка</string>
+    <string name="sensor_handover_old_action_title">Скончаны сенсар пасля перадачы</string>
+    <string name="sensor_handover_old_action_desc">Дэактываваць: скончаны сенсар застаецца ў спісе, пакуль вы яго не выдаліце. Выдаліць: як у акне выдалення, ключы спалучэння сціраюцца. Гісторыя вымярэнняў захоўваецца ў абодвух выпадках.</string>
+    <string name="sensor_handover_action_deactivate">Дэактываваць</string>
+    <string name="sensor_handover_action_remove">Выдаліць</string>
+    <string name="sensor_handover_switched_text">Пераключана з %1$s на %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s цяпер крыніца даных, але яшчэ праграваецца (каля %2$d хв). Паказанні аднавяцца пасля прагрэву.</string>
+    <string name="sensor_handover_multiple_text">Сенсар скончыўся, але актыўныя некалькі сенсараў-пераемнікаў. Аўтаматычная перадача прапушчана; пераключыцеся ўручную.</string>
+    <string name="sensor_handover_successor_ready">Сенсар-пераемнік гатовы; аўтаматычная перадача спрацуе пры заканчэнні</string>
 </resources>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2273,4 +2273,14 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="stats_pinned_remove">Vom Dashboard entfernen</string>
     <string name="stats_pinned_already">angeheftet</string>
     <string name="stats_pinned_remove_short">Entfernen</string>
+    <string name="sensor_handover_title">Automatische Sensor-Übergabe</string>
+    <string name="sensor_handover_desc">Nachfolge-Sensor rechtzeitig vorher aktivieren; läuft der alte Sensor ab, wechselt die App automatisch auf den Nachfolger</string>
+    <string name="sensor_handover_old_action_title">Abgelaufener Sensor nach der Übergabe</string>
+    <string name="sensor_handover_old_action_desc">Deaktivieren: der abgelaufene Sensor bleibt in der Liste, bis Sie ihn entfernen. Entfernen: wie die Entfernen-Maske, Kopplungsschlüssel werden gelöscht. Messdaten bleiben in beiden Fällen erhalten.</string>
+    <string name="sensor_handover_action_deactivate">Deaktivieren</string>
+    <string name="sensor_handover_action_remove">Entfernen</string>
+    <string name="sensor_handover_switched_text">Von %1$s auf %2$s gewechselt</string>
+    <string name="sensor_handover_warming_text">%1$s ist jetzt die Datenquelle, wärmt aber noch auf (ca. %2$d Min.). Werte kommen wieder, sobald die Aufwärmphase abgeschlossen ist.</string>
+    <string name="sensor_handover_multiple_text">Der Sensor ist abgelaufen, aber mehrere Nachfolge-Sensoren sind aktiv. Automatische Übergabe übersprungen; bitte manuell wechseln.</string>
+    <string name="sensor_handover_successor_ready">Nachfolge-Sensor ist bereit; die automatische Übergabe übernimmt beim Ablauf</string>
 </resources>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2240,4 +2240,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="stats_pinned_remove">Retirer du Tableau de bord</string>
     <string name="stats_pinned_already">épinglé</string>
     <string name="stats_pinned_remove_short">Retirer</string>
+    <string name="sensor_handover_title">Transfert automatique de capteur</string>
+    <string name="sensor_handover_desc">Activez le capteur successeur à l\'avance ; à l\'expiration de l\'ancien capteur, l\'application bascule automatiquement vers le successeur</string>
+    <string name="sensor_handover_old_action_title">Capteur expiré après le transfert</string>
+    <string name="sensor_handover_old_action_desc">Désactiver : le capteur expiré reste dans la liste jusqu\'à sa suppression. Supprimer : comme la boîte de suppression, les clés d\'appairage sont effacées. L\'historique des mesures est conservé dans les deux cas.</string>
+    <string name="sensor_handover_action_deactivate">Désactiver</string>
+    <string name="sensor_handover_action_remove">Supprimer</string>
+    <string name="sensor_handover_switched_text">Passage de %1$s à %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s est désormais la source de données mais est encore en préchauffage (environ %2$d min). Les mesures reprennent une fois le préchauffage terminé.</string>
+    <string name="sensor_handover_multiple_text">Le capteur a expiré, mais plusieurs capteurs successeurs sont actifs. Transfert automatique ignoré ; veuillez changer manuellement.</string>
+    <string name="sensor_handover_successor_ready">Le capteur successeur est prêt ; le transfert automatique prendra le relais à l\'expiration</string>
 </resources>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2224,4 +2224,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="stats_pinned_remove">Rimuovi dalla Dashboard</string>
     <string name="stats_pinned_already">fissato</string>
     <string name="stats_pinned_remove_short">Rimuovi</string>
+    <string name="sensor_handover_title">Passaggio automatico del sensore</string>
+    <string name="sensor_handover_desc">Attiva il sensore successore in anticipo; alla scadenza del vecchio sensore l\'app passa automaticamente al successore</string>
+    <string name="sensor_handover_old_action_title">Sensore scaduto dopo il passaggio</string>
+    <string name="sensor_handover_old_action_desc">Disattiva: il sensore scaduto resta nell\'elenco finché non lo rimuovi. Rimuovi: come la finestra di rimozione, le chiavi di associazione vengono eliminate. Lo storico delle misurazioni viene comunque conservato.</string>
+    <string name="sensor_handover_action_deactivate">Disattiva</string>
+    <string name="sensor_handover_action_remove">Rimuovi</string>
+    <string name="sensor_handover_switched_text">Passato da %1$s a %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s è ora la sorgente dati ma è ancora in riscaldamento (circa %2$d min). Le letture riprendono al termine del riscaldamento.</string>
+    <string name="sensor_handover_multiple_text">Il sensore è scaduto, ma sono attivi più sensori successori. Passaggio automatico saltato; cambia manualmente.</string>
+    <string name="sensor_handover_successor_ready">Il sensore successore è pronto; il passaggio automatico interverrà alla scadenza</string>
 </resources>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2349,4 +2349,14 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="stats_pinned_remove">Хяналтын самбараас хасах</string>
     <string name="stats_pinned_already">бэхлэгдсэн</string>
     <string name="stats_pinned_remove_short">Хасах</string>
+    <string name="sensor_handover_title">Мэдрэгчийн автомат шилжүүлэг</string>
+    <string name="sensor_handover_desc">Дараагийн мэдрэгчийг урьдчилан идэвхжүүлнэ үү; хуучин мэдрэгчийн хугацаа дуусахад апп автоматаар залгамжлагч руу шилжинэ</string>
+    <string name="sensor_handover_old_action_title">Шилжүүлгийн дараах хугацаа дууссан мэдрэгч</string>
+    <string name="sensor_handover_old_action_desc">Идэвхгүй болгох: хугацаа дууссан мэдрэгч устгах хүртэл жагсаалтад үлдэнэ. Устгах: устгах цонхтой адил, хослуулах түлхүүрүүд устана. Хэмжилтийн түүх хоёр тохиолдолд хадгалагдана.</string>
+    <string name="sensor_handover_action_deactivate">Идэвхгүй болгох</string>
+    <string name="sensor_handover_action_remove">Устгах</string>
+    <string name="sensor_handover_switched_text">%1$s-ээс %2$s руу шилжлээ</string>
+    <string name="sensor_handover_warming_text">%1$s одоо өгөгдлийн эх үүсвэр боловч халаалт үргэлжилж байна (ойролцоогоор %2$d мин). Халаалт дуусмагц хэмжилт үргэлжилнэ.</string>
+    <string name="sensor_handover_multiple_text">Мэдрэгчийн хугацаа дууссан ч хэд хэдэн залгамжлагч мэдрэгч идэвхтэй байна. Автомат шилжүүлгийг алгаслаа; гараар шилжүүлнэ үү.</string>
+    <string name="sensor_handover_successor_ready">Залгамжлагч мэдрэгч бэлэн; хугацаа дуусахад автомат шилжүүлэг ажиллана</string>
 </resources>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2277,4 +2277,14 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="stats_pinned_remove">Van Dashboard verwijderen</string>
     <string name="stats_pinned_already">vastgezet</string>
     <string name="stats_pinned_remove_short">Verwijderen</string>
+    <string name="sensor_handover_title">Automatische sensoroverdracht</string>
+    <string name="sensor_handover_desc">Activeer de opvolgende sensor ruim van tevoren; wanneer de oude sensor verloopt, schakelt de app automatisch over naar de opvolger</string>
+    <string name="sensor_handover_old_action_title">Verlopen sensor na de overdracht</string>
+    <string name="sensor_handover_old_action_desc">Deactiveren: de verlopen sensor blijft in de lijst totdat je hem verwijdert. Verwijderen: zoals het verwijdervenster, koppelingssleutels worden gewist. Meetgeschiedenis blijft in beide gevallen bewaard.</string>
+    <string name="sensor_handover_action_deactivate">Deactiveren</string>
+    <string name="sensor_handover_action_remove">Verwijderen</string>
+    <string name="sensor_handover_switched_text">Overgeschakeld van %1$s naar %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s is nu de gegevensbron maar is nog aan het opwarmen (ongeveer %2$d min). Metingen hervatten zodra het opwarmen klaar is.</string>
+    <string name="sensor_handover_multiple_text">De sensor is verlopen, maar er zijn meerdere opvolgende sensoren actief. Automatische overdracht overgeslagen; schakel handmatig over.</string>
+    <string name="sensor_handover_successor_ready">Opvolgende sensor is klaar; de automatische overdracht neemt het over bij verlopen</string>
 </resources>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2269,4 +2269,14 @@
     <string name="stats_pinned_remove">Usuń z Pulpitu</string>
     <string name="stats_pinned_already">przypięte</string>
     <string name="stats_pinned_remove_short">Usuń</string>
+    <string name="sensor_handover_title">Automatyczne przełączenie czujnika</string>
+    <string name="sensor_handover_desc">Aktywuj następny czujnik odpowiednio wcześniej; gdy stary czujnik wygaśnie, aplikacja automatycznie przełączy się na następcę</string>
+    <string name="sensor_handover_old_action_title">Wygasły czujnik po przełączeniu</string>
+    <string name="sensor_handover_old_action_desc">Dezaktywuj: wygasły czujnik pozostaje na liście, dopóki go nie usuniesz. Usuń: jak w oknie usuwania, klucze parowania zostają skasowane. Historia pomiarów jest zachowana w obu przypadkach.</string>
+    <string name="sensor_handover_action_deactivate">Dezaktywuj</string>
+    <string name="sensor_handover_action_remove">Usuń</string>
+    <string name="sensor_handover_switched_text">Przełączono z %1$s na %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s jest teraz źródłem danych, ale wciąż się rozgrzewa (około %2$d min). Odczyty wznowią się po zakończeniu rozgrzewania.</string>
+    <string name="sensor_handover_multiple_text">Czujnik wygasł, ale aktywnych jest kilka czujników następczych. Pominięto automatyczne przełączenie; przełącz ręcznie.</string>
+    <string name="sensor_handover_successor_ready">Czujnik następczy jest gotowy; automatyczne przełączenie nastąpi po wygaśnięciu</string>
 </resources>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2235,4 +2235,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="stats_pinned_remove">Remover do Painel</string>
     <string name="stats_pinned_already">fixado</string>
     <string name="stats_pinned_remove_short">Remover</string>
+    <string name="sensor_handover_title">Transferência automática de sensor</string>
+    <string name="sensor_handover_desc">Ative o sensor sucessor com antecedência; quando o sensor antigo expirar, o aplicativo muda automaticamente para o sucessor</string>
+    <string name="sensor_handover_old_action_title">Sensor expirado após a transferência</string>
+    <string name="sensor_handover_old_action_desc">Desativar: o sensor expirado permanece na lista até você removê-lo. Remover: como a caixa de remoção, as chaves de pareamento são apagadas. O histórico de medições é mantido em ambos os casos.</string>
+    <string name="sensor_handover_action_deactivate">Desativar</string>
+    <string name="sensor_handover_action_remove">Remover</string>
+    <string name="sensor_handover_switched_text">Mudou de %1$s para %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s agora é a fonte de dados, mas ainda está aquecendo (cerca de %2$d min). As leituras retomam quando o aquecimento terminar.</string>
+    <string name="sensor_handover_multiple_text">O sensor expirou, mas há vários sensores sucessores ativos. Transferência automática ignorada; mude manualmente.</string>
+    <string name="sensor_handover_successor_ready">O sensor sucessor está pronto; a transferência automática assume na expiração</string>
 </resources>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2277,4 +2277,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="stats_pinned_remove">Убрать с главного</string>
     <string name="stats_pinned_already">закреплено</string>
     <string name="stats_pinned_remove_short">Убрать</string>
+    <string name="sensor_handover_title">Автоматическая передача сенсора</string>
+    <string name="sensor_handover_desc">Активируйте следующий сенсор заранее; когда старый сенсор истечёт, приложение автоматически переключится на преемника</string>
+    <string name="sensor_handover_old_action_title">Истёкший сенсор после передачи</string>
+    <string name="sensor_handover_old_action_desc">Деактивировать: истёкший сенсор остаётся в списке, пока вы его не удалите. Удалить: как в окне удаления, ключи сопряжения стираются. История измерений сохраняется в обоих случаях.</string>
+    <string name="sensor_handover_action_deactivate">Деактивировать</string>
+    <string name="sensor_handover_action_remove">Удалить</string>
+    <string name="sensor_handover_switched_text">Переключено с %1$s на %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s теперь источник данных, но ещё прогревается (около %2$d мин). Показания возобновятся после прогрева.</string>
+    <string name="sensor_handover_multiple_text">Сенсор истёк, но активно несколько сенсоров-преемников. Автоматическая передача пропущена; переключитесь вручную.</string>
+    <string name="sensor_handover_successor_ready">Сенсор-преемник готов; автоматическая передача сработает при истечении</string>
 </resources>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2442,4 +2442,14 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="stats_pinned_remove">Ka saar Dashboard-ka</string>
     <string name="stats_pinned_already">lagu dhejiyay</string>
     <string name="stats_pinned_remove_short">Ka saar</string>
+    <string name="sensor_handover_title">Wareejin otomaatig ah oo dareeme</string>
+    <string name="sensor_handover_desc">Dareemaha beddelka ah horay u shid; marka kan hore uu dhaco, abku wuxuu si otomaatig ah ugu wareegayaa beddelka</string>
+    <string name="sensor_handover_old_action_title">Dareemaha dhacay wareejinta kadib</string>
+    <string name="sensor_handover_old_action_desc">Damin: dareemaha dhacay wuxuu ku sii jirayaa liiska ilaa aad ka saarto. Ka saarid: sida daaqadda ka-saaridda, furayaasha lammaanaha waa la tirtirayaa. Taariikhda cabbiraadda labada xaaladoodba waa la haynayaa.</string>
+    <string name="sensor_handover_action_deactivate">Damin</string>
+    <string name="sensor_handover_action_remove">Ka saar</string>
+    <string name="sensor_handover_switched_text">Waxaa laga beddelay %1$s loona wareejiyay %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s hadda waa isha xogta, laakiin weli wuu diirranayaa (qiyaastii %2$d daqiiqo). Akhrisyadu way soo noqonayaan marka diirintu dhammaato.</string>
+    <string name="sensor_handover_multiple_text">Dareemuhu wuu dhacay, laakiin dhowr dareeme oo beddel ah ayaa shaqaynaya. Wareejinta otomaatiga ah waa la dhaafay; fadlan gacanta ku beddel.</string>
+    <string name="sensor_handover_successor_ready">Dareemaha beddelka ah wuu diyaar yahay; wareejinta otomaatiga ah ayaa la wareegaysa marka uu dhaco</string>
 </resources>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2234,4 +2234,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="stats_pinned_remove">Ta bort från Översikt</string>
     <string name="stats_pinned_already">fäst</string>
     <string name="stats_pinned_remove_short">Ta bort</string>
+    <string name="sensor_handover_title">Automatiskt sensorbyte</string>
+    <string name="sensor_handover_desc">Aktivera efterföljande sensor i god tid; när den gamla sensorn löper ut byter appen automatiskt till efterträdaren</string>
+    <string name="sensor_handover_old_action_title">Utgången sensor efter bytet</string>
+    <string name="sensor_handover_old_action_desc">Avaktivera: den utgångna sensorn ligger kvar i listan tills du tar bort den. Ta bort: som borttagningsdialogen, parningsnycklar raderas. Mäthistoriken behålls i båda fallen.</string>
+    <string name="sensor_handover_action_deactivate">Avaktivera</string>
+    <string name="sensor_handover_action_remove">Ta bort</string>
+    <string name="sensor_handover_switched_text">Bytte från %1$s till %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s är nu datakällan men värmer fortfarande upp (cirka %2$d min). Avläsningarna återupptas när uppvärmningen är klar.</string>
+    <string name="sensor_handover_multiple_text">Sensorn har löpt ut, men flera efterföljande sensorer är aktiva. Automatiskt byte hoppades över; byt manuellt.</string>
+    <string name="sensor_handover_successor_ready">Efterföljande sensor är redo; det automatiska bytet tar över vid utgång</string>
 </resources>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2262,4 +2262,14 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="stats_pinned_remove">Panodan kaldır</string>
     <string name="stats_pinned_already">sabit</string>
     <string name="stats_pinned_remove_short">Kaldır</string>
+    <string name="sensor_handover_title">Otomatik sensör devri</string>
+    <string name="sensor_handover_desc">Yeni sensörü önceden etkinleştirin; eski sensörün süresi dolduğunda uygulama otomatik olarak halefe geçer</string>
+    <string name="sensor_handover_old_action_title">Devirden sonra süresi dolan sensör</string>
+    <string name="sensor_handover_old_action_desc">Devre dışı bırak: süresi dolan sensör siz kaldırana kadar listede kalır. Kaldır: kaldırma penceresindeki gibi, eşleştirme anahtarları silinir. Ölçüm geçmişi her iki durumda da korunur.</string>
+    <string name="sensor_handover_action_deactivate">Devre dışı bırak</string>
+    <string name="sensor_handover_action_remove">Kaldır</string>
+    <string name="sensor_handover_switched_text">%1$s yerine %2$s kullanılıyor</string>
+    <string name="sensor_handover_warming_text">%1$s artık veri kaynağı, ancak hâlâ ısınıyor (yaklaşık %2$d dk). Isınma bitince ölçümler devam eder.</string>
+    <string name="sensor_handover_multiple_text">Sensörün süresi doldu, ancak birden fazla halef sensör etkin. Otomatik devir atlandı; lütfen elle geçiş yapın.</string>
+    <string name="sensor_handover_successor_ready">Halef sensör hazır; süre dolunca otomatik devir devreye girer</string>
 </resources>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2306,4 +2306,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="stats_pinned_remove">Прибрати з головного</string>
     <string name="stats_pinned_already">закріплено</string>
     <string name="stats_pinned_remove_short">Прибрати</string>
+    <string name="sensor_handover_title">Автоматична передача сенсора</string>
+    <string name="sensor_handover_desc">Активуйте наступний сенсор заздалегідь; коли старий сенсор завершиться, застосунок автоматично перемкнеться на наступника</string>
+    <string name="sensor_handover_old_action_title">Завершений сенсор після передачі</string>
+    <string name="sensor_handover_old_action_desc">Деактивувати: завершений сенсор залишається у списку, доки ви його не видалите. Видалити: як у вікні видалення, ключі сполучення стираються. Історія вимірювань зберігається в обох випадках.</string>
+    <string name="sensor_handover_action_deactivate">Деактивувати</string>
+    <string name="sensor_handover_action_remove">Видалити</string>
+    <string name="sensor_handover_switched_text">Перемкнено з %1$s на %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s тепер джерело даних, але ще прогрівається (близько %2$d хв). Показання відновляться після прогріву.</string>
+    <string name="sensor_handover_multiple_text">Сенсор завершився, але активні кілька сенсорів-наступників. Автоматичну передачу пропущено; перемкніться вручну.</string>
+    <string name="sensor_handover_successor_ready">Сенсор-наступник готовий; автоматична передача спрацює після завершення</string>
 </resources>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2250,4 +2250,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="stats_pinned_remove">从主页移除</string>
     <string name="stats_pinned_already">已固定</string>
     <string name="stats_pinned_remove_short">移除</string>
+    <string name="sensor_handover_title">自动传感器交接</string>
+    <string name="sensor_handover_desc">提前激活后续传感器;旧传感器到期后,应用会自动切换到后续传感器</string>
+    <string name="sensor_handover_old_action_title">交接后的过期传感器</string>
+    <string name="sensor_handover_old_action_desc">停用:过期传感器保留在列表中,直到您将其移除。移除:与移除对话框相同,配对密钥将被删除。两种情况下测量历史均会保留。</string>
+    <string name="sensor_handover_action_deactivate">停用</string>
+    <string name="sensor_handover_action_remove">移除</string>
+    <string name="sensor_handover_switched_text">已从 %1$s 切换到 %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s 现在是数据来源,但仍在预热(约 %2$d 分钟)。预热完成后将恢复读数。</string>
+    <string name="sensor_handover_multiple_text">传感器已到期,但有多个后续传感器处于活动状态。已跳过自动交接;请手动切换。</string>
+    <string name="sensor_handover_successor_ready">后续传感器已就绪;到期时自动交接将接管</string>
 </resources>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2458,4 +2458,14 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="sibionics_reset_reminder_channel_desc">Reminders and actions for resetting Sibionics 2 before it expires</string>
     <string name="stats_span_days">%1$d days</string>
     <string name="stats_window_24h">24H</string>
+    <string name="sensor_handover_title">Automatic sensor handover</string>
+    <string name="sensor_handover_desc">Activate the successor sensor ahead of time; when the old sensor expires, the app switches to the successor automatically</string>
+    <string name="sensor_handover_old_action_title">Expired sensor after handover</string>
+    <string name="sensor_handover_old_action_desc">Deactivate: the expired sensor stays in the list until you remove it. Remove: like the remove dialog, pairing keys are deleted. Measurement history is kept either way.</string>
+    <string name="sensor_handover_action_deactivate">Deactivate</string>
+    <string name="sensor_handover_action_remove">Remove</string>
+    <string name="sensor_handover_switched_text">Switched from %1$s to %2$s</string>
+    <string name="sensor_handover_warming_text">%1$s is now the data source but is still warming up (about %2$d min). Readings resume once warmup finishes.</string>
+    <string name="sensor_handover_multiple_text">The sensor has expired, but several successor sensors are active. Automatic handover skipped; please switch manually.</string>
+    <string name="sensor_handover_successor_ready">Successor sensor is ready; automatic handover takes over at expiry</string>
 </resources>

--- a/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
@@ -68,6 +68,7 @@ import tk.glucodata.OutboundApiSettings
 import tk.glucodata.R
 import tk.glucodata.SensorBluetooth
 import tk.glucodata.SensorSourceResolver
+import tk.glucodata.alerts.SensorHandoverRuntime
 import tk.glucodata.data.calibration.CalibrationManager
 import tk.glucodata.drivers.ManagedSensorRuntime
 import tk.glucodata.ui.components.StyledSwitch
@@ -174,6 +175,21 @@ fun ExpressiveSettingsScreen(
     // Advanced settings
     var turbo by remember { mutableStateOf(Natives.getpriority()) }
     var autoConnect by remember { mutableStateOf(Natives.getAndroid13()) }
+    val handoverPrefs = remember {
+        context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+    }
+    var sensorHandoverEnabled by remember {
+        mutableStateOf(handoverPrefs.getBoolean(SensorHandoverRuntime.PREF_ENABLED, false))
+    }
+    var sensorHandoverAction by remember {
+        mutableStateOf(
+            handoverPrefs.getInt(
+                SensorHandoverRuntime.PREF_OLD_ACTION,
+                SensorHandoverRuntime.OLD_ACTION_DEACTIVATE
+            )
+        )
+    }
+    var showSensorHandoverActionDialog by remember { mutableStateOf(false) }
 
     val currentLocale = AppCompatDelegate.getApplicationLocales().get(0) ?: Locale.getDefault()
     val currentLangName = currentLocale.displayLanguage.replaceFirstChar { it.uppercase() }
@@ -516,6 +532,33 @@ fun ExpressiveSettingsScreen(
                     position = CardPosition.MIDDLE,
                     onCheckedChange = { SensorBluetooth.setAutoconnect(it); autoConnect = it }
                 )
+                SettingsSwitchItem(
+                    title = stringResource(R.string.sensor_handover_title),
+                    subtitle = stringResource(R.string.sensor_handover_desc),
+                    checked = sensorHandoverEnabled,
+                    icon = Icons.Default.SwapHoriz,
+                    iconTint = advColor,
+                    position = CardPosition.MIDDLE,
+                    onCheckedChange = {
+                        handoverPrefs.edit().putBoolean(SensorHandoverRuntime.PREF_ENABLED, it).apply()
+                        sensorHandoverEnabled = it
+                    }
+                )
+                if (sensorHandoverEnabled) {
+                    SettingsItem(
+                        title = stringResource(R.string.sensor_handover_old_action_title),
+                        subtitle = if (sensorHandoverAction == SensorHandoverRuntime.OLD_ACTION_REMOVE) {
+                            stringResource(R.string.sensor_handover_action_remove)
+                        } else {
+                            stringResource(R.string.sensor_handover_action_deactivate)
+                        },
+                        showArrow = true,
+                        icon = Icons.Default.DeleteSweep,
+                        iconTint = advColor,
+                        position = CardPosition.MIDDLE,
+                        onClick = { showSensorHandoverActionDialog = true }
+                    )
+                }
                 SettingsItem(
                     title = stringResource(R.string.graph_smoothing_title),
                     subtitle = graphSmoothingLabel,
@@ -698,6 +741,15 @@ fun ExpressiveSettingsScreen(
             showPreviewWindowDialog = false
         },
         onDismiss = { showPreviewWindowDialog = false }
+    )
+    if (showSensorHandoverActionDialog) SensorHandoverActionPickerDialog(
+        currentAction = sensorHandoverAction,
+        onSelect = {
+            handoverPrefs.edit().putInt(SensorHandoverRuntime.PREF_OLD_ACTION, it).apply()
+            sensorHandoverAction = it
+            showSensorHandoverActionDialog = false
+        },
+        onDismiss = { showSensorHandoverActionDialog = false }
     )
     if (showLanguageDialog) LanguagePickerDialog { showLanguageDialog = false }
     if (showClearHistoryDialog) ConfirmActionDialog(stringResource(R.string.clean_history_confirm), stringResource(R.string.clear_history_desc_long), Icons.Filled.History, { scope.launch { tk.glucodata.data.DataManagement.clearHistory() }; showClearHistoryDialog = false }, { showClearHistoryDialog = false })
@@ -1771,6 +1823,61 @@ private fun ThemePickerDialog(current: ThemeMode, onSelect: (ThemeMode) -> Unit,
                 }
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SensorHandoverActionPickerDialog(
+    currentAction: Int,
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val options = listOf(
+        stringResource(R.string.sensor_handover_action_deactivate) to SensorHandoverRuntime.OLD_ACTION_DEACTIVATE,
+        stringResource(R.string.sensor_handover_action_remove) to SensorHandoverRuntime.OLD_ACTION_REMOVE
+    )
+    BasicAlertDialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            tonalElevation = 6.dp,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh
+        ) {
+            Column(modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)) {
+                Text(
+                    text = stringResource(R.string.sensor_handover_old_action_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                )
+                Text(
+                    text = stringResource(R.string.sensor_handover_old_action_desc),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp)
+                )
+                options.forEach { (label, value) ->
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 56.dp)
+                            .clickable { onSelect(value) }
+                            .padding(horizontal = 24.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        RadioButton(selected = currentAction == value, onClick = null)
+                        Spacer(Modifier.width(16.dp))
+                        Text(label, style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 8.dp),
                     horizontalArrangement = Arrangement.End
                 ) {
                     TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }

--- a/Common/src/test/java/tk/glucodata/alerts/SensorHandoverStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/SensorHandoverStateTests.kt
@@ -1,0 +1,291 @@
+package tk.glucodata.alerts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SensorHandoverStateTests {
+
+    private val now = 1_000_000_000_000L
+    private val oldEnd = now - 60_000L          // primary expired a minute ago
+    private val futureEnd = now + 10L * 24 * 60 * 60 * 1000
+
+    private class FakeStore : SensorHandoverStore {
+        var handled: String? = null
+        var warned: String? = null
+        var suppressUntil = 0L
+        var suppressSuccessor: String? = null
+
+        override fun isHandled(serial: String, endMs: Long) = handled == "$serial|$endMs"
+        override fun markHandled(serial: String, endMs: Long) { handled = "$serial|$endMs" }
+        override fun isWarned(serial: String, endMs: Long) = warned == "$serial|$endMs"
+        override fun markWarned(serial: String, endMs: Long) { warned = "$serial|$endMs" }
+        override fun suppressionUntilMs() = suppressUntil
+        override fun suppressionSuccessor() = suppressSuccessor
+        override fun openSuppression(untilMs: Long, successorSerial: String) {
+            suppressUntil = untilMs
+            suppressSuccessor = successorSerial
+        }
+        override fun clearSuppression() {
+            suppressUntil = 0L
+            suppressSuccessor = null
+        }
+    }
+
+    private fun expiredPrimary(endMs: Long = oldEnd) =
+        HandoverSensor("OLD", startMs = endMs - 14L * 24 * 60 * 60 * 1000, endMs = endMs)
+
+    /** Successor activated 90 min ago: warmup is over, so "no reading" means disconnected, not warming. */
+    private fun successor(
+        serial: String = "NEW",
+        endMs: Long = futureEnd,
+        delivering: Boolean = true,
+        startMs: Long = now - 90 * 60_000L
+    ) = HandoverSensor(serial, startMs = startMs, endMs = endMs) { delivering }
+
+    /** Successor activated 20 min ago and silent: genuinely inside the warmup phase. */
+    private fun warmingSuccessor(serial: String = "NEW") =
+        successor(serial, delivering = false, startMs = now - 20 * 60_000L)
+
+    // Test 1: expired primary + one delivering successor -> exactly one switch.
+    @Test
+    fun switchesOnceWhenPrimaryExpiredAndSuccessorDelivers() {
+        val store = FakeStore()
+        val state = SensorHandoverState(store)
+        val decision = state.evaluate(true, expiredPrimary(), listOf(successor()), now)
+        assertEquals(HandoverDecision.Switch("OLD", "NEW", successorWarming = false), decision)
+
+        // The runtime latches before acting; afterwards the same expiry never retriggers.
+        store.markHandled("OLD", oldEnd)
+        assertEquals(
+            HandoverDecision.None,
+            state.evaluate(true, expiredPrimary(), listOf(successor()), now + 15_000L)
+        )
+    }
+
+    // Test 2: successor still in its warmup phase -> switch anyway, flagged as warming.
+    @Test
+    fun switchesToWarmingSuccessorWithWarmingFlag() {
+        val state = SensorHandoverState(FakeStore())
+        val decision = state.evaluate(
+            true, expiredPrimary(), listOf(warmingSuccessor()), now
+        )
+        assertEquals(HandoverDecision.Switch("OLD", "NEW", successorWarming = true), decision)
+    }
+
+    // A successor whose warmup is long over but which has no readings is
+    // disconnected, not warming: switch without the warming flag, so no
+    // suppression window can mask the outage.
+    @Test
+    fun silentSuccessorPastWarmupIsNotWarming() {
+        val state = SensorHandoverState(FakeStore())
+        val decision = state.evaluate(
+            true, expiredPrimary(), listOf(successor(delivering = false)), now
+        )
+        assertEquals(HandoverDecision.Switch("OLD", "NEW", successorWarming = false), decision)
+    }
+
+    // Unknown start time: cannot prove warmup, so never claim warming.
+    @Test
+    fun unknownStartSuccessorIsNotWarming() {
+        val state = SensorHandoverState(FakeStore())
+        val decision = state.evaluate(
+            true, expiredPrimary(), listOf(successor(delivering = false, startMs = 0L)), now
+        )
+        assertEquals(HandoverDecision.Switch("OLD", "NEW", successorWarming = false), decision)
+    }
+
+    // Test 3: no successor -> nothing happens (and no latch, so a successor
+    // scanned after the expiry still gets the handover).
+    @Test
+    fun noSuccessorDoesNothingUntilOneAppears() {
+        val store = FakeStore()
+        val state = SensorHandoverState(store)
+        assertEquals(HandoverDecision.None, state.evaluate(true, expiredPrimary(), emptyList(), now))
+        assertEquals(null, store.handled)
+
+        val later = now + 30 * 60_000L
+        assertEquals(
+            HandoverDecision.Switch("OLD", "NEW", successorWarming = true),
+            state.evaluate(
+                true,
+                expiredPrimary(),
+                listOf(successor(delivering = false, startMs = later - 10 * 60_000L)),
+                later
+            )
+        )
+    }
+
+    // Test 4: several candidates -> warn, no automatic switch.
+    @Test
+    fun multipleCandidatesWarnInsteadOfSwitching() {
+        val state = SensorHandoverState(FakeStore())
+        val decision = state.evaluate(
+            true, expiredPrimary(), listOf(successor("NEW1"), successor("NEW2")), now
+        )
+        assertEquals(
+            HandoverDecision.WarnMultiple("OLD", listOf("NEW1", "NEW2")),
+            decision
+        )
+    }
+
+    // The warning fires once per expiry ...
+    @Test
+    fun multipleCandidatesWarningIsLatchedPerExpiry() {
+        val store = FakeStore()
+        val state = SensorHandoverState(store)
+        store.markWarned("OLD", oldEnd)
+        assertEquals(
+            HandoverDecision.None,
+            state.evaluate(true, expiredPrimary(), listOf(successor("NEW1"), successor("NEW2")), now)
+        )
+    }
+
+    // ... but the switch stays armed: resolving the ambiguity resumes the automation.
+    @Test
+    fun resolvingTheAmbiguityStillSwitches() {
+        val store = FakeStore()
+        val state = SensorHandoverState(store)
+        store.markWarned("OLD", oldEnd)
+        assertEquals(
+            HandoverDecision.Switch("OLD", "NEW1", successorWarming = false),
+            state.evaluate(true, expiredPrimary(), listOf(successor("NEW1")), now + 60_000L)
+        )
+    }
+
+    // Test 5: setting off -> never anything, regardless of state.
+    @Test
+    fun disabledNeverDecidesAnything() {
+        val state = SensorHandoverState(FakeStore())
+        assertEquals(
+            HandoverDecision.None,
+            state.evaluate(false, expiredPrimary(), listOf(successor()), now)
+        )
+    }
+
+    @Test
+    fun notYetExpiredPrimaryDoesNothing() {
+        val state = SensorHandoverState(FakeStore())
+        val runningPrimary = HandoverSensor("OLD", startMs = now, endMs = now + 60_000L)
+        assertEquals(
+            HandoverDecision.None,
+            state.evaluate(true, runningPrimary, listOf(successor()), now)
+        )
+    }
+
+    @Test
+    fun unknownPrimaryEndNeverTriggers() {
+        val state = SensorHandoverState(FakeStore())
+        val unknownEnd = HandoverSensor("OLD", startMs = 0L, endMs = 0L)
+        assertEquals(
+            HandoverDecision.None,
+            state.evaluate(true, unknownEnd, listOf(successor()), now)
+        )
+    }
+
+    // An expired lingering sensor in the list is not a successor candidate.
+    @Test
+    fun expiredSensorIsNotACandidate() {
+        val state = SensorHandoverState(FakeStore())
+        val staleExpired = successor("STALE", endMs = now - 5 * 60_000L)
+        assertEquals(
+            HandoverDecision.Switch("OLD", "NEW", successorWarming = false),
+            state.evaluate(true, expiredPrimary(), listOf(staleExpired, successor()), now)
+        )
+    }
+
+    // Sensors with unknown ends stay candidates (they are in the active list).
+    @Test
+    fun unknownEndCandidateStaysEligible() {
+        val state = SensorHandoverState(FakeStore())
+        val unknownEndCandidate = HandoverSensor("NEW", startMs = now, endMs = 0L) { true }
+        assertEquals(
+            HandoverDecision.Switch("OLD", "NEW", successorWarming = false),
+            state.evaluate(true, expiredPrimary(), listOf(unknownEndCandidate), now)
+        )
+    }
+
+    // Test 7: idempotency across a process restart - fresh state over the same store.
+    @Test
+    fun restartDoesNotRepeatTheHandover() {
+        val store = FakeStore()
+        val first = SensorHandoverState(store)
+        assertEquals(
+            HandoverDecision.Switch("OLD", "NEW", successorWarming = false),
+            first.evaluate(true, expiredPrimary(), listOf(successor()), now)
+        )
+        store.markHandled("OLD", oldEnd)
+
+        val afterRestart = SensorHandoverState(store)
+        assertEquals(
+            HandoverDecision.None,
+            afterRestart.evaluate(true, expiredPrimary(), listOf(successor()), now + 60_000L)
+        )
+    }
+
+    // A later expiry (next sensor generation) rearms the latch.
+    @Test
+    fun nextExpiryRearmsAfterEarlierHandover() {
+        val store = FakeStore()
+        val state = SensorHandoverState(store)
+        store.markHandled("OLD", oldEnd)
+        val nextEnd = now + 100L
+        val nextPrimary = expiredPrimary(endMs = nextEnd)
+        assertEquals(
+            HandoverDecision.Switch("OLD", "NEW", successorWarming = false),
+            state.evaluate(true, nextPrimary, listOf(successor()), nextEnd + 15_000L)
+        )
+    }
+
+    // Two sensors sharing an end timestamp do not swallow each other's handover.
+    @Test
+    fun latchIsKeyedOnSerialPlusEnd() {
+        val store = FakeStore()
+        val state = SensorHandoverState(store)
+        store.markHandled("OTHER", oldEnd)
+        assertEquals(
+            HandoverDecision.Switch("OLD", "NEW", successorWarming = false),
+            state.evaluate(true, expiredPrimary(), listOf(successor()), now)
+        )
+    }
+
+    // Test 6: missed-reading suppression window around a warming handover.
+    @Test
+    fun suppressionWindowBlocksUntilSuccessorReading() {
+        val store = FakeStore()
+        val state = SensorHandoverState(store)
+        assertFalse(state.missedReadingSuppressed(now))
+
+        state.openMissedReadingSuppression(now, "NEW")
+        assertTrue(state.missedReadingSuppressed(now + 10 * 60_000L))
+
+        // A reading from some other sensor does not close the window.
+        state.onReading("OTHER")
+        assertTrue(state.missedReadingSuppressed(now + 11 * 60_000L))
+
+        // The successor's first reading does.
+        state.onReading("NEW")
+        assertFalse(state.missedReadingSuppressed(now + 12 * 60_000L))
+    }
+
+    @Test
+    fun suppressionWindowExpiresAtTheCap() {
+        val store = FakeStore()
+        val state = SensorHandoverState(store)
+        state.openMissedReadingSuppression(now, "NEW")
+        val afterCap = now + SensorHandoverState.MISSED_READING_GRACE_MS
+        assertFalse(state.missedReadingSuppressed(afterCap))
+        // The store is cleaned up so the window cannot reopen.
+        assertEquals(0L, store.suppressUntil)
+    }
+
+    @Test
+    fun readingWithoutOpenWindowIsIgnored() {
+        val store = FakeStore()
+        val state = SensorHandoverState(store)
+        state.onReading("NEW")
+        assertEquals(0L, store.suppressUntil)
+        assertFalse(state.missedReadingSuppressed(now))
+    }
+}


### PR DESCRIPTION
Adds an opt-in automatic handover between two overlapping sensors. The intended flow: you scan the successor an hour or two before the current sensor runs out and both run in parallel, with the newcomer already delivering as a peer. What does not move on its own today is the primary role: alarms, broadcasts and the notification keep following the expired sensor until you promote the new one by hand. This automates that last step at the official end time.

**What it does**

- Trigger: the primary sensor's official end time passes (`Natives.getSensorEndTime(dataptr, official=true)`, the same source the expiry alarm uses) and exactly one other active, non-expired sensor exists. That sensor becomes primary through the existing selection machinery (`MultiSensorSelection` + `SensorBluetooth.setCurrentSensorSelection`), and the expired one is deselected from the display selection, the same effect as unchecking it on its card. It stays in the sensor list until you remove it, like an expired sensor does today.
- If the successor is inside its warmup phase at that moment, the switch happens anyway (it is the only source) and the notification says so, with a minutes estimate. A successor that is merely disconnected (warmup long over, no readings) gets a plain receipt instead, so the missed-reading alarm can still do its job.
- If several successor candidates are active, nothing is automated: one warning notification per expiry, the user decides. The automation stays armed, though. Remove one of the two candidates and the handover still happens.
- Once per expiry: the latch (sensor serial plus end time) is persisted before the switch executes, so a process restart cannot repeat it. After the switch the code verifies the promotion actually took; if it did not, it logs an error instead of sending a false success receipt.
- Missed-reading alarm: suppressed from a warming handover until the successor's first reading, capped at 60 minutes. After the cap the alarm resumes normally, which doubles as the fallback warning.
- Sensor-expiry alarm: when the handover is armed and a unique delivering successor exists, the expiry warning gets a "successor ready" suffix instead of reading like a problem the user has to get up for. The expiry latch and its persistence are untouched.
- Second setting for the expired sensor: deactivate (default, just deselected as described) or remove (the forget path: pairing keys wiped, sensor dropped from list and prefs; measurement history is kept either way, this path never deletes readings).

**What it deliberately does not do**

- No activation at expiry. A freshly activated sensor needs its warmup; an activation-based switch would trade a working overlap for a guaranteed blind window. The feature only manages the handover between two sensors that both already exist.
- Nothing happens without a successor. The expiry alarm already covers that case.
- Default off. With the switch off, the evaluation returns before touching anything.

**Implementation notes**

- Decision logic lives in `SensorHandoverState` (pure, injected store, same shape as `SensorExpiryAlertState`), driven by `SensorHandoverRuntime` on the existing `AlertRuntimeManager` 15s tick. The tick only decides and latches; the actual switch work runs on a dedicated thread so the alert lock is never held across selection writes or BLE teardown, and incoming readings are not blocked.
- Candidates are deduplicated by logical sensor identity, so one physical sensor that sits in the registry under two serial forms cannot fake a second candidate.
- The remove path mirrors `SensorViewModel.forgetSensor` (view-model-scoped, not reachable from the alert runtime); the managed-driver branch defers to `terminateManagedSensor`/`removeManagedPersistence` as the sensor card does.
- Settings sit in the advanced group next to autoconnect; strings added to all 15 locales.
- 19 unit tests in `SensorHandoverStateTests` cover the trigger, candidate filtering, warming classification, the once-per-expiry latch across restarts, and the suppression window. Full mobile suite: 1176 tests, the only failures are the 11 known Sibionics Exact ones (missing replay fixtures, identical on a clean tree).

**Caveats**

- Libre 2 and similar sensors keep delivering for up to 12 hours past their official end (`expectedEndTime` adds the grace period). The trigger deliberately uses the official end anyway, since that is when the wear period is over; with the default deactivate action the old sensor keeps running and stays selectable, so nothing is lost. Only the opt-in remove action would cut a Libre 2 off during its grace window.
- Unlike a manual promotion, the handover does not run `HistorySync.mergeFullSyncForSensor` (mobile-only, not reachable from the runtime). The successor's history is already in Room from its time as a peer, so this should only matter in unusual cases.
- The runtime behavior (actual switch, notifications, teardown) has not been exercised on a device yet, only the decision logic is unit-tested. My notes also said "latest start time wins" for successor selection; with more than one candidate this implementation refuses to pick at all and warns instead. Automatically choosing between two viable glucose sources felt wrong. If you'd rather have the latest-start rule, happy to change it.
