### PR TITLE
Preserve Anytime transmitter trend direction

### DIFF
--- a/Common/src/main/java/ist/com/sdk/CurrentGlucose.kt
+++ b/Common/src/main/java/ist/com/sdk/CurrentGlucose.kt
@@ -25,7 +25,7 @@ class CurrentGlucose {
     @JvmField var bgMGAdvice: Int = 0
     @JvmField var bgCount: Int = 0
     @JvmField var bgICount: Int = 0
-    @JvmField var trend: Int = 6
+    @JvmField var trend: Int = tk.glucodata.drivers.anytime.AnytimeTrend.NONE
     @JvmField var errorCode: Int = 0
     @JvmField var warnCode: Int = 0
     @JvmField var calibrationStatus: Int = -1

--- a/Common/src/main/java/ist/com/sdk/DataOutput.kt
+++ b/Common/src/main/java/ist/com/sdk/DataOutput.kt
@@ -14,7 +14,7 @@ class DataOutput {
     @JvmField var BGICount: Int = 0
     @JvmField var warnCode: Int = 0
     @JvmField var errorCode: Int = 0
-    @JvmField var trend: Int = 6
+    @JvmField var trend: Int = tk.glucodata.drivers.anytime.AnytimeTrend.NONE
     @JvmField var calibrationStatus: Int = -1
     @JvmField var data_quality: Int = 0
     @JvmField var hypoglycemiaEarlyWarnMinutes: Int = 0

--- a/Common/src/main/java/tk/glucodata/BroadcastTrendRate.java
+++ b/Common/src/main/java/tk/glucodata/BroadcastTrendRate.java
@@ -69,6 +69,12 @@ public final class BroadcastTrendRate {
                 if (Log.doLog)
                     Log.i("BroadcastTrendRate", "resolveCurrent failed: " + th);
             }
+            if (current != null) {
+                final Float vendorRate = VendorTrendRate.resolve(current.getSensorId(), current.getTimeMillis());
+                if (vendorRate != null) {
+                    return vendorRate;
+                }
+            }
             points = DisplayTrendSource.resolveTrendPoints(points, current, sensorId);
             final int viewMode = Notify.resolveSensorViewMode(sensorId);
             // current is deliberately not handed to resolveArrowRate: when the history is too thin

--- a/Common/src/main/java/tk/glucodata/DisplayTrendSource.kt
+++ b/Common/src/main/java/tk/glucodata/DisplayTrendSource.kt
@@ -101,6 +101,9 @@ object DisplayTrendSource {
         isMmol: Boolean,
         fallbackRate: Float = 0f
     ): Float {
+        current?.let { snapshot ->
+            VendorTrendRate.resolve(snapshot.sensorId, snapshot.timeMillis)?.let { return it }
+        }
         val points = recentPoints ?: emptyList()
         val useRaw = viewMode == 1 || viewMode == 3
         if (hasUsableTrendHistory(points, useRaw)) {

--- a/Common/src/main/java/tk/glucodata/ExchangeTrend.java
+++ b/Common/src/main/java/tk/glucodata/ExchangeTrend.java
@@ -76,6 +76,13 @@ public final class ExchangeTrend {
     }
 
     public static ExchangeTrend resolve(String sensorId, long timeMillis, float fallbackRate) {
+        final int vendorIndex = VendorTrendRate.resolveExchangeTrendIndex(sensorId, timeMillis);
+        if (vendorIndex != UNKNOWN) {
+            final Float vendorRate = VendorTrendRate.resolve(sensorId, timeMillis);
+            return new ExchangeTrend(vendorIndex,
+                    vendorRate == null ? fallbackRate : vendorRate,
+                    "vendor");
+        }
         final ExchangeTrend cached = fromCache(sensorId, timeMillis);
         if (cached.isKnown()) {
             return cached;

--- a/Common/src/main/java/tk/glucodata/VendorTrendRate.kt
+++ b/Common/src/main/java/tk/glucodata/VendorTrendRate.kt
@@ -1,0 +1,62 @@
+package tk.glucodata
+
+/**
+ * Briefly retains a sensor-supplied trend for the exact sample that produced it.
+ * This prevents a display refresh from replacing an authoritative device arrow
+ * with a regression over older local history.
+ */
+object VendorTrendRate {
+    private const val MATCH_WINDOW_MS = 5_000L
+    private const val MAX_ENTRIES = 8
+
+    private data class Entry(
+        val sensorId: String,
+        val timestampMillis: Long,
+        val rate: Float,
+        val exchangeTrendIndex: Int,
+    )
+
+    @Volatile
+    private var entries: List<Entry> = emptyList()
+
+    @Synchronized
+    fun publish(
+        sensorId: String?,
+        timestampMillis: Long,
+        rate: Float,
+        exchangeTrendIndex: Int = ExchangeTrend.UNKNOWN,
+    ) {
+        val id = sensorId?.trim().orEmpty()
+        if (id.isEmpty() || timestampMillis <= 0L || !rate.isFinite()) return
+        val retained = entries.filterNot {
+            SensorIdentity.matches(it.sensorId, id) &&
+                kotlin.math.abs(it.timestampMillis - timestampMillis) <= MATCH_WINDOW_MS
+        }
+        entries = (retained + Entry(id, timestampMillis, rate, exchangeTrendIndex)).takeLast(MAX_ENTRIES)
+    }
+
+    @JvmStatic
+    fun resolve(sensorId: String?, timestampMillis: Long): Float? {
+        val id = sensorId?.trim().orEmpty()
+        if (id.isEmpty() || timestampMillis <= 0L) return null
+        return entries.asReversed().firstOrNull {
+            SensorIdentity.matches(it.sensorId, id) &&
+                kotlin.math.abs(it.timestampMillis - timestampMillis) <= MATCH_WINDOW_MS
+        }?.rate
+    }
+
+    @JvmStatic
+    fun resolveExchangeTrendIndex(sensorId: String?, timestampMillis: Long): Int {
+        val id = sensorId?.trim().orEmpty()
+        if (id.isEmpty() || timestampMillis <= 0L) return ExchangeTrend.UNKNOWN
+        return entries.asReversed().firstOrNull {
+            SensorIdentity.matches(it.sensorId, id) &&
+                kotlin.math.abs(it.timestampMillis - timestampMillis) <= MATCH_WINDOW_MS
+        }?.exchangeTrendIndex ?: ExchangeTrend.UNKNOWN
+    }
+
+    @Synchronized
+    internal fun clearForTests() {
+        entries = emptyList()
+    }
+}

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeAlgorithm.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeAlgorithm.kt
@@ -397,7 +397,7 @@ object AnytimeAlgorithm {
             ibNa = record.ibNa,
             iwNa = record.iwNa,
             temperatureC = record.temperatureC,
-            trend = 6, // TREND_NONE — linear path doesn't compute trend
+            trend = AnytimeTrend.NONE,
             errorCode = 0,
             warnCode = 0,
             source = Source.LINEAR,

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
@@ -56,6 +56,7 @@ import tk.glucodata.R
 import tk.glucodata.SensorBluetooth
 import tk.glucodata.SuperGattCallback
 import tk.glucodata.UiRefreshBus
+import tk.glucodata.VendorTrendRate
 import tk.glucodata.drivers.ManagedSensorViewModeStore
 import tk.glucodata.drivers.VirtualGlucoseSensorBridge
 
@@ -3124,9 +3125,18 @@ class AnytimeBleManager(
             val fallbackDisplayValue = displayFallbackValue(result)
             if (!fallbackDisplayValue.isFinite() || fallbackDisplayValue <= 0f) return
             if (!allowDirectFallback && !hasStoredDisplayPoint(sampleMs)) return
+            val vendorRate = AnytimeTrend.rateFor(result.trend)
+            if (vendorRate.isFinite()) {
+                VendorTrendRate.publish(
+                    SerialNumber,
+                    sampleMs,
+                    vendorRate,
+                    AnytimeTrend.exchangeIndexFor(result.trend),
+                )
+            }
             val displayValue = CurrentDisplaySource.resolveIncomingReading(
                 liveNumericValue = fallbackDisplayValue,
-                rate = 0f,
+                rate = vendorRate,
                 targetTimeMillis = sampleMs,
                 preferredSensorId = SerialNumber,
                 sensorGen = SENSOR_GEN,
@@ -3139,7 +3149,7 @@ class AnytimeBleManager(
             SuperGattCallback.processExternalCurrentReading(
                 SerialNumber,
                 displayValue,
-                0f,
+                vendorRate,
                 sampleMs,
                 SENSOR_GEN,
             )
@@ -3493,7 +3503,7 @@ class AnytimeBleManager(
             } else {
                 lastRawMgdl
             },
-            rate = Float.NaN,
+            rate = AnytimeTrend.rateFor(lastAlgorithmResult?.trend ?: AnytimeTrend.NONE),
             sensorGen = SENSOR_GEN,
         )
     }

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeFrames.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeFrames.kt
@@ -626,7 +626,7 @@ object AnytimeFrames {
         val temperature = (tPlus40 - AnytimeConstants.TEMP_INT_OFFSET) + tFrac / 100f
         if (ibRaw >= 0xFFF0 || iwRaw >= 0xFFF0 || temperature !in -20f..80f) return null
         val trendAndHigh = decoded[offset + 6].toInt() and 0xFF
-        val trend = (trendAndHigh ushr 4) and 0x0F
+        val trend = AnytimeTrend.fromCt5PackedCode((trendAndHigh ushr 4) and 0x0F)
         val glucoseMgdl = ((trendAndHigh and 0x0F) shl 8) or (decoded[offset + 7].toInt() and 0xFF)
         val error = decoded[offset + 8].toInt() and 0xFF
         if (glucoseMgdl <= 0) return null
@@ -853,7 +853,9 @@ object AnytimeFrames {
         val bgInt = bytes[AnytimeConstants.COMPUTED_OFFSET_BG_INT].toInt() and 0xFF
         val bgFrac = bytes[AnytimeConstants.COMPUTED_OFFSET_BG_FRAC].toInt() and 0xFF
         val err = bytes[AnytimeConstants.COMPUTED_OFFSET_ERROR].toInt() and 0xFF
-        val trend = bytes[AnytimeConstants.COMPUTED_OFFSET_TREND].toInt() and 0xFF
+        val trend = AnytimeTrend.fromCt3ComputedCode(
+            bytes[AnytimeConstants.COMPUTED_OFFSET_TREND].toInt() and 0xFF
+        )
         val warn = bytes[AnytimeConstants.COMPUTED_OFFSET_WARN].toInt() and 0xFF
         return AnytimeComputedRecord(
             glucoseId = idLo or (idHi shl 8),

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeTrend.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeTrend.kt
@@ -1,0 +1,53 @@
+package tk.glucodata.drivers.anytime
+
+import tk.glucodata.ExchangeTrend
+
+/** Official Anytime trend identifiers after normalizing family-specific wire codes. */
+object AnytimeTrend {
+    const val RISE_FAST = 2
+    const val RISE_SLOW = 1
+    const val STEADY = 0
+    const val DROP_SLOW = -1
+    const val DROP_FAST = -2
+    const val DROP_FAST_LOW = -3
+    const val NONE = 10
+
+    fun fromCt3ComputedCode(raw: Int): Int = when (raw) {
+        0 -> RISE_FAST
+        1 -> RISE_SLOW
+        2 -> STEADY
+        3 -> DROP_SLOW
+        4 -> DROP_FAST
+        5 -> DROP_FAST_LOW
+        else -> NONE
+    }
+
+    fun fromCt5PackedCode(raw: Int): Int = when (raw) {
+        1 -> DROP_FAST_LOW
+        2 -> DROP_FAST
+        3 -> DROP_SLOW
+        4 -> STEADY
+        5 -> RISE_SLOW
+        6 -> RISE_FAST
+        else -> NONE
+    }
+
+    /** Representative mg/dL/min rates that preserve the official arrow category. */
+    fun rateFor(trend: Int): Float = when (trend) {
+        RISE_FAST -> 1.5f
+        RISE_SLOW -> 0.75f
+        STEADY -> 0f
+        DROP_SLOW -> -0.75f
+        DROP_FAST, DROP_FAST_LOW -> -1.5f
+        else -> Float.NaN
+    }
+
+    fun exchangeIndexFor(trend: Int): Int = when (trend) {
+        RISE_FAST -> ExchangeTrend.SINGLE_UP
+        RISE_SLOW -> ExchangeTrend.FORTY_FIVE_UP
+        STEADY -> ExchangeTrend.FLAT
+        DROP_SLOW -> ExchangeTrend.FORTY_FIVE_DOWN
+        DROP_FAST, DROP_FAST_LOW -> ExchangeTrend.SINGLE_DOWN
+        else -> ExchangeTrend.UNKNOWN
+    }
+}

--- a/Common/src/main/java/tk/glucodata/logic/TrendEngine.kt
+++ b/Common/src/main/java/tk/glucodata/logic/TrendEngine.kt
@@ -43,6 +43,17 @@ object TrendEngine {
         val noiseLevel: Float = 0f // 0.0 - 1.0 (normalized CV, higher = noisier)
     )
 
+    fun stateForVelocity(velocity: Float): TrendState = when {
+        !velocity.isFinite() -> TrendState.Unknown
+        velocity > 2.0 -> TrendState.DoubleUp
+        velocity > 1.0 -> TrendState.SingleUp
+        velocity > 0.5 -> TrendState.FortyFiveUp
+        velocity > -0.5 -> TrendState.Flat
+        velocity > -1.0 -> TrendState.FortyFiveDown
+        velocity > -2.0 -> TrendState.SingleDown
+        else -> TrendState.DoubleDown
+    }
+
     /** Cadence the fixed 20 minute window was chosen for: Dexcom/Libre, one reading per 5 min. */
     private const val REFERENCE_CADENCE_MIN = 5.0
     private const val REFERENCE_WINDOW_MIN = 20.0
@@ -351,17 +362,8 @@ object TrendEngine {
         val noiseLevel = noiseLevel2
 
         // Map to State
-        val state = when {
-            velocity > 2.0 -> TrendState.DoubleUp
-            velocity > 1.0 -> TrendState.SingleUp
-            velocity > 0.5 -> TrendState.FortyFiveUp
-            velocity > -0.5 -> TrendState.Flat
-            velocity > -1.0 -> TrendState.FortyFiveDown
-            velocity > -2.0 -> TrendState.SingleDown
-            else -> TrendState.DoubleDown
-        }
+        val state = stateForVelocity(velocity)
 
         return TrendResult(state, velocity, acceleration, 1.0f, noiseLevel)
     }
 }
-

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -308,11 +308,41 @@ fun DashboardCombinedHeader(
              // The canonical trend list (live-augmented, newest-anchored window) —
              // the same points the notification and broadcast arrows regress over.
              val trendPoints = tk.glucodata.DisplayTrendSource.resolveTrendPoints(nativeList, currentSnapshot, null)
-             tk.glucodata.logic.TrendEngine.calculateTrend(trendPoints, useRaw = (viewMode == 1 || viewMode == 3), isMmol = isMmol)
+             val calculated = tk.glucodata.logic.TrendEngine.calculateTrend(
+                 trendPoints,
+                 useRaw = (viewMode == 1 || viewMode == 3),
+                 isMmol = isMmol,
+             )
+             val displayVelocity = tk.glucodata.DisplayTrendSource.resolveArrowRate(
+                 trendPoints,
+                 currentSnapshot,
+                 viewMode,
+                 isMmol,
+                 calculated.velocity,
+             )
+             calculated.copy(
+                 state = tk.glucodata.logic.TrendEngine.stateForVelocity(displayVelocity),
+                 velocity = displayVelocity,
+             )
         } else if (latestPoint != null) {
             // Fallback
              val nativeList = listOf(tk.glucodata.GlucosePoint(latestPoint.timestamp, latestPoint.value, latestPoint.rawValue))
-             tk.glucodata.logic.TrendEngine.calculateTrend(nativeList, useRaw = (viewMode == 1 || viewMode == 3), isMmol = isMmol)
+             val calculated = tk.glucodata.logic.TrendEngine.calculateTrend(
+                 nativeList,
+                 useRaw = (viewMode == 1 || viewMode == 3),
+                 isMmol = isMmol,
+             )
+             val displayVelocity = tk.glucodata.DisplayTrendSource.resolveArrowRate(
+                 nativeList,
+                 currentSnapshot,
+                 viewMode,
+                 isMmol,
+                 calculated.velocity,
+             )
+             calculated.copy(
+                 state = tk.glucodata.logic.TrendEngine.stateForVelocity(displayVelocity),
+                 velocity = displayVelocity,
+             )
         } else {
             tk.glucodata.logic.TrendEngine.TrendResult(tk.glucodata.logic.TrendEngine.TrendState.Unknown, 0f, 0f, 0f, 0f)
         }

--- a/Common/src/test/java/tk/glucodata/VendorTrendRateTests.kt
+++ b/Common/src/test/java/tk/glucodata/VendorTrendRateTests.kt
@@ -1,0 +1,71 @@
+package tk.glucodata
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import tk.glucodata.logic.TrendEngine
+import tk.glucodata.ui.DisplayValues
+
+class VendorTrendRateTests {
+    @After
+    fun clear() = VendorTrendRate.clearForTests()
+
+    @Test
+    fun resolvesOnlyTheMatchingSensorAndSample() {
+        VendorTrendRate.publish("ANYTIME-123", 1_700_000_000_000L, -0.75f)
+
+        assertEquals(-0.75f, VendorTrendRate.resolve("anytime-123", 1_700_000_004_000L)!!, 0f)
+        assertNull(VendorTrendRate.resolve("another-sensor", 1_700_000_000_000L))
+        assertNull(VendorTrendRate.resolve("ANYTIME-123", 1_700_000_006_000L))
+    }
+
+    @Test
+    fun vendorRateTakesPriorityOverUsableHistoryForThatSample() {
+        val timestamp = 1_700_000_000_000L
+        VendorTrendRate.publish("ANYTIME-123", timestamp, 1.5f)
+        val current = CurrentDisplaySource.Snapshot(
+            timeMillis = timestamp,
+            rate = 1.5f,
+            sensorId = "ANYTIME-123",
+            sensorGen = 0,
+            index = 0,
+            viewMode = 0,
+            source = "test",
+            autoValue = 100f,
+            rawValue = 100f,
+            sharedDisplayValue = 100f,
+            sharedMgdl = 100,
+            isMmol = false,
+            displayValues = DisplayValues(
+                primaryValue = 100f,
+                primaryStr = "100",
+                fullFormatted = "100",
+            ),
+        )
+        val history = listOf(
+            GlucosePoint(timestamp - 60_000L, 140f, 140f),
+            GlucosePoint(timestamp, 100f, 100f),
+        )
+
+        val rate = DisplayTrendSource.resolveArrowRate(history, current, 0, false)
+        assertEquals(1.5f, rate, 0f)
+        assertEquals(TrendEngine.TrendState.SingleUp, TrendEngine.stateForVelocity(rate))
+    }
+
+    @Test
+    fun explicitVendorDirectionSurvivesExchangeRateThresholdDifferences() {
+        val timestamp = 1_700_000_000_000L
+        VendorTrendRate.publish(
+            "ANYTIME-123",
+            timestamp,
+            -0.75f,
+            ExchangeTrend.FORTY_FIVE_DOWN,
+        )
+
+        val trend = ExchangeTrend.resolve("ANYTIME-123", timestamp, -0.75f)
+        assertEquals(ExchangeTrend.FORTY_FIVE_DOWN, trend.index)
+        assertEquals("FortyFiveDown", trend.name)
+        assertEquals("vendor", trend.source)
+    }
+}

--- a/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeFramesTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeFramesTests.kt
@@ -296,7 +296,7 @@ class AnytimeFramesTests {
         assertEquals(13.74f, rec.iwNa, 0.001f)
         assertEquals(33.10f, rec.temperatureC, 0.001f)
         assertEquals(123, rec.gluMgdl)
-        assertEquals(5, rec.trend)
+        assertEquals(AnytimeTrend.RISE_SLOW, rec.trend)
         assertEquals(0, rec.errorCode)
     }
 
@@ -330,7 +330,7 @@ class AnytimeFramesTests {
         assertEquals(7.87f, candidate.record.iwNa, 0.001f)
         assertEquals(34.48f, candidate.record.temperatureC, 0.001f)
         assertEquals(85, candidate.record.gluMgdl)
-        assertEquals(4, candidate.record.trend)
+        assertEquals(AnytimeTrend.STEADY, candidate.record.trend)
         assertEquals(0, candidate.record.errorCode)
     }
 

--- a/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeTrendTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeTrendTests.kt
@@ -1,0 +1,51 @@
+package tk.glucodata.drivers.anytime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.ExchangeTrend
+
+class AnytimeTrendTests {
+    @Test
+    fun ct3ComputedCodesNormalizeToOfficialTrendIds() {
+        assertEquals(AnytimeTrend.RISE_FAST, AnytimeTrend.fromCt3ComputedCode(0))
+        assertEquals(AnytimeTrend.RISE_SLOW, AnytimeTrend.fromCt3ComputedCode(1))
+        assertEquals(AnytimeTrend.STEADY, AnytimeTrend.fromCt3ComputedCode(2))
+        assertEquals(AnytimeTrend.DROP_SLOW, AnytimeTrend.fromCt3ComputedCode(3))
+        assertEquals(AnytimeTrend.DROP_FAST, AnytimeTrend.fromCt3ComputedCode(4))
+        assertEquals(AnytimeTrend.DROP_FAST_LOW, AnytimeTrend.fromCt3ComputedCode(5))
+        assertEquals(AnytimeTrend.NONE, AnytimeTrend.fromCt3ComputedCode(6))
+    }
+
+    @Test
+    fun ct5PackedCodesNormalizeToOfficialTrendIds() {
+        assertEquals(AnytimeTrend.NONE, AnytimeTrend.fromCt5PackedCode(0))
+        assertEquals(AnytimeTrend.DROP_FAST_LOW, AnytimeTrend.fromCt5PackedCode(1))
+        assertEquals(AnytimeTrend.DROP_FAST, AnytimeTrend.fromCt5PackedCode(2))
+        assertEquals(AnytimeTrend.DROP_SLOW, AnytimeTrend.fromCt5PackedCode(3))
+        assertEquals(AnytimeTrend.STEADY, AnytimeTrend.fromCt5PackedCode(4))
+        assertEquals(AnytimeTrend.RISE_SLOW, AnytimeTrend.fromCt5PackedCode(5))
+        assertEquals(AnytimeTrend.RISE_FAST, AnytimeTrend.fromCt5PackedCode(6))
+        assertEquals(AnytimeTrend.NONE, AnytimeTrend.fromCt5PackedCode(7))
+    }
+
+    @Test
+    fun representativeRatesStayInsideExpectedArrowCategories() {
+        assertEquals(1.5f, AnytimeTrend.rateFor(AnytimeTrend.RISE_FAST), 0f)
+        assertEquals(0.75f, AnytimeTrend.rateFor(AnytimeTrend.RISE_SLOW), 0f)
+        assertEquals(0f, AnytimeTrend.rateFor(AnytimeTrend.STEADY), 0f)
+        assertEquals(-0.75f, AnytimeTrend.rateFor(AnytimeTrend.DROP_SLOW), 0f)
+        assertEquals(-1.5f, AnytimeTrend.rateFor(AnytimeTrend.DROP_FAST), 0f)
+        assertTrue(AnytimeTrend.rateFor(AnytimeTrend.NONE).isNaN())
+    }
+
+    @Test
+    fun officialDirectionsMapExactlyForExchangeConsumers() {
+        assertEquals(ExchangeTrend.SINGLE_UP, AnytimeTrend.exchangeIndexFor(AnytimeTrend.RISE_FAST))
+        assertEquals(ExchangeTrend.FORTY_FIVE_UP, AnytimeTrend.exchangeIndexFor(AnytimeTrend.RISE_SLOW))
+        assertEquals(ExchangeTrend.FLAT, AnytimeTrend.exchangeIndexFor(AnytimeTrend.STEADY))
+        assertEquals(ExchangeTrend.FORTY_FIVE_DOWN, AnytimeTrend.exchangeIndexFor(AnytimeTrend.DROP_SLOW))
+        assertEquals(ExchangeTrend.SINGLE_DOWN, AnytimeTrend.exchangeIndexFor(AnytimeTrend.DROP_FAST))
+        assertEquals(ExchangeTrend.UNKNOWN, AnytimeTrend.exchangeIndexFor(AnytimeTrend.NONE))
+    }
+}


### PR DESCRIPTION
## Summary

- normalize Anytime CT3/CT4 and CT5 transmitter direction encodings using the official-app mapping
- preserve the exact vendor direction through dashboard arrows, notifications, broadcasts, and exchange output
- add focused mapping, frame, propagation, and fallback tests

## Why

The transmitter already supplies a categorical direction. Preserving that sample-specific direction avoids replacing it with a locally regressed approximation when the vendor value is available.

## Verification

- `:Common:testMobileDebugUnitTest` with Anytime trend/frame, vendor-rate, consumer point-list, exchange trend, logic, and dashboard trend-history tests
- mobile Kotlin and Java compilation passed as part of the focused test run
- `git diff --check`

## Limits

No Anytime hardware was available. The direction mapping was checked against the official APK and captured logs, but live transmitter arrow behavior remains hardware-unverified.