### PR TITLE
Nightscout: optional IOB/eIOB/COB devicestatus upload

### DIFF
--- a/Common/src/main/cpp/net/watchserver/uploader.cpp
+++ b/Common/src/main/cpp/net/watchserver/uploader.cpp
@@ -483,6 +483,34 @@ static bool uploadDeviceStatus() {
     return queued;
     }
 
+//Journal IOB/eIOB/COB devicestatus. Setting check, cadence and payload live on
+//the Java side (NightPost/NightscoutIobDeviceStatus) where the journal is
+//reachable and unit-testable; this just hands over the endpoint. Same
+//best-effort contract as the battery devicestatus above: never blocks the
+//serialized upload loop.
+static void uploadIobDeviceStatus() {
+    if(nightpostclass==nullptr || jnightuploadDevicestatusurl==nullptr)
+        return;
+    auto env=getenv();
+    if(env==nullptr)
+        return;
+    const static jmethodID mid=env->GetStaticMethodID(
+        nightpostclass,
+        "maybeUploadIobDeviceStatus",
+        "(Ljava/lang/String;Ljava/lang/String;)Z"
+    );
+    if(mid==nullptr) {
+        if(env->ExceptionCheck())
+            env->ExceptionClear();
+        return;
+        }
+    env->CallStaticBooleanMethod(nightpostclass,mid,jnightuploadDevicestatusurl,jnightuploadsecret);
+    if(env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        }
+    }
+
 
 extern double     calibrateONEtest(const SensorGlucoseData *sens,const ScanData &value);
 extern double getdelta(float change);
@@ -945,6 +973,7 @@ static void uploaderthread() {
         //Best effort: Java posts this on a bounded, dedicated executor. Its endpoint status never
         //overwrites the primary glucose uploader status or blocks this serialized upload loop.
         uploadDeviceStatus();
+        uploadIobDeviceStatus();
         waitmin=5*60;
         lastNightUploadWaitMinutes = waitmin;
         }

--- a/Common/src/main/java/tk/glucodata/NightPost.java
+++ b/Common/src/main/java/tk/glucodata/NightPost.java
@@ -344,6 +344,83 @@ static public int batteryPercent() {
         }
     }
 
+private static final String PREFS_NAME="tk.glucodata_preferences";
+private static final String PREF_UPLOAD_IOB="nightscout_upload_iob";
+private static long iobStatusUploadTime=0L;
+private static float iobStatusLastIob=Float.NaN;
+private static float iobStatusLastEiob=Float.NaN;
+private static float iobStatusLastCob=Float.NaN;
+
+/**
+ * Opt-in: off by default because enabling it changes which source the
+ * Nightscout site's IOB pill uses (NG's journal instead of Nightscout's own
+ * treatment calculation from its profile DIA).
+ */
+@Keep
+static public boolean getUploadIob() {
+    final Context context = Applic.getContext();
+    if(context == null)
+        return false;
+    return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(PREF_UPLOAD_IOB, false);
+    }
+
+@Keep
+static public void setUploadIob(boolean enabled) {
+    final Context context = Applic.getContext();
+    if(context == null)
+        return;
+    context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(PREF_UPLOAD_IOB, enabled)
+            .apply();
+    }
+
+/**
+ * Uploads the journal IOB/eIOB/COB as a Nightscout devicestatus when the
+ * opt-in setting is on and one is due. Called from the native uploader loop
+ * after entries and treatments; always best-effort, so failures here never
+ * hold back glucose. The journal snapshot is the same one the notification
+ * and the glucodata broadcast display, so the site shows the phone's number.
+ */
+@Keep
+static public boolean maybeUploadIobDeviceStatus(String httpurl,String secret) {
+    try {
+        if(!getUploadIob())
+            return true;
+        final long now=System.currentTimeMillis();
+        if(!NightscoutIobDeviceStatus.fastIntervalElapsed(now, iobStatusUploadTime))
+            return true;
+        final float[] values=JournalIobAccess.snapshot(now);
+        if(values==null || values.length<3)
+            return true;
+        if(!NightscoutIobDeviceStatus.shouldUpload(
+                now,
+                iobStatusUploadTime,
+                values[0],
+                values[1],
+                values[2],
+                iobStatusLastIob,
+                iobStatusLastEiob,
+                iobStatusLastCob))
+            return true;
+        final String document=NightscoutIobDeviceStatus.buildDocument(now,values[0],values[1],values[2]);
+        if(document==null)
+            return true;
+        if(uploadDeviceStatusAsync(httpurl,document.getBytes(java.nio.charset.StandardCharsets.UTF_8),secret,false)) {
+            iobStatusUploadTime=now;
+            iobStatusLastIob=values[0];
+            iobStatusLastEiob=values[1];
+            iobStatusLastCob=values[2];
+            }
+        return true;
+        }
+    catch(Throwable th) {
+        Log.e(LOG_ID,"maybeUploadIobDeviceStatus error:\n"+stackline(th));
+        return true;
+        }
+    }
+
 @Keep
 static public int upload(String httpurl,byte[] postdata,String secret,boolean put) {
     return uploadWithTimeouts(

--- a/Common/src/main/java/tk/glucodata/NightscoutIobDeviceStatus.java
+++ b/Common/src/main/java/tk/glucodata/NightscoutIobDeviceStatus.java
@@ -1,0 +1,115 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+// Builds the IOB devicestatus document for Nightscout and decides when one is
+// due. Nightscout's IOB plugin (lib/plugins/iob.js) reads openaps.iob first
+// and ignores devicestatus entries older than 30 minutes, so the cadence has
+// to stay well inside that window while values are moving. The standard
+// openaps field carries classic IOB: consumers (AAPS followers, caregivers,
+// loops) read it as insulin still on board, and eIOB is systematically
+// smaller, so publishing eIOB there would understate active insulin. eIOB and
+// COB travel in a separate "jugglucong" object instead; Nightscout stores
+// unknown devicestatus fields and serves them back over its API.
+// openaps.iob.activity is deliberately absent: OpenAPS defines it as insulin
+// activity per minute, which is not a value the journal computes.
+public class NightscoutIobDeviceStatus {
+    // Values are moving: upload at most every 5 minutes. Idle at zero: fall
+    // back to the same slow cadence as the battery devicestatus.
+    static final long FAST_INTERVAL_MILLIS = 5L * 60L * 1000L;
+    static final long SLOW_INTERVAL_MILLIS = 15L * 60L * 1000L;
+    // Below half of the 0.01-unit display quantum IOB counts as zero.
+    private static final float VALUE_QUANTUM = 0.01f;
+
+    private NightscoutIobDeviceStatus() {
+    }
+
+    // True once enough time has passed for an upload to even be considered —
+    // callers use this as a cheap gate before computing the journal snapshot.
+    static boolean fastIntervalElapsed(long nowMillis, long lastUploadMillis) {
+        return lastUploadMillis <= 0L || nowMillis - lastUploadMillis >= FAST_INTERVAL_MILLIS;
+    }
+
+    // Decides whether a devicestatus is due. Fast cadence while insulin is on
+    // board or any value moved since the last upload; slow cadence once IOB
+    // has settled at zero so an idle night does not spam the endpoint.
+    static boolean shouldUpload(
+            long nowMillis,
+            long lastUploadMillis,
+            float iob,
+            float eiob,
+            float cob,
+            float lastIob,
+            float lastEiob,
+            float lastCob
+    ) {
+        if (lastUploadMillis <= 0L)
+            return true;
+        final long elapsed = nowMillis - lastUploadMillis;
+        if (elapsed < FAST_INTERVAL_MILLIS)
+            return false;
+        final boolean changed = differs(iob, lastIob) || differs(eiob, lastEiob) || differs(cob, lastCob);
+        final boolean insulinOnBoard = !Float.isNaN(iob) && Math.abs(iob) >= VALUE_QUANTUM / 2f;
+        if (insulinOnBoard || changed)
+            return true;
+        return elapsed >= SLOW_INTERVAL_MILLIS;
+    }
+
+    private static boolean differs(float value, float last) {
+        if (Float.isNaN(value) || Float.isNaN(last))
+            return Float.isNaN(value) != Float.isNaN(last);
+        return Math.round(value / VALUE_QUANTUM) != Math.round(last / VALUE_QUANTUM);
+    }
+
+    // The devicestatus JSON array, or null when there is no classic IOB to
+    // report — without openaps.iob.iob the document would carry nothing
+    // Nightscout's IOB plugin can use. eIOB and COB are included only when
+    // the journal has data of that kind. All values are insulin units and
+    // grams; glucose units play no role here.
+    static String buildDocument(long nowMillis, float iob, float eiob, float cob) {
+        if (Float.isNaN(iob))
+            return null;
+        final String timestamp = isoTimestamp(nowMillis);
+        final StringBuilder out = new StringBuilder(224);
+        out.append("[{\"device\":\"JugglucoNG\",\"created_at\":\"").append(timestamp)
+                .append("\",\"openaps\":{\"iob\":{\"iob\":").append(formatUnits(iob))
+                .append(",\"timestamp\":\"").append(timestamp)
+                .append("\"}},\"jugglucong\":{\"iob\":").append(formatUnits(iob));
+        if (!Float.isNaN(eiob))
+            out.append(",\"eiob\":").append(formatUnits(eiob));
+        if (!Float.isNaN(cob))
+            out.append(",\"cob\":").append(formatUnits(cob));
+        out.append("}}]");
+        return out.toString();
+    }
+
+    // Same shape the native battery devicestatus emits (addNightscoutDateStringGMT).
+    static String isoTimestamp(long millis) {
+        final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT);
+        format.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return format.format(new Date(millis));
+    }
+
+    private static String formatUnits(float value) {
+        return String.format(Locale.ROOT, "%.2f", value);
+    }
+}

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1262,6 +1262,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightscout_send_long_insulin_desc">Basal- und ultralang wirkendes Insulin zu Nightscout hochladen</string>
     <string name="nightscout_receive_amounts">Mengen empfangen</string>
     <string name="nightscout_receive_amounts_desc">Nightscout-Insulin/Kohlenhydrate ins Journal importieren</string>
+    <string name="nightscout_upload_iob">IOB an Nightscout senden</string>
+    <string name="nightscout_upload_iob_desc">Nightscout zeigt dann diesen Wert statt seiner eigenen Berechnung aus dem Profil. eIOB und COB werden zusätzlich in einem eigenen Feld übertragen.</string>
     <string name="nightscout_settings_title">Nightscout-Einstellungen</string>
     <string name="nightscout_url_label">Nightscout-URL</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1545,6 +1545,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin_desc">Include basal and ultra-long insulin treatments in Nightscout uploads</string>
     <string name="nightscout_receive_amounts">Receive amounts</string>
     <string name="nightscout_receive_amounts_desc">Import Nightscout insulin/carbs into journal</string>
+    <string name="nightscout_upload_iob">Send IOB to Nightscout</string>
+    <string name="nightscout_upload_iob_desc">Nightscout then shows this value instead of its own calculation from its profile. eIOB and COB are sent along in a separate field.</string>
     <string name="nightscout_settings_title">Nightscout Settings</string>
     <string name="nightscout_sync_actions_title">Sync actions</string>
     <string name="nightscout_url_label">Nightscout URL</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -71,6 +71,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tk.glucodata.Natives
+import tk.glucodata.NightPost
 import tk.glucodata.R
 import tk.glucodata.data.journal.JournalTreatmentUploader
 import tk.glucodata.drivers.nightscout.NightscoutFollowerRegistry
@@ -142,6 +143,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
     var sendTreatments by rememberSaveable { mutableStateOf(Natives.getpostTreatments()) }
     var sendLongInsulin by rememberSaveable { mutableStateOf(JournalTreatmentUploader.getSendLongInsulin()) }
     var receiveTreatments by rememberSaveable { mutableStateOf(JournalTreatmentUploader.getReceiveTreatments()) }
+    var uploadIob by rememberSaveable { mutableStateOf(NightPost.getUploadIob()) }
     var isV3 by rememberSaveable { mutableStateOf(Natives.getnightscoutV3()) }
     var showSecret by rememberSaveable { mutableStateOf(false) }
     var lastResponseCode by rememberSaveable { mutableStateOf(0) }
@@ -513,6 +515,20 @@ fun NightscoutSettingsScreen(navController: NavController) {
                             icon = Icons.Default.Medication,
                             iconTint = MaterialTheme.colorScheme.tertiary,
                             enabled = isActive && sendTreatments,
+                            position = CardPosition.MIDDLE
+                        )
+                        SettingsSwitchItem(
+                            title = stringResource(R.string.nightscout_upload_iob),
+                            subtitle = stringResource(R.string.nightscout_upload_iob_desc),
+                            checked = uploadIob,
+                            onCheckedChange = {
+                                uploadIob = it
+                                NightPost.setUploadIob(it)
+                                if (it) Natives.wakeuploader()
+                            },
+                            icon = Icons.Default.CloudUpload,
+                            iconTint = MaterialTheme.colorScheme.secondary,
+                            enabled = isActive,
                             position = CardPosition.MIDDLE
                         )
                         SettingsSwitchItem(

--- a/Common/src/test/java/tk/glucodata/NightscoutIobDeviceStatusTests.kt
+++ b/Common/src/test/java/tk/glucodata/NightscoutIobDeviceStatusTests.kt
@@ -1,0 +1,132 @@
+package tk.glucodata
+
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NightscoutIobDeviceStatusTests {
+
+    private val now = 1_754_200_000_000L // 2025-08-03T06:26:40.000Z
+
+    // -- document shape ----------------------------------------------------
+
+    @Test
+    fun `document carries classic IOB in the openaps container Nightscout reads`() {
+        val doc = NightscoutIobDeviceStatus.buildDocument(now, 1.8f, 1.5f, 0f)!!
+        val entry = JSONArray(doc).getJSONObject(0)
+        assertEquals("JugglucoNG", entry.getString("device"))
+        val iob = entry.getJSONObject("openaps").getJSONObject("iob")
+        assertEquals(1.8, iob.getDouble("iob"), 1e-9)
+        assertTrue(
+            "timestamp must be ISO8601: " + iob.getString("timestamp"),
+            Regex("""\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z""").matches(iob.getString("timestamp"))
+        )
+        assertEquals(entry.getString("created_at"), iob.getString("timestamp"))
+    }
+
+    @Test
+    fun `eiob and cob travel in the jugglucong namespace not the standard field`() {
+        val doc = NightscoutIobDeviceStatus.buildDocument(now, 1.8f, 1.5f, 24f)!!
+        val entry = JSONArray(doc).getJSONObject(0)
+        val own = entry.getJSONObject("jugglucong")
+        assertEquals(1.8, own.getDouble("iob"), 1e-9)
+        assertEquals(1.5, own.getDouble("eiob"), 1e-9)
+        assertEquals(24.0, own.getDouble("cob"), 1e-9)
+        // The standard container must stay the classic-IOB contract.
+        val openapsIob = entry.getJSONObject("openaps").getJSONObject("iob")
+        assertFalse(openapsIob.has("eiob"))
+        assertFalse(openapsIob.has("cob"))
+    }
+
+    @Test
+    fun `activity and basaliob are absent because the journal has no such values`() {
+        val doc = NightscoutIobDeviceStatus.buildDocument(now, 1.8f, 1.5f, 0f)!!
+        val iob = JSONArray(doc).getJSONObject(0).getJSONObject("openaps").getJSONObject("iob")
+        assertFalse(iob.has("activity"))
+        assertFalse(iob.has("basaliob"))
+    }
+
+    @Test
+    fun `values without data of that kind are omitted`() {
+        val doc = NightscoutIobDeviceStatus.buildDocument(now, 1.8f, Float.NaN, Float.NaN)!!
+        val own = JSONArray(doc).getJSONObject(0).getJSONObject("jugglucong")
+        assertFalse(own.has("eiob"))
+        assertFalse(own.has("cob"))
+    }
+
+    @Test
+    fun `no classic IOB means no document`() {
+        assertNull(NightscoutIobDeviceStatus.buildDocument(now, Float.NaN, Float.NaN, 24f))
+    }
+
+    @Test
+    fun `insulin units pass through without glucose unit conversion`() {
+        // 18 units would come back as 1.0 if an mg-dl-to-mmol conversion leaked in.
+        val doc = NightscoutIobDeviceStatus.buildDocument(now, 18f, Float.NaN, Float.NaN)!!
+        val entry = JSONArray(doc).getJSONObject(0)
+        assertEquals(18.0, entry.getJSONObject("openaps").getJSONObject("iob").getDouble("iob"), 1e-9)
+    }
+
+    @Test
+    fun `timestamp is rendered in GMT`() {
+        assertEquals("2026-01-02T03:04:05.678Z", NightscoutIobDeviceStatus.isoTimestamp(1_767_323_045_678L))
+    }
+
+    // -- cadence -----------------------------------------------------------
+
+    private val fast = NightscoutIobDeviceStatus.FAST_INTERVAL_MILLIS
+    private val slow = NightscoutIobDeviceStatus.SLOW_INTERVAL_MILLIS
+
+    private fun due(
+        elapsed: Long,
+        iob: Float,
+        eiob: Float = iob * 0.8f,
+        cob: Float = 0f,
+        lastIob: Float = iob,
+        lastEiob: Float = eiob,
+        lastCob: Float = cob
+    ) = NightscoutIobDeviceStatus.shouldUpload(now + elapsed, now, iob, eiob, cob, lastIob, lastEiob, lastCob)
+
+    @Test
+    fun `first upload is always due`() {
+        assertTrue(NightscoutIobDeviceStatus.shouldUpload(now, 0L, 1.8f, 1.5f, 0f, Float.NaN, Float.NaN, Float.NaN))
+    }
+
+    @Test
+    fun `changing values upload at most every five minutes`() {
+        assertFalse(due(fast - 1, iob = 1.6f, lastIob = 1.8f))
+        assertTrue(due(fast, iob = 1.6f, lastIob = 1.8f))
+    }
+
+    @Test
+    fun `active insulin keeps the fast cadence even when the rounded value is unchanged`() {
+        assertTrue(due(fast, iob = 1.8f))
+    }
+
+    @Test
+    fun `idle at zero falls back to the slow cadence`() {
+        assertFalse(due(fast, iob = 0f, eiob = 0f))
+        assertFalse(due(slow - 1, iob = 0f, eiob = 0f))
+        assertTrue(due(slow, iob = 0f, eiob = 0f))
+    }
+
+    @Test
+    fun `cob movement at zero insulin still uploads on the fast cadence`() {
+        assertTrue(due(fast, iob = 0f, eiob = 0f, cob = 12f, lastCob = 24f))
+    }
+
+    @Test
+    fun `value jitter below the display quantum does not count as a change`() {
+        assertFalse(due(fast, iob = 0f, eiob = 0f, cob = 24.001f, lastCob = 24.004f))
+    }
+
+    @Test
+    fun `fast gate matches the cadence decision`() {
+        assertTrue(NightscoutIobDeviceStatus.fastIntervalElapsed(now, 0L))
+        assertFalse(NightscoutIobDeviceStatus.fastIntervalElapsed(now + fast - 1, now))
+        assertTrue(NightscoutIobDeviceStatus.fastIntervalElapsed(now + fast, now))
+    }
+}


### PR DESCRIPTION
NG uploads entries and treatments, but its devicestatus documents carry only the uploader battery. Nightscout therefore derives IOB from treatments with its own profile DIA, a different curve than the one configured in the app. This adds an optional devicestatus upload with the journal IOB in the `openaps.iob` container that Nightscout's IOB plugin reads (`lib/plugins/iob.js`), so the site shows the same number the phone does. Nightscout keeps its treatment-derived value as `treatmentIob`, so nothing is lost.

The standard field carries classic IOB. Anything that reads it (AAPS followers, caregivers, loop systems) interprets the number as insulin still on board, and eIOB is systematically smaller, so publishing eIOB there would understate active insulin. eIOB and COB travel in a `jugglucong` object instead; Nightscout stores unknown devicestatus fields and serves them back over its API.

```json
[{
  "device": "JugglucoNG",
  "created_at": "2026-08-03T12:00:00.000Z",
  "openaps": { "iob": { "iob": 1.80, "timestamp": "2026-08-03T12:00:00.000Z" } },
  "jugglucong": { "iob": 1.80, "eiob": 1.50, "cob": 24.00 }
}]
```

Details:

- `openaps.iob.activity` and `basaliob` are left out. OpenAPS defines activity as insulin action per minute and basaliob presumes a basal concept; the journal computes neither.
- `jugglucong.eiob` and `cob` are omitted when the journal has no data of that kind. Without classic IOB no document is sent at all.
- The values come from the same journal snapshot the notification and the glucodata broadcast show (`OutboundApiJournalSnapshot.broadcastIobSnapshot`), so phone and site agree.
- The cadence is separate from the 15-minute battery devicestatus because the IOB plugin ignores entries older than 30 minutes: at most one upload per 5 minutes while insulin is on board or a value moved, dropping to the 15-minute cadence once IOB settles at zero. The battery devicestatus is unchanged and stays its own document; both go through the same best-effort async path and never block entries or treatments.
- Off by default. Enabling it changes which source the site's IOB pill uses. Through the openaps container NG reports as source "OpenAPS"; if a real loop uploads in parallel, Nightscout prefers the device reporting as "Loop", so the two won't fight.

The setting sits with the other Nightscout upload options (EN/DE strings). Unit tests cover the document shape (classic IOB in `openaps.iob`, ISO 8601 timestamps, no activity/basaliob, omission of missing values, insulin units passing through untouched) and the cadence rules.
