### PR TITLE
Sensor expiry: adopt only thresholds new to the configuration

### DIFF
--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -102,7 +102,10 @@ object AlertRepository {
      * adoption at save time; the runtime baseline then treats it like any
      * already-warned window. Thresholds that were already configured keep their
      * state: one that is due but was never warned (process was down at window
-     * entry) stays eligible for the catch-up warning.
+     * entry) stays eligible for the catch-up warning. That includes thresholds
+     * configured while the alert was switched off - toggling the alert off and
+     * on is not a fresh start, and treating it as one silenced every open
+     * window for the rest of the sensor.
      */
     private fun adoptOpenWindowsForNewExpiryThresholds(config: AlertConfig) {
         if (!config.enabled) {
@@ -114,10 +117,12 @@ object AlertRepository {
             return
         }
         val previous = loadConfig(config.type)
-        val previouslyActive = if (previous.enabled) previous.expiryWarningMinutes else emptySet()
-        val newlyOpen = sanitizeExpiryWarningMinutes(config.expiryWarningMinutes).filter {
-            it !in previouslyActive && endTimeMs - nowMs <= it.toLong() * 60_000L
-        }
+        val newlyOpen = newlyOpenExpiryThresholds(
+            previousMinutes = previous.expiryWarningMinutes,
+            currentMinutes = config.expiryWarningMinutes,
+            endTimeMs = endTimeMs,
+            nowMs = nowMs
+        )
         if (newlyOpen.isEmpty()) {
             return
         }

--- a/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
@@ -56,6 +56,31 @@ internal fun resolveSensorExpiryEndMs(preferredSensorId: String?, nowMs: Long): 
 }
 
 /**
+ * Thresholds that are new to the configuration and whose warning window is
+ * already open, so a settings save can adopt them (mark them warned) instead of
+ * letting them fire retroactively on the next tick.
+ *
+ * "New" means absent from the previous configuration, independent of whether the
+ * alert was enabled back then: an enable/disable cycle mid-sensor must not turn
+ * every configured threshold into a new one. Doing so adopted every currently
+ * open window at once and left the rest of the sensor without a single warning.
+ */
+internal fun newlyOpenExpiryThresholds(
+    previousMinutes: Set<Int>,
+    currentMinutes: Set<Int>,
+    endTimeMs: Long,
+    nowMs: Long
+): Set<Int> {
+    if (endTimeMs <= 0L) {
+        return emptySet()
+    }
+    val previouslyConfigured = sanitizeExpiryWarningMinutes(previousMinutes)
+    return sanitizeExpiryWarningMinutes(currentMinutes).filter {
+        it !in previouslyConfigured && endTimeMs - nowMs <= it.toLong() * 60_000L
+    }.toSet()
+}
+
+/**
  * Durable memory of which expiry thresholds already warned, keyed by the
  * sensor's end time. Production backs this with SharedPreferences
  * ([AlertRepository.sensorExpiryWarnedStore]); tests inject a fake.
@@ -85,7 +110,9 @@ internal interface ExpiryWarnedStore {
  *  - **Newly enabled thresholds** whose window is already open are adopted
  *    (marked warned, never fired retroactively). Mid-process that happens
  *    here; across a restart [AlertRepository.saveConfig] persists the
- *    adoption at save time.
+ *    adoption at save time. Only a threshold never configured in this episode
+ *    counts as new: deselecting and reselecting one keeps its window history,
+ *    so it is neither adopted nor fired for an edge it already passed.
  *  - **Cascade guard:** if several thresholds come due in the same tick (e.g. the
  *    app resumes deep inside multiple windows), fire only the smallest (most
  *    urgent) and silently mark the rest as warned.
@@ -132,10 +159,6 @@ internal class SensorExpiryAlertState(private val store: ExpiryWarnedStore) {
             }
         }
 
-        // Forget thresholds the user has removed so the maps stay bounded.
-        wasInWindow.keys.retainAll(thresholdsMinutes)
-        alertedForEnd.keys.retainAll(thresholdsMinutes)
-
         if (!activeNow || snoozed) {
             return emptySet()
         }
@@ -156,14 +179,24 @@ internal class SensorExpiryAlertState(private val store: ExpiryWarnedStore) {
                 }
             }
         } else {
+            // A deselected threshold keeps being tracked for the rest of the
+            // episode: its window state must stay current so re-selecting it is
+            // neither mistaken for a brand-new threshold (silent adoption) nor
+            // fired for an edge that passed while it was off. The maps stay
+            // bounded by EXPIRY_WARNING_PRESETS.
+            for (t in wasInWindow.keys.toList()) {
+                if (t !in thresholdsMinutes) {
+                    wasInWindow[t] = inWindow(t)
+                }
+            }
             for (t in thresholdsMinutes) {
                 val inside = inWindow(t)
                 val known = wasInWindow.containsKey(t)
                 val prev = wasInWindow[t] ?: false
                 wasInWindow[t] = inside
                 if (!known) {
-                    // Threshold enabled mid-episode: adopt like the baseline, never
-                    // fire retroactively for a window that is already open.
+                    // Threshold never configured in this episode: adopt like the
+                    // baseline, never fire retroactively for an open window.
                     if (inside && alertedForEnd[t] != endTimeMs) {
                         alertedForEnd[t] = endTimeMs
                         persistWarned()

--- a/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
@@ -181,6 +181,93 @@ class SensorExpiryAlertStateTests {
     }
 
     @Test
+    fun editingThresholdsMidEpisodeKeepsTheConfiguredOnesArmed() {
+        // Field regression: the user had 3d/2d/1d/12h/1h configured, got the 3d
+        // warning and nothing afterwards, while the persisted warned-set showed
+        // every threshold marked for that sensor. Adding one threshold must not
+        // silence the ones that were configured all along.
+        val s = newState()
+        val before = setOf(4320, 2880, 1440, 720, 60)
+        val after = before + T6H
+        assertEquals(emptySet<Int>(), s.fire(5760, before))
+        assertEquals(setOf(4320), s.fire(4320, before))
+        assertEquals(emptySet<Int>(), s.fire(2900, after))   // 6h added, its window still shut
+        assertEquals(setOf(2880), s.fire(2880, after))
+        assertEquals(setOf(1440), s.fire(1440, after))
+        assertEquals(setOf(720), s.fire(720, after))
+        assertEquals(setOf(T6H), s.fire(360, after))
+        assertEquals(setOf(60), s.fire(60, after))
+    }
+
+    @Test
+    fun reselectingAThresholdIsNotTreatedAsANewOne() {
+        val store = FakeWarnedStore()
+        val s1 = SensorExpiryAlertState(store)
+        s1.fire(5760, setOf(T3D, T1D))                                  // baseline outside both
+        assertEquals(setOf(T3D), s1.fire(4320, setOf(T3D, T1D)))
+        assertEquals(emptySet<Int>(), s1.fire(2000, setOf(T3D)))        // 1d deselected
+        assertEquals(emptySet<Int>(), s1.fire(1400, setOf(T3D)))        // its edge passes while off
+        // Reselected inside the open window: not fired retroactively, but not
+        // recorded as warned either - it never was.
+        assertEquals(emptySet<Int>(), s1.fire(1300, setOf(T3D, T1D)))
+        assertEquals(setOf("$end:$T3D"), store.entries)
+        // ...so the usual catch-up still applies after a restart.
+        assertEquals(setOf(T1D), SensorExpiryAlertState(store).fire(1290, setOf(T3D, T1D)))
+    }
+
+    @Test
+    fun disableEnableCycleMidEpisodeLeavesLaterThresholdsArmed() {
+        val s = newState()
+        val t = setOf(4320, 2880, 1440, 720, 60)
+        assertEquals(emptySet<Int>(), s.fire(5760, t))
+        assertEquals(setOf(4320), s.fire(4320, t))
+        // User switches the alert off and back on again.
+        assertEquals(
+            emptySet<Int>(),
+            s.triggeredThresholds(false, true, false, end, end - min(4000), t)
+        )
+        assertEquals(emptySet<Int>(), s.fire(4000, t))    // re-enabled: 3d stays warned, nothing due
+        assertEquals(setOf(2880), s.fire(2880, t))
+        assertEquals(setOf(60), s.fire(60, t))
+    }
+
+    @Test
+    fun onlyThresholdsAbsentFromThePreviousConfigCountAsNew() {
+        val configured = setOf(4320, 2880, 1440, 720, 60)
+        val nowMs = end - min(30)
+        // Same set saved again (e.g. after an enable/disable cycle): nothing is new,
+        // so no open window may be adopted.
+        assertEquals(
+            emptySet<Int>(),
+            newlyOpenExpiryThresholds(configured, configured, end, nowMs)
+        )
+        // One threshold genuinely added while several windows are open: only that
+        // one is adopted.
+        assertEquals(
+            setOf(T6H),
+            newlyOpenExpiryThresholds(configured, configured + T6H, end, nowMs)
+        )
+    }
+
+    @Test
+    fun newThresholdIsAdoptedOnlyWhileItsWindowIsOpen() {
+        val nowMs = end - min(300)   // 5h before the end
+        assertEquals(
+            setOf(T6H),
+            newlyOpenExpiryThresholds(setOf(T3D), setOf(T3D, T6H), end, nowMs)
+        )
+        assertEquals(
+            emptySet<Int>(),
+            newlyOpenExpiryThresholds(setOf(T3D), setOf(T3D, 60), end, nowMs)
+        )
+        // No plausible sensor end: nothing to adopt against.
+        assertEquals(
+            emptySet<Int>(),
+            newlyOpenExpiryThresholds(setOf(T3D), setOf(T3D, T6H), 0L, nowMs)
+        )
+    }
+
+    @Test
     fun newSensorRearmsAndPrunesOldPersistedEntries() {
         val store = FakeWarnedStore()
         val t = setOf(T1D)


### PR DESCRIPTION
Follow-up to #97 (multiple configurable expiry warnings) and #112 (real end-time source plus the persisted warned-set).

A user with 3d / 2d / 1d / 12h / 1h configured got exactly one warning over the whole life of a sensor, the 3-day one, and nothing afterwards, not even an hour before expiry. The alert prefs of that sensor after it expired:

```xml
<set name="alert_11_expiryWarned">
    <string>1785685448000:720</string>
    <string>1785685448000:60</string>
    <string>1785685448000:1440</string>
    <string>1785685448000:2880</string>
    <string>1785685448000:4320</string>
    <string>1785685448000:360</string>
</set>
```

All six thresholds are marked warned under one plausible, constant end time, so the end-time source from #112 is healthy. Only 4320 was ever delivered. The other five were silently adopted, and the set contains 360, which that user had not configured at the start, so the threshold set changed during the sensor's runtime.

Adoption is there so a threshold switched on inside its already-open window does not fire retroactively. The intent is right; the definition of "new" was too wide, in two places.

`AlertRepository.adoptOpenWindowsForNewExpiryThresholds` compared the saved set against `if (previous.enabled) previous.expiryWarningMinutes else emptySet()`. If the alert had been switched off at any point, the comparison set is empty, every configured threshold counts as new on the next save, and each one whose window is already open gets persisted as warned. One off/on cycle in the alarm settings silences the rest of the sensor.

At runtime, `SensorExpiryAlertState.triggeredThresholds` called `wasInWindow.keys.retainAll(thresholdsMinutes)`, dropping a threshold's window state as soon as the set changed. On the next pass a threshold that is back in the set looks unknown and takes the same silent-adoption branch, although it had been configured all along.

What changed:

* Adoption compares against the previous configuration alone, regardless of the enabled flag. The predicate moved into a pure `newlyOpenExpiryThresholds()` so unit tests can reach it without SharedPreferences.
* The latch keeps tracking a deselected threshold's window state for the rest of the episode instead of pruning it. Reselecting one is then neither adopted nor fired for an edge that passed while it was off. Both maps are keyed by `EXPIRY_WARNING_PRESETS` values and cleared per sensor, so they stay bounded without the pruning.

I chose the in-memory variant over a second persisted `expirySeen` set on purpose. The `!known` branch is reachable only within a single process run: after a restart the baseline pass handles the same situation and a genuinely new threshold has already been persisted as warned by the settings save or by the adoption branch itself. A second prefs key would add its own per-sensor pruning for state that never has to survive a restart.

Edge detection, cascade guard and the warned-set persistence are unchanged. One behaviour does change: switching the alert on mid-sensor while a window is already open now produces one catch-up warning instead of silence, which matches what a process restart in the same situation already does.

Tests: `SensorExpiryAlertStateTests` gains the field scenario (adding a threshold mid-sensor leaves the configured ones armed and every later edge fires), the off/on cycle, the deselect/reselect round trip, and the adoption predicate itself. The reselect case fails on the current code and passes with this change. The remaining 23 cases in that class are untouched and stay green.
