### PR TITLE
Stats: persist selected time range across restarts

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsRangeStore.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsRangeStore.kt
@@ -1,0 +1,74 @@
+package tk.glucodata.ui.stats
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/** The persisted statistics range selection: either a quick preset or a custom date range. */
+sealed interface StatsRangeSelection {
+    data class Preset(val range: StatsTimeRange) : StatsRangeSelection
+    data class Custom(val range: StatsDateRange) : StatsRangeSelection
+}
+
+/**
+ * Persists the selected statistics time range in the shared preference file the rest
+ * of the app already uses, so the choice survives a process restart. Preset and custom
+ * are mutually exclusive: writing one clears the other.
+ */
+object StatsRangeStore {
+
+    private const val PREFS = "tk.glucodata_preferences"
+    private const val KEY_PRESET = "stats_range_preset"
+    private const val KEY_CUSTOM_START = "stats_range_custom_start"
+    private const val KEY_CUSTOM_END = "stats_range_custom_end"
+
+    fun load(context: Context?): StatsRangeSelection? {
+        val store = prefs(context) ?: return null
+        return resolveStoredStatsRange(
+            presetName = store.getString(KEY_PRESET, null),
+            customStartMillis = store.getLong(KEY_CUSTOM_START, Long.MIN_VALUE),
+            customEndMillis = store.getLong(KEY_CUSTOM_END, Long.MIN_VALUE)
+        )
+    }
+
+    fun savePreset(context: Context?, range: StatsTimeRange) {
+        prefs(context)?.edit()
+            ?.putString(KEY_PRESET, range.name)
+            ?.remove(KEY_CUSTOM_START)
+            ?.remove(KEY_CUSTOM_END)
+            ?.apply()
+    }
+
+    fun saveCustom(context: Context?, range: StatsDateRange) {
+        prefs(context)?.edit()
+            ?.remove(KEY_PRESET)
+            ?.putLong(KEY_CUSTOM_START, range.startMillis)
+            ?.putLong(KEY_CUSTOM_END, range.endMillis)
+            ?.apply()
+    }
+
+    private fun prefs(context: Context?): SharedPreferences? =
+        context?.applicationContext?.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}
+
+/**
+ * Pure so it stays unit-testable. A preset name that no longer resolves (saved by an
+ * older or newer version) and garbage millis both come back as null, which callers
+ * treat as "nothing stored".
+ */
+internal fun resolveStoredStatsRange(
+    presetName: String?,
+    customStartMillis: Long,
+    customEndMillis: Long
+): StatsRangeSelection? {
+    if (presetName != null) {
+        return runCatching { StatsTimeRange.valueOf(presetName) }
+            .getOrNull()
+            ?.let { StatsRangeSelection.Preset(it) }
+    }
+    if (customStartMillis in 0..customEndMillis) {
+        return StatsRangeSelection.Custom(
+            StatsDateRange(startMillis = customStartMillis, endMillis = customEndMillis)
+        )
+    }
+    return null
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsViewModel.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -95,10 +97,22 @@ class StatsViewModel : ViewModel() {
         val state: StatsUiState
     )
 
-    private val _selectedRange = MutableStateFlow<StatsTimeRange?>(StatsTimeRange.DAY_1)
+    private val restoredSelection: StatsRangeSelection? = StatsRangeStore.load(Applic.app)
+    private val _selectedRange = MutableStateFlow<StatsTimeRange?>(
+        when (restoredSelection) {
+            is StatsRangeSelection.Preset -> restoredSelection.range
+            is StatsRangeSelection.Custom -> null
+            null -> DEFAULT_STATS_RANGE
+        }
+    )
     val selectedRange: StateFlow<StatsTimeRange?> = _selectedRange.asStateFlow()
-    private val _customRange = MutableStateFlow<StatsDateRange?>(null)
+    private val _customRange = MutableStateFlow(
+        (restoredSelection as? StatsRangeSelection.Custom)?.range
+    )
     private val _availableRange = MutableStateFlow<StatsDateRange?>(null)
+    // A restored custom range may reach outside the data that exists today; it gets
+    // clamped once the available range is known.
+    private var pendingRestoredCustomClamp = restoredSelection is StatsRangeSelection.Custom
 
     private val _unit = MutableStateFlow(GlucoseUnit.MGDL)
     private val _targets = MutableStateFlow(StatsTargets())
@@ -183,22 +197,45 @@ class StatsViewModel : ViewModel() {
 
     init {
         observeUiRefreshBus()
+        if (pendingRestoredCustomClamp) {
+            clampRestoredCustomRangeWhenAvailable()
+        }
         refreshFromNative()
     }
 
     fun setTimeRange(range: StatsTimeRange) {
+        pendingRestoredCustomClamp = false
         if (_selectedRange.value == range && _customRange.value == null) return
         _selectedRange.value = range
         _customRange.value = null
+        StatsRangeStore.savePreset(Applic.app, range)
         resubscribeToRequestedWindow()
     }
 
     fun setCustomRange(startMillis: Long, endMillis: Long) {
+        pendingRestoredCustomClamp = false
         val normalizedRange = normalizeCustomRange(startMillis, endMillis)
         if (_customRange.value == normalizedRange && _selectedRange.value == null) return
         _selectedRange.value = null
         _customRange.value = normalizedRange
+        StatsRangeStore.saveCustom(Applic.app, normalizedRange)
         resubscribeToRequestedWindow()
+    }
+
+    private fun clampRestoredCustomRangeWhenAvailable() {
+        viewModelScope.launch {
+            val available = _availableRange.filterNotNull().first()
+            if (!pendingRestoredCustomClamp) return@launch
+            pendingRestoredCustomClamp = false
+            val restored = _customRange.value ?: return@launch
+            val clamped = clampStatsDateRangeToAvailable(restored, available)
+            if (clamped == null) {
+                _customRange.value = null
+                _selectedRange.value = DEFAULT_STATS_RANGE
+            } else if (clamped != restored) {
+                _customRange.value = clamped
+            }
+        }
     }
 
     private fun observeUiRefreshBus() {

--- a/Common/src/test/java/tk/glucodata/ui/stats/StatsRangePersistenceTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/stats/StatsRangePersistenceTests.kt
@@ -1,0 +1,118 @@
+package tk.glucodata.ui.stats
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The pure part of restoring the statistics range selection: what a stored value
+ * resolves to, and how a restored custom range is clamped to the data that exists
+ * today. Writing to SharedPreferences itself is left to the device.
+ */
+class StatsRangePersistenceTests {
+
+    @Test
+    fun storedPresetNameResolvesToThatPreset() {
+        val resolved = resolveStoredStatsRange(
+            presetName = "DAY_30",
+            customStartMillis = Long.MIN_VALUE,
+            customEndMillis = Long.MIN_VALUE
+        )
+        assertEquals(StatsRangeSelection.Preset(StatsTimeRange.DAY_30), resolved)
+    }
+
+    @Test
+    fun unknownPresetNameFallsBackToNothingStored() {
+        val resolved = resolveStoredStatsRange(
+            presetName = "DAY_365",
+            customStartMillis = Long.MIN_VALUE,
+            customEndMillis = Long.MIN_VALUE
+        )
+        assertNull(resolved)
+    }
+
+    @Test
+    fun storedCustomMillisResolveToACustomRange() {
+        val resolved = resolveStoredStatsRange(
+            presetName = null,
+            customStartMillis = 1_000L,
+            customEndMillis = 2_000L
+        )
+        assertEquals(
+            StatsRangeSelection.Custom(StatsDateRange(startMillis = 1_000L, endMillis = 2_000L)),
+            resolved
+        )
+    }
+
+    @Test
+    fun garbageCustomMillisFallBackToNothingStored() {
+        assertNull(
+            resolveStoredStatsRange(
+                presetName = null,
+                customStartMillis = 2_000L,
+                customEndMillis = 1_000L
+            )
+        )
+        assertNull(
+            resolveStoredStatsRange(
+                presetName = null,
+                customStartMillis = -5L,
+                customEndMillis = 1_000L
+            )
+        )
+        assertNull(
+            resolveStoredStatsRange(
+                presetName = null,
+                customStartMillis = 1_000L,
+                customEndMillis = Long.MIN_VALUE
+            )
+        )
+    }
+
+    @Test
+    fun nothingStoredResolvesToNull() {
+        assertNull(
+            resolveStoredStatsRange(
+                presetName = null,
+                customStartMillis = Long.MIN_VALUE,
+                customEndMillis = Long.MIN_VALUE
+            )
+        )
+    }
+
+    @Test
+    fun presetWinsOverLeftoverCustomMillis() {
+        // The store clears one when writing the other, but a preset must still win
+        // over stale custom keys from an interrupted write.
+        val resolved = resolveStoredStatsRange(
+            presetName = "DAY_7",
+            customStartMillis = 1_000L,
+            customEndMillis = 2_000L
+        )
+        assertEquals(StatsRangeSelection.Preset(StatsTimeRange.DAY_7), resolved)
+    }
+
+    @Test
+    fun restoredCustomRangeInsideAvailableDataIsKept() {
+        val available = StatsDateRange(startMillis = 0L, endMillis = 10_000L)
+        val restored = StatsDateRange(startMillis = 2_000L, endMillis = 8_000L)
+        assertEquals(restored, clampStatsDateRangeToAvailable(restored, available))
+    }
+
+    @Test
+    fun restoredCustomRangePartlyOutsideAvailableDataIsClamped() {
+        val available = StatsDateRange(startMillis = 5_000L, endMillis = 10_000L)
+        val restored = StatsDateRange(startMillis = 2_000L, endMillis = 8_000L)
+        assertEquals(
+            StatsDateRange(startMillis = 5_000L, endMillis = 8_000L),
+            clampStatsDateRangeToAvailable(restored, available)
+        )
+    }
+
+    @Test
+    fun restoredCustomRangeFullyOutsideAvailableDataFallsBackToAvailable() {
+        val available = StatsDateRange(startMillis = 5_000L, endMillis = 10_000L)
+        val restored = StatsDateRange(startMillis = 1_000L, endMillis = 2_000L)
+        assertEquals(available, clampStatsDateRangeToAvailable(restored, available))
+    }
+}


### PR DESCRIPTION
The statistics screen always reopens at the 1D range after an app update. The selected range lives only in `StatsViewModel` (`_selectedRange`, hard-coded to `DAY_1`) with no persistence, so any process restart drops it; an update is just the most reliable process kill in daily use, a forced stop or reboot loses it the same way.

The selection (preset or custom range) is now stored in SharedPreferences alongside the existing stats layout preferences and restored on init, with `DAY_1` as the fallback when nothing is stored or a stored value no longer resolves (enum name from an older version, garbage millis). Presets are stored as the enum name, custom ranges as start/end millis, and writing one clears the other so the stored state stays unambiguous. A restored custom range is clamped to the available data via the existing `clampStatsDateRangeToAvailable` once the available range is known, so a range that has since scrolled out of the data doesn't leave an empty screen.

No new setting and no UI change; fresh installs keep the 1D default.

Tests (`StatsRangePersistenceTests`) cover the stored-value resolution (valid preset, unknown enum name, valid and garbage custom millis, nothing stored, preset winning over leftover custom keys) and the clamp behavior for restored custom ranges (inside, partly outside, fully outside the available data). Full mobile unit test suite: 1166 tests, only the 11 known SibionicsExact fixture failures.
