### PR TITLE
Nightscout follower: read IOB/eIOB/COB from devicestatus

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerDeviceStatus.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerDeviceStatus.kt
@@ -1,0 +1,98 @@
+package tk.glucodata.drivers.nightscout
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Remote IOB/eIOB/COB read from Nightscout devicestatus documents uploaded by
+ * another JugglucoNG device (classic IOB in the openaps.iob container, eIOB
+ * and COB in the "jugglucong" namespace). While a fresh document exists the
+ * follower shows the uploader's numbers instead of recomputing them from
+ * imported treatments with its own insulin presets; once the document ages
+ * out, the local computation takes over again.
+ */
+object NightscoutFollowerDeviceStatus {
+
+    // Matches Nightscout's own RECENCY_THRESHOLD (lib/plugins/iob.js): the
+    // site stops trusting devicestatus IOB after 30 minutes, so following the
+    // same window keeps site and follower in agreement.
+    const val FRESHNESS_WINDOW_MS = 30L * 60L * 1000L
+
+    data class RemoteIob(
+        val iobUnits: Float,
+        /** NaN when the document carries no eiob field. */
+        val eiobUnits: Float,
+        /** NaN when the document carries no cob field. */
+        val cobGrams: Float,
+        val timestampMillis: Long,
+    )
+
+    @Volatile
+    private var latest: RemoteIob? = null
+
+    /**
+     * Stores a parsed snapshot. A null result of a poll keeps the previous
+     * snapshot: the freshness window retires it on its own, and dropping it
+     * early would make one failed fetch flip the displayed source.
+     */
+    fun update(remote: RemoteIob?) {
+        if (remote != null) latest = remote
+    }
+
+    fun clear() {
+        latest = null
+    }
+
+    /**
+     * The stored snapshot while it is inside the freshness window, else null.
+     * Timestamps ahead of the local clock count as fresh — the uploader's
+     * clock may run slightly ahead of the follower's.
+     */
+    @JvmStatic
+    fun fresh(nowMillis: Long): RemoteIob? =
+        latest?.takeIf { nowMillis - it.timestampMillis <= FRESHNESS_WINDOW_MS }
+
+    /**
+     * The newest document carrying a jugglucong block with a finite iob, or
+     * null. Documents from foreign uploaders (plain openaps loops) have no
+     * such block and are ignored.
+     */
+    fun parseNewest(body: String): RemoteIob? {
+        val array = runCatching { JSONArray(body) }.getOrNull() ?: return null
+        var newest: RemoteIob? = null
+        for (index in 0 until array.length()) {
+            val parsed = parseDocument(array.optJSONObject(index) ?: continue) ?: continue
+            if (newest == null || parsed.timestampMillis > newest.timestampMillis) {
+                newest = parsed
+            }
+        }
+        return newest
+    }
+
+    private fun parseDocument(doc: JSONObject): RemoteIob? {
+        val block = doc.optJSONObject("jugglucong") ?: return null
+        val iob = block.optDouble("iob", Double.NaN)
+        if (!iob.isFinite()) return null
+        val timestampMillis = doc.optJSONObject("openaps")?.optJSONObject("iob")
+            ?.optString("timestamp").let(::parseIsoMillis)
+            ?: parseIsoMillis(doc.optString("created_at"))
+            ?: doc.optLong("mills", 0L).takeIf { it > 0L }
+            ?: return null
+        return RemoteIob(
+            iobUnits = iob.toFloat(),
+            eiobUnits = block.optDouble("eiob", Double.NaN).toFloat(),
+            cobGrams = block.optDouble("cob", Double.NaN).toFloat(),
+            timestampMillis = timestampMillis,
+        )
+    }
+
+    private fun parseIsoMillis(value: String?): Long? {
+        val trimmed = value?.trim().orEmpty()
+        if (trimmed.isEmpty()) return null
+        return runCatching { Instant.parse(trimmed).toEpochMilli() }
+            .recoverCatching { OffsetDateTime.parse(trimmed).toInstant().toEpochMilli() }
+            .getOrNull()
+    }
+}

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
@@ -37,6 +37,7 @@ class NightscoutFollowerManager(
         private const val RETRY_INTERVAL_MS = 30_000L
         private const val PROBE_INTERVAL_MS = 59_000L
         private const val TREATMENT_COUNT = 512
+        private const val DEVICE_STATUS_COUNT = 5
         private const val MMOL_TO_MGDL = 18.0182f
     }
 
@@ -157,6 +158,7 @@ class NightscoutFollowerManager(
         stop = true
         handler.removeCallbacksAndMessages(null)
         mainHandler.removeCallbacks(probeRunnable)
+        NightscoutFollowerDeviceStatus.clear()
         setStatus(Phase.IDLE, localizedString(R.string.nightscout_follow_status_paused, "Nightscout follower paused"))
     }
 
@@ -178,6 +180,7 @@ class NightscoutFollowerManager(
         stop = true
         handler.removeCallbacksAndMessages(null)
         mainHandler.removeCallbacks(probeRunnable)
+        NightscoutFollowerDeviceStatus.clear()
         if (wipeData) {
             Applic.app?.let { NightscoutFollowerRegistry.disableFollowerSensor(it) }
         }
@@ -214,6 +217,7 @@ class NightscoutFollowerManager(
             val fetched = fetchReadings()
             val readings = fetched.latestReadings
             importRemoteTreatments()
+            refreshRemoteDeviceStatus()
             if (readings.isEmpty()) {
                 setStatus(Phase.IDLE, localizedString(R.string.nightscout_follow_status_no_readings, "No Nightscout readings yet"))
                 scheduleRefresh(POLL_INTERVAL_MS)
@@ -382,6 +386,45 @@ class NightscoutFollowerManager(
             }
             0
         }
+
+    // Devicestatus is optional enrichment on top of entries/treatments: a
+    // failing endpoint (404 on old servers, 401, malformed body) must never
+    // block the glucose refresh, so the whole step stays inside runCatching.
+    private fun refreshRemoteDeviceStatus() {
+        runCatching {
+            val body = fetchDeviceStatusJson()
+            if (body.isBlank() || body == "[]") return
+            NightscoutFollowerDeviceStatus.update(NightscoutFollowerDeviceStatus.parseNewest(body))
+        }.onFailure { error ->
+            Log.w(TAG, "Nightscout devicestatus ignored: ${error.message}")
+        }
+    }
+
+    private fun fetchDeviceStatusJson(): String {
+        val endpoint = "${NightscoutFollowerRegistry.normalizeUrl(url)}/api/v1/devicestatus.json?count=$DEVICE_STATUS_COUNT"
+        val connection = (URL(endpoint).openConnection() as HttpURLConnection).apply {
+            connectTimeout = 15_000
+            readTimeout = 30_000
+            requestMethod = "GET"
+            setRequestProperty("Accept", "application/json")
+            setRequestProperty("User-Agent", "JugglucoNG Nightscout follower")
+            NightscoutFollowerRegistry.applyAuth(this, secret)
+        }
+        try {
+            val code = connection.responseCode
+            val body = (if (code in 200..299) connection.inputStream else connection.errorStream)
+                ?.bufferedReader()
+                ?.use { it.readText() }
+                .orEmpty()
+            if (code == 404) return "[]"
+            if (code !in 200..299) {
+                throw IllegalStateException("Nightscout devicestatus HTTP $code: ${body.take(160)}")
+            }
+            return body
+        } finally {
+            connection.disconnect()
+        }
+    }
 
     private fun fetchTreatmentsJson(): String {
         val endpoint = "${NightscoutFollowerRegistry.normalizeUrl(url)}/api/v1/treatments.json?count=$TREATMENT_COUNT"

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1699,6 +1699,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="notification_iob_risk_without_cob_desc">Insulin ohne erfasste Kohlenhydrate als ungedeckt werten</string>
     <string name="journal_iob_expanded">IOB %1$s E verbleibend</string>
     <string name="journal_eiob_expanded">eIOB %1$s E wirksam</string>
+    <string name="journal_iob_source_remote">Werte vom Uploader-Gerät (Nightscout)</string>
     <string name="journal_visible_events">Sichtbare Ereignisse</string>
     <string name="journal_empty">Noch keine Journalereignisse in diesem Fenster</string>
     <string name="journal_type_insulin">Insulin</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2112,6 +2112,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_iob_risk_without_cob_desc">Treat insulin as uncovered when no carbs are logged</string>
     <string name="journal_iob_expanded">IOB %1$sU remaining</string>
     <string name="journal_eiob_expanded">eIOB %1$sU acting</string>
+    <string name="journal_iob_source_remote">Values from the uploading device (Nightscout)</string>
     <string name="journal_visible_events">Visible events</string>
     <string name="journal_empty">No journal events in this window yet</string>
     <string name="journal_type_insulin">Insulin</string>

--- a/Common/src/mobile/java/tk/glucodata/OutboundApiJournalSnapshot.kt
+++ b/Common/src/mobile/java/tk/glucodata/OutboundApiJournalSnapshot.kt
@@ -127,10 +127,21 @@ object OutboundApiJournalSnapshot {
         } else {
             Float.NaN
         }
+        // A fresh devicestatus from the uploading device replaces the local
+        // journal math: IOB, eIOB and COB switch source together because they
+        // come from one document and one computation — mixing them would be
+        // inconsistent. The one exception is a field the document lacks (an
+        // uploader without carb data omits cob): that field alone stays
+        // local. The 30-minute-window projections keep the local values in
+        // either case; they only feed the notification risk tint and have no
+        // remote counterpart.
+        val remote = tk.glucodata.drivers.nightscout.NightscoutFollowerDeviceStatus.fresh(atMillis)
+        val localIob = if (hasInsulin) insulin.iobUnits else Float.NaN
+        val localEiob = if (hasInsulin) insulin.eiobUnits else Float.NaN
         return floatArrayOf(
-            if (hasInsulin) insulin.iobUnits else Float.NaN,
-            if (hasInsulin) insulin.eiobUnits else Float.NaN,
-            cobNow,
+            remote?.iobUnits ?: localIob,
+            remote?.eiobUnits?.takeIf { it.isFinite() } ?: localEiob,
+            remote?.cobGrams?.takeIf { it.isFinite() } ?: cobNow,
             if (hasInsulin) iobNextWindow else Float.NaN,
             cobNextWindow
         )

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
@@ -656,6 +656,7 @@ fun DashboardChartSection(
     peerPredictionSeries: Map<String, List<GlucosePredictionSeries>> = emptyMap(),
     journalMarkers: List<JournalChartMarker> = emptyList(),
     activeInsulinSummary: JournalActiveInsulinSummary? = null,
+    activeInsulinFromRemote: Boolean = false,
     showEiob: Boolean = true,
     appChartRangeColors: Boolean = false,
     predictionPoints: List<GlucosePredictionPoint> = emptyList(),
@@ -699,6 +700,7 @@ fun DashboardChartSection(
                         peerPredictionSeries = peerPredictionSeries,
                         journalMarkers = journalMarkers,
                         activeInsulinSummary = activeInsulinSummary,
+                        activeInsulinFromRemote = activeInsulinFromRemote,
                         showEiob = showEiob,
                         appChartRangeColors = appChartRangeColors,
                         predictionPoints = predictionPoints,
@@ -772,6 +774,7 @@ fun InteractiveGlucoseChart(
     peerPredictionSeries: Map<String, List<GlucosePredictionSeries>> = emptyMap(),
     journalMarkers: List<JournalChartMarker> = emptyList(),
     activeInsulinSummary: JournalActiveInsulinSummary? = null,
+    activeInsulinFromRemote: Boolean = false,
     showEiob: Boolean = true,
     appChartRangeColors: Boolean = false,
     predictionPoints: List<GlucosePredictionPoint> = emptyList(),
@@ -3716,6 +3719,13 @@ fun InteractiveGlucoseChart(
                                             java.text.DateFormat.getTimeInstance(java.text.DateFormat.SHORT)
                                                 .format(java.util.Date(nextEndingAt))
                                         ),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                if (activeInsulinFromRemote) {
+                                    Text(
+                                        text = stringResource(R.string.journal_iob_source_remote),
                                         style = MaterialTheme.typography.bodySmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -164,6 +164,8 @@ import tk.glucodata.ui.journal.JournalFloatingActionMenu
 import tk.glucodata.ui.journal.JournalInlineChip
 import tk.glucodata.ui.journal.JournalSettingsScreen
 import tk.glucodata.data.journal.JournalIobCalculator
+import tk.glucodata.data.journal.JournalActiveInsulinSummary
+import tk.glucodata.drivers.nightscout.NightscoutFollowerDeviceStatus
 import tk.glucodata.ui.journal.buildJournalChartMarkers
 import tk.glucodata.ui.journal.journalQuickAddTimestamp
 import tk.glucodata.ui.viewmodel.DashboardViewModel
@@ -397,13 +399,32 @@ fun DashboardScreen(
             buildJournalChartMarkers(scopedJournalEntries, journalPresetsById, unit, glucoseHistory, journalFoodsById)
         }
     }
-    val activeInsulinSummary = remember(journalEnabled, scopedJournalEntries, journalPresetsById, journalNow) {
+    val localInsulinSummary = remember(journalEnabled, scopedJournalEntries, journalPresetsById, journalNow) {
         if (!journalEnabled || scopedJournalEntries.isEmpty()) {
             null
         } else {
             JournalIobCalculator.buildActiveInsulinSummary(scopedJournalEntries, journalPresetsById, journalNow)
         }
     }
+    // A fresh devicestatus published by the followed uploader replaces the
+    // locally recomputed IOB/eIOB so both devices show the same numbers; the
+    // journalNow ticker re-evaluates the freshness window, so a stale
+    // document falls back to the local computation on its own.
+    val remoteInsulin = remember(journalEnabled, journalNow) {
+        if (journalEnabled) NightscoutFollowerDeviceStatus.fresh(journalNow) else null
+    }
+    val activeInsulinSummary = remember(localInsulinSummary, remoteInsulin) {
+        when {
+            remoteInsulin == null -> localInsulinSummary
+            localInsulinSummary == null && remoteInsulin.iobUnits < 0.005f -> null
+            else -> (localInsulinSummary ?: JournalActiveInsulinSummary(0, 0f, 0, null)).copy(
+                iobUnits = remoteInsulin.iobUnits,
+                eiobUnits = remoteInsulin.eiobUnits.takeIf { it.isFinite() }
+                    ?: localInsulinSummary?.eiobUnits ?: 0f
+            )
+        }
+    }
+    val activeInsulinFromRemote = remoteInsulin != null && activeInsulinSummary != null
     val predictionSettings = remember(
         predictiveSimulationEnabled,
         predictionTrendMomentumEnabled,
@@ -1400,6 +1421,7 @@ fun DashboardScreen(
                                     peerPredictionSeries = peerPredictionSeries,
                                     journalMarkers = journalChartMarkers,
                                     activeInsulinSummary = activeInsulinSummary,
+                                    activeInsulinFromRemote = activeInsulinFromRemote,
                                     showEiob = journalEiobDisplayEnabled,
                                     appChartRangeColors = appChartRangeColorsEnabled,
                                     predictionSeries = predictionSeries,
@@ -1602,6 +1624,7 @@ fun DashboardScreen(
                                     peerPredictionSeries = peerPredictionSeries,
                                     journalMarkers = journalChartMarkers,
                                     activeInsulinSummary = activeInsulinSummary,
+                                    activeInsulinFromRemote = activeInsulinFromRemote,
                                     showEiob = journalEiobDisplayEnabled,
                                     appChartRangeColors = appChartRangeColorsEnabled,
                                     predictionSeries = predictionSeries,

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalScreen.kt
@@ -54,7 +54,9 @@ import tk.glucodata.data.journal.JournalEntry
 import tk.glucodata.data.journal.JournalEntryType
 import tk.glucodata.data.journal.JournalFood
 import tk.glucodata.data.journal.JournalInsulinPreset
+import tk.glucodata.data.journal.JournalActiveInsulinSummary
 import tk.glucodata.data.journal.JournalIobCalculator
+import tk.glucodata.drivers.nightscout.NightscoutFollowerDeviceStatus
 import tk.glucodata.ui.ChartViewportSnapshot
 import tk.glucodata.ui.DashboardChartSection
 import tk.glucodata.ui.GlucosePoint
@@ -469,9 +471,25 @@ private fun JournalMetricsPanel(
     val todaysEntries = remember(entries, startOfDayMillis, nowMillis) {
         entries.filter { it.timestamp in startOfDayMillis..nowMillis }
     }
-    val activeInsulin = remember(entries, presetsById, nowMillis) {
+    val localActiveInsulin = remember(entries, presetsById, nowMillis) {
         JournalIobCalculator.buildActiveInsulinSummary(entries, presetsById, nowMillis)
     }
+    // Mirrors the dashboard chip: a fresh devicestatus from the followed
+    // uploader wins over the local recomputation, and the ticker above
+    // retires it once it leaves the freshness window.
+    val remoteInsulin = remember(nowMillis) { NightscoutFollowerDeviceStatus.fresh(nowMillis) }
+    val activeInsulin = remember(localActiveInsulin, remoteInsulin) {
+        when {
+            remoteInsulin == null -> localActiveInsulin
+            localActiveInsulin == null && remoteInsulin.iobUnits < 0.005f -> null
+            else -> (localActiveInsulin ?: JournalActiveInsulinSummary(0, 0f, 0, null)).copy(
+                iobUnits = remoteInsulin.iobUnits,
+                eiobUnits = remoteInsulin.eiobUnits.takeIf { it.isFinite() }
+                    ?: localActiveInsulin?.eiobUnits ?: 0f
+            )
+        }
+    }
+    val activeInsulinFromRemote = remoteInsulin != null && activeInsulin != null
     val iobUnits = activeInsulin?.iobUnits?.coerceAtLeast(0f) ?: 0f
     val eiobUnits = activeInsulin?.eiobUnits?.coerceAtLeast(0f) ?: 0f
     val activeUntilFormatter = remember { SimpleDateFormat("HH:mm", Locale.getDefault()) }
@@ -578,6 +596,13 @@ private fun JournalMetricsPanel(
                                     R.string.journal_active_insulin_until,
                                     activeUntilFormatter.format(Date(endingAt))
                                 ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        if (activeInsulinFromRemote) {
+                            Text(
+                                text = stringResource(R.string.journal_iob_source_remote),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )

--- a/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerDeviceStatusTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerDeviceStatusTests.kt
@@ -1,0 +1,136 @@
+package tk.glucodata.drivers.nightscout
+
+import java.time.Instant
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NightscoutFollowerDeviceStatusTests {
+
+    private val docTime = "2026-08-03T12:00:00.000Z"
+    private val docMillis = Instant.parse(docTime).toEpochMilli()
+
+    @After
+    fun tearDown() {
+        NightscoutFollowerDeviceStatus.clear()
+    }
+
+    private fun uploaderDocument(
+        createdAt: String = docTime,
+        openapsTimestamp: String? = createdAt,
+        eiob: String = ",\"eiob\":1.25",
+        cob: String = ",\"cob\":18.00",
+    ): String {
+        val openaps = openapsTimestamp
+            ?.let { "\"openaps\":{\"iob\":{\"iob\":2.50,\"timestamp\":\"$it\"}}," }
+            .orEmpty()
+        return "{\"device\":\"JugglucoNG\",\"created_at\":\"$createdAt\",$openaps" +
+            "\"jugglucong\":{\"iob\":2.50$eiob$cob}}"
+    }
+
+    @Test
+    fun parsesUploaderDocument() {
+        val remote = NightscoutFollowerDeviceStatus.parseNewest("[${uploaderDocument()}]")
+        assertNotNull(remote)
+        assertEquals(2.50f, remote!!.iobUnits, 0.0001f)
+        assertEquals(1.25f, remote.eiobUnits, 0.0001f)
+        assertEquals(18.00f, remote.cobGrams, 0.0001f)
+        assertEquals(docMillis, remote.timestampMillis)
+    }
+
+    @Test
+    fun ignoresForeignUploaderDocuments() {
+        // A real loop system publishes openaps.iob but no jugglucong block.
+        val foreign = "[{\"device\":\"loop://iPhone\",\"created_at\":\"$docTime\"," +
+            "\"openaps\":{\"iob\":{\"iob\":3.10,\"timestamp\":\"$docTime\"}}}]"
+        assertNull(NightscoutFollowerDeviceStatus.parseNewest(foreign))
+    }
+
+    @Test
+    fun picksNewestDocumentByTimestamp() {
+        val older = uploaderDocument(createdAt = "2026-08-03T11:40:00.000Z")
+        val body = "[$older,${uploaderDocument()}]"
+        assertEquals(docMillis, NightscoutFollowerDeviceStatus.parseNewest(body)!!.timestampMillis)
+        val reversed = "[${uploaderDocument()},$older]"
+        assertEquals(docMillis, NightscoutFollowerDeviceStatus.parseNewest(reversed)!!.timestampMillis)
+    }
+
+    @Test
+    fun prefersOpenapsTimestampOverCreatedAt() {
+        val body = "[${uploaderDocument(createdAt = "2026-08-03T12:05:00.000Z", openapsTimestamp = docTime)}]"
+        assertEquals(docMillis, NightscoutFollowerDeviceStatus.parseNewest(body)!!.timestampMillis)
+    }
+
+    @Test
+    fun fallsBackToCreatedAtWithoutOpenapsBlock() {
+        val body = "[${uploaderDocument(openapsTimestamp = null)}]"
+        assertEquals(docMillis, NightscoutFollowerDeviceStatus.parseNewest(body)!!.timestampMillis)
+    }
+
+    @Test
+    fun missingCobAndEiobParseAsNaN() {
+        val remote = NightscoutFollowerDeviceStatus.parseNewest(
+            "[${uploaderDocument(eiob = "", cob = "")}]"
+        )
+        assertNotNull(remote)
+        assertTrue(remote!!.eiobUnits.isNaN())
+        assertTrue(remote.cobGrams.isNaN())
+        assertEquals(2.50f, remote.iobUnits, 0.0001f)
+    }
+
+    @Test
+    fun documentWithoutIobIsIgnored() {
+        val body = "[{\"created_at\":\"$docTime\",\"jugglucong\":{\"eiob\":1.0,\"cob\":10.0}}]"
+        assertNull(NightscoutFollowerDeviceStatus.parseNewest(body))
+    }
+
+    @Test
+    fun malformedBodiesParseToNull() {
+        assertNull(NightscoutFollowerDeviceStatus.parseNewest("not json"))
+        assertNull(NightscoutFollowerDeviceStatus.parseNewest("{}"))
+        assertNull(NightscoutFollowerDeviceStatus.parseNewest("[]"))
+        assertNull(NightscoutFollowerDeviceStatus.parseNewest("[{\"created_at\":\"nonsense\",\"jugglucong\":{\"iob\":1.0}}]"))
+    }
+
+    @Test
+    fun freshnessWindowMatchesNightscoutRecency() {
+        NightscoutFollowerDeviceStatus.update(NightscoutFollowerDeviceStatus.parseNewest("[${uploaderDocument()}]"))
+        val window = NightscoutFollowerDeviceStatus.FRESHNESS_WINDOW_MS
+        assertNotNull(NightscoutFollowerDeviceStatus.fresh(docMillis))
+        assertNotNull(NightscoutFollowerDeviceStatus.fresh(docMillis + window))
+        assertNull(NightscoutFollowerDeviceStatus.fresh(docMillis + window + 1L))
+        // The uploader's clock running slightly ahead still counts as fresh.
+        assertNotNull(NightscoutFollowerDeviceStatus.fresh(docMillis - 60_000L))
+    }
+
+    @Test
+    fun staleThenFreshDocumentSwitchesBackWithoutStickingValues() {
+        NightscoutFollowerDeviceStatus.update(NightscoutFollowerDeviceStatus.parseNewest("[${uploaderDocument()}]"))
+        val laterTime = "2026-08-03T13:00:00.000Z"
+        val laterMillis = Instant.parse(laterTime).toEpochMilli()
+        // Old document has aged out: local computation applies.
+        assertNull(NightscoutFollowerDeviceStatus.fresh(laterMillis))
+        // A new upload arrives: remote applies again, with the new values.
+        NightscoutFollowerDeviceStatus.update(
+            NightscoutFollowerDeviceStatus.parseNewest("[${uploaderDocument(createdAt = laterTime)}]")
+        )
+        assertEquals(laterMillis, NightscoutFollowerDeviceStatus.fresh(laterMillis)!!.timestampMillis)
+    }
+
+    @Test
+    fun failedPollKeepsPreviousSnapshotUntilItExpires() {
+        NightscoutFollowerDeviceStatus.update(NightscoutFollowerDeviceStatus.parseNewest("[${uploaderDocument()}]"))
+        NightscoutFollowerDeviceStatus.update(null)
+        assertNotNull(NightscoutFollowerDeviceStatus.fresh(docMillis + 60_000L))
+    }
+
+    @Test
+    fun clearDropsTheSnapshot() {
+        NightscoutFollowerDeviceStatus.update(NightscoutFollowerDeviceStatus.parseNewest("[${uploaderDocument()}]"))
+        NightscoutFollowerDeviceStatus.clear()
+        assertNull(NightscoutFollowerDeviceStatus.fresh(docMillis))
+    }
+}


### PR DESCRIPTION
A follow-only install currently recomputes IOB/eIOB from the treatments it imports, using its own insulin presets. That diverges from the uploading device whenever the presets differ, and it lags by one upload/poll cycle. With #155 the uploader publishes IOB in the `openaps.iob` container plus eIOB/COB in a `jugglucong` namespace on devicestatus, so the follower can simply read them back: it polls `devicestatus.json?count=5` alongside entries and treatments and prefers fresh remote values over its local computation. Outside a 30-minute freshness window it falls back to the local one; the window matches Nightscout's own `RECENCY_THRESHOLD` in `lib/plugins/iob.js`, so site and follower agree on when a value is too old. No Nightscout-side change is needed, unknown devicestatus fields are stored and served back as-is.

How the switch behaves:

- IOB, eIOB and COB change source together. They come from one document and one computation, so taking IOB from the uploader while computing COB locally would show an inconsistent pair. The one exception is a field the document lacks (an uploader without carb data omits `cob`): that field alone stays local.
- Remote values appear wherever the journal already shows IOB: the dashboard insulin chip, the journal IOB card, and the notification/broadcast snapshot. The expanded chip and card add a line "Values from the uploading device (Nightscout)" so the origin is visible. The per-dose details (dose count, total units, activity percent, "until" time) stay local, they describe the imported treatments.
- Documents from foreign uploaders, for example a real loop that publishes only `openaps.iob`, are ignored. The newest document with a `jugglucong` block wins.
- A devicestatus fetch failure (404 on servers without the endpoint, 401, malformed body) never blocks entries or treatments; the follower keeps computing locally. A single failed poll also does not flip the source, the freshness window retires a stale value on its own. Pausing or removing the follower clears the stored value immediately.
- Treatment import is unchanged and remains the fallback; journal entries and chart markers appear as before. The journal-enabled gates are also untouched: with the journal feature off there is still no IOB surface, remote or not.

There is deliberately no setting: for a follower the uploader's value is the accurate one. If you would rather have a switch, I would make it default-on and can add it.

One known edge: a device that both follows a site and uploads IOB to the same site (`nightscout_upload_iob` on) would republish the remote numbers under its own timestamp. That setup already duplicates glucose uploads today, so I left it alone rather than special-casing it; happy to add a guard if you think it matters.

Tests: `NightscoutFollowerDeviceStatusTests` covers the parser (uploader document round-trip, foreign documents, newest-document selection, timestamp fallbacks, missing fields) and the freshness window (boundary, clock skew, stale-then-fresh transition, failed poll, clear). Full mobile unit suite passes with only the known Sibionics fixture failures. Strings added in English and German.
