### PR TITLE
Sensor expiry: do not count a warning as warned until it was delivered

### DIFF
--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -102,7 +102,10 @@ object AlertRepository {
      * adoption at save time; the runtime baseline then treats it like any
      * already-warned window. Thresholds that were already configured keep their
      * state: one that is due but was never warned (process was down at window
-     * entry) stays eligible for the catch-up warning.
+     * entry) stays eligible for the catch-up warning. That includes thresholds
+     * configured while the alert was switched off - toggling the alert off and
+     * on is not a fresh start, and treating it as one silenced every open
+     * window for the rest of the sensor.
      */
     private fun adoptOpenWindowsForNewExpiryThresholds(config: AlertConfig) {
         if (!config.enabled) {
@@ -114,10 +117,12 @@ object AlertRepository {
             return
         }
         val previous = loadConfig(config.type)
-        val previouslyActive = if (previous.enabled) previous.expiryWarningMinutes else emptySet()
-        val newlyOpen = sanitizeExpiryWarningMinutes(config.expiryWarningMinutes).filter {
-            it !in previouslyActive && endTimeMs - nowMs <= it.toLong() * 60_000L
-        }
+        val newlyOpen = newlyOpenExpiryThresholds(
+            previousMinutes = previous.expiryWarningMinutes,
+            currentMinutes = config.expiryWarningMinutes,
+            endTimeMs = endTimeMs,
+            nowMs = nowMs
+        )
         if (newlyOpen.isEmpty()) {
             return
         }

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -416,10 +416,16 @@ object AlertRuntimeManager {
             return
         }
 
+        // The sensor ages whether or not a reading is available, and readings
+        // often stop exactly when it is about to expire. Without a value the
+        // notification path cannot deliver, so the threshold stays pending and is
+        // offered again on the next tick instead of counting as warned (#98).
         val glucoseValue = currentGlucoseValueLocked() ?: return
         val message = sensorExpiryMessage(triggered.first())
 
-        triggerAlert(type, glucoseValue, currentRateLocked(), message)
+        if (triggerAlert(type, glucoseValue, currentRateLocked(), message)) {
+            sensorExpiryState.confirmDelivered(triggered.first())
+        }
     }
 
     private fun evaluateDeltaAlarmsLocked() {

--- a/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
@@ -116,18 +116,39 @@ internal interface ExpiryWarnedStore {
  *  - **Cascade guard:** if several thresholds come due in the same tick (e.g. the
  *    app resumes deep inside multiple windows), fire only the smallest (most
  *    urgent) and silently mark the rest as warned.
+ *  - **Delivery handshake:** a threshold counts as warned only once the caller
+ *    reports it delivered via [confirmDelivered]. A tick that cannot deliver
+ *    (no current glucose reading, notification suppressed) leaves it pending and
+ *    it is offered again, instead of being marked warned and lost for good.
  */
 internal class SensorExpiryAlertState(private val store: ExpiryWarnedStore) {
     private var baselineReady = false
     private var lastEndTimeMs = 0L
     private val wasInWindow = mutableMapOf<Int, Boolean>()   // threshold -> inside window last tick
     private val alertedForEnd = mutableMapOf<Int, Long>()    // threshold -> endTime already warned for
+    private val pendingDelivery = mutableSetOf<Int>()        // returned, not yet confirmed delivered
 
     fun reset() {
         baselineReady = false
         lastEndTimeMs = 0L
         wasInWindow.clear()
         alertedForEnd.clear()
+        pendingDelivery.clear()
+    }
+
+    /**
+     * The caller delivered the alert for [threshold]; only now is it warned.
+     * Until this arrives the threshold stays pending and is offered again on
+     * every tick, because its window edge has already passed and nothing else
+     * would bring it back.
+     */
+    fun confirmDelivered(threshold: Int) {
+        if (lastEndTimeMs <= 0L || threshold !in pendingDelivery) {
+            return
+        }
+        pendingDelivery.remove(threshold)
+        alertedForEnd[threshold] = lastEndTimeMs
+        persistWarned()
     }
 
     /**
@@ -154,6 +175,7 @@ internal class SensorExpiryAlertState(private val store: ExpiryWarnedStore) {
             lastEndTimeMs = endTimeMs
             wasInWindow.clear()
             alertedForEnd.clear()
+            pendingDelivery.clear()
             for (t in store.load(endTimeMs)) {
                 alertedForEnd[t] = endTimeMs
             }
@@ -210,15 +232,24 @@ internal class SensorExpiryAlertState(private val store: ExpiryWarnedStore) {
         }
 
         if (newlyDue.isEmpty()) {
-            return emptySet()
+            // Nothing new, but a warning that was offered and never delivered is
+            // still owed: its edge has passed, so re-offering here is the only
+            // thing that can bring it back.
+            return pendingDelivery.minOrNull()?.let { setOf(it) } ?: emptySet()
         }
 
-        // Cascade guard: fire only the most urgent (smallest lead time); mark the
-        // rest as warned so they never fire late.
-        val fire = newlyDue.min()
-        for (t in newlyDue) {
-            alertedForEnd[t] = endTimeMs
+        // Cascade guard: offer only the most urgent (smallest lead time); mark the
+        // rest as warned so they never fire late. An undelivered threshold that a
+        // more urgent one overtakes is dropped for the same reason.
+        val candidates = newlyDue.toSet() + pendingDelivery
+        val fire = candidates.min()
+        for (t in candidates) {
+            if (t != fire) {
+                alertedForEnd[t] = endTimeMs
+            }
         }
+        pendingDelivery.clear()
+        pendingDelivery.add(fire)
         persistWarned()
         return setOf(fire)
     }

--- a/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/SensorExpiryAlertState.kt
@@ -56,6 +56,31 @@ internal fun resolveSensorExpiryEndMs(preferredSensorId: String?, nowMs: Long): 
 }
 
 /**
+ * Thresholds that are new to the configuration and whose warning window is
+ * already open, so a settings save can adopt them (mark them warned) instead of
+ * letting them fire retroactively on the next tick.
+ *
+ * "New" means absent from the previous configuration, independent of whether the
+ * alert was enabled back then: an enable/disable cycle mid-sensor must not turn
+ * every configured threshold into a new one. Doing so adopted every currently
+ * open window at once and left the rest of the sensor without a single warning.
+ */
+internal fun newlyOpenExpiryThresholds(
+    previousMinutes: Set<Int>,
+    currentMinutes: Set<Int>,
+    endTimeMs: Long,
+    nowMs: Long
+): Set<Int> {
+    if (endTimeMs <= 0L) {
+        return emptySet()
+    }
+    val previouslyConfigured = sanitizeExpiryWarningMinutes(previousMinutes)
+    return sanitizeExpiryWarningMinutes(currentMinutes).filter {
+        it !in previouslyConfigured && endTimeMs - nowMs <= it.toLong() * 60_000L
+    }.toSet()
+}
+
+/**
  * Durable memory of which expiry thresholds already warned, keyed by the
  * sensor's end time. Production backs this with SharedPreferences
  * ([AlertRepository.sensorExpiryWarnedStore]); tests inject a fake.
@@ -85,7 +110,9 @@ internal interface ExpiryWarnedStore {
  *  - **Newly enabled thresholds** whose window is already open are adopted
  *    (marked warned, never fired retroactively). Mid-process that happens
  *    here; across a restart [AlertRepository.saveConfig] persists the
- *    adoption at save time.
+ *    adoption at save time. Only a threshold never configured in this episode
+ *    counts as new: deselecting and reselecting one keeps its window history,
+ *    so it is neither adopted nor fired for an edge it already passed.
  *  - **Cascade guard:** if several thresholds come due in the same tick (e.g. the
  *    app resumes deep inside multiple windows), fire only the smallest (most
  *    urgent) and silently mark the rest as warned.
@@ -132,10 +159,6 @@ internal class SensorExpiryAlertState(private val store: ExpiryWarnedStore) {
             }
         }
 
-        // Forget thresholds the user has removed so the maps stay bounded.
-        wasInWindow.keys.retainAll(thresholdsMinutes)
-        alertedForEnd.keys.retainAll(thresholdsMinutes)
-
         if (!activeNow || snoozed) {
             return emptySet()
         }
@@ -156,14 +179,24 @@ internal class SensorExpiryAlertState(private val store: ExpiryWarnedStore) {
                 }
             }
         } else {
+            // A deselected threshold keeps being tracked for the rest of the
+            // episode: its window state must stay current so re-selecting it is
+            // neither mistaken for a brand-new threshold (silent adoption) nor
+            // fired for an edge that passed while it was off. The maps stay
+            // bounded by EXPIRY_WARNING_PRESETS.
+            for (t in wasInWindow.keys.toList()) {
+                if (t !in thresholdsMinutes) {
+                    wasInWindow[t] = inWindow(t)
+                }
+            }
             for (t in thresholdsMinutes) {
                 val inside = inWindow(t)
                 val known = wasInWindow.containsKey(t)
                 val prev = wasInWindow[t] ?: false
                 wasInWindow[t] = inside
                 if (!known) {
-                    // Threshold enabled mid-episode: adopt like the baseline, never
-                    // fire retroactively for a window that is already open.
+                    // Threshold never configured in this episode: adopt like the
+                    // baseline, never fire retroactively for an open window.
                     if (inside && alertedForEnd[t] != endTimeMs) {
                         alertedForEnd[t] = endTimeMs
                         persistWarned()

--- a/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
@@ -181,6 +181,93 @@ class SensorExpiryAlertStateTests {
     }
 
     @Test
+    fun editingThresholdsMidEpisodeKeepsTheConfiguredOnesArmed() {
+        // Field regression: the user had 3d/2d/1d/12h/1h configured, got the 3d
+        // warning and nothing afterwards, while the persisted warned-set showed
+        // every threshold marked for that sensor. Adding one threshold must not
+        // silence the ones that were configured all along.
+        val s = newState()
+        val before = setOf(4320, 2880, 1440, 720, 60)
+        val after = before + T6H
+        assertEquals(emptySet<Int>(), s.fire(5760, before))
+        assertEquals(setOf(4320), s.fire(4320, before))
+        assertEquals(emptySet<Int>(), s.fire(2900, after))   // 6h added, its window still shut
+        assertEquals(setOf(2880), s.fire(2880, after))
+        assertEquals(setOf(1440), s.fire(1440, after))
+        assertEquals(setOf(720), s.fire(720, after))
+        assertEquals(setOf(T6H), s.fire(360, after))
+        assertEquals(setOf(60), s.fire(60, after))
+    }
+
+    @Test
+    fun reselectingAThresholdIsNotTreatedAsANewOne() {
+        val store = FakeWarnedStore()
+        val s1 = SensorExpiryAlertState(store)
+        s1.fire(5760, setOf(T3D, T1D))                                  // baseline outside both
+        assertEquals(setOf(T3D), s1.fire(4320, setOf(T3D, T1D)))
+        assertEquals(emptySet<Int>(), s1.fire(2000, setOf(T3D)))        // 1d deselected
+        assertEquals(emptySet<Int>(), s1.fire(1400, setOf(T3D)))        // its edge passes while off
+        // Reselected inside the open window: not fired retroactively, but not
+        // recorded as warned either - it never was.
+        assertEquals(emptySet<Int>(), s1.fire(1300, setOf(T3D, T1D)))
+        assertEquals(setOf("$end:$T3D"), store.entries)
+        // ...so the usual catch-up still applies after a restart.
+        assertEquals(setOf(T1D), SensorExpiryAlertState(store).fire(1290, setOf(T3D, T1D)))
+    }
+
+    @Test
+    fun disableEnableCycleMidEpisodeLeavesLaterThresholdsArmed() {
+        val s = newState()
+        val t = setOf(4320, 2880, 1440, 720, 60)
+        assertEquals(emptySet<Int>(), s.fire(5760, t))
+        assertEquals(setOf(4320), s.fire(4320, t))
+        // User switches the alert off and back on again.
+        assertEquals(
+            emptySet<Int>(),
+            s.triggeredThresholds(false, true, false, end, end - min(4000), t)
+        )
+        assertEquals(emptySet<Int>(), s.fire(4000, t))    // re-enabled: 3d stays warned, nothing due
+        assertEquals(setOf(2880), s.fire(2880, t))
+        assertEquals(setOf(60), s.fire(60, t))
+    }
+
+    @Test
+    fun onlyThresholdsAbsentFromThePreviousConfigCountAsNew() {
+        val configured = setOf(4320, 2880, 1440, 720, 60)
+        val nowMs = end - min(30)
+        // Same set saved again (e.g. after an enable/disable cycle): nothing is new,
+        // so no open window may be adopted.
+        assertEquals(
+            emptySet<Int>(),
+            newlyOpenExpiryThresholds(configured, configured, end, nowMs)
+        )
+        // One threshold genuinely added while several windows are open: only that
+        // one is adopted.
+        assertEquals(
+            setOf(T6H),
+            newlyOpenExpiryThresholds(configured, configured + T6H, end, nowMs)
+        )
+    }
+
+    @Test
+    fun newThresholdIsAdoptedOnlyWhileItsWindowIsOpen() {
+        val nowMs = end - min(300)   // 5h before the end
+        assertEquals(
+            setOf(T6H),
+            newlyOpenExpiryThresholds(setOf(T3D), setOf(T3D, T6H), end, nowMs)
+        )
+        assertEquals(
+            emptySet<Int>(),
+            newlyOpenExpiryThresholds(setOf(T3D), setOf(T3D, 60), end, nowMs)
+        )
+        // No plausible sensor end: nothing to adopt against.
+        assertEquals(
+            emptySet<Int>(),
+            newlyOpenExpiryThresholds(setOf(T3D), setOf(T3D, T6H), 0L, nowMs)
+        )
+    }
+
+    @Test
     fun newSensorRearmsAndPrunesOldPersistedEntries() {
         val store = FakeWarnedStore()
         val t = setOf(T1D)

--- a/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/SensorExpiryAlertStateTests.kt
@@ -25,8 +25,21 @@ class SensorExpiryAlertStateTests {
 
     private fun newState(store: ExpiryWarnedStore = FakeWarnedStore()) = SensorExpiryAlertState(store)
 
-    /** Evaluate a tick "minutesBefore" minutes before [endMs]. */
+    /**
+     * Evaluate a tick "minutesBefore" minutes before [endMs], with delivery
+     * succeeding - what the runtime does when a reading is available.
+     */
     private fun SensorExpiryAlertState.fire(
+        minutesBefore: Int,
+        thresholds: Set<Int>,
+        endMs: Long = end,
+        snoozed: Boolean = false,
+        active: Boolean = true
+    ): Set<Int> = fireUndelivered(minutesBefore, thresholds, endMs, snoozed, active)
+        .also { triggered -> triggered.forEach { confirmDelivered(it) } }
+
+    /** Same tick, but the alert never reached the user (no reading, suppressed). */
+    private fun SensorExpiryAlertState.fireUndelivered(
         minutesBefore: Int,
         thresholds: Set<Int>,
         endMs: Long = end,
@@ -265,6 +278,43 @@ class SensorExpiryAlertStateTests {
             emptySet<Int>(),
             newlyOpenExpiryThresholds(setOf(T3D), setOf(T3D, T6H), 0L, nowMs)
         )
+    }
+
+    @Test
+    fun undeliveredWarningIsOfferedAgainInsteadOfBeingSwallowed() {
+        // #98: no current glucose reading means the notification path cannot
+        // deliver. The warning must survive that tick, not count as warned.
+        val store = FakeWarnedStore()
+        val s = SensorExpiryAlertState(store)
+        s.fire(1800, setOf(T1D))
+        assertEquals(setOf(T1D), s.fireUndelivered(1440, setOf(T1D)))   // edge, delivery fails
+        assertEquals(setOf<String>(), store.entries)                    // nothing recorded as warned
+        assertEquals(setOf(T1D), s.fireUndelivered(1400, setOf(T1D)))   // still owed
+        assertEquals(setOf(T1D), s.fire(1300, setOf(T1D)))              // reading is back: delivered
+        assertEquals(setOf("$end:$T1D"), store.entries)
+        assertEquals(emptySet<Int>(), s.fire(1200, setOf(T1D)))         // and only once
+    }
+
+    @Test
+    fun undeliveredWarningStillFiresAfterRestart() {
+        val store = FakeWarnedStore()
+        val s1 = SensorExpiryAlertState(store)
+        s1.fire(1800, setOf(T1D))
+        assertEquals(setOf(T1D), s1.fireUndelivered(1440, setOf(T1D)))  // never delivered, process dies
+        assertEquals(setOf(T1D), SensorExpiryAlertState(store).fire(1430, setOf(T1D)))
+    }
+
+    @Test
+    fun moreUrgentThresholdSupersedesAnUndeliveredOne() {
+        val store = FakeWarnedStore()
+        val s = SensorExpiryAlertState(store)
+        s.fire(5760, setOf(T1D, T6H))
+        assertEquals(setOf(T1D), s.fireUndelivered(1440, setOf(T1D, T6H)))  // 1d owed, undelivered
+        // The 6h edge arrives first: it wins, and the stale 1d warning is dropped
+        // rather than queued behind it.
+        assertEquals(setOf(T6H), s.fire(360, setOf(T1D, T6H)))
+        assertEquals(setOf("$end:$T1D", "$end:$T6H"), store.entries)
+        assertEquals(emptySet<Int>(), s.fire(120, setOf(T1D, T6H)))
     }
 
     @Test


### PR DESCRIPTION
Stacks on #151, which touches the same function. The diff to review here is the second commit, `Sensor expiry: do not count a warning as warned until it was delivered`.

This is related to #98 but it is not the change that issue asks for. Details at the end.

`evaluateSensorExpiryLocked` returns before firing when there is no current glucose value:

```kotlin
val glucoseValue = currentGlucoseValueLocked() ?: return
```

By that point `SensorExpiryAlertState.triggeredThresholds` has already marked the threshold as warned and written it to SharedPreferences. The window edge has passed, so no later tick offers it again, and the persisted entry keeps it silent after a restart as well. The warning is not delayed, it is lost.

#98 estimates the impact as small because a threshold "normally fires on a later tick once a reading is back". That held before the warned-set was persisted in #112. It does not hold now, and the case where it matters is not rare: readings tend to stop exactly when a sensor is about to expire, which is when the last thresholds come due. There is no fallback value either, since a non-finite reading resets `lastGlucoseValue` and `lastDisplaySnapshot`, and `bootstrapLastReadingLocked` only recovers a value inside `Notify.glucosetimeout` (5.5 minutes).

The latch now hands the caller a pending threshold and records it as warned only when `confirmDelivered()` reports that the notification went out. A tick that cannot deliver leaves it pending and offers it again on the next one. If a more urgent threshold comes due in the meantime it wins and the stale one is dropped, which is the rule the cascade guard already applies when several thresholds come due at once. The standard glucose alerts have used this handshake for a while through `AlertEpisodeState.markPendingDelivery`, so this brings the expiry latch in line with them rather than adding a new mechanism.

What this does not do: it does not remove the glucose-value requirement. A warning still waits for a reading before it can go out, so a sensor whose readings never come back can still expire without its last warning being seen. Removing the requirement needs a value-less path through the notification layer, and that raises a question worth deciding separately: what an expiry alarm should show when there is no reading. `triggerSupplementalGlucoseAlert` rejects a non-finite value up front, `lossofsignalalarm` is a working value-less path but bypasses `AlertStateTracker` and the retry session, and `legacyWatchAlertMessage` and `launchOrQueueAlarmActivityResult` already tolerate NaN. I would rather not show a stale reading on an alarm screen without saying how old it is, so I left #98 open.

Tests: three new cases in `SensorExpiryAlertStateTests` covering the undelivered warning being offered again, surviving a process restart, and being superseded by a more urgent threshold. Two of the three fail on the current code. The existing cases are unchanged; the shared test helper now confirms delivery, which is what the runtime does when a reading is available, so their assertions keep their original meaning.
