### PR TITLE
Delta alarms: a failed delivery no longer consumes the alarm

### DIFF
--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -486,7 +486,12 @@ object AlertRuntimeManager {
 
         val label = Applic.app.getString(type.nameResId)
         val message = "$label ${Notify.glucosestr(glucoseValue)}"
-        triggerAlert(type, glucoseValue, currentRateLocked(), message)
+        if (!triggerAlert(type, glucoseValue, currentRateLocked(), message)) {
+            // The latch disarmed on the offer; a failed delivery must not consume
+            // the alarm. Re-armed, it fires again while the run stands and dies
+            // with it if the run breaks.
+            state.rearmAfterFailedDelivery()
+        }
     }
 
     /** Notification text naming the threshold that fired ("... in 3 days" / "... in 6 hours"). */

--- a/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/DeltaAlarmState.kt
@@ -75,6 +75,16 @@ internal class DeltaAlarmState(private val falling: Boolean) {
         armed = true
     }
 
+    /**
+     * The alert offered by the last true [shouldTrigger] never reached the user
+     * (delivery suppressed or failed). Re-arm so the next evaluation offers it
+     * again while the steep run still stands; if the run has broken meanwhile,
+     * the stale alarm dies with it instead of firing late.
+     */
+    fun rearmAfterFailedDelivery() {
+        armed = true
+    }
+
     fun shouldTrigger(
         enabled: Boolean,
         activeNow: Boolean,

--- a/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/DeltaAlarmStateTests.kt
@@ -470,4 +470,31 @@ class DeltaAlarmStateTests {
         // 28 from the NEW anchor -> no alarm; the stale 150 anchor would have given 38.
         assertFalse(state.feed(112f, 18, earlyTrigger = true))
     }
+
+    // ---- Failed delivery must not consume the alarm ----
+
+    @Test
+    fun failedDeliveryReoffersWhileTheRunStands() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))
+        assertFalse(state.feed(130f, 10))
+        assertTrue(state.feed(120f, 15))       // fires, but delivery fails
+        state.rearmAfterFailedDelivery()
+        assertTrue(state.feed(110f, 20))       // run still steep: offered again
+        assertFalse(state.feed(100f, 25))      // delivered this time -> once per run
+    }
+
+    @Test
+    fun failedDeliveryDoesNotFireAfterTheRunBreaks() {
+        val state = DeltaAlarmState(falling = true)
+        assertFalse(state.feed(150f, 0))
+        assertFalse(state.feed(140f, 5))
+        assertFalse(state.feed(130f, 10))
+        assertTrue(state.feed(120f, 15))       // fires, delivery fails
+        state.rearmAfterFailedDelivery()
+        // Reversal breaks the run: the stale falling-fast alarm dies with it.
+        assertFalse(state.feed(131f, 20))
+        assertFalse(state.feed(130f, 25))      // no late fire from the old run
+    }
 }


### PR DESCRIPTION
`DeltaAlarmState` disarms itself the moment it offers an alarm (`armed = false; return true`), and `evaluateDeltaAlarmLocked` discarded `triggerAlert`'s result. A falling-fast or rising-fast alarm whose delivery failed - suppressed by the alert state tracker's first-fire gate, or a notification error - was consumed silently. Nothing fires again until the run breaks and a whole new steep run accumulates, which is to say: during exactly the movement the alarm was configured to catch.

Same defect shape as the expiry-warning swallow fixed in #152, found while searching for other sites that consume a latch before delivery is known.

The fix is caller-side: when `triggerAlert` returns false, re-arm the latch. The run counter is untouched, so the next evaluation offers the alarm again while the steep run still stands - each re-offer with the then-current value, not a stored one. If the movement reverses meanwhile, `breakRun()` ends the episode and the stale alarm dies with it; a "falling fast" alarm must not fire after the fall has stopped. The expiry latch needed a pending-set for this because its trigger is an edge that passes; here the condition is level-held while the run lives, so re-arming is the whole fix.

Two new tests: a failed delivery is re-offered on the next reading and delivered once, and a failed delivery does not fire late after the run breaks. The first fails if the re-arm is a no-op. Existing delta tests are untouched.
