### PR TITLE
Ottai: warmup gate, continuity anchor, session key, cloud unbind + native wear duration

### DIFF
--- a/Common/proguard-rules.my
+++ b/Common/proguard-rules.my
@@ -65,6 +65,20 @@
     public final void markSensorReset(java.lang.String);
 }
 
+# Keep the hidden-framework connection-parameter callback.
+# BluetoothGattCallback#onConnectionUpdated exists since Android O but is absent from the SDK
+# stubs, so SuperGattCallback declares it without @Override and nothing in the compiled code
+# ever calls it -- the platform binds it at runtime by name+descriptor. R8 sees an unreachable
+# method and does not rename it but DELETES it: no shipped mapping.txt has ever contained
+# onConnectionUpdated, and in the 2026-08-01 jamming storm the framework invoked it 210/207
+# times into the two running apps while the app logged zero "conn params" lines. Same failure
+# class as the HistoryRepository note above -- dispatch by name that R8 cannot see -- and the
+# same silence: with the method gone the link-parameter history of an outage exists nowhere.
+# The declaration also carries @Keep, which cannot drift; keep both in sync.
+-keepclassmembers class * extends android.bluetooth.BluetoothGattCallback {
+    public void onConnectionUpdated(android.bluetooth.BluetoothGatt, int, int, int, int);
+}
+
 # Keep CalibrationManager names and reflected members stable.
 # CalibrationAccess in src/main resolves these mobile-only methods by name.
 -keepnames class tk.glucodata.data.calibration.CalibrationManager

--- a/Common/src/dex/java/tk/glucodata/AccuGattCallback.java
+++ b/Common/src/dex/java/tk/glucodata/AccuGattCallback.java
@@ -251,6 +251,7 @@ private boolean connected=false;
 @SuppressLint("MissingPermission")
 @Override
 public void onConnectionStateChange(BluetoothGatt bluetoothGatt, int status, int newState) {
+    noteFirstGattCallback("onConnectionStateChange", bluetoothGatt);
     long tim = System.currentTimeMillis();
     if(stop) {
         constatchange[1] = tim; //Needed? ever displayed?

--- a/Common/src/dex/java/tk/glucodata/DexGattCallback.java
+++ b/Common/src/dex/java/tk/glucodata/DexGattCallback.java
@@ -184,6 +184,7 @@ private int connectionTimeouts=0;
     @SuppressLint("MissingPermission")
     @Override
     public void onConnectionStateChange(BluetoothGatt bluetoothGatt, int status, int newState) {
+        noteFirstGattCallback("onConnectionStateChange", bluetoothGatt);
         if (stop) {
             releaselock();
             {if(doLog) {Log.i(LOG_ID, "onConnectionStateChange stop==true");};};

--- a/Common/src/libre3/java/tk/glucodata/Libre3GattCallback.java
+++ b/Common/src/libre3/java/tk/glucodata/Libre3GattCallback.java
@@ -136,6 +136,7 @@ private boolean connected=false;
     @SuppressLint("MissingPermission")
     @Override 
     public void onConnectionStateChange(BluetoothGatt bluetoothGatt, int status, int newState) {
+        noteFirstGattCallback("onConnectionStateChange", bluetoothGatt);
         checkBluetoothGatt(bluetoothGatt);
 
 

--- a/Common/src/main/cpp/SensorGlucoseData.hpp
+++ b/Common/src/main/cpp/SensorGlucoseData.hpp
@@ -857,7 +857,16 @@ public:
         isSibionics1() ? maxSIhours
                        : ((isAccuChek() ? maxdaysAccu : info->days + 1) * 24);
 #endif
-    uint32_t maxtime = hours * 60 * 60 + getstarttime();
+    // info->days is the shell's storage geometry — 14 for a direct-stream
+    // shell seeded before its lifetime was known — while a longer activated
+    // lifetime only ever lands in wearduration2 (setSensorWearDays). Where the
+    // two disagree the longer one is the real end; otherwise checkinfo()
+    // retires a 28-day sensor on day 14 and it silently leaves the watch feed.
+    // Only AiDex, Libre3 and direct-stream shells carry wearduration2, and for
+    // the first two it never exceeds days*24*60, so this is a no-op there.
+    const int minutes =
+        std::max(hours * 60, static_cast<int>(info->wearduration2));
+    uint32_t maxtime = minutes * 60 + getstarttime();
 
     // ARCHITECTURAL FIX: Support Custom Calibration for aged sensors.
     // If user enabled Custom Calibration (index != 0), we allow the sensor to

--- a/Common/src/main/cpp/g.cpp
+++ b/Common/src/main/cpp/g.cpp
@@ -1529,10 +1529,14 @@ extern "C" JNIEXPORT jlong JNICALL fromjava(ensureSensorShellWithCapacity)(
 // Set the wear duration (days) for a direct-stream sensor (e.g. Ottai) by id. The
 // AiDex helper aidexSetWearDays takes an aidexstream* and cannot be reused here —
 // direct-stream sensors are plain SensorGlucoseData*. Writes info->wearduration2
-// (minutes) so officialendtime()/expectedEndTime() reflect the real activated life.
+// (minutes) so officialendtime()/expectedEndTime() and getmaxtime() reflect the
+// real activated life.
 extern "C" JNIEXPORT void JNICALL fromjava(setSensorWearDays)(
     JNIEnv *env, jclass cl, jstring sensorId, jint days) {
-  if (!sensors || !sensorId || days <= 0)
+  // wearduration2 is uint16_t minutes, so past 45 days the product wraps into a
+  // lifetime shorter than the sensor's; a garbage value must not land at all.
+  constexpr const jint maxweardays = 0xFFFF / (24 * 60);
+  if (!sensors || !sensorId || days <= 0 || days > maxweardays)
     return;
   const char *str = env->GetStringUTFChars(sensorId, NULL);
   if (!str)
@@ -1541,6 +1545,14 @@ extern "C" JNIEXPORT void JNICALL fromjava(setSensorWearDays)(
     if (!hist->error()) {
       if (auto *info = hist->getinfo()) {
         info->wearduration2 = static_cast<uint16_t>(days * 24 * 60);
+        // Deliberately NOT raising info->days here. It is the shell's storage
+        // geometry, and data.dat/polls.dat/current.dat are all sized from it in
+        // the SensorGlucoseData constructor's initializer list, while maxpos()
+        // and maxstreampos() recompute from it on every call. Raising it
+        // mid-session would leave those bounds describing twice the region that
+        // is actually mapped. getmaxtime() consults wearduration2 instead, so
+        // the lifetime the sensor negotiated is honoured without touching the
+        // geometry of files that are already open.
         LOGGER("setSensorWearDays: %s days=%d wear=%u\n", str, days,
                info->wearduration2);
       }

--- a/Common/src/main/java/tk/glucodata/Applic.java
+++ b/Common/src/main/java/tk/glucodata/Applic.java
@@ -820,6 +820,10 @@ public class Applic extends Application implements androidx.work.Configuration.P
         if (!initproccalled) {
             if (!numio.setlibrary(this))
                 return false;
+            // First thing after the natives are up, so Log reaches trace.log: whatever killed the
+            // previous process is otherwise lost. Both apps died inside the 2026-08-01 jamming
+            // storm and 767s of the downtime is unattributed purely because no log line says why.
+            ProcessExitReasons.logPrevious(this);
             if (isWearable) {
                 if (Natives.getWifi())
                     UseWifi.usewifi();

--- a/Common/src/main/java/tk/glucodata/Libre2GattCallback.java
+++ b/Common/src/main/java/tk/glucodata/Libre2GattCallback.java
@@ -140,6 +140,7 @@ private PendingIntent onalarm=null;
 	@SuppressLint("MissingPermission")
 	@Override
 	public void onConnectionStateChange(BluetoothGatt bluetoothGatt, int status, int newState) {
+		noteFirstGattCallback("onConnectionStateChange", bluetoothGatt);
 		endBLEHandler();
 		if(stop) {
 			{if(doLog) {Log.i(LOG_ID,"onConnectionStateChange stop==true");};};

--- a/Common/src/main/java/tk/glucodata/ProcessExitReasons.kt
+++ b/Common/src/main/java/tk/glucodata/ProcessExitReasons.kt
@@ -1,0 +1,104 @@
+// ProcessExitReasons.kt — read back why the previous process(es) of this app ended.
+
+package tk.glucodata
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.content.Context
+import android.os.Build
+
+/**
+ * Writes Android's own record of how the last processes of this app died into the app's trace log.
+ *
+ * On 2026-08-01 both running apps died and restarted inside the jamming-storm window
+ * ("Sat Aug 1 20:32:50 2026 10382 Start logging" and "... 20:33:01 2026 11747 Start logging"), and
+ * 767 s — 13 % of the measured downtime — stayed unattributed because nothing in either log says
+ * why: the kill could only be bounded to [1785605312, 1785605570]. The platform has kept the answer
+ * since API 30 and the app simply never asked for it.
+ *
+ * Asked at startup, because the record of a process is dropped once the app is uninstalled or the
+ * ring buffer wraps, and written through [Log] rather than android.util.Log, because the trace log
+ * is the file the user exports — the logcat of the dead process is gone by the time anyone looks.
+ */
+object ProcessExitReasons {
+
+    private const val LOG_ID = "ProcessExit"
+
+    /**
+     * Enough to show a restart loop rather than only its last iteration; on 2026-08-01 the two
+     * deaths of interest were 11 s apart. Each record is one parcelled row, read once per process.
+     */
+    private const val MAX_RECORDS = 5
+
+    @JvmStatic
+    fun logPrevious(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+        runCatching {
+            val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+                ?: return
+            val records = manager.getHistoricalProcessExitReasons(context.packageName, 0, MAX_RECORDS)
+            if (records.isEmpty()) {
+                Log.i(LOG_ID, "no historical process exit reasons recorded")
+                return
+            }
+            for (info in records) {
+                Log.i(
+                    LOG_ID,
+                    describe(
+                        processName = info.processName,
+                        pid = info.pid,
+                        reason = info.reason,
+                        status = info.status,
+                        importance = info.importance,
+                        timestampMs = info.timestamp,
+                        description = info.description,
+                    ),
+                )
+            }
+        }.onFailure { Log.stack(LOG_ID, "getHistoricalProcessExitReasons", it) }
+    }
+
+    /**
+     * One line per dead process. The timestamp is emitted in seconds because that is the clock
+     * every other line of trace.log carries, so the kill lands on the same axis as the BLE events
+     * it has to be correlated with.
+     */
+    internal fun describe(
+        processName: String?,
+        pid: Int,
+        reason: Int,
+        status: Int,
+        importance: Int,
+        timestampMs: Long,
+        description: String?,
+    ): String =
+        "previous process ${processName ?: "?"} pid=$pid died at=${timestampMs / 1000L} " +
+            "reason=${reasonName(reason)}($reason) status=$status importance=$importance " +
+            "description=${description ?: "none"}"
+
+    /**
+     * ApplicationExitInfo reports the reason as a bare int, and the numbers that matter here are
+     * the ones that look alike in a log: LOW_MEMORY vs EXCESSIVE_RESOURCE_USAGE vs FREEZER all
+     * mean "the system took the app away" but for very different, differently-fixable reasons.
+     */
+    internal fun reasonName(reason: Int): String = when (reason) {
+        ApplicationExitInfo.REASON_EXIT_SELF -> "EXIT_SELF"
+        ApplicationExitInfo.REASON_SIGNALED -> "SIGNALED"
+        ApplicationExitInfo.REASON_LOW_MEMORY -> "LOW_MEMORY"
+        ApplicationExitInfo.REASON_CRASH -> "CRASH"
+        ApplicationExitInfo.REASON_CRASH_NATIVE -> "CRASH_NATIVE"
+        ApplicationExitInfo.REASON_ANR -> "ANR"
+        ApplicationExitInfo.REASON_INITIALIZATION_FAILURE -> "INITIALIZATION_FAILURE"
+        ApplicationExitInfo.REASON_PERMISSION_CHANGE -> "PERMISSION_CHANGE"
+        ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE -> "EXCESSIVE_RESOURCE_USAGE"
+        ApplicationExitInfo.REASON_USER_REQUESTED -> "USER_REQUESTED"
+        ApplicationExitInfo.REASON_USER_STOPPED -> "USER_STOPPED"
+        ApplicationExitInfo.REASON_DEPENDENCY_DIED -> "DEPENDENCY_DIED"
+        ApplicationExitInfo.REASON_OTHER -> "OTHER"
+        ApplicationExitInfo.REASON_FREEZER -> "FREEZER"
+        ApplicationExitInfo.REASON_PACKAGE_STATE_CHANGE -> "PACKAGE_STATE_CHANGE"
+        ApplicationExitInfo.REASON_PACKAGE_UPDATED -> "PACKAGE_UPDATED"
+        ApplicationExitInfo.REASON_UNKNOWN -> "UNKNOWN"
+        else -> "UNNAMED"
+    }
+}

--- a/Common/src/main/java/tk/glucodata/SensorBluetooth.java
+++ b/Common/src/main/java/tk/glucodata/SensorBluetooth.java
@@ -579,6 +579,19 @@ public class SensorBluetooth {
     }
 
     private boolean scanstart = false;
+
+    /**
+     * Whether the managed scan is running or about to run, the same condition scanStarter()
+     * refuses a second scan on. Android throttles startScan per app, not per scanner: a driver
+     * opening its own scanner while this one is up spends one of the five starts the platform
+     * allows in 30s, and the call the platform then fails can be this scan -- the discovery and
+     * recovery path for every sensor family.
+     */
+    static public boolean scanActiveOrPending() {
+        final SensorBluetooth blue = blueone;
+        return blue != null && (blue.mScanning || blue.scanstart);
+    }
+
     long scantime = 0L;
     final private Runnable scanRunnable = new Runnable() {
         @Override

--- a/Common/src/main/java/tk/glucodata/SuperGattCallback.java
+++ b/Common/src/main/java/tk/glucodata/SuperGattCallback.java
@@ -31,6 +31,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 
+import androidx.annotation.Keep;
+
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
@@ -43,6 +45,7 @@ import static android.bluetooth.BluetoothDevice.BOND_BONDING;
 import static android.bluetooth.BluetoothDevice.BOND_NONE;
 import static android.bluetooth.BluetoothGatt.CONNECTION_PRIORITY_BALANCED;
 import static android.bluetooth.BluetoothGatt.CONNECTION_PRIORITY_HIGH;
+import static android.bluetooth.BluetoothGatt.GATT_SUCCESS;
 import static android.bluetooth.BluetoothGattDescriptor.ENABLE_INDICATION_VALUE;
 import static android.bluetooth.BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE;
 import static java.util.Objects.isNull;
@@ -101,6 +104,10 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
     protected BluetoothGatt mBluetoothGatt;
     private volatile boolean connectPending = false;
     private volatile ScheduledFuture<?> pendingConnectFuture = null;
+    /** connectGatt() timestamp of the attempt now in flight, cleared by the first callback the
+     * stack delivers for it. Zero means "already reported", so a live connection pays one
+     * volatile read per callback and nothing else. */
+    private volatile long connectGattAtMs = 0L;
     boolean superseded = false;
     public final int sensorgen;
     public int readrssi = 9999;
@@ -980,6 +987,56 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
 
     }
 
+    /**
+     * Connect mode for this sensor's GATT connections.
+     * <p>
+     * The backing field is one application-wide static that the {@link SensorBluetooth}
+     * constructor overwrites from {@code Natives.getAndroid13()}, so until this hook existed a
+     * driver had no say at all: every one of the 103 connect attempts logged during the
+     * 2026-08-01 jamming storm (52 + 51, two Ottai sensors) used autoConnect=true and not one
+     * used false. Whether a direct connect would do better on any particular peripheral is still
+     * unmeasured — see {@link #noteFirstGattCallback} for the number that would decide it — so
+     * every driver deliberately keeps inheriting the user's setting here.
+     */
+    protected boolean useAutoConnect() {
+        return autoconnect;
+    }
+
+    private void armConnectCallbackLatency() {
+        connectGattAtMs = System.currentTimeMillis();
+    }
+
+    /**
+     * Time from connectGatt() to the first callback the stack delivered for that attempt, and the
+     * mode it was asked for. Comparing autoConnect=true against false needs this number and the
+     * app has never recorded it: the 2026-08-01 logs show how long an outage lasted but not how
+     * long a connect took to produce its first sign of life, which is the part the two modes
+     * differ in.
+     * <p>
+     * Subclasses have to call this from their own onConnectionStateChange — that is in practice
+     * the first callback of an attempt, and no driver except AiDex chains to super, so the base
+     * class cannot funnel it. They call it first, above their own staleness guards, so the gatt
+     * is taken here instead: a late callback from a retired GATT belongs to an earlier attempt,
+     * and letting it consume the timestamp would publish its age against the attempt in flight —
+     * corrupting exactly the number this exists to collect, in the drivers with the most
+     * retired-GATT churn. A null mBluetoothGatt is the window between connectGatt() returning and
+     * the driver storing it, and that attempt IS the one being timed.
+     */
+    protected final void noteFirstGattCallback(String which, BluetoothGatt gatt) {
+        final long started = connectGattAtMs;
+        if (started == 0L)
+            return;
+        final BluetoothGatt current = mBluetoothGatt;
+        if (current != null && gatt != null && gatt != current)
+            return;
+        connectGattAtMs = 0L;
+        if (doLog) {
+            Log.i(LOG_ID, SerialNumber + " first GATT callback " + which + " "
+                    + (System.currentTimeMillis() - started) + "ms after connectGatt autoConnect="
+                    + useAutoConnect());
+        }
+    }
+
     private Runnable getConnectDevice() {
         var cb = this;
         if (cb.mBluetoothGatt != null) {
@@ -1051,22 +1108,24 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
                 {
                     if (doLog) {
                         Log.d(LOG_ID, SerialNumber + " Try connection to " + device.getAddress() + " " + devname
-                                + " autoconnect=" + autoconnect);
+                                + " autoconnect=" + cb.useAutoConnect());
                     }
                     ;
                 }
                 ;
             }
             try {
+                cb.armConnectCallbackLatency();
                 if (isWearable) {
-                    cb.mBluetoothGatt = device.connectGatt(Applic.app, autoconnect, cb, BluetoothDevice.TRANSPORT_LE);
+                    cb.mBluetoothGatt = device.connectGatt(Applic.app, cb.useAutoConnect(), cb,
+                            BluetoothDevice.TRANSPORT_LE);
                     cb.setGattOptions(cb.mBluetoothGatt);
                 } else {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                        cb.mBluetoothGatt = device.connectGatt(Applic.app, autoconnect, cb,
+                        cb.mBluetoothGatt = device.connectGatt(Applic.app, cb.useAutoConnect(), cb,
                                 BluetoothDevice.TRANSPORT_LE);
                     } else {
-                        cb.mBluetoothGatt = device.connectGatt(Applic.app, autoconnect, cb);
+                        cb.mBluetoothGatt = device.connectGatt(Applic.app, cb.useAutoConnect(), cb);
                     }
                 }
 
@@ -1180,8 +1239,15 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
      * after every LL connection-parameter update, including ones the peripheral requested,
      * so it is the only signal that a sensor renegotiated away from the fast interval the
      * app asked for. Signature must stay exactly this for runtime dispatch to bind.
+     *
+     * No compiled call site reaches it, so R8 deleted it outright from every release build ever
+     * shipped -- the framework called it 210 times into app1 and 207 into app2 during the
+     * 2026-08-01 storm and not one "conn params" line was written. @Keep plus the matching rule
+     * in proguard-rules.my; both, because the rule can drift and the annotation cannot.
      */
+    @Keep
     public void onConnectionUpdated(BluetoothGatt gatt, int interval, int latency, int timeout, int status) {
+        noteFirstGattCallback("onConnectionUpdated", gatt);
         onConnectionParamsUpdated(gatt, interval, latency, timeout, status);
     }
 
@@ -1313,9 +1379,33 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
 
     @Override
     public void onPhyUpdate(BluetoothGatt gatt, int txPhy, int rxPhy, int status) {
+        noteFirstGattCallback("onPhyUpdate", gatt);
         {
             if (doLog) {
                 Log.i(LOG_ID, "onPhyUpdate txPhy=" + txPhy + " rxPhy=" + rxPhy + " status=" + status);
+            }
+            ;
+        }
+        ;
+    }
+
+    /**
+     * Relay for {@link BluetoothGatt#readRemoteRssi()}. Five drivers declared their own copy of
+     * this callback and the base class had none, so a driver that did not was simply unable to see
+     * a signal level: the whole 2026-08-01 jamming storm was logged without a single RSSI value in
+     * it, which is why "jammed" and "out of range" are still indistinguishable in that dataset.
+     * {@link #readrssi} is what the sensor screens read, so it is filled here for every driver
+     * rather than once per driver; the drivers that already override this keep their own handling.
+     */
+    @Override
+    public void onReadRemoteRssi(BluetoothGatt gatt, int rssi, int status) {
+        noteFirstGattCallback("onReadRemoteRssi", gatt);
+        if (status == GATT_SUCCESS) {
+            readrssi = rssi;
+        }
+        {
+            if (doLog) {
+                Log.i(LOG_ID, SerialNumber + " onReadRemoteRssi rssi=" + rssi + " status=" + status);
             }
             ;
         }

--- a/Common/src/main/java/tk/glucodata/drivers/aidex/native/ble/AiDexBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/aidex/native/ble/AiDexBleManager.kt
@@ -1764,6 +1764,7 @@ class AiDexBleManager(
     }
 
     override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+        noteFirstGattCallback("onConnectionStateChange", gatt)
         super.onConnectionStateChange(gatt, status, newState)
         if (newState == BluetoothProfile.STATE_CONNECTED || newState == BluetoothProfile.STATE_DISCONNECTED) {
             connectAttemptInFlight = false

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
@@ -1571,6 +1571,7 @@ class AnytimeBleManager(
     }
 
     override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+        noteFirstGattCallback("onConnectionStateChange", gatt)
         if (stop) return
         when (newState) {
             BluetoothProfile.STATE_CONNECTED -> {

--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
@@ -1164,6 +1164,7 @@ class ICanHealthBleManager(
     }
 
     override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+        noteFirstGattCallback("onConnectionStateChange", gatt)
         if (stop) return
         val stateAddress = gatt.device?.address?.trim()?.uppercase(Locale.US)
         if (stateAddress != null && stateAddress in rejectedOnboardingAddresses) {

--- a/Common/src/main/java/tk/glucodata/drivers/mq/MQBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/mq/MQBleManager.kt
@@ -770,6 +770,7 @@ class MQBleManager(
     }
 
     override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+        noteFirstGattCallback("onConnectionStateChange", gatt)
         if (stop) return
         when (newState) {
             BluetoothProfile.STATE_CONNECTED -> {

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiAdvertisementProbe.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiAdvertisementProbe.kt
@@ -1,0 +1,116 @@
+// OttaiAdvertisementProbe.kt — observe-only "is the sensor advertising?" scan during an outage.
+
+package tk.glucodata.drivers.ottai
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.Context
+import android.os.Handler
+
+/**
+ * Performs one short, filtered scan for a single Ottai sensor's advertisement after its link drops.
+ *
+ * Purely a measurement. The driver never scans during an outage — 16 SensorBluetooth lines in the
+ * 8995-line 2026-08-01 trace, zero scan results, not one advertisement timestamp for
+ * 70:D0:7E:42:31:DE — so the app cannot tell a jammed sensor from an absent one and the real
+ * ceiling on any reconnect change is unknown. This answers only "when did it advertise again", and
+ * deliberately does nothing with the answer: it never connects, never touches the parked
+ * autoConnect GATT, and never feeds the activation-candidate path.
+ *
+ * Same shape as [tk.glucodata.drivers.sibionics.SibionicsAdvertisementRecovery], which is the
+ * proven non-destructive scan in this app, including its filtered-scan requirement: Android 8.1+
+ * silently discards results from an unfiltered scan while the screen is off, which is exactly the
+ * background outage this runs in.
+ */
+@SuppressLint("MissingPermission")
+internal class OttaiAdvertisementProbe(
+    context: Context?,
+    private val handler: Handler,
+    private val onFinished: (rssi: Int?) -> Unit,
+) {
+    // Nullable, because a driver can be constructed from a headless service before Applic.app is
+    // assigned, and a missing context must cost the measurement, not the sensor.
+    private val appContext = context?.applicationContext
+    private var scanner: BluetoothLeScanner? = null
+    private var callback: ScanCallback? = null
+    private var timeout: Runnable? = null
+
+    @get:Synchronized
+    val isActive: Boolean
+        get() = callback != null
+
+    @Synchronized
+    fun start(address: String, timeoutMs: Long): Boolean {
+        if (callback != null) return true
+        val context = appContext ?: return false
+        val bluetoothScanner = runCatching {
+            (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)
+                ?.adapter
+                ?.takeIf { it.isEnabled }
+                ?.bluetoothLeScanner
+        }.getOrNull() ?: return false
+
+        lateinit var scanCallback: ScanCallback
+        scanCallback = object : ScanCallback() {
+            override fun onScanResult(callbackType: Int, result: ScanResult) {
+                if (!result.device.address.equals(address, ignoreCase = true)) return
+                val rssi = result.rssi
+                handler.post { complete(scanCallback, rssi) }
+            }
+
+            override fun onScanFailed(errorCode: Int) {
+                handler.post { complete(scanCallback, null) }
+            }
+        }
+
+        scanner = bluetoothScanner
+        callback = scanCallback
+        timeout = Runnable { complete(scanCallback, null) }.also {
+            handler.postDelayed(it, timeoutMs.coerceAtLeast(1L))
+        }
+        return runCatching {
+            // BALANCED, not the LOW_LATENCY the Sibionics recovery uses. That one REPLACES the
+            // connect — SibionicsBleManager cancels its reconnect runnable before starting it —
+            // whereas this scan runs alongside a connectGatt that is already initiating, in the
+            // very regime the outage is about (~95% of the downtime is spent waiting for an
+            // advertisement to get through). A 100%-duty-cycle scan across every outage would be
+            // ~1300s of added continuous scanning per sensor over a window like 2026-08-01, and
+            // could plausibly degrade the thing it exists to measure; "when did it advertise
+            // again", to the second, tolerates a duty-cycled scan.
+            val settings = ScanSettings.Builder()
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+                .build()
+            val filters = listOf(ScanFilter.Builder().setDeviceAddress(address).build())
+            bluetoothScanner.startScan(filters, settings, scanCallback)
+            true
+        }.getOrElse {
+            stop()
+            false
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        val activeCallback = callback
+        timeout?.let(handler::removeCallbacks)
+        timeout = null
+        callback = null
+        if (activeCallback != null) {
+            runCatching { scanner?.stopScan(activeCallback) }
+        }
+        scanner = null
+    }
+
+    private fun complete(expectedCallback: ScanCallback, rssi: Int?) {
+        synchronized(this) {
+            if (callback !== expectedCallback) return
+            stop()
+        }
+        onFinished(rssi)
+    }
+}

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleAuth.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleAuth.kt
@@ -12,8 +12,9 @@
 //   p.w  bytes->int   : little-endian int32 of the first 4 bytes
 //   p.l0 int->bytes   : 4 bytes little-endian
 //   p.r  BigInt->bytes: toByteArray, drop leading 0x00 sign byte, min-24 left-pad
-//   shared-secret hex : BigInteger(X).toByteArray() with 33->32 sign-byte strip
-//                       (NOT fixed-32 left-pad) — matters for the char-pick.
+//   shared-secret hex : the fixed 32-byte big-endian X, leading zeros kept — the
+//                       hex length feeds the char-pick, so it must not vary
+//                       (see deriveSessionKey).
 
 package tk.glucodata.drivers.ottai
 
@@ -133,10 +134,9 @@ object OttaiBleAuth {
 
     /**
      * ECDH session key. Computes the shared point X with the device's public key
-     * and our private key, encodes X exactly as the app does (BigInteger
-     * toByteArray with 33->32 sign-byte strip, no fixed-32 left-pad), hex-encodes
-     * it, then runs the char-pick. Returns the session-key string (>=32 chars) or
-     * null if the pick is too short.
+     * and our private key, hex-encodes X as the fixed-length big-endian field
+     * element, then runs the char-pick. Returns the session-key string (>=32
+     * chars) or null if the pick is too short.
      */
     fun deriveSessionKey(devPubXHex: String, devPubYHex: String, ourPrivate: ECPrivateKey): String? {
         val x = BigInteger(devPubXHex, 16)
@@ -152,14 +152,31 @@ object OttaiBleAuth {
         val ka = KeyAgreement.getInstance("ECDH")
         ka.init(ourPrivate)
         ka.doPhase(devPub, true)
-        val sharedX = BigInteger(1, ka.generateSecret()) // canonical positive X
-        // App encoding: toByteArray, strip a 33-byte leading 0x00 sign byte; keep
-        // shorter results as-is (no left-pad) — this changes the hex length and
-        // therefore the char-pick, so we must replicate it exactly.
-        var xb = sharedX.toByteArray()
-        if (xb.size == 33 && xb[0] == 0.toByte()) xb = xb.copyOfRange(1, 33)
-        val sharedHex = OttaiCrypto.bytesToHex(xb)
+        // generateSecret() already returns X as the fixed-length big-endian field
+        // element (SEC1/RFC 5903), leading zeros kept — the form the sensor derives
+        // too; fieldLen only guards a provider that trims. Do NOT round-trip
+        // through BigInteger the way the vendor app does: toByteArray drops the
+        // leading 0x00 whenever X < 2^247 (1 handshake in 512), leaving 62 hex
+        // chars, so the char-pick yields 30 and the key comes out empty — observed
+        // 2 of 459 handshakes over 16 days, each costing a dead link until the
+        // sensor gave up (status=19). Every X that fills the field encodes
+        // identically either way, so only the case that always failed changes.
+        val fieldLen = (ecSpec.curve.field.fieldSize + 7) / 8 // 32 for secp256r1
+        val sharedHex = OttaiCrypto.bytesToHex(fixedFieldBytes(ka.generateSecret(), fieldLen))
         return sessionKeyPick(sharedHex)
+    }
+
+    /** Big-endian field element of exactly [fieldLen] bytes: left-pad, never strip. */
+    fun fixedFieldBytes(value: ByteArray, fieldLen: Int): ByteArray {
+        if (value.size == fieldLen) return value
+        val out = ByteArray(fieldLen)
+        if (value.size < fieldLen) {
+            System.arraycopy(value, 0, out, fieldLen - value.size, value.size)
+        } else {
+            // over-long can only be a sign-prefixed BigInteger encoding: keep the low bytes
+            System.arraycopy(value, value.size - fieldLen, out, 0, fieldLen)
+        }
+        return out
     }
 
     /**

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -51,6 +51,15 @@ class OttaiBleManager(
         private const val TAG = OttaiConstants.TAG
         const val SENSOR_GEN = 0
         private const val RECONNECT_DELAY_MS = 3_000L
+        // Link supervision timeout — the peer stopped answering rather than closing the link.
+        // Android exports no constant for the BTA GATT_CONN_* codes, and this was the status on
+        // all 88 drops of the 2026-08-01 jamming storm. See reconnectDelayAfterDisconnectMs.
+        private const val GATT_CONN_TIMEOUT = 8
+        private const val SUPERVISION_TIMEOUT_RECONNECT_DELAY_MS = 1_500L
+        // The generic stack error a connectGatt() issued before registerApp() has settled comes
+        // back as; see fastReArmBounced.
+        private const val GATT_ERROR_STATUS = 133
+        private const val FAST_REARM_BOUNCE_WINDOW_MS = 2_000L
         private const val MTU = 247
         private const val MTU_SETTLE_BEFORE_DISCOVERY_MS = 1_250L
         private const val MTU_CALLBACK_FALLBACK_MS = 2_500L
@@ -127,6 +136,20 @@ class OttaiBleManager(
         internal const val SLOW_CONN_INTERVAL_UNITS = 100 // 1.25ms units -> 125ms
         internal const val SLOW_CONN_LATENCY = 2
         internal const val PRIORITY_REASSERT_MIN_GAP_MS = 20_000L
+        // ...and only twice per link. The grip above was written blind because its own callback
+        // was being deleted by R8; the 2026-08-01 storm logs, taken after the keep rule landed,
+        // say the sensor takes the fast params back every single time: 46/46 reclaims, median
+        // 5.8s (min 5.2, max 18.8), always returning to interval=308 latency=4 timeout=600. It
+        // also buys nothing measurable -- 1 drop per 564s of fast params against 82 per 23963s of
+        // slow ones, Poisson p~0.42. And linkUnstable (2 abnormal drops in 15min) is permanently
+        // true in that RF environment, so an unbounded grip is ~133 reasserts per sensor per 4h,
+        // each cutting the sensor's effective listen period from 1925ms to 15ms for ~5.8s --
+        // ~128x the connection events, on firmware budgeted for a 15-day battery.
+        // Counting the reclaims themselves and giving up after two was tried and dropped: every
+        // STATE_CONNECTED asks for CONNECTION_PRIORITY_HIGH, so the fast-param update answering
+        // that request clears any "the sensor already said no" memory on each of the ~44
+        // reconnects per sensor, and a reclaim cap could never be reached.
+        internal const val MAX_PRIORITY_REASSERTS_PER_CONNECTION = 2
         // A pending autoconnect only fires when the sensor's advertisement gets through;
         // tearing it down every 90s in a jamming storm kept destroying the one object
         // that could end the outage. Back the CONNECTING stale threshold off per
@@ -160,10 +183,94 @@ class OttaiBleManager(
         // than holding a baseline the sensor has clearly left behind.
         internal const val MAX_CONSECUTIVE_CONTINUITY_REJECTS = 3
 
+        // ---- outage instrumentation ----
+        // None of the three measurements below changes what the driver does; they exist because
+        // the 2026-08-01 analysis could not answer three questions from an 8995-line trace, and
+        // no further reconnect work can be justified without them.
+
+        // How long the outage probe listens for the sensor's advertisement. Long enough to cover
+        // the median connectGatt->connected of that storm (22s and 33s for the two sensors), short
+        // enough that a link dropping every ~2.7min on average is not scanning continuously.
+        private const val OUTAGE_PROBE_TIMEOUT_MS = 30_000L
+        // Android throttles an app to 5 scan starts per 30s and parks the offender for half an
+        // hour. One probe per outage already bounds this, but a burst of drops can end and restart
+        // an outage several times a minute, so hold a floor between probes as well — and hold it
+        // per process, not per sensor: the throttle is per uid, the 2026-08-01 storm had two Ottai
+        // sensors dropping together, and the startScan the platform refuses can just as easily be
+        // SensorBluetooth's managed scan, which is the recovery path for every other sensor.
+        internal const val OUTAGE_PROBE_MIN_GAP_MS = 60_000L
+        @Volatile private var lastOutageProbeAtMsShared = 0L
+        // RSSI cadence. Every few minutes, not every reading: the question it answers ("was the
+        // sensor far away or was the band busy?") does not move in seconds, and the sensor screens
+        // read one value.
+        internal const val RSSI_POLL_INTERVAL_MS = 300_000L
+        // The first sample must land early: 88 drops in 4h means the median session is minutes
+        // long, and an RSSI series that only starts after five of them would be empty exactly
+        // during a storm.
+        private const val RSSI_FIRST_POLL_DELAY_MS = 20_000L
+
+        /**
+         * Whether an outage may be probed for the sensor's advertisement now.
+         *
+         * [activationScanActive] is the hard exclusion: the activation/candidate scan owns the
+         * radio and the transport during setup, and a second scan racing it is exactly the
+         * interference this probe must never introduce. [managedScanActive] is the same argument
+         * one level up — SensorBluetooth's scan finds every sensor family, and losing its
+         * startScan to this app's own throttle would cost far more than the measurement is worth.
+         */
+        internal fun shouldProbeOutageAdvertisement(
+            alreadyProbedThisOutage: Boolean,
+            activationScanActive: Boolean,
+            managedScanActive: Boolean,
+            nowMs: Long,
+            lastProbeAtMs: Long,
+        ): Boolean {
+            if (alreadyProbedThisOutage || activationScanActive || managedScanActive) return false
+            if (lastProbeAtMs <= 0L) return true
+            val sinceMs = nowMs - lastProbeAtMs
+            // A clock step backwards must not latch the probe off for good — same rule as
+            // shouldReadLiveAfterHistory, and this one would otherwise be silent forever.
+            return sinceMs < 0L || sinceMs >= OUTAGE_PROBE_MIN_GAP_MS
+        }
+
+        /** Whether the RSSI poll is due. Off outside STREAMING: there is no link to measure. */
+        internal fun shouldPollRssi(streaming: Boolean, nowMs: Long, lastRssiReadAtMs: Long): Boolean {
+            if (!streaming) return false
+            if (lastRssiReadAtMs <= 0L) return true
+            val sinceMs = nowMs - lastRssiReadAtMs
+            return sinceMs < 0L || sinceMs >= RSSI_POLL_INTERVAL_MS
+        }
+
+        /**
+         * Stale-activity threshold while streaming. The poll interval is what the sensor is
+         * expected to speak on, so a slow poll must widen the window it is judged against.
+         */
+        internal fun streamingStaleThresholdMs(livePollIntervalMs: Long): Long =
+            maxOf(STREAM_ACTIVITY_STALE_MS, livePollIntervalMs * 3L + 15_000L)
+
         internal fun isFreshLiveSample(receivedAtMs: Long, sampleMs: Long): Boolean =
             receivedAtMs > 0L &&
                 sampleMs > 0L &&
                 abs(receivedAtMs - sampleMs) <= CURRENT_SAMPLE_FRESH_MS + CURRENT_SAMPLE_FLOOR_GRACE_MS
+
+        /**
+         * Whether the one-shot live read after a history payload is worth its round-trip.
+         *
+         * The one-shot exists for a history burst that ends several minutes behind wall time, but
+         * that is not how history is normally asked for: requestRoomBackfillAfterLive issues it
+         * about a second after a live frame, which in the 2026-08-01 logs was 100% of the requests.
+         * All 26 re-reads returned records the app already held — 24 a byte-identical ciphertext,
+         * the other 2 a fresh ciphertext carrying a dataNo a live notify had brought in 0-1 s
+         * earlier — for an ATT round-trip, an AES-CBC decrypt and a ~200 KB appendTemperatureHistory
+         * rebuild each. Below a record interval the sensor has nothing newer to give.
+         */
+        internal fun shouldReadLiveAfterHistory(receivedAtMs: Long, lastLiveFrameAtMs: Long): Boolean {
+            if (lastLiveFrameAtMs <= 0L) return true
+            val sinceLiveMs = receivedAtMs - lastLiveFrameAtMs
+            // A clock step backwards must not latch the one-shot off: this is the only read that
+            // catches up a history burst which ended behind wall time.
+            return sinceLiveMs < 0L || sinceLiveMs >= RECORD_INTERVAL_MS
+        }
 
         /**
          * Adjacency window for the continuity gate: is [dataNo]/[sampleMs] close enough behind
@@ -343,13 +450,69 @@ class OttaiBleManager(
             unstable: Boolean,
             nowMs: Long,
             lastReassertMs: Long,
+            reassertsThisConnection: Int,
         ): Boolean =
             unstable &&
+                reassertsThisConnection < MAX_PRIORITY_REASSERTS_PER_CONNECTION &&
                 (intervalUnits >= SLOW_CONN_INTERVAL_UNITS || latency >= SLOW_CONN_LATENCY) &&
                 nowMs - lastReassertMs >= PRIORITY_REASSERT_MIN_GAP_MS
 
         internal fun connectingStaleThresholdMs(stallStreak: Int): Long =
             SETUP_ACTIVITY_STALE_MS shl stallStreak.coerceIn(0, MAX_CONNECT_STALL_BACKOFF_SHIFTS)
+
+        /**
+         * How long the ordinary disconnect path waits before re-arming the connect.
+         *
+         * A supervision timeout says the peer stopped answering, not that it went away. In the
+         * 2026-08-01 storm all 88 drops were status=8, and 15 of those outages ended within 10s
+         * of close() — the sensor was there and catchable while the driver sat out its 3s
+         * default. Worth ~38s across both sensors over the window even if the re-arm were instant
+         * (0.7% of the downtime) and zero recovered readings — this takes half of that, no more:
+         * the pre-teardown hold is only 129s/2520s and 120s/2799s of
+         * the two downtime budgets, the other ~95% being spent after the connect is armed,
+         * waiting for an advertisement to get through (connectGatt->connected p50 22s/33s, max
+         * 374s/387s). Cheap, so worth taking; not a fix for the outages.
+         *
+         * 1500ms and not the 250ms recoverGattAndReconnect uses: that path fires from the
+         * watchdog with no callback in flight, whereas this one has just run gatt.close() on the
+         * BT callback thread with the disconnect event still being delivered, and a connectGatt()
+         * issued before unregisterApp()/registerApp() has settled is the classic way to earn a
+         * status=133 that costs a whole extra outage. On MIUI that cycle churned clientIf
+         * 163,167,171,179,183,191...243 in 4h. Nothing measures where the floor actually is, so
+         * take the half of the 3s that the evidence justifies and leave the rest — and if a 133
+         * does arrive right after one of these re-arms, [fastReArmBounced] gives the whole idea up
+         * for the rest of the outage.
+         *
+         * Note for anyone reading the CONNECTING backoff ladder: this also moves that ladder's
+         * origin 1.5s earlier per status=8 outage, because connectDevice() stamps
+         * lastBleActivityAtMs and arms the watchdog. The rungs (90/180/360s) are unchanged.
+         *
+         * Every other status deliberately keeps the 3s default:
+         *  - 19 (GATT_CONN_TERMINATE_PEER_USER) is a live peer closing the link itself, and a
+         *    fast re-arm against that is how a connect/terminate loop gets built. 3s works —
+         *    drop at 1785606352, reconnected 1785606359.
+         *  - 22 (GATT_CONN_TERMINATE_LOCAL_HOST) is our own teardown, likewise.
+         *  - 133 never occurred on this path: all five in the logs were ATT reads
+         *    ("read err 00002aa7 ... phase=STREAMING").
+         */
+        internal fun reconnectDelayAfterDisconnectMs(status: Int, fastReArmAllowed: Boolean): Long =
+            if (status == GATT_CONN_TIMEOUT && fastReArmAllowed) SUPERVISION_TIMEOUT_RECONNECT_DELAY_MS
+            else RECONNECT_DELAY_MS
+
+        /**
+         * Whether this disconnect looks like the shortened re-arm above bouncing off the stack's
+         * own client registration rather than off the sensor.
+         *
+         * A 133 landing within a couple of seconds of a re-armed connect is the documented shape
+         * of connecting inside the post-close() clientIf window; it has never been seen on this
+         * driver's disconnect path, but it has also never been asked for a connect this soon after
+         * close(). One is enough — the shortened delay is worth 0.7% of the downtime, so it is not
+         * worth a single extra bounce, let alone a loop of them.
+         */
+        internal fun fastReArmBounced(status: Int, nowMs: Long, fastReArmAtMs: Long): Boolean =
+            status == GATT_ERROR_STATUS &&
+                fastReArmAtMs > 0L &&
+                (nowMs - fastReArmAtMs) in 0L..FAST_REARM_BOUNCE_WINDOW_MS
 
         internal fun acceptedMaxActiveToCommit(
             commandStatus: Int,
@@ -395,9 +558,28 @@ class OttaiBleManager(
     // feeds the fast-params hold and is only touched under its own lock (binder threads).
     private val abnormalDropAtMs = ArrayDeque<Long>()
     @Volatile private var lastPriorityReassertAtMs = 0L
+    // Read-modify-written only from onConnectionParamsUpdated and reset only from
+    // STATE_CONNECTED, both of which the stack delivers on the one binder thread that owns this
+    // GATT — unlike abnormalDropAtMs above, which several threads reach.
+    @Volatile private var priorityReassertCount = 0
     @Volatile private var connectStallStreak = 0
     @Volatile private var liveReadRetryCount = 0
     @Volatile private var lastUserReconnectAtMs = 0L
+    // When the connect a shortened post-supervision-timeout re-arm scheduled is due to fire (not
+    // when it was scheduled — the bounce this watches for happens at the connect), and whether
+    // the shortened delay has been withdrawn for this outage. See reconnectDelayAfterDisconnectMs.
+    @Volatile private var fastReArmAtMs = 0L
+    @Volatile private var fastReArmWithdrawn = false
+
+    // ---- outage instrumentation (measurement only; never drives the state machine) ----
+    private val advertisementProbe = OttaiAdvertisementProbe(
+        context = Applic.getContext(),
+        handler = handler,
+        onFinished = ::finishOutageAdvertisementProbe,
+    )
+    @Volatile private var outageStartedAtMs = 0L
+    @Volatile private var probedThisOutage = false
+    @Volatile private var lastRssiReadAtMs = 0L
 
     private var svcDeviceInfo: BluetoothGattService? = null
     private var svcCgm: BluetoothGattService? = null
@@ -569,6 +751,12 @@ class OttaiBleManager(
     // When the sensor last pushed a live frame on its own. The poll below is a safety net for
     // notifications stopping, not a second data path, so it stands down while they are flowing.
     @Volatile private var lastLiveNotifyAtMs = 0L
+    // When a live frame last decoded, from EITHER source. The post-history one-shot consults this,
+    // and lastLiveNotifyAtMs cannot serve it: that one is written only from onCharacteristicChanged,
+    // and in the 2026-08-01 logs the driver was on the polled read path — at 1785605688 the last
+    // notify was 389 s old, so a notify-based guard would have been inert on exactly the path it is
+    // meant to close.
+    @Volatile private var lastLiveFrameAtMs = 0L
     private val recentlyRejectedSamples = object : LinkedHashMap<Int, RejectedSample>(64, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Int, RejectedSample>?): Boolean = size > 64
     }
@@ -597,6 +785,25 @@ class OttaiBleManager(
         val gatt = mBluetoothGatt ?: return@Runnable
         readLiveGlucose(gatt, "post-history")
         scheduleLivePoll()
+    }
+
+    // Whether the sensor was out of range or the band was busy is not decidable from anything the
+    // app records today: there is no RSSI anywhere in the 2026-08-01 trace. Reads are only issued
+    // while streaming, and a read that cannot start is not retried — this is instrumentation, and
+    // a missing sample costs nothing.
+    private val rssiPollRunnable = Runnable {
+        if (stop) return@Runnable
+        val gatt = mBluetoothGatt
+        if (gatt == null || !shouldPollRssi(phase == Phase.STREAMING, System.currentTimeMillis(), lastRssiReadAtMs)) {
+            scheduleRssiPoll()
+            return@Runnable
+        }
+        val started = runCatching { gatt.readRemoteRssi() }.getOrDefault(false)
+        // Mark the attempt, not the answer: a read that never comes back must still not be
+        // retried before the next slot, or a jammed link turns this into a busy loop.
+        lastRssiReadAtMs = System.currentTimeMillis()
+        if (!started) logi(TAG) { "rssi read could not start" }
+        scheduleRssiPoll()
     }
 
     @Volatile private var activationConfirmAttempt = 0
@@ -757,7 +964,7 @@ class OttaiBleManager(
 
     private fun connectionStaleThresholdMs(): Long =
         when {
-            phase == Phase.STREAMING -> maxOf(STREAM_ACTIVITY_STALE_MS, livePollIntervalMs * 3L + 15_000L)
+            phase == Phase.STREAMING -> streamingStaleThresholdMs(livePollIntervalMs)
             phase == Phase.CONNECTING -> connectingStaleThresholdMs(connectStallStreak)
             else -> SETUP_ACTIVITY_STALE_MS
         }
@@ -793,6 +1000,7 @@ class OttaiBleManager(
         if (markSignalLoss) constatstatusstr = lossOfSignalText()
         handler.removeCallbacks(livePollRunnable)
         handler.removeCallbacks(postHistoryLiveRunnable)
+        handler.removeCallbacks(rssiPollRunnable)
         handler.removeCallbacks(pendingHistoryChunkRunnable)
         handler.removeCallbacks(endedHistoryBackfillRunnable)
         handler.removeCallbacks(initialHistoryRunnable)
@@ -800,12 +1008,18 @@ class OttaiBleManager(
         handler.removeCallbacks(pendingActivationNfcPromptRunnable)
         handler.removeCallbacks(serviceDiscoveryRunnable)
         handler.removeCallbacks(serviceDiscoveryTimeoutRunnable)
+        advertisementProbe.stop()
         pendingServiceDiscoveryGatt = null
         clearPendingHistoryRange()
         svcDeviceInfo = null
         svcCgm = null
         svcAuth = null
         sessionKeyHex = ""
+        // Session-scoped like the key: a live frame from the link being torn down must not answer
+        // the post-history one-shot's freshness question about the next one, and readrssi's 9999
+        // sentinel is what the sensor screens read as "no live link".
+        lastLiveFrameAtMs = 0L
+        readrssi = 9999
         authStep = AuthStep.NONE
         actStep = ActStep.NONE
         if (!preserveActivationNegotiation) resetActivationNegotiation()
@@ -950,6 +1164,7 @@ class OttaiBleManager(
     }
 
     override fun close() {
+        advertisementProbe.stop()
         if (stop) {
             // Permanent shutdown: free() sets stop=true before calling close(), so
             // quit the HandlerThread here — otherwise it outlives the sensor object.
@@ -1183,6 +1398,7 @@ class OttaiBleManager(
     }
 
     override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+        noteFirstGattCallback("onConnectionStateChange", gatt)
         if (stop) return
         when (newState) {
             BluetoothProfile.STATE_CONNECTED -> {
@@ -1204,6 +1420,18 @@ class OttaiBleManager(
                 lastBleActivityAtMs = connectTime
                 connectStallStreak = 0
                 liveReadRetryCount = 0
+                // The outage is over. Stop the probe rather than letting it run out its window:
+                // the link landing IS an advertisement getting through, and a probe that is only
+                // ever read out on timeout would leave every fast recovery out of the sample.
+                if (advertisementProbe.isActive) {
+                    val outageSec = ((connectTime - outageStartedAtMs).coerceAtLeast(0L)) / 1000L
+                    logi(TAG) { "advertisement probe ended by connect afterOutageSec=$outageSec" }
+                    advertisementProbe.stop()
+                }
+                probedThisOutage = false
+                priorityReassertCount = 0
+                fastReArmWithdrawn = false
+                fastReArmAtMs = 0L
                 // A link landed, so the abandoned-scan latch has served its purpose: a later
                 // activation attempt in this session may legitimately arm discovery again.
                 freshActivationAdvertisementAbandoned = false
@@ -1252,6 +1480,7 @@ class OttaiBleManager(
                 phase = Phase.IDLE
                 handler.removeCallbacks(livePollRunnable)
                 handler.removeCallbacks(postHistoryLiveRunnable)
+                handler.removeCallbacks(rssiPollRunnable)
                 handler.removeCallbacks(pendingHistoryChunkRunnable)
                 handler.removeCallbacks(endedHistoryBackfillRunnable)
                 handler.removeCallbacks(initialHistoryRunnable)
@@ -1262,6 +1491,11 @@ class OttaiBleManager(
                 clearPendingHistoryRange()
                 svcDeviceInfo = null; svcCgm = null; svcAuth = null
                 sessionKeyHex = ""
+                // Same session scope as the key above: the next link asks its own freshness
+                // question, and the sensor screens must not keep rendering the dead link's RSSI
+                // for the whole outage.
+                lastLiveFrameAtMs = 0L
+                readrssi = 9999
                 authStep = AuthStep.NONE
                 actStep = ActStep.NONE
                 pendingActivation = false
@@ -1305,8 +1539,21 @@ class OttaiBleManager(
                         scheduleReconnect("setup activation pre-status disconnect", 1_000L)
                     }
                 } else if (!stop) {
-                    scheduleReconnect("gatt disconnect")
+                    val now = System.currentTimeMillis()
+                    if (fastReArmBounced(status, now, fastReArmAtMs)) {
+                        fastReArmWithdrawn = true
+                        Log.w(TAG, "status=$status ${now - fastReArmAtMs}ms after a shortened " +
+                            "re-arm connected; back to the ${RECONNECT_DELAY_MS}ms delay for this outage")
+                    }
+                    val delayMs = reconnectDelayAfterDisconnectMs(status, !fastReArmWithdrawn)
+                    fastReArmAtMs =
+                        if (delayMs == SUPERVISION_TIMEOUT_RECONNECT_DELAY_MS) now + delayMs else 0L
+                    scheduleReconnect("gatt disconnect", delayMs)
                 }
+                // Last, so the guard sees whatever the branches above decided: an activation scan
+                // armed there owns the radio and this must stand aside. The reconnect is already
+                // scheduled either way — the probe only watches.
+                if (status != 0) startOutageAdvertisementProbe(status)
                 UiRefreshBus.requestStatusRefresh()
             }
         }
@@ -1326,6 +1573,51 @@ class OttaiBleManager(
     private fun linkUnstable(nowMs: Long): Boolean =
         synchronized(abnormalDropAtMs) { isLinkUnstable(abnormalDropAtMs.toList(), nowMs) }
 
+    /**
+     * Listen once, at the start of an outage, for the sensor's own advertisement.
+     *
+     * Observe-only by construction: it scans the registry address — never a candidate one probe
+     * may have retargeted us at — and its result is written to the log and nowhere else. The
+     * driver's recovery is untouched; the reconnect it was going to make is already armed.
+     */
+    private fun startOutageAdvertisementProbe(status: Int) {
+        if (stop) return
+        val explicitActivationRequest =
+            activateRequestedFor?.let { matchesManagedSensorId(it) } == true
+        val now = System.currentTimeMillis()
+        if (!shouldProbeOutageAdvertisement(
+                alreadyProbedThisOutage = probedThisOutage,
+                // activationNegotiationActive covers the lifetime-retry branch too: that one
+                // reconnects without arming either scanning sub-state, and the maxActive
+                // candidate walk is the last path that should be sharing the radio.
+                activationScanActive = activationNegotiationActive ||
+                    activationCandidateDiscoveryPending ||
+                    awaitingFreshActivationAdvertisement ||
+                    explicitActivationRequest,
+                managedScanActive = SensorBluetooth.scanActiveOrPending(),
+                nowMs = now,
+                lastProbeAtMs = lastOutageProbeAtMsShared,
+            )
+        ) {
+            return
+        }
+        val address = ownRecordAddress() ?: return
+        probedThisOutage = true
+        outageStartedAtMs = now
+        lastOutageProbeAtMsShared = now
+        val started = advertisementProbe.start(address, OUTAGE_PROBE_TIMEOUT_MS)
+        logi(TAG) { "advertisement probe started=$started after status=$status address=$address" }
+    }
+
+    private fun finishOutageAdvertisementProbe(rssi: Int?) {
+        val afterOutageSec = ((System.currentTimeMillis() - outageStartedAtMs).coerceAtLeast(0L)) / 1000L
+        if (rssi == null) {
+            logi(TAG) { "advertisement not seen within ${OUTAGE_PROBE_TIMEOUT_MS / 1000L}s of the drop" }
+        } else {
+            logi(TAG) { "advertisement seen afterOutageSec=$afterOutageSec rssi=$rssi" }
+        }
+    }
+
     override fun onConnectionParamsUpdated(
         gatt: BluetoothGatt,
         interval: Int,
@@ -1334,10 +1626,26 @@ class OttaiBleManager(
         status: Int,
     ) {
         if (stop || status != 0 || gatt !== mBluetoothGatt) return
+        // This line has always been unconditional; what changed is that it is now reachable. R8
+        // deleted onConnectionUpdated from every release build ever shipped, so the ~136 lines per
+        // sensor per 4h of link-parameter history it writes existed nowhere at all. logi() reaches
+        // trace.log in release builds (only android.util.Log is stripped there), which is the only
+        // place an outage can be read back from a user's device.
         logi(TAG) { "conn params interval=$interval latency=$latency timeout=$timeout" }
         val now = System.currentTimeMillis()
-        if (!shouldHoldFastParams(interval, latency, linkUnstable(now), now, lastPriorityReassertAtMs)) return
+        if (!shouldHoldFastParams(
+                interval,
+                latency,
+                linkUnstable(now),
+                now,
+                lastPriorityReassertAtMs,
+                priorityReassertCount,
+            )
+        ) {
+            return
+        }
         lastPriorityReassertAtMs = now
+        priorityReassertCount++
         Log.i(TAG, "unstable link: holding fast conn params over interval=$interval latency=$latency timeout=$timeout")
         runCatching { gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH) }
     }
@@ -1774,6 +2082,8 @@ class OttaiBleManager(
                 }
                 phase = Phase.STREAMING
                 Log.i(TAG, "auth complete; session=ok")
+                lastRssiReadAtMs = 0L
+                scheduleRssiPoll(RSSI_FIRST_POLL_DELAY_MS)
                 run {
                     val address = OttaiConstants.normalizeBleAddress(gatt.device?.address, allowPlain = false)
                     val context = Applic.app
@@ -2150,6 +2460,13 @@ class OttaiBleManager(
             Log.w(TAG, "$kind $source dropped ${readings.size - plausible.size} corrupt records dataNo>ceiling=$ceiling")
         }
         noteCeilingOutcome(offered = readings.size, kept = plausible.size, ceiling = ceiling)
+        // A live frame that survived the ceiling means the app holds the sensor's current
+        // position, whether or not the sample inside it turns out to be one Room already has —
+        // which is exactly what the post-history one-shot needs to know, so it is stamped here
+        // rather than after the emit. Below the ceiling filter, though: a frame whose records were
+        // all dropped as corrupt says nothing about where the sensor is, and under the known
+        // dataNoCeiling poison state that is every live frame there will ever be.
+        if (live && plausible.isNotEmpty()) lastLiveFrameAtMs = receivedAtMs
         val emittedReadings = ArrayList<EmittedReading>(plausible.size)
         for ((index, r) in plausible.withIndex()) {
             if (!r.valid) {
@@ -2187,9 +2504,12 @@ class OttaiBleManager(
                 if (!continueHistoryAfterPayload(plausible)) {
                     // History can arrive in a long burst and still end several minutes behind
                     // wall time. Ask live immediately afterwards on a one-shot that cgm-info
-                    // cadence updates cannot cancel.
-                    handler.removeCallbacks(postHistoryLiveRunnable)
-                    handler.postDelayed(postHistoryLiveRunnable, 1_000L)
+                    // cadence updates cannot cancel — unless live is already current, which the
+                    // room-backfill caller makes the common case.
+                    if (shouldReadLiveAfterHistory(receivedAtMs, lastLiveFrameAtMs)) {
+                        handler.removeCallbacks(postHistoryLiveRunnable)
+                        handler.postDelayed(postHistoryLiveRunnable, 1_000L)
+                    }
                 }
             }
             UiRefreshBus.requestStatusRefresh()
@@ -3559,6 +3879,26 @@ class OttaiBleManager(
         if (stop || phase != Phase.STREAMING || sessionKeyHex.isBlank()) return
         handler.removeCallbacks(livePollRunnable)
         handler.postDelayed(livePollRunnable, delayMs.coerceIn(5_000L, 3_600_000L))
+    }
+
+    private fun scheduleRssiPoll(delayMs: Long = RSSI_POLL_INTERVAL_MS) {
+        if (stop || phase != Phase.STREAMING) return
+        handler.removeCallbacks(rssiPollRunnable)
+        handler.postDelayed(rssiPollRunnable, delayMs)
+    }
+
+    override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
+        super.onReadRemoteRssi(gatt, rssi, status)
+        if (stop || gatt !== mBluetoothGatt) return
+        if (status != 0) {
+            logi(TAG) { "rssi read failed status=$status" }
+            return
+        }
+        // Deliberately NOT noteGattActivity(): readRemoteRssi is HCI_Read_RSSI answered by the
+        // local controller from the last packet it saw, so the peer takes no part in it and a
+        // successful read is no evidence the sensor is still answering. Counting it as liveness
+        // would push worst-case detection of a wedged ATT path in STREAMING from 195s to ~390s.
+        logi(TAG) { "rssi=$rssi phase=$phase" }
     }
 
     /** Returns true if a write was issued (characteristic resolved), false if missing. */

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -75,6 +75,19 @@ class OttaiBleManager(
         private const val INITIAL_HISTORY_DELAY_MS = 4_000L
         private const val INITIAL_HISTORY_RETRY_MS = 5_000L
         private const val INITIAL_HISTORY_MAX_ATTEMPTS = 4
+        // A sensor this young has nothing behind its live frame — dataNo counts minutes since
+        // activation and estimatedNewestDataNo() stays two records short of now, so the backstop
+        // cannot possibly find a basis. Defer instead of burning attempts: on 2026-07-29 it
+        // probed a sensor activated four seconds earlier five times and closed with a "gave up"
+        // warning that reads like a failure after every successful activation.
+        private const val INITIAL_HISTORY_MIN_SENSOR_AGE_MS = 3L * 60_000L
+        // Confirming that activation took is the only read worth issuing straight after the
+        // command; see markActivationCommandSent. Retried a few times because a read that cannot
+        // start (another operation still in flight) otherwise leaves status=3 unseen until some
+        // later poll happens to pick it up.
+        private const val POST_ACTIVATION_CONFIRM_DELAY_MS = 1_000L
+        private const val POST_ACTIVATION_CONFIRM_RETRY_MS = 1_500L
+        private const val POST_ACTIVATION_CONFIRM_MAX_ATTEMPTS = 4
         // History chunk-chain watchdog: an in-flight chunk whose response never lands (dropped
         // notify or short/empty frame) silently stalls the whole download. If no progress within
         // the timeout, retry the same window a bounded number of times, then skip it after
@@ -141,11 +154,36 @@ class OttaiBleManager(
         private const val CURRENT_SAMPLE_FLOOR_GRACE_MS = RECORD_INTERVAL_MS
         private const val MAX_REASONABLE_DATA_NO_AHEAD = 120
         private const val MGDL_PER_MMOLL = 18.0f
+        // Consecutive continuity rejections after which the gate yields and re-baselines onto the
+        // next sample. Sustained >=1.5 mmol/min steps are not physiology, but latching forever
+        // would blind the driver to a genuine electrode restart, so the gate gives way rather
+        // than holding a baseline the sensor has clearly left behind.
+        internal const val MAX_CONSECUTIVE_CONTINUITY_REJECTS = 3
 
         internal fun isFreshLiveSample(receivedAtMs: Long, sampleMs: Long): Boolean =
             receivedAtMs > 0L &&
                 sampleMs > 0L &&
                 abs(receivedAtMs - sampleMs) <= CURRENT_SAMPLE_FRESH_MS + CURRENT_SAMPLE_FLOOR_GRACE_MS
+
+        /**
+         * Adjacency window for the continuity gate: is [dataNo]/[sampleMs] close enough behind
+         * the previously evaluated sample for a one-minute excursion comparison to mean anything?
+         *
+         * Two records or 135 s, whichever the caller can establish. The dataNo test comes first
+         * because it survives a missing/derived timestamp; the time test covers a replay whose
+         * counter has been reset.
+         */
+        internal fun isAdjacentSample(
+            previousDataNo: Int,
+            previousSampleMs: Long,
+            dataNo: Int,
+            sampleMs: Long,
+        ): Boolean {
+            if (previousDataNo < 0) return false
+            if (dataNo - previousDataNo in 1..2) return true
+            if (previousSampleMs <= 0L || sampleMs <= previousSampleMs) return false
+            return (sampleMs - previousSampleMs) in 1..(2 * RECORD_INTERVAL_MS + 15_000L)
+        }
 
         internal fun isPersistedDataNoAheadOfLive(previousDataNo: Int, liveDataNo: Int): Boolean =
             previousDataNo >= 0 &&
@@ -392,6 +430,9 @@ class OttaiBleManager(
     @Volatile private var activationRetryPending = false
     @Volatile private var activationRetryAddress: String? = null
     @Volatile private var activationCandidateDiscoveryPending = false
+    // When the current candidate scan was armed. For the first few seconds only this sensor's own
+    // address is admitted; see OttaiConstants.isActivationExactOnlyWindowOpen.
+    @Volatile private var activationDiscoveryStartedAtMs = 0L
     @Volatile private var activationCandidateProbeActive = false
     // This sensor's own record-backed BLE address, captured when candidate discovery is
     // armed. selectActivationCandidate retargets activationRetryAddress/mActiveDeviceAddress
@@ -491,6 +532,20 @@ class OttaiBleManager(
     @Volatile private var lastAcceptedSampleMs = 0L
     @Volatile private var lastAcceptedMmol = Float.NaN
     @Volatile private var lastAcceptedRawCurrent = 0
+    // Adjacency anchor for the continuity gate. Unlike lastAccepted* this also advances on a
+    // sample the gate itself rejected. Anchoring adjacency on the last ACCEPTED sample meant two
+    // consecutive rejections pushed the next sample outside the 2-record / 135 s window, so the
+    // adjacency test went false, the excursion test was skipped entirely, and the third sample
+    // went out unchecked — then became the baseline the rest of the ramp inherited. Observed on the
+    // 2026-07-29 activation: dataNo 1 and 2 rejected at 2.40 mmol, dataNo 3 published at
+    // 2.80 mmol (50 mg/dL) in the middle of a warmup ramp that ran on to 6.10 mmol.
+    @Volatile private var lastEvaluatedDataNo = -1
+    @Volatile private var lastEvaluatedSampleMs = 0L
+    // Safety valve for the anchor above: the comparison baseline only moves on an ACCEPTED
+    // sample, so a genuine step change (or a real electrode restart) would otherwise be refused
+    // for the rest of the session. After this many consecutive continuity rejections the next
+    // sample is admitted and re-baselines the gate.
+    @Volatile private var consecutiveContinuityRejects = 0
     @Volatile private var lastDataNo = -1
     @Volatile private var consecutiveCeilingFullDrops = 0
     @Volatile private var ceilingDistrusted = false
@@ -511,6 +566,9 @@ class OttaiBleManager(
     // First reliable activation start seen this session, held until a second one corroborates it.
     @Volatile private var pendingConfirmedStartMs = 0L
     @Volatile private var lastBleActivityAtMs = 0L
+    // When the sensor last pushed a live frame on its own. The poll below is a safety net for
+    // notifications stopping, not a second data path, so it stands down while they are flowing.
+    @Volatile private var lastLiveNotifyAtMs = 0L
     private val recentlyRejectedSamples = object : LinkedHashMap<Int, RejectedSample>(64, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Int, RejectedSample>?): Boolean = size > 64
     }
@@ -520,6 +578,16 @@ class OttaiBleManager(
     private val livePollRunnable = Runnable {
         if (stop || phase != Phase.STREAMING || sessionKeyHex.isBlank() || commandStatus >= 4) return@Runnable
         val gatt = mBluetoothGatt ?: return@Runnable
+        // Stand down while notifications are arriving on schedule. The poll timer is restarted by
+        // every accepted live sample, so it comes due at the same instant as the next notify and
+        // then re-reads what has just been delivered: over the 8 h after the 2026-07-29
+        // activation, 216 of 219 polled reads returned records a notify had already brought in
+        // milliseconds earlier — roughly 650 redundant encrypted ATT reads a day.
+        val sinceNotifyMs = System.currentTimeMillis() - lastLiveNotifyAtMs
+        if (lastLiveNotifyAtMs > 0L && sinceNotifyMs < livePollIntervalMs) {
+            scheduleLivePoll()
+            return@Runnable
+        }
         readLiveGlucose(gatt, "poll")
         scheduleLivePoll()
     }
@@ -529,6 +597,28 @@ class OttaiBleManager(
         val gatt = mBluetoothGatt ?: return@Runnable
         readLiveGlucose(gatt, "post-history")
         scheduleLivePoll()
+    }
+
+    @Volatile private var activationConfirmAttempt = 0
+
+    /**
+     * Read the command byte back after the activation writes until it reports 3, or the attempts
+     * run out. Self-rescheduling rather than a fixed delay, because a read that could not start
+     * produces no callback to hang the next step off.
+     */
+    private val activationConfirmRunnable = object : Runnable {
+        override fun run() {
+            if (stop || commandStatus == 3) return
+            val gatt = mBluetoothGatt ?: return
+            if (activationConfirmAttempt >= POST_ACTIVATION_CONFIRM_MAX_ATTEMPTS) {
+                Log.w(TAG, "activation confirmation read never landed after " +
+                    "$activationConfirmAttempt attempts; awaiting the next poll or reconnect")
+                return
+            }
+            activationConfirmAttempt++
+            runCatching { readChar(gatt, OttaiConstants.SERVICE_CGM, OttaiConstants.CHAR_COMMAND) }
+            handler.postDelayed(this, POST_ACTIVATION_CONFIRM_RETRY_MS)
+        }
     }
 
     private val pendingHistoryChunkRunnable = Runnable {
@@ -612,6 +702,11 @@ class OttaiBleManager(
             lastAcceptedSampleMs = it.sampleMs
             lastAcceptedMmol = it.mmol
             lastAcceptedRawCurrent = it.rawCurrent
+            // Seed the adjacency anchor from the same record. Leaving it at -1 would disable the
+            // gate for the first sample after every restart, which is exactly when the restored
+            // baseline is there to be used.
+            lastEvaluatedDataNo = it.dataNo
+            lastEvaluatedSampleMs = it.sampleMs
         }
         // Auth V2 signs the cloud id bytes, not necessarily the Android BLE address.
         macBytes = runCatching { OttaiCrypto.hexToBytes(OttaiConstants.canonicalSensorId(id)) }.getOrDefault(ByteArray(0))
@@ -949,6 +1044,7 @@ class OttaiBleManager(
         // user-driven retry working while connectDevice()'s automatic branch stays suppressed.
         freshActivationAdvertisementAbandoned = false
         activationCandidateDiscoveryPending = true
+        activationDiscoveryStartedAtMs = System.currentTimeMillis()
         activationCandidateProbeActive = false
         clearDeferredActivationCandidateCgmInfo()
         mActiveDeviceAddress = address
@@ -1058,10 +1154,18 @@ class OttaiBleManager(
             advertisedName = advertisedName,
             rejectedAddresses = rejectedActivationCandidateAddresses,
             allowNameMatch = allowActivationCandidateNameMatch(),
+            exactOnlyWindowOpen = OttaiConstants.isActivationExactOnlyWindowOpen(
+                activationDiscoveryStartedAtMs,
+                System.currentTimeMillis(),
+            ),
         )
         if (!selected) return false
         if (!scannedAddress.equals(expectedAddress, ignoreCase = true)) {
-            Log.i(TAG, "probing NFC-woken Ottai address=$scannedAddress previous=$expectedAddress")
+            // Not necessarily NFC: this branch is reached by the name-only fallback too, which
+            // admits ANY advertisement containing "ottai". Saying "NFC-woken" invented a user
+            // action that had not happened and hid the real reason a stranger was being probed.
+            Log.i(TAG, "probing Ottai activation candidate address=$scannedAddress " +
+                "expected=$expectedAddress (name-only match)")
         }
         activationRetryAddress = scannedAddress
         mActiveDeviceAddress = scannedAddress
@@ -1466,6 +1570,7 @@ class OttaiBleManager(
                 Applic.app?.let { OttaiNfcWakeReminder.cancel(it, sensorId) }
             }
             handler.removeCallbacks(endedHistoryBackfillRunnable)
+            handler.removeCallbacks(activationConfirmRunnable)
             needsActivationAttempted = false
             resetActivationNegotiation()
             if (previous >= 4) {
@@ -1651,11 +1756,25 @@ class OttaiBleManager(
             authStep == AuthStep.WRITE_APP_SIGN && ch.uuid == OttaiConstants.CHAR_AUTH_SIGN -> {
                 deriveSession()
                 authStep = AuthStep.DONE
-                phase = Phase.STREAMING
                 lastBleActivityAtMs = System.currentTimeMillis()
-                val sessionOk = sessionKeyHex.isNotBlank()
-                Log.i(TAG, "auth complete; session=${if (sessionOk) "ok" else "FAILED"}")
-                if (sessionOk) {
+                if (sessionKeyHex.isBlank()) {
+                    // Derivation produced no usable key (a shared X whose top byte is zero and
+                    // whose next byte is below 0x80 — 1 handshake in 512). Everything downstream
+                    // is gated on this, so the old fall-through left the link in STREAMING with
+                    // nothing to do — and STREAMING selects the 180 s stale threshold instead of
+                    // the 90 s setup one, so the watchdog would not have intervened for another
+                    // three minutes. On 2026-07-29 the app sat silent for 59 s until the SENSOR
+                    // gave up (status=19), which cost 73 s of a six-minute activation. Drop the
+                    // link ourselves and re-authenticate: the failure is per-handshake, so the
+                    // retry succeeds immediately.
+                    Log.w(TAG, "auth complete; session=FAILED — no session key derived, reconnecting")
+                    UiRefreshBus.requestStatusRefresh()
+                    recoverGattAndReconnect("session key derivation failed")
+                    return
+                }
+                phase = Phase.STREAMING
+                Log.i(TAG, "auth complete; session=ok")
+                run {
                     val address = OttaiConstants.normalizeBleAddress(gatt.device?.address, allowPlain = false)
                     val context = Applic.app
                     val id = SerialNumber
@@ -1679,7 +1798,7 @@ class OttaiBleManager(
                 // activation). Reads on this post-CCCD char may work even though writes hit
                 // Invalid Handle — and this tells us whether the empty glucose is because
                 // the sensor was never started vs. a dead element.
-                if (sessionOk) readChar(gatt, OttaiConstants.SERVICE_CGM, OttaiConstants.CHAR_COMMAND)
+                readChar(gatt, OttaiConstants.SERVICE_CGM, OttaiConstants.CHAR_COMMAND)
                 // Do not infer activation from cloud or provisional timestamps. The command
                 // byte read above is the sensor's authoritative state: 0..2 activates, 3
                 // streams, and 4+ follows the ended-sensor path.
@@ -1704,11 +1823,12 @@ class OttaiBleManager(
             OttaiCrypto.bytesToHex(devicePubY),
             priv,
         ).orEmpty()
-        // DEBUG (remove): dump the session key so a captured live/history cipher can be
-        // decrypted offline in every mode — to settle whether records are genuinely empty
-        // or our AES-ECB path is wrong (different ciphers → identical empty payload is
-        // impossible for correct ECB). Local single-sensor RE only; not a normal secret log.
-        Log.i(TAG, "DEBUG sessionKey=$sessionKeyHex")
+        // Length only — never the key itself. trace.log is user-exportable and gets attached to
+        // bug reports, and this AES session key decrypts every live/history frame in the capture.
+        // The length is what actually matters diagnostically: a derivation that drops a leading
+        // zero byte yields a short (or empty) key, which is how the 1-in-512 auth failure was
+        // found in the first place.
+        Log.i(TAG, "session key derived len=${sessionKeyHex.length}")
     }
 
     // ---- streaming ----
@@ -1718,7 +1838,10 @@ class OttaiBleManager(
         val value = ch.value ?: return
         noteGattActivity()
         when (ch.uuid) {
-            OttaiConstants.CHAR_GLUCOSE_LIVE -> handleGlucosePayload(value, live = true, source = "notify")
+            OttaiConstants.CHAR_GLUCOSE_LIVE -> {
+                lastLiveNotifyAtMs = System.currentTimeMillis()
+                handleGlucosePayload(value, live = true, source = "notify")
+            }
             OttaiConstants.CHAR_GLUCOSE_HISTORY -> handleGlucosePayload(value, live = false, source = "notify")
             OttaiConstants.CHAR_CGM_INFO_NOTIFY -> handleCgmInfo(value, source = "notify")
         }
@@ -1760,14 +1883,25 @@ class OttaiBleManager(
             Log.w(TAG, "maxActive read out of plausible range — ignoring")
             return
         }
-        val ms = secs * 1000L
-        if (ms == activatedMaxActiveMs) return
+        adoptActivatedMaxActive(secs * 1000L, "sensor-readback")
+    }
+
+    /**
+     * Adopt [ms] as this sensor's provisioned lifetime — in memory, in prefs and in the native
+     * shell — and report whether anything changed. Idempotent.
+     *
+     * Every path that learns the real lifetime funnels through here so none of them can persist
+     * a value the others do not see.
+     */
+    private fun adoptActivatedMaxActive(ms: Long, source: String): Boolean {
+        if (ms <= 0L || ms == activatedMaxActiveMs) return false
         activatedMaxActiveMs = ms
         val id = SerialNumber.orEmpty()
         Applic.app?.let { ctx -> if (id.isNotBlank()) OttaiRegistry.saveAcceptedMaxActive(ctx, id, ms) }
         applyActivatedWearToNative(id)
         UiRefreshBus.requestStatusRefresh()
-        Log.i(TAG, "activated lifetime recovered from sensor = ${days}d")
+        Log.i(TAG, "activated lifetime = ${ms / 86_400_000L}d source=$source")
+        return true
     }
 
     // b8fd9848 holds the activated maxActive duration. The write format is
@@ -1864,14 +1998,29 @@ class OttaiBleManager(
             ?: provisionalActiveTimeMs.takeIf { it > 0L }
             ?: 0L
 
-    private fun preheatPeriodMs(): Long =
-        materials.preheatPeriodMs.takeIf { it > 0L } ?: OttaiConstants.DEFAULT_PREHEAT_PERIOD_MS
-
     private fun warmupRemainingMs(now: Long = System.currentTimeMillis()): Long {
-        val start = effectiveActiveTimeMs()
+        val start = warmupAnchorMs()
         if (start <= 0L) return -1L
-        return (start + preheatPeriodMs() - now).coerceAtLeast(0L)
+        return (start + OttaiConstants.WARMUP_SUPPRESS_MS - now).coerceAtLeast(0L)
     }
+
+    /**
+     * Start instant the warmup gate is allowed to trust — deliberately narrower than
+     * [effectiveActiveTimeMs].
+     *
+     * It refuses provisionalActiveTimeMs and streamStartTimeMs because both can be derived from
+     * the cgm-info 0x0477 sliding window, which for a sensor the vendor app activated days ago
+     * always reads "just now"; warming up on those would blank ten minutes of good readings on
+     * every fresh connect. The fallback is the instant this session itself wrote the activation
+     * command, which is the only trustworthy start available in the first ~80 s after our own
+     * activation — materials.activeTimeMs is not confirmed until the live anchor corroborates it
+     * (on the 2026-07-29 run the command went out at 17:18:15 and the start was confirmed at
+     * 17:19:00, by which point four readings had already been published).
+     */
+    private fun warmupAnchorMs(): Long =
+        materials.activeTimeMs.takeIf { it > 0L }
+            ?: activationCommandSentAtMs.takeIf { it > 0L }
+            ?: 0L
 
     private fun setProvisionalActiveTime(activeTimeMs: Long, reason: String) {
         if (activeTimeMs <= 0L || materials.activeTimeMs > 0L) return
@@ -2107,7 +2256,16 @@ class OttaiBleManager(
             Log.w(TAG, "no active-time anchor — skipping emit dataNo=${r.record.dataNo}")
             return null
         }
+        // Post-activation settling. The sensor streams from dataNo 0 but the electrode has not
+        // equilibrated, so these records are decoded and logged and then dropped — they must not
+        // reach current publishing, Room, the native journal or any exchange consumer. Gated on
+        // the sample rather than on the clock so a later history replay of the same records
+        // reaches the same verdict instead of re-admitting what the live path refused.
+        if (OttaiConstants.isWithinWarmup(warmupAnchorMs(), sampleMs)) {
+            return rejectReading(r, mmol, live, "warmup")
+        }
         continuityRejectReason(r, mmol, sampleMs, live, batch, batchIndex)?.let { reason ->
+            noteContinuityRejection(r.record.dataNo, sampleMs)
             return rejectReading(r, mmol, live, reason)
         }
         val previousGlucoseAtMs = lastGlucoseAtMs
@@ -2230,9 +2388,34 @@ class OttaiBleManager(
         lastAcceptedSampleMs = sampleMs
         lastAcceptedMmol = mmol
         lastAcceptedRawCurrent = r.record.rawCurrent
+        noteContinuityEvaluated(r.record.dataNo, sampleMs)
+        consecutiveContinuityRejects = 0
         Applic.app?.let {
             OttaiRegistry.saveContinuityBaseline(it, SerialNumber.orEmpty(), r.record.dataNo, sampleMs, mmol, r.record.rawCurrent)
         }
+    }
+
+    /**
+     * Move the continuity gate's adjacency anchor onto a sample it just refused, and count the
+     * refusal towards [MAX_CONSECUTIVE_CONTINUITY_REJECTS].
+     *
+     * Only continuity refusals land here. Hard rejects (corrupt temperature, impossible glucose)
+     * must NOT move the anchor: those frames carry garbage dataNos — 34044 and 47902 appear in
+     * the 2026-07-29 trace between legitimate readings in the twenty-thousands — and adopting one
+     * would push every following sample out of the adjacency window, which is the very failure
+     * this anchor exists to prevent.
+     */
+    private fun noteContinuityRejection(dataNo: Int, sampleMs: Long) {
+        consecutiveContinuityRejects++
+        noteContinuityEvaluated(dataNo, sampleMs)
+    }
+
+    private fun noteContinuityEvaluated(dataNo: Int, sampleMs: Long) {
+        // History replay walks backwards through records the live path already passed; letting it
+        // drag the anchor back would re-open the same skip-the-gate hole from the other side.
+        if (dataNo < lastEvaluatedDataNo) return
+        lastEvaluatedDataNo = dataNo
+        lastEvaluatedSampleMs = sampleMs
     }
 
     private data class NeighborSample(
@@ -2249,7 +2432,18 @@ class OttaiBleManager(
         batch: List<OttaiReading>,
         batchIndex: Int,
     ): String? {
-        if (isAdjacentToLastAccepted(r.record.dataNo, sampleMs) &&
+        // The comparison baseline only advances on an ACCEPTED sample, so once the sensor
+        // genuinely steps to a new level — an electrode restart, a real discontinuity — the gate
+        // would refuse every sample for the rest of the session. Yield after a bounded run and
+        // let the next one re-baseline. Sustained >=1.5 mmol/min steps are not physiology, so
+        // reaching this is already a sign the baseline is the thing that is wrong.
+        if (consecutiveContinuityRejects >= MAX_CONSECUTIVE_CONTINUITY_REJECTS) {
+            Log.w(TAG, "continuity gate yielding after $consecutiveContinuityRejects consecutive " +
+                "rejections; re-baselining on dataNo=${r.record.dataNo} mmol=%.2f raw=%d".format(
+                    mmol, r.record.rawCurrent))
+            return null
+        }
+        if (isAdjacentToLastEvaluated(r.record.dataNo, sampleMs) &&
             OttaiOutputFilter.isOneMinuteRawExcursion(
                 candidateMmol = mmol,
                 candidateRaw = r.record.rawCurrent,
@@ -2278,16 +2472,17 @@ class OttaiBleManager(
         return null
     }
 
-    private fun isAdjacentToLastAccepted(dataNo: Int, sampleMs: Long): Boolean {
-        val previousDataNo = lastAcceptedDataNo
-        if (previousDataNo < 0) return false
-        val dataNoGap = dataNo - previousDataNo
-        if (dataNoGap in 1..2) return true
-        val previousMs = lastAcceptedSampleMs
-        if (previousMs <= 0L || sampleMs <= previousMs) return false
-        val timeGap = sampleMs - previousMs
-        return timeGap in 1..(2 * RECORD_INTERVAL_MS + 15_000L)
-    }
+    /**
+     * Whether this sample sits close enough behind the last sample the gate looked at for a
+     * one-minute excursion test to be meaningful.
+     *
+     * Anchored on the last EVALUATED sample, not the last accepted one. Anchoring on the accepted
+     * sample let two consecutive rejections carry the anchor out of range — dataNo gap 3 and a
+     * 180 s time gap after refusing two records — so the gate silently stopped testing and passed
+     * the third bad sample straight through.
+     */
+    private fun isAdjacentToLastEvaluated(dataNo: Int, sampleMs: Long): Boolean =
+        isAdjacentSample(lastEvaluatedDataNo, lastEvaluatedSampleMs, dataNo, sampleMs)
 
     private fun isImmediatelyBeforeLastAccepted(dataNo: Int, sampleMs: Long): Boolean {
         val nextDataNo = lastAcceptedDataNo
@@ -2651,18 +2846,18 @@ class OttaiBleManager(
             }
         }
         Log.i(TAG, "activation command sent; sensor accepted activation writes")
-        mBluetoothGatt?.let { gatt ->
-            handler.postDelayed({ runCatching { readCgmInfo(gatt) } }, 1_000)
-            handler.postDelayed({
-                runCatching {
-                    readLiveGlucose(gatt, "post-activation")
-                    scheduleLivePoll()
-                }
-            }, 2_000)
-            // Re-read the cmd/activation byte: if our writes took, an expired (cmd>3) unit
-            // should drop back to 3 (activated). Logs "cmd/activation status=N".
-            handler.postDelayed({ runCatching { readChar(gatt, OttaiConstants.SERVICE_CGM, OttaiConstants.CHAR_COMMAND) } }, 3_000)
-        }
+        // Confirm the activation took, and issue nothing else. Android allows one outstanding
+        // GATT operation per connection, and the old fixed-delay chain (cgm-info at +1 s, a live
+        // read at +2 s, the confirmation at +3 s) raced itself: on 2026-07-29 the confirmation
+        // came back started=false while the live read was still in flight, and status=3 was only
+        // seen after that read died with status=133 and forced a reconnect. The live read was
+        // worthless anyway — two seconds after activation the sensor has nothing to give
+        // ("live read no records payloadLen=8"). Once status=3 lands, handleCommandStatus ->
+        // startStreamingAfterCommandStatus() does the cgm-info read, the first live read and the
+        // poll schedule, in an order that does not collide.
+        activationConfirmAttempt = 0
+        handler.removeCallbacks(activationConfirmRunnable)
+        handler.postDelayed(activationConfirmRunnable, POST_ACTIVATION_CONFIRM_DELAY_MS)
         UiRefreshBus.requestStatusRefresh()
     }
 
@@ -2753,6 +2948,7 @@ class OttaiBleManager(
     private fun beginActivationCandidateDiscovery(reason: String) {
         if (!activationNegotiationActive || !activationRetryPending) return
         activationCandidateDiscoveryPending = true
+        activationDiscoveryStartedAtMs = System.currentTimeMillis()
         activationCandidateProbeActive = false
         // This is the second way into candidate discovery, and it used to leave the home address
         // at the null beginActivationNegotiation() writes — which made rejectActivationCandidate's
@@ -2779,6 +2975,15 @@ class OttaiBleManager(
         activationRetryPending = false
         pendingAcceptedMaxActiveMs = acceptedMs
         Log.i(TAG, "maxActive accepted duration=${acceptedMs / 1000L}s; staged until status=3")
+        // Write through now rather than only at status=3. The firmware has already ACKed the
+        // value, so it is a fact about the sensor whether or not the activate command that
+        // follows lands. Deferring it lost the negotiated lifetime on 2026-07-29: a status=133
+        // read error between the activate write and the confirmation tore the link down,
+        // clearGattTransport cleared the staged state, and commitStagedActivationLifetime then
+        // committed nothing — the 28 days survived only because an optional display-only readback
+        // probe happened to succeed one second later. If activation ultimately fails the value is
+        // still what the sensor holds, and the next negotiation overwrites it.
+        adoptActivatedMaxActive(acceptedMs, "activation-accept")
         UiRefreshBus.requestStatusRefresh()
     }
 
@@ -2789,12 +2994,7 @@ class OttaiBleManager(
             pendingAcceptedMaxActiveMs,
         )
         if (acceptedMs <= 0L) return
-        activatedMaxActiveMs = acceptedMs
-        val id = SerialNumber.orEmpty()
-        Applic.app?.takeIf { id.isNotBlank() }?.let { context ->
-            OttaiRegistry.saveAcceptedMaxActive(context, id, acceptedMs)
-        }
-        applyActivatedWearToNative(id)
+        adoptActivatedMaxActive(acceptedMs, "activation-commit")
         clearStagedActivationLifetime()
         Log.i(TAG, "activation confirmed status=3; committed maxActive=${acceptedMs / 1000L}s")
     }
@@ -2860,6 +3060,16 @@ class OttaiBleManager(
         if (stop || phase != Phase.STREAMING || sessionKeyHex.isBlank() || commandStatus != 3) return
         if (roomBackfillChecked) return // the live path already issued the backfill
         SerialNumber ?: return
+        // Nothing to fetch yet on a sensor we have only just started. Come back when it is old
+        // enough to have history rather than spending the bounded attempts on empty live reads.
+        val sensorAgeMs = warmupAnchorMs().takeIf { it > 0L }?.let { System.currentTimeMillis() - it } ?: -1L
+        if (sensorAgeMs in 0 until INITIAL_HISTORY_MIN_SENSOR_AGE_MS) {
+            val waitMs = INITIAL_HISTORY_MIN_SENSOR_AGE_MS - sensorAgeMs
+            Log.i(TAG, "initial history backfill deferred ${waitMs / 1000L}s — sensor is ${sensorAgeMs / 1000L}s old")
+            handler.removeCallbacks(initialHistoryRunnable)
+            handler.postDelayed(initialHistoryRunnable, waitMs)
+            return
+        }
         val estimate = estimatedNewestDataNo()
         val newest = maxOf(lastDataNo, estimate)
         if (newest <= 0) {
@@ -3403,11 +3613,28 @@ class OttaiBleManager(
     // ~14d for these units), falling back to the local default. Uses the effective activation so a
     // sensor started in the vendor app (no cloud activeTime, start recovered over BLE) still shows
     // a rated end instead of a blank.
+    /**
+     * Official end of this sensor's life.
+     *
+     * Once the firmware has accepted a maxActive at activation, THAT is the official end: the
+     * cloud's activeExpireTime is only what the account plan rates the sensor at, and this fork
+     * deliberately rewrites the firmware value above it. Reporting the cloud figure here made the
+     * sensor card disagree with its own countdown ring by two weeks and, worse, aimed every
+     * sensor-expiry warning at 2026-08-12 for a sensor provisioned to 2026-08-26 — two weeks of
+     * false alarms ending in silence, because an end already in the past is treated as expired.
+     *
+     * Deliberately fixed here rather than in the shared alert path: other managed drivers use
+     * expectedEndMs for an ADVISORY horizon that is longer than their rated life (iCan defaults
+     * it to 28 days for every profile, including 7- and 8-day units), so preferring the longer of
+     * the two there would have suppressed their genuine warnings.
+     */
     override fun getOfficialEndMs(): Long {
         val start = effectiveActiveTimeMs()
         if (start <= 0L) return 0L
-        val ratedMs = materials.activeExpireTimeMs.takeIf { it > 0L } ?: OttaiConstants.DEFAULT_ACTIVE_EXPIRE_MS
-        return start + ratedMs
+        val acceptedMs = activatedMaxActiveMs.takeIf { it > 0L }
+            ?: Applic.app?.let { OttaiRegistry.loadAcceptedMaxActive(it, SerialNumber.orEmpty()) }
+            ?: 0L
+        return start + OttaiConstants.expectedLifetimeMs(materials.activeExpireTimeMs, acceptedMs)
     }
     // Expected end follows the maxActive value this sensor accepted. Before activation (or
     // for installations upgraded from older builds), fall back to the cloud-rated lifetime.

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -443,20 +443,34 @@ class OttaiBleManager(
     /** A `[start, endExclusive)` window of records the local store does not have. */
     internal data class MissingRange(val start: Int, val endExclusive: Int)
 
-    // Set by requestRoomBackfillAfterLive once it enters the local-store diff, which is the
-    // branch taken when the previous dataNo is unusable.
-    //
-    // The live path answers a negative backfill result by calling requestHistoryAfterLive, and
-    // that function's behaviour for an unusable previous dataNo is to ask for [0, live) — the
-    // exact full pull the diff exists to eliminate, reached by a second route. It fires not
-    // only when the diff cannot run but also when it runs fine and merely fails to get its
-    // first GATT write out, which under RF trouble is routine.
-    //
-    // Suppressing it there is safe: the diff ledgers every window before issuing anything, the
-    // ledger's retry driver owns recovery. If the diff itself cannot run yet, the separate
-    // pending flag forces a later live sample back through the diff instead of taking the cheap
-    // incremental branch and incorrectly latching history complete.
-    @Volatile private var historyDiffOwnsRecovery = false
+    /**
+     * What one [requestRoomBackfillAfterLive] call did. [issued] is all the two backstop callers
+     * need; [diffOwnsRecovery] exists for the live caller.
+     *
+     * The live path answers a negative backfill result by calling requestHistoryAfterLive, and
+     * that function's behaviour for an unusable previous dataNo is to ask for [0, live) — the
+     * exact full pull the diff exists to eliminate, reached by a second route. It fires not only
+     * when the diff cannot run but also when it runs fine and merely fails to get its first GATT
+     * write out, which under RF trouble is routine. [diffOwnsRecovery] tells the caller the diff
+     * has taken responsibility so that fallback stays shut.
+     *
+     * Suppressing it there is safe: the diff ledgers every window before issuing anything, the
+     * ledger's retry driver owns recovery. If the diff itself cannot run yet, the separate
+     * [historyDiffRetryPending] flag forces a later live sample back through the diff instead of
+     * taking the cheap incremental branch and incorrectly latching history complete.
+     *
+     * This is returned rather than published through a field on purpose. As a field it was
+     * written at the top of the call and read by the caller *after* the call returned, so the
+     * driver's HandlerThread and the BLE binder thread — both of which reach this path — could
+     * interleave a second call into that window and answer the first caller with the second
+     * call's verdict.
+     */
+    private data class BackfillOutcome(val issued: Boolean, val diffOwnsRecovery: Boolean) {
+        companion object {
+            val NOT_ISSUED = BackfillOutcome(issued = false, diffOwnsRecovery = false)
+        }
+    }
+
     @Volatile private var historyDiffRetryPending = false
     private val historyHolesLock = Any()
     private val historyHoles = mutableListOf<HistoryHole>()
@@ -539,7 +553,7 @@ class OttaiBleManager(
         }
         val endExclusive = lastDataNo + 1
         if (endExclusive <= 0) return
-        val issued = requestRoomBackfillAfterLive(endExclusive, -1)
+        val issued = requestRoomBackfillAfterLive(endExclusive, -1).issued
         Log.i(TAG, "ended history backfill endExclusive=$endExclusive issued=$issued")
     }
 
@@ -2013,10 +2027,8 @@ class OttaiBleManager(
                 // independent backstop so the two don't both issue (which would wipe and restart
                 // the in-flight chunk chain via clearPendingHistoryRange).
                 handler.removeCallbacks(initialHistoryRunnable)
-                if (!requestRoomBackfillAfterLive(liveDataNo, previousForHistory) &&
-                    !roomBackfillChecked &&
-                    !historyDiffOwnsRecovery
-                ) {
+                val backfill = requestRoomBackfillAfterLive(liveDataNo, previousForHistory)
+                if (!backfill.issued && !backfill.diffOwnsRecovery && !roomBackfillChecked) {
                     val missingBeforeLive = liveDataNo - previousForHistory - 1
                     if (previousForHistory < 0 || missingBeforeLive > 0) {
                         handler.postDelayed({ requestHistoryAfterLive(previousForHistory, liveDataNo) }, 1_500L)
@@ -2878,7 +2890,7 @@ class OttaiBleManager(
             newest,
             previousForHistory,
             observedNewest = estimate > 0 && lastDataNo <= estimate,
-        )
+        ).issued
         Log.i(TAG, "initial history backfill newest=$newest previous=$previousForHistory issued=$issued")
     }
 
@@ -2899,10 +2911,9 @@ class OttaiBleManager(
         liveDataNo: Int,
         previousDataNo: Int,
         observedNewest: Boolean = true,
-    ): Boolean {
-        historyDiffOwnsRecovery = false
-        if (roomBackfillChecked || liveDataNo <= 0) return false
-        val id = SerialNumber ?: return false
+    ): BackfillOutcome {
+        if (roomBackfillChecked || liveDataNo <= 0) return BackfillOutcome.NOT_ISSUED
+        val id = SerialNumber ?: return BackfillOutcome.NOT_ISSUED
         // The one-shot is consumed only by an actually-issued request or a trusted "nothing
         // missing" verdict — an early-out on a no-op (stale basis, missing anchor, failed
         // issue) must leave it clear so the live path can still do the real check.
@@ -2911,17 +2922,19 @@ class OttaiBleManager(
             if (missingBeforeLive <= 0) {
                 if (observedNewest) roomBackfillChecked = true
                 Log.i(TAG, "skip history reason=room-backfill previous=$previousDataNo live=$liveDataNo observed=$observedNewest")
-                return false
+                return BackfillOutcome.NOT_ISSUED
             }
-            return requestHistoryRange("room-backfill", previousDataNo + 1, missingBeforeLive)
-                .also { if (it) roomBackfillChecked = true }
+            return BackfillOutcome(
+                issued = requestHistoryRange("room-backfill", previousDataNo + 1, missingBeforeLive)
+                    .also { if (it) roomBackfillChecked = true },
+                diffOwnsRecovery = false,
+            )
         }
-        // From here on the diff owns recovery for this payload — see historyDiffOwnsRecovery.
-        historyDiffOwnsRecovery = true
+        // From here on the diff owns recovery for this payload — see BackfillOutcome.
         val startMs = streamStartTimeMs.takeIf { it > 0L } ?: run {
             historyDiffRetryPending = true
             Log.w(TAG, "history diff missing stream anchor — deferring backfill live=$liveDataNo")
-            return false
+            return BackfillOutcome(issued = false, diffOwnsRecovery = true)
         }
         val endMs = (System.currentTimeMillis() + RECORD_INTERVAL_MS).coerceAtLeast(startMs)
         val existing = HistorySyncAccess.getHistoryTimestampsForSensorOrNull(
@@ -2936,12 +2949,15 @@ class OttaiBleManager(
             // pending so a later live sample retries this query even with a usable lastDataNo.
             historyDiffRetryPending = true
             Log.e(TAG, "history diff unavailable — deferring backfill live=$liveDataNo")
-            return false
+            return BackfillOutcome(issued = false, diffOwnsRecovery = true)
         }
         historyDiffRetryPending = false
         if (existing.isEmpty()) {
-            return requestHistoryRange("room-backfill", 0, liveDataNo)
-                .also { if (it) roomBackfillChecked = true }
+            return BackfillOutcome(
+                issued = requestHistoryRange("room-backfill", 0, liveDataNo)
+                    .also { if (it) roomBackfillChecked = true },
+                diffOwnsRecovery = true,
+            )
         }
         val present = BooleanArray(liveDataNo)
         for (timestamp in existing) {
@@ -2951,7 +2967,7 @@ class OttaiBleManager(
         val gaps = missingRanges(present)
         if (gaps.isEmpty()) {
             roomBackfillChecked = true // verified complete against Room = trusted
-            return false
+            return BackfillOutcome(issued = false, diffOwnsRecovery = true)
         }
         // Run the newest gap as the live chain — that is the data the chart is waiting for —
         // and put the older ones on the books first. The ledger's retry driver picks those up
@@ -2968,7 +2984,7 @@ class OttaiBleManager(
                 "missing=${gaps.sumOf { it.endExclusive - it.start }} " +
                 "head=[${head.start},${head.endExclusive}) issued=$issued"
         )
-        return issued
+        return BackfillOutcome(issued = issued, diffOwnsRecovery = true)
     }
 
     private fun requestRecentHistory(reason: String): Boolean {
@@ -3242,6 +3258,11 @@ class OttaiBleManager(
                 }
             }
             if (!overlapped) {
+                // Deliberately not capped at MAX_HISTORY_HOLES the way addHistoryHole is. That
+                // cap drops the OLDEST window and loses its records; here every entry already
+                // carries a failure and is retired by HISTORY_HOLE_MAX_ATTEMPTS, so the ledger
+                // drains on its own. Applying the size cap would discard a window that still has
+                // retries left in favour of one that is already on its way out.
                 historyHoles += HistoryHole(start, endExclusive, 1)
                 historyHoles.sortBy { it.start }
             }

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiCloudClient.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiCloudClient.kt
@@ -38,10 +38,30 @@ object OttaiCloudClient {
     private const val PKG = "com.ottai.tag.watch"
     private const val TIMEOUT_MS = 30_000
 
-    /** Last non-secret failure reason (HTTP + business code/message), for the UI. */
+    // Business codes a caller has to branch on rather than merely show. An account holds one
+    // bound sensor at a time, so until the previous one is released every device call for a new
+    // MAC is refused with AppUser_AlreadyBinding ("there are other devices that were not
+    // unbound") — observed 12 times in a row while activating a replacement sensor on
+    // 2026-07-29, with the UI showing only the generic "no materials for this cloud ID".
+    const val BIZ_ALREADY_BINDING = "AppUser_AlreadyBinding"
+    // The server already considers the sensor finished. For [unbind] that is the state the caller
+    // was asking for, so it counts as released. Not yet observed on-device.
+    const val BIZ_END_USING = "AppDevice_EndUsing"
+
+    /**
+     * A non-secret cloud failure: [text] is what the UI appends, [code] is the backend's business
+     * code (see the BIZ_ constants) for the callers that act on a specific one. [code] is blank
+     * for the failures we raise ourselves, before any response exists.
+     */
+    data class CloudFailure(val text: String, val code: String = "")
+
+    /** Last non-secret failure reason (HTTP + business code/message); null after a call that succeeded. */
     @Volatile
-    var lastError: String = ""
+    var lastFailure: CloudFailure? = null
         private set
+
+    /** [lastFailure] as the string the UI shows; blank when the last call succeeded. */
+    val lastError: String get() = lastFailure?.text.orEmpty()
 
     data class LoginResult(val userId: String, val accessToken: String, val glucoseSecretKey: String) {
         val ok: Boolean get() = accessToken.isNotBlank() && glucoseSecretKey.isNotBlank()
@@ -153,7 +173,7 @@ object OttaiCloudClient {
 
     /** POST /user/smsCode — needs apiToken; sig over (phone, apiToken). Returns requestId. */
     fun requestSmsCode(ctx: Context, phone: String): String? {
-        val apiToken = getApiToken(ctx, OttaiConstants.API_BASE) ?: run { lastError = "apiToken failed"; Log.w(TAG, "apiToken failed"); return null }
+        val apiToken = getApiToken(ctx, OttaiConstants.API_BASE) ?: run { lastFailure = CloudFailure("apiToken failed"); Log.w(TAG, "apiToken failed"); return null }
         val ts = now()
         val deviceId = OttaiRegistry.loadOrCreateDeviceId(ctx)
         val ph = normalizePhone(phone)
@@ -215,7 +235,7 @@ object OttaiCloudClient {
         authorizationOverride: String? = null,
     ): LoginResult? {
         val acct = account.trim()
-        if (acct.isBlank() || password.isBlank()) { lastError = "account/password required"; return null }
+        if (acct.isBlank() || password.isBlank()) { lastFailure = CloudFailure("account/password required"); return null }
         // Username + password login on a GLOBAL backend (seas.ottai.com / api.syai.com) — same
         // API + signature scheme, different host. The server keys on the account USERNAME, which
         // is a server-assigned RANDOM string (verified: NOT derived from the email), so the email
@@ -223,7 +243,7 @@ object OttaiCloudClient {
         // is PLAINTEXT; sig arg-order = sign(apiToken, account, password). SINGLE attempt only —
         // a wrong password is a real failed-login attempt, so do NOT retry variants (lockout).
         val apiToken = getApiToken(ctx, base, authorizationOverride)
-            ?: run { lastError = "apiToken failed"; return null }
+            ?: run { lastFailure = CloudFailure("apiToken failed"); return null }
         val ts = now()
         val deviceId = OttaiRegistry.loadOrCreateDeviceId(ctx)
         val body = JSONObject().apply {
@@ -286,7 +306,7 @@ object OttaiCloudClient {
     fun bind(ctx: Context, mac: String, deviceVersion: String, userId: String): DeviceResp? {
         val canonical = OttaiConstants.canonicalSensorId(mac)
         if (canonical.isBlank() || deviceVersion.isBlank() || userId.isBlank()) {
-            lastError = "bind requires mac, deviceVersion and userId"
+            lastFailure = CloudFailure("bind requires mac, deviceVersion and userId")
             return null
         }
         val ts = now()
@@ -311,10 +331,10 @@ object OttaiCloudClient {
         val canonical = OttaiConstants.canonicalSensorId(mac)
         val userId = OttaiRegistry.loadUserId(ctx)
         val resp = bind(ctx, canonical, deviceVersion.trim(), userId) ?: return null
-        val bindError = lastError
+        val bindFailure = lastFailure
         runCatching { unbind(ctx, canonical) }
             .onFailure { Log.w(TAG, "unbind after material fetch failed: ${it.message}") }
-        lastError = bindError
+        lastFailure = bindFailure
         return resp
     }
 
@@ -330,7 +350,10 @@ object OttaiCloudClient {
         }
         val resp = httpPostJson(base(ctx) + OttaiConstants.EP_UNBIND, body.toString(), headers(ctx, ts, base(ctx))) ?: return false
         val bizCode = resp.opt("code")?.toString().orEmpty()
-        return bizCode.isBlank() || bizCode == "200" || bizCode.equals("OK", ignoreCase = true)
+        // BIZ_END_USING says the server had already finished with this sensor, so the binding the
+        // caller wanted released is gone either way — not a failure to report.
+        return bizCode.isBlank() || bizCode == "200" || bizCode.equals("OK", ignoreCase = true) ||
+            bizCode.equals(BIZ_END_USING, ignoreCase = true)
     }
 
     /** GET /deviceBind/getBindDevice — current account-bound sensor, no signature. */
@@ -542,7 +565,7 @@ object OttaiCloudClient {
      */
     private fun webPostRetry(webBase: String, path: String, buildBody: (apiToken: String, ts: Long) -> JSONObject): JSONObject? {
         repeat(5) { attempt ->
-            val apiToken = getWebApiToken(webBase) ?: run { lastError = "apiToken failed"; return null }
+            val apiToken = getWebApiToken(webBase) ?: run { lastFailure = CloudFailure("apiToken failed"); return null }
             val ts = now()
             val resp = httpPostJson("$webBase$path", buildBody(apiToken, ts).toString(), webHeaders(webBase, ts)) ?: return null
             if (!resp.optString("code").equals("User_SignatureInvalid", ignoreCase = true)) return resp
@@ -562,7 +585,7 @@ object OttaiCloudClient {
      */
     fun mailLogin(ctx: Context, email: String, password: String, webBase: String = WEB_BASE): LoginResult? {
         val em = email.trim()
-        if (em.isBlank() || password.isBlank()) { lastError = "email/password required"; return null }
+        if (em.isBlank() || password.isBlank()) { lastFailure = CloudFailure("email/password required"); return null }
         val resp = if (isSyai(webBase)) {
             val encInfo = webEncrypt(JSONObject().put("email", em).put("password", password).toString())
             webPostRetry(webBase, "/user/mail/login") { apiToken, ts ->
@@ -611,7 +634,7 @@ object OttaiCloudClient {
         // A Syai web JWT can validate a device but carries no material-decryption root. Persisting
         // it would make sign-in look successful while every fresh sensor fails material loading.
         if (isSyai(webBase)) {
-            if (lastError.isBlank()) lastError = "Syai mobile login upgrade failed"
+            if (lastError.isBlank()) lastFailure = CloudFailure("Syai mobile login upgrade failed")
             return null
         }
         // Fallback for an Ottai web account whose profile does not expose a mobile username.
@@ -780,14 +803,18 @@ object OttaiCloudClient {
                 ?.toString().orEmpty().takeIf { it != "null" }.orEmpty()
             val bizOk = bizCode.isBlank() || bizCode == "200" || bizCode.equals("OK", ignoreCase = true)
             if (code !in 200..299 || !bizOk) {
-                lastError = "http=$code biz=$bizCode ${bizMsg.take(120)}".trim()
+                lastFailure = CloudFailure("http=$code biz=$bizCode ${bizMsg.take(120)}".trim(), bizCode)
                 Log.w(TAG, "$path -> $lastError")
             } else {
-                lastError = ""
+                lastFailure = null
+                // Without this a successful cloud phase is invisible and reconstructable only from
+                // the absence of warnings. Path and status ONLY: the body carries keyA and the
+                // account glucoseSecretKey.
+                Log.i(TAG, "$path -> http=$code")
             }
             json
         } catch (t: Throwable) {
-            lastError = "network: ${t.message}"
+            lastFailure = CloudFailure("network: ${t.message}")
             Log.w(TAG, "request failed ${url.substringBefore('?')}: ${t.message}")
             null
         } finally {

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiConstants.kt
@@ -241,6 +241,23 @@ object OttaiConstants {
      * Otherwise the manager retargets its transport at every neighbouring Ottai in turn,
      * each one failing the auth-signature check, and never reaches its own sensor.
      */
+    /**
+     * How long a freshly armed candidate scan insists on the sensor's own address before the
+     * name-only fallback is allowed to admit anything else.
+     *
+     * The fallback exists for the address-changed case, but the scanner stops on the first hit,
+     * so every stranger it admits costs a whole connect/discover/auth cycle and another scan
+     * restart before the real sensor can be seen. On 2026-07-29 three wrong units were probed at
+     * +0 s, +12 s and +15 s and the correct one was only reached at +21 s; the sensor's own
+     * advertisement is normally in the very first burst, so holding out briefly costs nothing
+     * when the address is unchanged and delays only the genuine address-changed case.
+     */
+    const val ACTIVATION_EXACT_ONLY_WINDOW_MS = 15_000L
+
+    @JvmStatic
+    fun isActivationExactOnlyWindowOpen(discoveryStartedAtMs: Long, nowMs: Long): Boolean =
+        discoveryStartedAtMs > 0L && nowMs - discoveryStartedAtMs < ACTIVATION_EXACT_ONLY_WINDOW_MS
+
     fun shouldProbeActivationAdvertisement(
         discoveryPending: Boolean,
         scannedAddress: String?,
@@ -248,6 +265,7 @@ object OttaiConstants {
         advertisedName: String?,
         rejectedAddresses: Set<String> = emptySet(),
         allowNameMatch: Boolean = true,
+        exactOnlyWindowOpen: Boolean = false,
     ): Boolean {
         if (!discoveryPending) return false
         val scanned = normalizeBleAddress(scannedAddress, allowPlain = false) ?: return false
@@ -259,7 +277,7 @@ object OttaiConstants {
         }
         val expected = normalizeBleAddress(expectedAddress, allowPlain = false)
         if (expected?.equals(scanned, ignoreCase = true) == true) return true
-        if (!allowNameMatch) return false
+        if (!allowNameMatch || exactOnlyWindowOpen) return false
         return advertisedName?.trim()?.contains("ottai", ignoreCase = true) == true
     }
 
@@ -272,6 +290,37 @@ object OttaiConstants {
     /** Default warmup seconds (device_manage_warmup_duration). */
     const val DEFAULT_WARMUP_SECONDS = 3200
     const val DEFAULT_PREHEAT_PERIOD_MS = 3_600_000L
+
+    /**
+     * Post-activation window during which readings are decoded and logged but never published,
+     * stored or exported.
+     *
+     * The vendor's own preheat (DEFAULT_PREHEAT_PERIOD_MS, or the cloud's preheatPeriodTime) is
+     * 60 min, but the settling ramp measured on this hardware is over well inside 10 minutes: on
+     * the 2026-07-29 activation dataNo 3 read 2.80 mmol (published as 50 mg/dL) and climbed
+     * monotonically — 3.00, 3.30, 3.80, 5.00, 5.70, 6.00, 6.10 — reaching plateau by dataNo 11.
+     * Suppressing a full hour would throw away usable data, so this window is deliberately
+     * shorter than the vendor's and is the value this fork enforces.
+     */
+    const val WARMUP_SUPPRESS_MS = 600_000L
+
+    /**
+     * Whether a sample falls inside the post-activation settling window and so must not be
+     * published, stored or exported.
+     *
+     * Deliberately a property of the SAMPLE rather than of the wall clock: a history replay of
+     * the same records then reaches the same verdict on every pass and across restarts, instead
+     * of re-admitting during warmup whatever the live path already refused.
+     *
+     * [activationStartMs] must be an authoritative start — pass 0 to disable the gate rather than
+     * feeding it a provisional, which for a vendor-activated sensor always reads "just now" and
+     * would blank ten minutes of good readings on every fresh connect.
+     */
+    @JvmStatic
+    fun isWithinWarmup(activationStartMs: Long, sampleMs: Long): Boolean =
+        activationStartMs > 0L &&
+            sampleMs > 0L &&
+            sampleMs < activationStartMs + WARMUP_SUPPRESS_MS
 
     // ---- SharedPreferences keys ----
 

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiManagedSensorIdentityAdapter.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiManagedSensorIdentityAdapter.kt
@@ -3,12 +3,23 @@
 package tk.glucodata.drivers.ottai
 
 import android.content.Context
+import java.util.concurrent.Executors
 import tk.glucodata.Applic
+import tk.glucodata.Log
 import tk.glucodata.SensorBluetooth
 import tk.glucodata.SuperGattCallback
 import tk.glucodata.drivers.ManagedSensorIdentityAdapter
 
 object OttaiManagedSensorIdentityAdapter : ManagedSensorIdentityAdapter {
+
+    private const val TAG = OttaiConstants.TAG
+
+    // Removal is a UI action and the unbind below is a blocking call with a 30 s timeout, so it
+    // never runs on the caller's thread. Daemon: nothing about a released binding is worth
+    // holding the process open for.
+    private val unbindExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "Ottai-unbind").apply { isDaemon = true }
+    }
 
     override fun matchesCallbackId(callbackId: String?, sensorId: String): Boolean {
         val normalized = callbackId?.trim().takeIf { !it.isNullOrEmpty() } ?: return false
@@ -78,7 +89,25 @@ object OttaiManagedSensorIdentityAdapter : ManagedSensorIdentityAdapter {
     }
 
     override fun removePersistedSensor(context: Context, sensorId: String?) {
+        // Release the account binding as well. The account holds one bound sensor at a time, and
+        // wiping only the local prefs left nothing that ever calls unbind — so the cloud stayed
+        // bound to the sensor the user just removed and every device call for the NEXT one came
+        // back AppUser_AlreadyBinding (12 in a row on 2026-07-29; that activation finished with
+        // no successful cloud call at all).
+        //
+        // Best-effort throughout: the canonical id must be read before the wipe removes the
+        // record that resolves it, the request is fire-and-forget on a background thread, and a
+        // failure changes nothing locally — the sensor is gone from the app either way.
+        val canonical = resolveCanonicalSensorId(sensorId)
+            ?.takeIf { OttaiConstants.looksLikeMac(it) && OttaiRegistry.loadAccessToken(context).isNotBlank() }
         OttaiRegistry.removeSensor(context, sensorId)
+        if (canonical == null) return
+        val app = context.applicationContext
+        unbindExecutor.execute {
+            runCatching { OttaiCloudClient.unbind(app, canonical) }
+                .onSuccess { Log.i(TAG, "cloud unbind $canonical released=$it") }
+                .onFailure { Log.w(TAG, "cloud unbind $canonical failed: ${it.message}") }
+        }
     }
 
     override fun isExternallyManagedBleSensor(sensorId: String?): Boolean =

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiOutputFilter.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiOutputFilter.kt
@@ -11,6 +11,12 @@ import kotlin.math.abs
 object OttaiOutputFilter {
     const val MIN_RAW_CURRENT = 1_000
     const val MAX_TEMPERATURE_C = 45.0
+
+    // A body-worn sensor never reports this cold. The gate had no lower bound at all, so a
+    // corrupt frame only got caught when its temperature happened to decode HIGH — the
+    // 2026-07-14 corruption produced 185.07, 360.93, 421.01, 325.39 and 388.72 C, all refused,
+    // while nothing would have stopped the same garbage decoding to a negative value.
+    const val MIN_TEMPERATURE_C = 15.0
     const val MAX_GLUCOSE_MMOL = 40.0f
 
     // A one-minute CGM point moving this far while the electrode current jumps this much
@@ -23,7 +29,10 @@ object OttaiOutputFilter {
         if (!mmol.isFinite() || mmol <= 0f) return "glucose=$mmol"
         if (mmol > MAX_GLUCOSE_MMOL) return "glucose=$mmol"
         if (record.rawCurrent < MIN_RAW_CURRENT) return "raw=${record.rawCurrent}"
-        if (!record.temperatureC.isFinite() || record.temperatureC > MAX_TEMPERATURE_C) {
+        if (!record.temperatureC.isFinite() ||
+            record.temperatureC > MAX_TEMPERATURE_C ||
+            record.temperatureC < MIN_TEMPERATURE_C
+        ) {
             return "temp=${record.temperatureC}"
         }
         return null

--- a/Common/src/main/java/tk/glucodata/drivers/sibionics/SibionicsBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/sibionics/SibionicsBleManager.kt
@@ -505,6 +505,7 @@ class SibionicsBleManager(
     }
 
     override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+        noteFirstGattCallback("onConnectionStateChange", gatt)
         // A late callback from a retired GATT must not invalidate the active connection's
         // notification queue. The handler repeats this ownership check before mutating state.
         if (isCurrentGatt(gatt)) {

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1948,6 +1948,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="ottai_connect_saved">Подключить</string>
     <string name="ottai_login_fail">Вход не выполнен - проверьте телефон/код</string>
     <string name="ottai_connect_saved_fail">Нет материалов в аккаунте или сохраненных материалов для этого облачного ID</string>
+    <string name="ottai_cloud_already_binding">К аккаунту Ottai всё ещё привязан другой датчик. Отвяжите его в приложении Ottai или удалите тот датчик здесь, чтобы освободить привязку, затем повторите.</string>
+    <string name="ottai_cloud_offline_routes">Импортируйте файл учётных данных, чтобы продолжить без облака — QR только заполняет код датчика, а NFC только будит его.</string>
     <string name="ottai_status_needs_ble_address">Нужен BLE-адрес</string>
     <string name="ottai_status_warmup_provisional">Предварительный прогрев • осталось %1$d мин</string>
     <string name="ottai_status_loading_history">Загрузка истории • %1$d%%</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1014,6 +1014,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="ottai_connect_saved">Connect</string>
     <string name="ottai_login_fail">Sign-in failed — check phone/code</string>
     <string name="ottai_connect_saved_fail">No account or saved materials for this cloud ID</string>
+    <string name="ottai_cloud_already_binding">The Ottai account still has another sensor bound. Unbind it in the Ottai app, or remove that sensor here to release it, then try again.</string>
+    <string name="ottai_cloud_offline_routes">Import a credentials file to continue without the cloud — a QR scan only fills the sensor code, and NFC only wakes the sensor.</string>
     <string name="ottai_status_needs_ble_address">Needs BLE address</string>
     <string name="ottai_status_warmup_provisional">Provisional warmup • %1$dm left</string>
     <string name="ottai_status_loading_history">Loading history • %1$d%%</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -316,6 +316,12 @@ fun DashboardScreen(
     // Read outside the lazy list: an item that renders nothing still costs the list's
     // inter-item spacing, so the row has to be omitted rather than emitted empty.
     val showPinnedStats = tk.glucodata.ui.stats.hasPinnedStats()
+    // Owned here, not inside the strip: portrait and landscape compose it from two different
+    // call sites, so state living in the strip was discarded on every rotation and the window
+    // fell back to 24h. This screen stays in composition across the orientation change.
+    val pinnedStatsWindow = rememberSaveable {
+        mutableStateOf(tk.glucodata.ui.stats.PinnedWindow.H24)
+    }
     val chartSmoothingMinutes by viewModel.chartSmoothingMinutes.collectAsState()
     val dataSmoothingGraphOnly by viewModel.dataSmoothingGraphOnly.collectAsState()
     val dataSmoothingCollapseChunks by viewModel.dataSmoothingCollapseChunks.collectAsState()
@@ -1284,7 +1290,10 @@ fun DashboardScreen(
                     // two, rather than four cells squeezed across it.
                     if (showPinnedStats) {
                         item {
-                            tk.glucodata.ui.stats.PinnedStatsStrip(rows = 2)
+                            tk.glucodata.ui.stats.PinnedStatsStrip(
+                                rows = 2,
+                                windowState = pinnedStatsWindow
+                            )
                         }
                     }
 
@@ -1692,7 +1701,8 @@ fun DashboardScreen(
                                 // full 12 dp here and read as a hole, 2 dp had the strip
                                 // welded to the chart card once the chart collapses.
                                 top = 8.dp
-                            )
+                            ),
+                            windowState = pinnedStatsWindow
                         )
                     }
 }

--- a/Common/src/mobile/java/tk/glucodata/ui/setup/OttaiSetupWizard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/setup/OttaiSetupWizard.kt
@@ -111,17 +111,33 @@ private const val OTTAI_SCAN_DURATION_MS = 30_000L
 private const val OTTAI_OFFICIAL_RSSI_THRESHOLD = -70
 
 /**
+ * What one [fetchOttaiMaterials] run produced: [materials] when a route yielded a usable auth-key
+ * set, and the FIRST cloud failure the chain hit.
+ *
+ * Only the first failure is actionable, and it cannot be read off
+ * [OttaiCloudClient.lastFailure] afterwards: every route clears that field the moment its own HTTP
+ * call succeeds, and getBindDevice DOES succeed for a MAC the account has not bound — it just
+ * answers with a different sensor. So validate's AppUser_AlreadyBinding was erased by the very next
+ * step and the user was left with the generic "no materials for this cloud ID".
+ */
+private data class OttaiMaterialFetch(
+    val materials: OttaiRegistry.DeviceMaterials?,
+    val failure: OttaiCloudClient.CloudFailure? = null,
+)
+
+/**
  * Fetch + decrypt the per-sensor materials for a MAC: prefer locally-saved ones, else
  * validate-by-mac against the cloud (requires being signed in) and persist. Returns
- * null if neither yields a usable auth-key set.
+ * no materials if neither yields a usable auth-key set.
  */
 private fun fetchOttaiMaterials(
     context: Context,
     mac: String,
     deviceVersion: String? = null,
-): OttaiRegistry.DeviceMaterials? {
-    val canonical = OttaiConstants.canonicalSensorId(mac).ifEmpty { return null }
-    OttaiRegistry.loadMaterials(context, canonical).takeIf { it.authKeys != null }?.let { return it }
+): OttaiMaterialFetch {
+    val canonical = OttaiConstants.canonicalSensorId(mac).ifEmpty { return OttaiMaterialFetch(null) }
+    OttaiRegistry.loadMaterials(context, canonical).takeIf { it.authKeys != null }
+        ?.let { return OttaiMaterialFetch(it) }
     // validate-by-mac works for an unbound sensor, but one we already activated returns
     // AppDevice_AlreadyUsed there. Fall back to getBindDevice — the currently-bound sensor's
     // materials (incl. the cgmDeviceMethodVO method) — without needing to re-bind. Previously-used
@@ -138,13 +154,24 @@ private fun fetchOttaiMaterials(
         return OttaiCloudClient.toMaterials(context, boundId, resp)?.takeIf { it.authKeys != null }
     }
     fun viaTemporaryBind(): OttaiRegistry.DeviceMaterials? {
+        // Deliberately still gated on a deviceVersion supplied by an explicit tap on the account
+        // device list. Looking it up by MAC would make this route reachable from the auto-fetch
+        // effect, which is keyed on the cloud id and runs on every edit of the MAC field and on
+        // every QR scan — and bindForMaterials POSTs activeTime = now(), which the server echoes
+        // back and saveMaterials persists. Typing the MAC of a sensor that is currently running
+        // would then silently reset its start time, the exact corruption class that produces a
+        // poisoned dataNo ceiling. Reaching this route must stay a deliberate act.
         val version = deviceVersion?.trim()?.takeIf { it.isNotBlank() } ?: return null
         val resp = OttaiCloudClient.bindForMaterials(context, canonical, version) ?: return null
         val boundId = OttaiConstants.canonicalSensorId(resp.mac).ifBlank { canonical }
         if (!OttaiConstants.matchesCanonicalOrKnownNativeAlias(boundId, canonical)) return null
         return OttaiCloudClient.toMaterials(context, canonical, resp)?.takeIf { it.authKeys != null }
     }
-    val m = viaValidate() ?: viaBound() ?: viaTemporaryBind() ?: return null
+    var failure: OttaiCloudClient.CloudFailure? = null
+    fun step(route: () -> OttaiRegistry.DeviceMaterials?): OttaiRegistry.DeviceMaterials? =
+        route().also { if (it == null && failure == null) failure = OttaiCloudClient.lastFailure }
+    val m = step { viaValidate() } ?: step { viaBound() } ?: step { viaTemporaryBind() }
+        ?: return OttaiMaterialFetch(null, failure)
     OttaiRegistry.saveDraftRecord(
         context,
         canonical,
@@ -152,7 +179,30 @@ private fun fetchOttaiMaterials(
         OttaiConstants.DEFAULT_DISPLAY_NAME,
     )
     OttaiRegistry.saveMaterials(context, canonical, m)
-    return m
+    return OttaiMaterialFetch(m)
+}
+
+/**
+ * The message for a material fetch that produced nothing. AppUser_AlreadyBinding gets its own
+ * headline because the generic one hides the single thing the user can act on, and every failure
+ * names the credentials-file route: the 2026-07-29 activation ended there after twelve refused
+ * validate calls, with the cloud never supplying anything.
+ */
+private fun ottaiMaterialFailureMessage(
+    context: Context,
+    failure: OttaiCloudClient.CloudFailure?,
+): String {
+    // A fetch that THREW never returned its captured failure, so fall back to the client's last
+    // one rather than showing a bare headline — that path used to append lastError and must not
+    // come out of this change with less detail than it had.
+    val effective = failure ?: OttaiCloudClient.lastFailure
+    val headline = if (effective?.code.equals(OttaiCloudClient.BIZ_ALREADY_BINDING, ignoreCase = true)) {
+        context.getString(R.string.ottai_cloud_already_binding)
+    } else {
+        context.getString(R.string.ottai_connect_saved_fail)
+    }
+    val detail = effective?.text.orEmpty().takeIf { it.isNotBlank() }?.let { "\n$it" }.orEmpty()
+    return headline + detail + "\n" + context.getString(R.string.ottai_cloud_offline_routes)
 }
 
 /**
@@ -359,11 +409,11 @@ fun OttaiSetupWizard(
                     .getOrNull()
             }
             if (OttaiConstants.canonicalSensorId(cloudId) == canonical) {
-                currentMaterials = fetched
-                if (!fetched?.deviceVersion.isNullOrBlank()) selectedDeviceVersion = fetched?.deviceVersion.orEmpty()
+                val materials = fetched?.materials
+                currentMaterials = materials
+                if (!materials?.deviceVersion.isNullOrBlank()) selectedDeviceVersion = materials?.deviceVersion.orEmpty()
                 materialLoading = false
-                status = if (fetched != null) "" else context.getString(R.string.ottai_connect_saved_fail) +
-                    OttaiCloudClient.lastError.takeIf { it.isNotBlank() }?.let { "\n$it" }.orEmpty()
+                status = if (materials != null) "" else ottaiMaterialFailureMessage(context, fetched?.failure)
             }
         } else {
             materialLoading = false
@@ -597,8 +647,8 @@ fun OttaiSetupWizard(
                         scope.launch {
                             val result = withContext(Dispatchers.IO) {
                                 runCatching {
-                                    val materials = fetchOttaiMaterials(context, canonical, selectedDeviceVersion)
-                                        ?: return@runCatching null
+                                    val fetched = fetchOttaiMaterials(context, canonical, selectedDeviceVersion)
+                                    if (fetched.materials == null) return@runCatching fetched to false
                                     val explicitBle = OttaiConstants.normalizeBleAddress(bleAddress, allowPlain = false)
                                     val connected = connectOttaiSensor(
                                         context,
@@ -606,18 +656,23 @@ fun OttaiSetupWizard(
                                         explicitBle,
                                         activate = materialState == OttaiMaterialState.READY_TO_ACTIVATE,
                                     )
-                                    materials to connected
+                                    fetched to connected
                                 }.onFailure { Log.w(tag, "connect: ${it.message}") }.getOrNull()
                             }
                             busy = false
-                            if (result?.second == true) {
-                                currentMaterials = result.first
-                                if (result.first.deviceVersion.isNotBlank()) selectedDeviceVersion = result.first.deviceVersion
+                            val materials = result?.first?.materials
+                            if (result?.second == true && materials != null) {
+                                currentMaterials = materials
+                                if (materials.deviceVersion.isNotBlank()) selectedDeviceVersion = materials.deviceVersion
                                 savedRefresh += 1
                                 step = OttaiSetupStep.CONNECTING
+                            } else if (materials != null) {
+                                // Materials in hand and the connect still refused: that is a local
+                                // registry failure, so the fetch message's offline routes would
+                                // not help.
+                                status = context.getString(R.string.ottai_connect_saved_fail)
                             } else {
-                                status = context.getString(R.string.ottai_connect_saved_fail) +
-                                    OttaiCloudClient.lastError.takeIf { it.isNotBlank() }?.let { "\n$it" }.orEmpty()
+                                status = ottaiMaterialFailureMessage(context, result?.first?.failure)
                             }
                         }
                     }

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -854,7 +855,9 @@ internal fun PinnedMetricChip(
  * Today and 3 days have no [StatsTimeRange] of their own, so they go through the
  * custom-range path instead; the rest map straight onto a quick range.
  */
-private enum class PinnedWindow(@get:StringRes val labelResId: Int) {
+// internal, not private: the Dashboard owns the strip's selection so that its portrait and
+// landscape call sites share one window. See PinnedStatsStrip's windowState parameter.
+internal enum class PinnedWindow(@get:StringRes val labelResId: Int) {
     TODAY(R.string.stats_window_today),
     H24(R.string.stats_window_24h),
     D3(R.string.stats_window_3d),
@@ -901,11 +904,19 @@ fun hasPinnedStats(): Boolean {
  * calibration projection, so the strip reported 54% time in range against the
  * Statistics screen's 92% for the same window. Sharing the source is the only way the
  * two can be guaranteed to agree.
+ *
+ * [windowState] is hoisted because the Dashboard composes this strip from two mutually
+ * exclusive call sites — the portrait column and the landscape left column, which asks for
+ * two rows. Owning the state here gave each call site its own copy, so rotating swapped one
+ * for the other and the user's window silently reverted to 24h. The activity is never
+ * recreated on rotation (`configChanges` covers `orientation|screenSize`), so a caller-level
+ * `rememberSaveable` outlives the swap and both call sites read the same one.
  */
 @Composable
-fun PinnedStatsStrip(
+internal fun PinnedStatsStrip(
     modifier: Modifier = Modifier,
-    rows: Int = 1
+    rows: Int = 1,
+    windowState: MutableState<PinnedWindow> = rememberSaveable { mutableStateOf(PinnedWindow.H24) },
 ) {
     val context = LocalContext.current
     LaunchedEffect(context) { StatsLayoutStore.ensureLoaded(context) }
@@ -915,7 +926,7 @@ fun PinnedStatsStrip(
     val uiState by statsViewModel.uiState.collectAsState()
     if (pinned.isEmpty() || uiState.summary.readingCount == 0) return
 
-    var window by rememberSaveable { mutableStateOf(PinnedWindow.H24) }
+    var window by windowState
     // -1 means the picker was opened from the add slot.
     var editingSlot by remember { mutableStateOf<Int?>(null) }
     val dragState = rememberMetricDragState(

--- a/Common/src/mobileSi/java/tk/glucodata/SiGattCallback.java
+++ b/Common/src/mobileSi/java/tk/glucodata/SiGattCallback.java
@@ -143,6 +143,7 @@ public class SiGattCallback extends SuperGattCallback {
    @SuppressLint("MissingPermission")
    @Override
    public void onConnectionStateChange(BluetoothGatt bluetoothGatt, int status, int newState) {
+      noteFirstGattCallback("onConnectionStateChange", bluetoothGatt);
       if (stop) {
          if (newState == BluetoothProfile.STATE_DISCONNECTED) {
             bluetoothGatt.close();

--- a/Common/src/test/java/tk/glucodata/ConnectModeLeverTests.kt
+++ b/Common/src/test/java/tk/glucodata/ConnectModeLeverTests.kt
@@ -1,0 +1,100 @@
+package tk.glucodata
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the connect-mode lever and the measurement that would justify ever pulling it.
+ *
+ * SuperGattCallback.autoconnect is a single application-wide static that the SensorBluetooth
+ * constructor overwrites from Natives.getAndroid13(); while the connectGatt call sites read it
+ * directly no driver could choose its own mode, and the 2026-08-01 jamming storm accordingly
+ * logged 103 connect attempts (52 + 51, two Ottai sensors) at autoConnect=true and none at false.
+ * useAutoConnect() makes a per-driver choice expressible — deliberately with no override anywhere
+ * yet, because the modelled effect of a direct connect on these sensors ranges from 1071s saved to
+ * 280s lost and nothing in the dataset decides between them. These are source scans because the
+ * classes involved need the Android runtime and the native library to be constructed at all.
+ */
+class ConnectModeLeverTests {
+
+    private fun repoRoot(): File {
+        var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        while (dir != null) {
+            if (File(dir, "Common/src/main/java/tk/glucodata/SuperGattCallback.java").isFile) return dir
+            dir = dir.parentFile
+        }
+        throw AssertionError("Common/src not found from ${System.getProperty("user.dir")}")
+    }
+
+    private fun superGattCallback(): String =
+        File(repoRoot(), "Common/src/main/java/tk/glucodata/SuperGattCallback.java").readText()
+
+    private fun sources(vararg roots: String): List<File> =
+        roots.flatMap { root ->
+            File(repoRoot(), root).walkTopDown()
+                .filter { it.isFile && (it.extension == "java" || it.extension == "kt") }
+                .toList()
+        }
+
+    @Test
+    fun everyConnectGattCallSiteAsksTheDriver() {
+        val text = superGattCallback().replace(Regex("\\s+"), " ")
+        val callSites = Regex("connectGatt\\(Applic\\.app, ([A-Za-z.()]+),").findAll(text)
+            .map { it.groupValues[1] }
+            .toList()
+        assertEquals(
+            "SuperGattCallback must keep exactly the three connectGatt call sites",
+            3,
+            callSites.size,
+        )
+        assertTrue(
+            "every connectGatt call site must read the connect mode through useAutoConnect(), not " +
+                "the application-wide static: $callSites",
+            callSites.all { it == "cb.useAutoConnect()" },
+        )
+    }
+
+    @Test
+    fun noDriverOverridesTheDefault() {
+        // R2(a) is a lever, not a change of behaviour: an override appearing here means some
+        // driver now connects in a mode the 2026-08-01 dataset never measured.
+        val overriders = sources("Common/src")
+            .filter { it.name != "SuperGattCallback.java" && it.name != "ConnectModeLeverTests.kt" }
+            .filter { it.readText().contains("useAutoConnect") }
+            .map { it.name }
+        assertTrue(
+            "no driver may override useAutoConnect() without field measurements of the other " +
+                "mode; found $overriders",
+            overriders.isEmpty(),
+        )
+    }
+
+    @Test
+    fun everyGattDriverRecordsItsFirstCallbackLatency() {
+        // The base class cannot funnel this: onConnectionStateChange is in practice the first
+        // callback of an attempt and no driver except AiDex chains to super, so a driver that
+        // declares it and forgets the call contributes nothing to the comparison.
+        // Every source set, not src/main alone: Libre3 and Si are the app's primary sensors and
+        // both live in flavour source sets, so a src/main scan stayed green while the measurement
+        // was absent for most users. GlucoseMeterGatt is a plain BluetoothGattCallback and has no
+        // connectGatt of ours to time, hence the subclass filter.
+        val missing = sources("Common/src")
+            .filterNot { it.path.replace('\\', '/').contains("/Common/src/test/") }
+            .filter { it.name != "SuperGattCallback.java" }
+            .filter { file ->
+                val text = file.readText()
+                (text.contains("extends SuperGattCallback") || text.contains(": SuperGattCallback("))
+                    && (text.contains("override fun onConnectionStateChange(")
+                        || text.contains("public void onConnectionStateChange("))
+                    && !text.contains("noteFirstGattCallback(")
+            }
+            .map { it.name }
+        assertTrue(
+            "every SuperGattCallback subclass must report how long connectGatt took to produce " +
+                "its first callback; missing in $missing",
+            missing.isEmpty(),
+        )
+    }
+}

--- a/Common/src/test/java/tk/glucodata/ProcessExitReasonsTests.kt
+++ b/Common/src/test/java/tk/glucodata/ProcessExitReasonsTests.kt
@@ -1,0 +1,65 @@
+package tk.glucodata
+
+import android.app.ApplicationExitInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The 767 s of the 2026-08-01 downtime that stayed unattributed did so because the log said only
+ * that a new process had started, never why the old one ended. What matters about the line that
+ * closes that gap is that it is readable next to the BLE events: same seconds-since-epoch clock,
+ * and a reason that is a name rather than a bare int — LOW_MEMORY, EXCESSIVE_RESOURCE_USAGE and
+ * FREEZER all read as "the system took the app away" and are three different problems.
+ */
+class ProcessExitReasonsTests {
+
+    @Test
+    fun everyDocumentedReasonHasAName() {
+        val reasons = intArrayOf(
+            ApplicationExitInfo.REASON_UNKNOWN,
+            ApplicationExitInfo.REASON_EXIT_SELF,
+            ApplicationExitInfo.REASON_SIGNALED,
+            ApplicationExitInfo.REASON_LOW_MEMORY,
+            ApplicationExitInfo.REASON_CRASH,
+            ApplicationExitInfo.REASON_CRASH_NATIVE,
+            ApplicationExitInfo.REASON_ANR,
+            ApplicationExitInfo.REASON_INITIALIZATION_FAILURE,
+            ApplicationExitInfo.REASON_PERMISSION_CHANGE,
+            ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE,
+            ApplicationExitInfo.REASON_USER_REQUESTED,
+            ApplicationExitInfo.REASON_USER_STOPPED,
+            ApplicationExitInfo.REASON_DEPENDENCY_DIED,
+            ApplicationExitInfo.REASON_OTHER,
+            ApplicationExitInfo.REASON_FREEZER,
+            ApplicationExitInfo.REASON_PACKAGE_STATE_CHANGE,
+            ApplicationExitInfo.REASON_PACKAGE_UPDATED,
+        )
+        val names = reasons.map { ProcessExitReasons.reasonName(it) }
+        assertTrue("an unnamed reason would read as a bare int: $names", names.none { it == "UNNAMED" })
+        assertEquals("no two reasons may share a name: $names", reasons.size, names.toSet().size)
+        assertEquals("UNNAMED", ProcessExitReasons.reasonName(Int.MAX_VALUE))
+    }
+
+    /**
+     * The kill of 2026-08-01 could only be bounded to [1785605312, 1785605570] because nothing tied
+     * it to a timestamp. trace.log lines carry seconds since the epoch, so this one has to as well
+     * or it cannot be lined up with the drops around it.
+     */
+    @Test
+    fun theLineCarriesTheSameClockAsTheRestOfTheTrace() {
+        val line = ProcessExitReasons.describe(
+            processName = "tk.glucodata",
+            pid = 10382,
+            reason = ApplicationExitInfo.REASON_LOW_MEMORY,
+            status = 0,
+            importance = 400,
+            timestampMs = 1_785_605_570_123L,
+            description = null,
+        )
+        assertTrue(line, line.contains("at=1785605570"))
+        assertTrue(line, line.contains("pid=10382"))
+        assertTrue(line, line.contains("reason=LOW_MEMORY(${ApplicationExitInfo.REASON_LOW_MEMORY})"))
+        assertTrue("a missing description must not read as a null: $line", line.contains("description=none"))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/ProguardKeepRulesTests.kt
+++ b/Common/src/test/java/tk/glucodata/ProguardKeepRulesTests.kt
@@ -1,0 +1,91 @@
+package tk.glucodata
+
+import java.io.File
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the keep rules whose loss is silent.
+ *
+ * Twice now a missing rule has disabled a whole mechanism in release builds with no crash and no
+ * log line: 713631f9 (HistoryRepository lookup by name -> "no rows" -> the Ottai driver re-pulled
+ * the sensor's entire history on every reconnect) and the hidden onConnectionUpdated callback,
+ * which R8 deleted outright so that a 4h jamming storm produced 210 framework invocations and
+ * zero app log lines. Neither shows up in a debug build, and nothing else in the tree checks that
+ * the rules survive an edit of proguard-rules.my.
+ */
+class ProguardKeepRulesTests {
+
+    private fun proguardRulesMy(): File {
+        // Gradle runs unit tests with the module directory as the working directory, but walk up
+        // anyway so the test does not depend on that.
+        var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        while (dir != null) {
+            val candidate = File(dir, "Common/proguard-rules.my")
+            if (candidate.isFile) return candidate
+            val here = File(dir, "proguard-rules.my")
+            if (here.isFile) return here
+            dir = dir.parentFile
+        }
+        throw AssertionError("proguard-rules.my not found from ${System.getProperty("user.dir")}")
+    }
+
+    private fun rulesText(): String = proguardRulesMy().readText()
+
+    /**
+     * Comment lines stripped before matching: the premise of this class is that a rule which does
+     * not apply is as good as no rule, and a rule pasted into a `#` line is exactly that.
+     */
+    private fun activeRules(): String =
+        rulesText().lines()
+            .filterNot { it.trimStart().startsWith("#") }
+            .joinToString(" ")
+            .replace(Regex("\\s+"), " ")
+
+    @Test
+    fun theHiddenConnectionParamsCallbackIsKept() {
+        val text = activeRules()
+        assertTrue(
+            "proguard-rules.my must keep BluetoothGattCallback#onConnectionUpdated; without it R8 " +
+                "deletes SuperGattCallback's declaration and the driver never sees a link-parameter " +
+                "update again",
+            text.contains(
+                "-keepclassmembers class * extends android.bluetooth.BluetoothGattCallback { " +
+                    "public void onConnectionUpdated(android.bluetooth.BluetoothGatt, int, int, int, int); }",
+            ),
+        )
+    }
+
+    @Test
+    fun theHistoryRepositoryLookupNamesAreKept() {
+        // The 713631f9 case: this one method was the omission, and its absence cost a full history
+        // re-pull per reconnect.
+        val text = activeRules()
+        assertTrue(text.contains("-keepnames class tk.glucodata.data.HistoryRepository"))
+        assertTrue(text.contains("getHistoryTimestampsForSensorBlocking"))
+    }
+
+    @Test
+    fun theKeptCallbackIsStillDeclaredWithThatExactSignature() {
+        // A rule that no longer matches the declaration is as good as no rule, and R8 does not
+        // warn about a keep rule matching nothing.
+        var dir: File? = proguardRulesMy().parentFile
+        var source: File? = null
+        while (dir != null && source == null) {
+            val candidate = File(dir, "src/main/java/tk/glucodata/SuperGattCallback.java")
+            if (candidate.isFile) source = candidate
+            dir = dir.parentFile
+        }
+        assertNotNull("SuperGattCallback.java not found next to proguard-rules.my", source)
+        val text = source!!.readText().replace(Regex("\\s+"), " ")
+        assertTrue(
+            "SuperGattCallback must declare onConnectionUpdated(BluetoothGatt,int,int,int,int) " +
+                "with @Keep for runtime dispatch to bind it",
+            text.contains(
+                "@Keep public void onConnectionUpdated(BluetoothGatt gatt, int interval, " +
+                    "int latency, int timeout, int status)",
+            ),
+        )
+    }
+}

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiBleAuthTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiBleAuthTests.kt
@@ -48,6 +48,55 @@ class OttaiBleAuthTests {
     }
 
     @Test
+    fun sharedSecretWithLeadingZero_keepsFullLengthKey() {
+        // Shared X below 2^247: the fixed-length field encoding starts 0x00 and the
+        // char-pick still yields 32 chars, while the vendor's BigInteger round-trip
+        // drops that byte (31 bytes / 62 hex) and the pick falls to 30 -> null.
+        val secret = ByteArray(32) { if (it == 0) 0 else (it * 7 + 1).toByte() }
+        assertArrayEq(secret, OttaiBleAuth.fixedFieldBytes(secret, 32))
+        val key = OttaiBleAuth.sessionKeyPick(OttaiCrypto.bytesToHex(secret))
+        assertNotNull(key)
+        assertEquals(32, key!!.length)
+
+        val stripped = java.math.BigInteger(1, secret).toByteArray()
+        assertEquals(31, stripped.size)
+        assertEquals(null, OttaiBleAuth.sessionKeyPick(OttaiCrypto.bytesToHex(stripped)))
+        assertArrayEq(secret, OttaiBleAuth.fixedFieldBytes(stripped, 32))
+    }
+
+    @Test
+    fun deriveSessionKey_survivesLeadingZeroSharedSecret() {
+        // ECDH against the curve generator gives shared X = X(d*G), so d selects the
+        // shared secret directly. Scanning up from d=2, d=379 is the first whose
+        // X < 2^247 (leading 0x00, second byte 0x55) — the 1-in-512 case that used
+        // to derive an empty key mid-handshake. Fixed curve + fixed scalar, so the
+        // secret is the same on every run and provider.
+        val params = java.security.AlgorithmParameters.getInstance("EC")
+            .apply { init(java.security.spec.ECGenParameterSpec(OttaiBleAuth.CURVE)) }
+        val ecSpec = params.getParameterSpec(java.security.spec.ECParameterSpec::class.java)
+        val kf = java.security.KeyFactory.getInstance("EC")
+        val gPub = kf.generatePublic(
+            java.security.spec.ECPublicKeySpec(ecSpec.generator, ecSpec),
+        ) as ECPublicKey
+        val priv = kf.generatePrivate(
+            java.security.spec.ECPrivateKeySpec(java.math.BigInteger.valueOf(379), ecSpec),
+        ) as ECPrivateKey
+
+        val ka = javax.crypto.KeyAgreement.getInstance("ECDH")
+        ka.init(priv)
+        ka.doPhase(gPub, true)
+        val shared = ka.generateSecret()
+        assertEquals(32, shared.size) // provider hands back the padded field element
+        assertEquals(0.toByte(), shared[0])
+        assertEquals(31, java.math.BigInteger(1, shared).toByteArray().size) // would strip
+
+        val key = OttaiBleAuth.deriveSessionKey(ecSpec.generator.affineX, ecSpec.generator.affineY, priv)
+        assertNotNull(key)
+        assertEquals(32, key!!.length)
+        assertEquals(OttaiBleAuth.sessionKeyPick(OttaiCrypto.bytesToHex(shared)), key)
+    }
+
+    @Test
     fun bytesIntLE_roundTrip() {
         for (v in listOf(0, 1, 255, 256, 0x010203, 0x7FFFFFFF, -1)) {
             assertEquals(v, OttaiBleAuth.bytesToIntLE(OttaiBleAuth.intToBytesLE(v)))

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiLifetimeTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiLifetimeTests.kt
@@ -254,6 +254,51 @@ class OttaiLifetimeTests {
         )
     }
 
+    @Test
+    fun activationProbeHoldsOutForTheExactAddressWhileTheScanIsYoung() {
+        val ours = "60:83:DA:F7:D9:15"
+        val neighbour = "C0:9B:9E:60:07:37"
+        val armedAt = 1_785_334_591_000L
+
+        // The three units probed on 2026-07-29 were all admitted by the name-only fallback
+        // within 15 s of arming, each costing a connect/discover/auth cycle and a scan restart
+        // before our own sensor could be seen.
+        assertTrue(OttaiConstants.isActivationExactOnlyWindowOpen(armedAt, armedAt + 12_000L))
+        assertFalse(
+            OttaiConstants.shouldProbeActivationAdvertisement(
+                discoveryPending = true,
+                scannedAddress = neighbour,
+                expectedAddress = ours,
+                advertisedName = "Ottai CGM",
+                exactOnlyWindowOpen = true,
+            ),
+        )
+        // Our own address is always admitted, window or not — that is the whole point of it.
+        assertTrue(
+            OttaiConstants.shouldProbeActivationAdvertisement(
+                discoveryPending = true,
+                scannedAddress = ours,
+                expectedAddress = ours,
+                advertisedName = null,
+                exactOnlyWindowOpen = true,
+            ),
+        )
+        // Once the window closes the fallback returns, so a genuinely rotated address is still
+        // reachable — just not before the sensor has had a chance to advertise itself.
+        assertFalse(OttaiConstants.isActivationExactOnlyWindowOpen(armedAt, armedAt + 15_000L))
+        assertTrue(
+            OttaiConstants.shouldProbeActivationAdvertisement(
+                discoveryPending = true,
+                scannedAddress = neighbour,
+                expectedAddress = ours,
+                advertisedName = "Ottai CGM",
+                exactOnlyWindowOpen = false,
+            ),
+        )
+        // No armed timestamp means no window; never hold out on a scan we cannot age.
+        assertFalse(OttaiConstants.isActivationExactOnlyWindowOpen(0L, armedAt))
+    }
+
     private companion object {
         const val DAY_MS = 24L * 60L * 60L * 1000L
     }

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiLiveFreshnessTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiLiveFreshnessTests.kt
@@ -31,4 +31,61 @@ class OttaiLiveFreshnessTests {
         assertFalse(OttaiBleManager.isFreshLiveSample(0L, 1_782_823_440_000L))
         assertFalse(OttaiBleManager.isFreshLiveSample(1_782_823_566_000L, 0L))
     }
+
+    /**
+     * The 2026-08-01 room-backfill round trip: live read at 1785605688, history requested at
+     * 1785605689, its payload back a second later — the re-read at 1785605690 returned the same
+     * front=14332 the live read had just brought in.
+     */
+    @Test
+    fun skipsPostHistoryLiveReadRightAfterALiveFrame() {
+        assertFalse(
+            OttaiBleManager.shouldReadLiveAfterHistory(
+                receivedAtMs = 1_785_605_689_000L,
+                lastLiveFrameAtMs = 1_785_605_688_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun readsLiveAfterAHistoryBurstThatEndedBehindWallTime() {
+        assertTrue(
+            OttaiBleManager.shouldReadLiveAfterHistory(
+                receivedAtMs = 1_785_605_689_000L,
+                lastLiveFrameAtMs = 1_785_605_299_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun readsLiveWhenNoLiveFrameHasBeenSeenYet() {
+        assertTrue(OttaiBleManager.shouldReadLiveAfterHistory(1_785_605_689_000L, 0L))
+    }
+
+    /** One whole record has passed, so the sensor has something new to give. */
+    @Test
+    fun readsLiveExactlyOneRecordIntervalAfterTheLastFrame() {
+        assertTrue(
+            OttaiBleManager.shouldReadLiveAfterHistory(
+                receivedAtMs = 1_785_605_688_000L + 60_000L,
+                lastLiveFrameAtMs = 1_785_605_688_000L,
+            ),
+        )
+        assertFalse(
+            OttaiBleManager.shouldReadLiveAfterHistory(
+                receivedAtMs = 1_785_605_688_000L + 59_999L,
+                lastLiveFrameAtMs = 1_785_605_688_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun readsLiveWhenTheClockSteppedBackwards() {
+        assertTrue(
+            OttaiBleManager.shouldReadLiveAfterHistory(
+                receivedAtMs = 1_785_605_688_000L,
+                lastLiveFrameAtMs = 1_785_605_988_000L,
+            ),
+        )
+    }
 }

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiOutageInstrumentationTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiOutageInstrumentationTests.kt
@@ -1,0 +1,154 @@
+package tk.glucodata.drivers.ottai
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The three measurements the 2026-08-01 analysis could not make: when the sensor advertises again
+ * after a drop, and how strong the link was while it lasted. Both are gates on how often the app
+ * is allowed to spend radio on asking, and getting either gate wrong turns instrumentation into a
+ * second RF problem — so the gates, and only the gates, are pinned here.
+ */
+class OttaiOutageInstrumentationTests {
+
+    private val now = 1_785_605_570_000L
+
+    @Test
+    fun theFirstOutageIsProbedImmediately() {
+        assertTrue(
+            OttaiBleManager.shouldProbeOutageAdvertisement(
+                alreadyProbedThisOutage = false,
+                activationScanActive = false,
+                managedScanActive = false,
+                nowMs = now,
+                lastProbeAtMs = 0L,
+            ),
+        )
+    }
+
+    /**
+     * 88 drops in four hours: without a once-per-outage latch the probe would restart on every
+     * disconnect callback of a flapping link and hit Android's 5-scans-per-30s throttle, which
+     * parks the offending app's scans for half an hour — including the managed scan the driver
+     * needs to find sensors at all.
+     */
+    @Test
+    fun oneOutageIsProbedOnlyOnce() {
+        assertFalse(
+            OttaiBleManager.shouldProbeOutageAdvertisement(
+                alreadyProbedThisOutage = true,
+                activationScanActive = false,
+                managedScanActive = false,
+                nowMs = now,
+                lastProbeAtMs = now - OttaiBleManager.OUTAGE_PROBE_MIN_GAP_MS * 10,
+            ),
+        )
+    }
+
+    @Test
+    fun probesAreSpacedEvenAcrossSeparateOutages() {
+        assertFalse(
+            OttaiBleManager.shouldProbeOutageAdvertisement(
+                alreadyProbedThisOutage = false,
+                activationScanActive = false,
+                managedScanActive = false,
+                nowMs = now,
+                lastProbeAtMs = now - OttaiBleManager.OUTAGE_PROBE_MIN_GAP_MS + 1_000L,
+            ),
+        )
+        assertTrue(
+            OttaiBleManager.shouldProbeOutageAdvertisement(
+                alreadyProbedThisOutage = false,
+                activationScanActive = false,
+                managedScanActive = false,
+                nowMs = now,
+                lastProbeAtMs = now - OttaiBleManager.OUTAGE_PROBE_MIN_GAP_MS,
+            ),
+        )
+    }
+
+    /**
+     * The activation/candidate scan owns the radio and the transport during setup. A probe racing
+     * it is exactly the interference this must never introduce, so it stands aside regardless of
+     * how long ago the last probe ran.
+     */
+    @Test
+    fun anArmedActivationScanSuppressesTheProbeEntirely() {
+        assertFalse(
+            OttaiBleManager.shouldProbeOutageAdvertisement(
+                alreadyProbedThisOutage = false,
+                activationScanActive = true,
+                managedScanActive = false,
+                nowMs = now,
+                lastProbeAtMs = 0L,
+            ),
+        )
+    }
+
+    /**
+     * Android's scan throttle is per app, not per scanner: five starts in 30s parks the offender
+     * for half an hour, and the startScan the platform then refuses can be SensorBluetooth's — the
+     * discovery and recovery path for every sensor family, restarted on its own interval loop.
+     * A measurement must never be the reason that call fails.
+     */
+    @Test
+    fun theManagedScanOutranksTheProbe() {
+        assertFalse(
+            OttaiBleManager.shouldProbeOutageAdvertisement(
+                alreadyProbedThisOutage = false,
+                activationScanActive = false,
+                managedScanActive = true,
+                nowMs = now,
+                lastProbeAtMs = 0L,
+            ),
+        )
+    }
+
+    @Test
+    fun aClockStepBackwardsDoesNotLatchTheProbeOff() {
+        // Only an accepted probe writes lastProbeAtMs, so a timestamp from the future would
+        // otherwise silence the measurement for as long as the clock stayed behind it.
+        assertTrue(
+            OttaiBleManager.shouldProbeOutageAdvertisement(
+                alreadyProbedThisOutage = false,
+                activationScanActive = false,
+                managedScanActive = false,
+                nowMs = now,
+                lastProbeAtMs = now + 24L * 3_600_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun rssiIsNotReadOutsideStreaming() {
+        assertFalse(OttaiBleManager.shouldPollRssi(streaming = false, nowMs = now, lastRssiReadAtMs = 0L))
+    }
+
+    @Test
+    fun rssiIsReadOncePerCadenceAndNotSooner() {
+        assertTrue(OttaiBleManager.shouldPollRssi(streaming = true, nowMs = now, lastRssiReadAtMs = 0L))
+        assertFalse(
+            OttaiBleManager.shouldPollRssi(
+                streaming = true,
+                nowMs = now,
+                lastRssiReadAtMs = now - OttaiBleManager.RSSI_POLL_INTERVAL_MS + 1_000L,
+            ),
+        )
+        assertTrue(
+            OttaiBleManager.shouldPollRssi(
+                streaming = true,
+                nowMs = now,
+                lastRssiReadAtMs = now - OttaiBleManager.RSSI_POLL_INTERVAL_MS,
+            ),
+        )
+        assertTrue(
+            OttaiBleManager.shouldPollRssi(
+                streaming = true,
+                nowMs = now,
+                lastRssiReadAtMs = now + 24L * 3_600_000L,
+            ),
+        )
+    }
+
+}

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiOutputFilterTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiOutputFilterTests.kt
@@ -22,6 +22,13 @@ class OttaiOutputFilterTests {
         assertNull(OttaiOutputFilter.hardRejectReason(record(raw = 12_000, temp = 32.0), 7.4f))
         assertTrue(OttaiOutputFilter.hardRejectReason(record(raw = 999), 7.4f)!!.startsWith("raw="))
         assertTrue(OttaiOutputFilter.hardRejectReason(record(temp = 45.1), 7.4f)!!.startsWith("temp="))
+        // Observed corruption decoded high (185.07, 360.93, 421.01 C); nothing stopped the same
+        // garbage decoding cold, so the gate is bounded at both ends now.
+        assertTrue(OttaiOutputFilter.hardRejectReason(record(temp = 14.9), 7.4f)!!.startsWith("temp="))
+        assertTrue(OttaiOutputFilter.hardRejectReason(record(temp = -40.0), 7.4f)!!.startsWith("temp="))
+        // The whole range the sensor actually reported over 16 days (25.0-41.1 C) still passes.
+        assertNull(OttaiOutputFilter.hardRejectReason(record(temp = 25.0), 7.4f))
+        assertNull(OttaiOutputFilter.hardRejectReason(record(temp = 41.1), 7.4f))
         assertTrue(OttaiOutputFilter.hardRejectReason(record(), 40.1f)!!.startsWith("glucose="))
         assertTrue(OttaiOutputFilter.hardRejectReason(record(), 0f)!!.startsWith("glucose="))
     }

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiReconnectPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiReconnectPolicyTests.kt
@@ -214,6 +214,7 @@ class OttaiReconnectPolicyTests {
                 unstable = true,
                 nowMs = now,
                 lastReassertMs = 0L,
+                reassertsThisConnection = 0,
             ),
         )
     }
@@ -227,6 +228,7 @@ class OttaiReconnectPolicyTests {
                 unstable = true,
                 nowMs = now,
                 lastReassertMs = 0L,
+                reassertsThisConnection = 0,
             ),
         )
     }
@@ -240,6 +242,7 @@ class OttaiReconnectPolicyTests {
                 unstable = true,
                 nowMs = now,
                 lastReassertMs = 0L,
+                reassertsThisConnection = 0,
             ),
         )
     }
@@ -253,6 +256,7 @@ class OttaiReconnectPolicyTests {
                 unstable = false,
                 nowMs = now,
                 lastReassertMs = 0L,
+                reassertsThisConnection = 0,
             ),
         )
     }
@@ -266,6 +270,40 @@ class OttaiReconnectPolicyTests {
                 unstable = true,
                 nowMs = now,
                 lastReassertMs = now - OttaiBleManager.PRIORITY_REASSERT_MIN_GAP_MS + 1_000L,
+                reassertsThisConnection = 0,
+            ),
+        )
+    }
+
+    /**
+     * linkUnstable is permanently true for a user in a jamming environment — two abnormal drops in
+     * 15 minutes is a low bar — so without a per-connection cap the grip runs for the life of the
+     * link: ~133 reasserts per sensor per 4h in the 2026-08-01 logs, each one dropping the
+     * sensor's effective listen period from 1925ms to 15ms for ~5.8s.
+     */
+    @Test
+    fun theReassertIsCappedPerConnection() {
+        val cap = OttaiBleManager.MAX_PRIORITY_REASSERTS_PER_CONNECTION
+        for (done in 0 until cap) {
+            assertTrue(
+                OttaiBleManager.shouldHoldFastParams(
+                    intervalUnits = 308,
+                    latency = 4,
+                    unstable = true,
+                    nowMs = now,
+                    lastReassertMs = 0L,
+                    reassertsThisConnection = done,
+                ),
+            )
+        }
+        assertFalse(
+            OttaiBleManager.shouldHoldFastParams(
+                intervalUnits = 308,
+                latency = 4,
+                unstable = true,
+                nowMs = now,
+                lastReassertMs = 0L,
+                reassertsThisConnection = cap,
             ),
         )
     }
@@ -277,5 +315,62 @@ class OttaiReconnectPolicyTests {
         assertEquals(360_000L, OttaiBleManager.connectingStaleThresholdMs(2))
         assertEquals(360_000L, OttaiBleManager.connectingStaleThresholdMs(7))
         assertEquals(90_000L, OttaiBleManager.connectingStaleThresholdMs(-1))
+    }
+
+    /**
+     * All 88 drops of the 2026-08-01 storm were status=8, and 15 of those outages ended within
+     * 10s of close(); the peer had stopped answering but was still there, so the 3s default was
+     * pure hold. Half of it and no more: this path re-arms from the BT callback thread with the
+     * disconnect event still in flight, and connecting inside MIUI's registerApp() churn is how a
+     * status=133 gets earned.
+     */
+    @Test
+    fun aSupervisionTimeoutReArmsSooner() {
+        assertEquals(1_500L, OttaiBleManager.reconnectDelayAfterDisconnectMs(8, fastReArmAllowed = true))
+    }
+
+    /**
+     * 19 is a live peer closing the link itself — re-arming early against that builds a
+     * connect/terminate loop, and the 3s default demonstrably recovered from it (drop at
+     * 1785606352, reconnected 1785606359). 22 is our own teardown, 133 never appeared on this
+     * path at all (all five in the logs were ATT reads), and 0 is a clean close.
+     */
+    @Test
+    fun everyOtherDisconnectStatusKeepsTheThreeSecondDefault() {
+        for (status in intArrayOf(0, 19, 22, 62, 133, 147)) {
+            assertEquals(
+                3_000L,
+                OttaiBleManager.reconnectDelayAfterDisconnectMs(status, fastReArmAllowed = true),
+            )
+        }
+    }
+
+    /**
+     * The shortened re-arm is worth 0.7% of the storm's downtime, so one bounce off the stack's
+     * own client registration is enough to give it up: after that the outage runs on the default.
+     */
+    @Test
+    fun aWithdrawnFastReArmFallsBackToTheDefault() {
+        assertEquals(3_000L, OttaiBleManager.reconnectDelayAfterDisconnectMs(8, fastReArmAllowed = false))
+    }
+
+    @Test
+    fun aStatusOneThreeThreeRightAfterAShortenedReArmWithdrawsIt() {
+        assertTrue(OttaiBleManager.fastReArmBounced(133, now, now - 1_800L))
+        assertTrue(OttaiBleManager.fastReArmBounced(133, now, now))
+    }
+
+    @Test
+    fun anUnrelatedOneThreeThreeLeavesTheShortenedReArmAlone() {
+        // Nothing armed: the pre-existing 133s were ATT reads on an established link, not
+        // connect bounces, and they must not disable a delay that was never used.
+        assertFalse(OttaiBleManager.fastReArmBounced(133, now, 0L))
+        // Long after the re-arm — that is an ordinary failed connect, not the clientIf window.
+        assertFalse(OttaiBleManager.fastReArmBounced(133, now, now - 30_000L))
+        // A clock step backwards must not count as a bounce either.
+        assertFalse(OttaiBleManager.fastReArmBounced(133, now, now + 5_000L))
+        // Every other status leaves it armed, supervision timeouts above all.
+        assertFalse(OttaiBleManager.fastReArmBounced(8, now, now - 500L))
+        assertFalse(OttaiBleManager.fastReArmBounced(19, now, now - 500L))
     }
 }

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiWarmupContinuityTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiWarmupContinuityTests.kt
@@ -1,0 +1,169 @@
+package tk.glucodata.drivers.ottai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression cover for the two defects the 2026-07-29 activation exposed:
+ *
+ *  - nothing suppressed the post-activation settling ramp, so the sensor's first minutes were
+ *    published as real glucose;
+ *  - the continuity gate anchored its adjacency window on the last ACCEPTED sample, so exactly
+ *    two consecutive rejections switched the gate off and let the third sample through unchecked.
+ *
+ * The numbers below are the readings actually recorded that evening, anchored on
+ * `confirmed activeTime=1785334740` (2026-07-29 17:19:00 +0300).
+ */
+class OttaiWarmupContinuityTests {
+
+    private companion object {
+        const val ACTIVATION_MS = 1_785_334_740_000L
+
+        // dataNo -> (mmol, rawCurrent), straight off the device trace.
+        val OBSERVED_RAMP = listOf(
+            Sample(0, 5.60f, 9_396),
+            Sample(1, 2.40f, 3_064),
+            Sample(2, 2.40f, 3_056),
+            Sample(3, 2.80f, 3_669),
+            Sample(4, 3.00f, 3_975),
+            Sample(5, 3.30f, 4_635),
+            Sample(6, 3.80f, 5_735),
+            Sample(7, 5.00f, 7_935),
+            Sample(8, 5.70f, 9_341),
+            Sample(9, 5.90f, 9_726),
+            Sample(10, 6.00f, 9_875),
+            Sample(11, 6.10f, 10_017),
+        )
+    }
+
+    private data class Sample(val dataNo: Int, val mmol: Float, val raw: Int) {
+        val sampleMs: Long get() = ACTIVATION_MS + dataNo * 60_000L
+    }
+
+    @Test
+    fun warmupWindow_suppressesTheWholeSettlingRamp() {
+        // The false 50 mg/dL (dataNo 3) and everything before the plateau must be inside it.
+        val suppressed = OBSERVED_RAMP.filter {
+            OttaiConstants.isWithinWarmup(ACTIVATION_MS, it.sampleMs)
+        }
+        assertEquals((0..9).toList(), suppressed.map { it.dataNo })
+
+        // dataNo 10 is the first sample at the boundary, and by then the ramp has plateaued.
+        val first = OBSERVED_RAMP.first { !OttaiConstants.isWithinWarmup(ACTIVATION_MS, it.sampleMs) }
+        assertEquals(10, first.dataNo)
+        assertEquals(6.00f, first.mmol, 0.001f)
+    }
+
+    @Test
+    fun warmupWindow_isDisabledWithoutATrustedStart() {
+        // A provisional start must never reach the gate; 0 means "no trusted anchor" and has to
+        // fail open, otherwise a vendor-activated sensor is blanked on every fresh connect.
+        assertFalse(OttaiConstants.isWithinWarmup(0L, ACTIVATION_MS + 60_000L))
+        assertFalse(OttaiConstants.isWithinWarmup(ACTIVATION_MS, 0L))
+    }
+
+    @Test
+    fun adjacencyWindow_holdsAcrossTwoRecordsOrOneHundredThirtyFiveSeconds() {
+        assertTrue(OttaiBleManager.isAdjacentSample(10, ACTIVATION_MS, 11, ACTIVATION_MS + 60_000L))
+        assertTrue(OttaiBleManager.isAdjacentSample(10, ACTIVATION_MS, 12, ACTIVATION_MS + 120_000L))
+        // Three records apart with a matching 180 s time gap is outside both tests.
+        assertFalse(OttaiBleManager.isAdjacentSample(10, ACTIVATION_MS, 13, ACTIVATION_MS + 180_000L))
+        // No anchor yet -> nothing to compare against.
+        assertFalse(OttaiBleManager.isAdjacentSample(-1, 0L, 0, ACTIVATION_MS))
+    }
+
+    @Test
+    fun continuityGate_rejectsTheThirdSampleAfterTwoRejections() {
+        // The exact sequence that produced the published 50 mg/dL. Warmup is not involved here:
+        // this is the gate's own mechanism, which still guards every later spike in the session.
+        val gate = ContinuityGate()
+        assertTrue(gate.offer(OBSERVED_RAMP[0]))   // 5.60 / 9396 -> baseline
+        assertFalse(gate.offer(OBSERVED_RAMP[1]))  // 2.40 / 3064 -> excursion
+        assertFalse(gate.offer(OBSERVED_RAMP[2]))  // 2.40 / 3056 -> excursion
+        assertFalse(gate.offer(OBSERVED_RAMP[3]))  // 2.80 / 3669 -> was published before the fix
+    }
+
+    @Test
+    fun continuityGate_anchoringOnTheAcceptedSampleIsWhatLetItThrough() {
+        // Pin the defect itself: with the old anchor the third sample is not adjacent to the last
+        // ACCEPTED record (dataNo gap 3, time gap 180 s), so the excursion test never ran.
+        val accepted = OBSERVED_RAMP[0]
+        val third = OBSERVED_RAMP[3]
+        assertFalse(
+            OttaiBleManager.isAdjacentSample(accepted.dataNo, accepted.sampleMs, third.dataNo, third.sampleMs)
+        )
+        // The excursion test would have caught it comfortably had it been reached.
+        assertTrue(
+            OttaiOutputFilter.isOneMinuteRawExcursion(
+                candidateMmol = third.mmol,
+                candidateRaw = third.raw,
+                baselineMmol = accepted.mmol,
+                baselineRaw = accepted.raw,
+            )
+        )
+    }
+
+    @Test
+    fun continuityGate_yieldsRatherThanLatchingForever() {
+        // The comparison baseline only moves on an accepted sample, so a genuine step change must
+        // not be able to blind the gate for the rest of the session.
+        val gate = ContinuityGate()
+        assertTrue(gate.offer(Sample(0, 12.0f, 22_000)))
+        var dataNo = 1
+        repeat(OttaiBleManager.MAX_CONSECUTIVE_CONTINUITY_REJECTS) {
+            assertFalse(gate.offer(Sample(dataNo++, 4.0f, 6_000)))
+        }
+        assertTrue(gate.offer(Sample(dataNo, 4.0f, 6_000)))
+        // ...and the yielded sample becomes the new baseline, so the stream continues normally.
+        assertTrue(gate.offer(Sample(dataNo + 1, 4.1f, 6_100)))
+    }
+
+    /**
+     * Mirrors the accept/reject bookkeeping of OttaiBleManager.emitReading around the continuity
+     * gate, using the same pure predicates the driver calls.
+     */
+    private class ContinuityGate {
+        private var baselineMmol = Float.NaN
+        private var baselineRaw = 0
+        private var evaluatedDataNo = -1
+        private var evaluatedSampleMs = 0L
+        private var consecutiveRejects = 0
+
+        fun offer(s: Sample): Boolean {
+            if (consecutiveRejects >= OttaiBleManager.MAX_CONSECUTIVE_CONTINUITY_REJECTS) {
+                accept(s)
+                return true
+            }
+            val reject = OttaiBleManager.isAdjacentSample(
+                evaluatedDataNo, evaluatedSampleMs, s.dataNo, s.sampleMs,
+            ) && OttaiOutputFilter.isOneMinuteRawExcursion(
+                candidateMmol = s.mmol,
+                candidateRaw = s.raw,
+                baselineMmol = baselineMmol,
+                baselineRaw = baselineRaw,
+            )
+            if (reject) {
+                consecutiveRejects++
+                noteEvaluated(s)
+                return false
+            }
+            accept(s)
+            return true
+        }
+
+        private fun accept(s: Sample) {
+            baselineMmol = s.mmol
+            baselineRaw = s.raw
+            consecutiveRejects = 0
+            noteEvaluated(s)
+        }
+
+        private fun noteEvaluated(s: Sample) {
+            if (s.dataNo < evaluatedDataNo) return
+            evaluatedDataNo = s.dataNo
+            evaluatedSampleMs = s.sampleMs
+        }
+    }
+}


### PR DESCRIPTION
Eight commits on top of `6514516d`, 39 files, +2156/−153. Mostly Ottai forensics from three
on-device windows (the 2026-07-29 activation, the 2026-07-14 corruption, the 2026-08-01 jamming
storm in Anapa), plus one native lifetime fix and two smaller ones.

| Commit | Subject |
|---|---|
| `bbf69e49` | Ottai: return the backfill verdict instead of publishing it through a field |
| `0e39bb82` | stats: one pinned window for both dashboard orientations |
| `5c769544` | native: honour the negotiated wear duration in `getmaxtime()` |
| `e350b01a` | Ottai: derive the session key from the fixed-length shared secret |
| `8b64d2da` | Ottai: bound the output filter's temperature gate at both ends |
| `fa70a8af` | Ottai: release the cloud binding on removal and report the real cloud error |
| `c1fbe265` | Ottai: suppress the warmup ramp, and stop the continuity gate switching itself off |
| `32fc0965` | Ottai: revive the conn-param callback R8 was deleting, and instrument the outages |

## Rebased onto your follow-up, not over it

`bbf69e49` and `f40b2d56` ("Ottai: retry deferred history diffs") touch the same function.
Your `historyDiffRetryPending` / `shouldDiffStoredHistory` mechanism is kept exactly as written;
only `historyDiffOwnsRecovery` is replaced, because that one was a field and the fix is that it
must not be. Every return path past the `shouldDiffStoredHistory` gate carries
`diffOwnsRecovery = true`, every path before it carries `false` — the same values the field held
at each point. Your `OttaiHistoryDiffTests` (14 tests) pass unchanged.

## The reading that should never have shipped

`c1fbe265` is the one worth reading in full. On the 2026-07-29 activation, dataNo 3 published
**2.80 mmol / 50 mg/dL** to the notification, the widget and the native journal — at the foot of
a settling ramp that climbed monotonically to 6.10 by dataNo 11. Two independent defects had to
line up:

- **Warmup was never enforced.** The driver knew the vendor's preheat period but wired it only to
  a UI status string, which itself went dark on the first reading. `emitReading` had no age term
  at all. Readings inside the window are now dropped before publish, persist and export — gated on
  the *sample* time, not the clock, so a later history replay reaches the same verdict instead of
  re-admitting what the live path refused.
- **The continuity gate switched itself off.** The excursion test ran only when the sample was
  adjacent to the last *accepted* one, and rejections did not move that anchor. Two consecutive
  refusals put the next sample 3 records and 180 s out, both outside the window, so the gate
  skipped itself and the third sample became the baseline the rest of the ramp inherited.
  Adjacency now anchors on the last *evaluated* sample.

The warmup anchor deliberately never uses the provisional activation time — that reads "just now"
for a vendor-activated sensor and would blank ten minutes of good readings on every fresh connect.

## A fix from July that has never actually run

`32fc0965` comes out of the 2026-08-01 jamming window: 88 links, 87 lost to `status=8`
(supervision timeout), 18–20 % downtime across two sensors on one phone over 4 h 11 min.

**No data was lost** — dataNo 14170–14419 and 4344–4594 arrived with no holes, 26 room-backfill
requests all answered, zero hole-ledger entries. The history machinery did its job.

What the window exposed is that one of the four fixes from the 2026-07-25 storm has never
executed once in a release build. `onConnectionUpdated` is a hidden framework callback, so its
declaration correctly carries no `@Override` — and R8 therefore sees nothing overriding anything
and deletes it. Verified on this branch against a real `assembleMobileLibre3SiDexGoogleRelease`:
before the keep rule the method is in `usage.txt` (stripped), after it, it is in `mapping.txt`
and absent from `usage.txt`. `ProguardKeepRulesTests` pins the rule so it cannot rot again.

The rest of the commit is instrumentation for these outages (`ProcessExitReasons`,
`OttaiAdvertisementProbe`), not behaviour.

## The two-week-early expiry

`5c769544` is native and affects more than Ottai. A direct-stream shell is seeded at
`info->days = 14` and only ever gets its real lifetime written to `info->wearduration2`, which
`getweardurationMIN()` reads but `getmaxtime()` did not. Once `getmaxtime()` falls behind,
`Sensoren::checkinfo` marks the record finished and the watch uploader drops the sensor, since it
picks its nightsensor on `getmaxtime() > now`. For the Ottai activated on 2026-07-29 with
`maxActive = 28d` that would have hit on **2026-08-12**, two weeks early, with no sign of it on
the phone.

It takes the longer of the two fields rather than raising `info->days`: that field is the shell's
storage geometry — `data.dat`, `polls.dat` and `current.dat` are all sized from it in the
constructor's initializer list, and `maxpos()`/`maxstreampos()` recompute from it on every call —
so raising it mid-session would leave those bounds describing twice the region actually mapped.
`setSensorWearDays` also now rejects `days > 45`, past which the `uint16_t` minutes field wraps
into a lifetime *shorter* than the sensor's.

## The rest

- **`e350b01a`** — `deriveSessionKey` round-tripped the ECDH shared X through `BigInteger`, which
  strips the leading `0x00` whenever the top byte is zero and the next is below `0x80`. The hex
  string then measures 62 characters, the `>= 32` gate returns null, and the handshake completes
  with an empty key: 1 agreement in 512, seen twice in 459 handshakes over 16 days, one of them
  mid-activation for 73 s. `generateSecret()` already returns the fixed-length field element, so
  use it directly. Only the case that always failed changes behaviour.
- **`8b64d2da`** — `hardRejectReason` refused temperatures only *above* 45 °C, so a corrupt frame
  was caught solely when it happened to decode hot. The 2026-07-14 corruption produced 185, 361,
  421, 325 and 389 °C and was refused; nothing would have stopped the same garbage decoding cold.
  A floor of 15 °C is added (measured range over 16 days: 25.0–41.1 °C). The 45 °C ceiling is left
  alone deliberately — the one corrupt frame that *did* get through read 41.1 °C.
- **`fa70a8af`** — activating a sensor spent ~3 minutes on twelve `validateDeviceByMacV2` calls
  all answering `AppUser_AlreadyBinding`, while the wizard showed only a generic "no materials".
  Removing a sensor wiped local prefs and nothing else, so `unbind` had no caller anywhere in the
  tree; and `request()` clears `lastError` on success, so `getBindDevice` — which *does* succeed
  for an unbound MAC, answering with a different sensor — erased validate's business error before
  anyone could show it. Removal now fires a best-effort background unbind, and the chain returns
  the first non-empty failure instead of reading a field the next call clobbers.
- **`0e39bb82`** — the strip rework gave the Dashboard two `PinnedStatsStrip` call sites and the
  window lived inside the strip, so each owned its own copy: picking 7d in portrait and rotating
  showed 24h. `rememberSaveable` could not have saved it — `MainActivity` declares
  `configChanges="orientation|screenSize|…"`, so rotation never triggers the save/restore path at
  all. The window is hoisted to `DashboardScreen`, which stays in composition across the swap.

## Verification

- `:Common:testMobileLibre3SiDexGoogleDebugUnitTest` — **1193 tests, 12 failures**, all 12
  pre-existing on `6514516d` (11 `SibionicsExact` fixture tests, plus
  `DashboardReadingDeltaTests.mmolKeepsOneDecimalAndItsSign`, which I confirmed fails on a clean
  checkout of your `main` too — untouched by this branch).
- Ottai + new suites re-run in isolation: **147 tests, 0 failures**.
- `:Common:assembleMobileLibre3SiDexGoogleRelease` — BUILD SUCCESSFUL. Native compiles, R8 runs
  with the new keep rules, `lintVital` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
