### PR TITLE
Add Satellite Bluetooth meter support

### DIFF
--- a/Common/src/main/cpp/meter/java.cpp
+++ b/Common/src/main/cpp/meter/java.cpp
@@ -72,6 +72,52 @@ struct MeterSaveResult {
   bool recentLegacyValue{};
 };
 
+static MeterSaveResult storeDecodedGlucoseMeter(GlucoseMeter *meter,
+                                                jint meterIndex,
+                                                uint32_t timestamp,
+                                                float mgdL) {
+  if (!meter) {
+    LOGGER("GlucoseMeterSave no meter at %d\n", meterIndex);
+    return {};
+  }
+  if (!std::isfinite(mgdL) || mgdL <= 0.0f) {
+    LOGGER("GlucoseMeterSave invalid glucose %.2f\n", mgdL);
+    return {};
+  }
+  MeterSaveResult result;
+  if (timestamp <= meter->lastTime)
+    return result;
+
+  result.timestamp = timestamp;
+  result.mgdlTenths = std::lround(mgdL * 10.0f);
+  result.stored = true;
+
+  const auto bloodvar = settings->data()->bloodvar;
+  if (bloodvar < maxvarnr) {
+    float displayValue;
+    if (settings->data()->unit == 1) {
+      displayValue = std::round(convertmultmmol * 100.0f * mgdL) * .1f;
+    } else {
+      displayValue = std::roundf(mgdL);
+    }
+    Numdata *numda = getherenums();
+    if (Num *num = numda->numsaveonly(timestamp, displayValue, bloodvar, 0)) {
+      uint32_t now = time(nullptr);
+      if (abs((int)(now - timestamp)) < 60) {
+        addCalibration(timestamp, bloodvar, num, numda);
+        if (backup)
+          backup->wakebackup(Backup::wakenums);
+        setnumchanged(now);
+        result.recentLegacyValue = true;
+      }
+    }
+  } else {
+    LOGAR("GlucoseMeterSave: no legacy blood glucose label set; journal only");
+  }
+  meter->lastTime = timestamp;
+  return result;
+}
+
 static MeterSaveResult saveGlucoseMeter(JNIEnv *env, jint meterIndex,
                                         jbyteArray value) {
   const auto arlen = env->GetArrayLength(value);
@@ -106,37 +152,8 @@ static MeterSaveResult saveGlucoseMeter(JNIEnv *env, jint meterIndex,
          ctime_r(&ort, timebuf1), meter->timeoffset, timeoffset,
          ctime_r(&cort, timebuf2));
 #endif
-  MeterSaveResult result;
-  if (timcorrected > meter->lastTime) {
-    result.timestamp = timcorrected;
-    result.mgdlTenths = std::lround(mgdL * 10.0f);
-    result.stored = true;
-
-    const auto bloodvar = settings->data()->bloodvar;
-    if (bloodvar < maxvarnr) {
-      float displayValue;
-      if (settings->data()->unit == 1) {
-        displayValue = std::round(convertmultmmol * 100.0f * mgdL) * .1f;
-      } else {
-        displayValue = std::roundf(mgdL);
-      }
-      Numdata *numda = getherenums();
-      if (Num *num =
-              numda->numsaveonly(timcorrected, displayValue, bloodvar, 0)) {
-        uint32_t now = time(nullptr);
-        if (abs((int)(now - timcorrected)) < 60) {
-          addCalibration(timcorrected, bloodvar, num, numda);
-          if (backup)
-            backup->wakebackup(Backup::wakenums);
-          setnumchanged(now);
-          result.recentLegacyValue = true;
-        }
-      }
-    } else {
-      LOGAR("GlucoseMeterSave: no legacy blood glucose label set; journal only");
-    }
-    meter->lastTime = timcorrected;
-  }
+  MeterSaveResult result =
+      storeDecodedGlucoseMeter(meter, meterIndex, timcorrected, mgdL);
   meter->nextIndex = glu->index + 1;
   return result;
 }
@@ -149,6 +166,32 @@ extern "C" JNIEXPORT jboolean JNICALL fromjava(GlucoseMeterSave)(
 extern "C" JNIEXPORT jlongArray JNICALL fromjava(GlucoseMeterSaveResult)(
     JNIEnv *env, jclass cl, jint meterIndex, jbyteArray value) {
   const auto result = saveGlucoseMeter(env, meterIndex, value);
+  if (!result.stored)
+    return nullptr;
+  const jlong data[]{static_cast<jlong>(result.timestamp) * 1000LL,
+                     static_cast<jlong>(result.mgdlTenths),
+                     result.recentLegacyValue ? 1LL : 0LL};
+  jlongArray out = env->NewLongArray(3);
+  if (out)
+    env->SetLongArrayRegion(out, 0, 3, data);
+  return out;
+}
+
+extern "C" JNIEXPORT jlongArray JNICALL fromjava(GlucoseMeterSaveDecodedResult)(
+    JNIEnv *env, jclass cl, jint meterIndex, jlong timestampMillis,
+    jint mgdlTenths) {
+  const auto timestampSeconds = timestampMillis / 1000LL;
+  const auto now = static_cast<jlong>(time(nullptr));
+  if (timestampMillis <= 0 || timestampSeconds > static_cast<jlong>(UINT32_MAX) ||
+      timestampSeconds > now + 24LL * 60LL * 60LL ||
+      mgdlTenths < 200 || mgdlTenths > 7000) {
+    LOGAR("GlucoseMeterSaveDecodedResult invalid input");
+    return nullptr;
+  }
+  GlucoseMeter *meter = settings->data()->getGlucoseMeter(meterIndex);
+  const auto result = storeDecodedGlucoseMeter(
+      meter, meterIndex, static_cast<uint32_t>(timestampSeconds),
+      static_cast<float>(mgdlTenths) / 10.0f);
   if (!result.stored)
     return nullptr;
   const jlong data[]{static_cast<jlong>(result.timestamp) * 1000LL,

--- a/Common/src/main/java/tk/glucodata/Natives.java
+++ b/Common/src/main/java/tk/glucodata/Natives.java
@@ -1538,6 +1538,7 @@ public class Natives {
 
         /** Returns timestamp millis, mg/dL tenths, and recent-legacy flag for a newly accepted reading. */
         public static native long[] GlucoseMeterSaveResult(int meterIndex, byte[] value);
+        public static native long[] GlucoseMeterSaveDecodedResult(int meterIndex, long timestampMillis, int mgdlTenths);
 
         public static native boolean GlucoseMeterProcessContext(int meterIndex, byte[] value);
 

--- a/Common/src/main/java/tk/glucodata/glucosemeter/SatelliteMeterCredentials.kt
+++ b/Common/src/main/java/tk/glucodata/glucosemeter/SatelliteMeterCredentials.kt
@@ -1,0 +1,26 @@
+package tk.glucodata.glucosemeter
+
+import android.content.Context
+import java.util.Locale
+import tk.glucodata.Applic
+
+object SatelliteMeterCredentials {
+    private const val PREFS = "tk.glucodata_preferences"
+    private const val KEY_CODE = "satellite_meter_code"
+
+    @JvmStatic
+    fun load(): String = Applic.app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .getString(KEY_CODE, "")
+        .orEmpty()
+
+    @JvmStatic
+    fun save(code: String) {
+        Applic.app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_CODE, code.trim().uppercase(Locale.US))
+            .apply()
+    }
+
+    @JvmStatic
+    fun isValid(code: String?): Boolean = SatelliteMeterProtocol.resolvePin(code) != null
+}

--- a/Common/src/main/java/tk/glucodata/glucosemeter/SatelliteMeterProtocol.kt
+++ b/Common/src/main/java/tk/glucodata/glucosemeter/SatelliteMeterProtocol.kt
@@ -1,0 +1,178 @@
+package tk.glucodata.glucosemeter
+
+import java.nio.charset.StandardCharsets
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+import kotlin.math.roundToInt
+
+/** ELTA Satellite (Сателлит+) Nordic UART glucose-meter protocol. */
+object SatelliteMeterProtocol {
+    @JvmField
+    val SERVICE_UUID: UUID = UUID.fromString("6e400001-b5a3-f393-e0a9-e50e24dcca9e")
+    @JvmField
+    val RX_UUID: UUID = UUID.fromString("6e400002-b5a3-f393-e0a9-e50e24dcca9e")
+    @JvmField
+    val TX_UUID: UUID = UUID.fromString("6e400003-b5a3-f393-e0a9-e50e24dcca9e")
+
+    const val MAX_BACKFILL_RECORDS = 10
+    private const val EMPTY_SLOT = "rd000000000000000000"
+    private const val CAPILLARY_TO_PLASMA = 1.12
+    private const val MGDL_PER_MMOLL = 18.0182
+    private val rawPinPattern = Regex("^\\d{3}$")
+    private val printedCodePattern = Regex("^[DE]\\d{7,}$", RegexOption.IGNORE_CASE)
+    private val recordPattern = Regex("^rd(\\d{12})(\\d{3})(\\d{3})$", RegexOption.IGNORE_CASE)
+
+    data class Reading(val timestampMillis: Long, val mgdlTenths: Int)
+
+    @JvmStatic
+    fun decode(value: ByteArray?): String =
+        value?.toString(StandardCharsets.US_ASCII)?.trim().orEmpty()
+
+    @JvmStatic
+    fun resolvePin(input: String?): String? {
+        val value = input?.trim().orEmpty()
+        if (rawPinPattern.matches(value)) return value
+        if (!printedCodePattern.matches(value)) return null
+        val digits = value.substring(1).takeLast(6).toLong()
+        val scrambled = (digits * 599_681_139L + 123L) and 0xFFFF_FFFFL
+        return String.format(Locale.US, "%03d", scrambled % 1_000L)
+    }
+
+    @JvmStatic
+    fun pinCommand(pin: String): ByteArray = ascii("pin.$pin")
+
+    @JvmStatic
+    fun setTimeCommand(epochMillis: Long): ByteArray {
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.US).apply {
+            timeInMillis = epochMillis
+        }
+        return ascii(
+            String.format(
+                Locale.US,
+                "settime.%02d%02d%02d%02d%02d%02d",
+                calendar.get(Calendar.YEAR) % 100,
+                calendar.get(Calendar.MONTH) + 1,
+                calendar.get(Calendar.DAY_OF_MONTH),
+                calendar.get(Calendar.HOUR_OF_DAY),
+                calendar.get(Calendar.MINUTE),
+                calendar.get(Calendar.SECOND),
+            )
+        )
+    }
+
+    @JvmStatic
+    fun recordCommand(index: Int): ByteArray =
+        ascii(String.format(Locale.US, "rd.%03d", index.coerceIn(0, 999)))
+
+    @JvmStatic
+    fun isPinAccepted(response: String): Boolean = response.equals("pin.ok", ignoreCase = true)
+
+    @JvmStatic
+    fun isEmptySlot(response: String): Boolean = response.equals(EMPTY_SLOT, ignoreCase = true)
+
+    @JvmStatic
+    fun parseRecord(response: String): Reading? {
+        val match = recordPattern.matchEntire(response) ?: return null
+        val timestamp = parseUtcTimestamp(match.groupValues[1]) ?: return null
+        val glucoseRaw = match.groupValues[3].toIntOrNull() ?: return null
+        val mgdlTenths = (glucoseRaw * CAPILLARY_TO_PLASMA * MGDL_PER_MMOLL).roundToInt()
+        if (mgdlTenths !in 200..7_000) return null
+        return Reading(timestampMillis = timestamp, mgdlTenths = mgdlTenths)
+    }
+
+    private fun parseUtcTimestamp(token: String): Long? = runCatching {
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.US).apply {
+            isLenient = false
+            clear()
+            set(
+                2000 + token.substring(0, 2).toInt(),
+                token.substring(2, 4).toInt() - 1,
+                token.substring(4, 6).toInt(),
+                token.substring(6, 8).toInt(),
+                token.substring(8, 10).toInt(),
+                token.substring(10, 12).toInt(),
+            )
+        }
+        calendar.timeInMillis
+    }.getOrNull()
+
+    private fun ascii(value: String): ByteArray = value.toByteArray(StandardCharsets.US_ASCII)
+}
+
+data class SatelliteSessionUpdate(
+    val command: ByteArray? = null,
+    val readings: List<SatelliteMeterProtocol.Reading> = emptyList(),
+    val complete: Boolean = false,
+    val error: String? = null,
+)
+
+/** One-command-at-a-time Satellite authentication, clock sync and bounded backfill. */
+class SatelliteMeterSession(
+    private val pin: String,
+    private val nowMillis: Long,
+) {
+    private enum class Stage { READY, AWAITING_PIN, AWAITING_TIME_ACK, AWAITING_RECORD, COMPLETE }
+
+    private var stage = Stage.READY
+    private var recordIndex = 0
+    private val readings = mutableListOf<SatelliteMeterProtocol.Reading>()
+
+    @Synchronized
+    fun notificationsEnabled(): SatelliteSessionUpdate {
+        if (stage != Stage.READY) return fail("Satellite session already started")
+        stage = Stage.AWAITING_PIN
+        return SatelliteSessionUpdate(command = SatelliteMeterProtocol.pinCommand(pin))
+    }
+
+    @Synchronized
+    fun onNotification(value: ByteArray?): SatelliteSessionUpdate {
+        val response = SatelliteMeterProtocol.decode(value)
+        return when (stage) {
+            Stage.AWAITING_PIN -> {
+                if (!SatelliteMeterProtocol.isPinAccepted(response)) return fail("Satellite PIN rejected")
+                stage = Stage.AWAITING_TIME_ACK
+                SatelliteSessionUpdate(command = SatelliteMeterProtocol.setTimeCommand(nowMillis))
+            }
+            Stage.AWAITING_TIME_ACK -> {
+                stage = Stage.AWAITING_RECORD
+                recordIndex = 0
+                SatelliteSessionUpdate(command = SatelliteMeterProtocol.recordCommand(recordIndex))
+            }
+            Stage.AWAITING_RECORD -> handleRecord(response)
+            Stage.READY -> fail("Satellite notification before authentication")
+            Stage.COMPLETE -> SatelliteSessionUpdate(complete = true)
+        }
+    }
+
+    private fun handleRecord(response: String): SatelliteSessionUpdate {
+        if (SatelliteMeterProtocol.isEmptySlot(response)) return finish()
+        val reading = SatelliteMeterProtocol.parseRecord(response)
+            ?: return fail("Malformed Satellite record")
+        if (reading.timestampMillis > nowMillis + 24L * 60L * 60L * 1_000L) {
+            return fail("Satellite record timestamp is in the future")
+        }
+        readings += reading
+        recordIndex++
+        return if (recordIndex >= SatelliteMeterProtocol.MAX_BACKFILL_RECORDS) {
+            finish()
+        } else {
+            SatelliteSessionUpdate(command = SatelliteMeterProtocol.recordCommand(recordIndex))
+        }
+    }
+
+    private fun finish(): SatelliteSessionUpdate {
+        stage = Stage.COMPLETE
+        return SatelliteSessionUpdate(readings = readings.sortedBy { it.timestampMillis }, complete = true)
+    }
+
+    private fun fail(message: String): SatelliteSessionUpdate {
+        stage = Stage.COMPLETE
+        return SatelliteSessionUpdate(
+            readings = readings.sortedBy { it.timestampMillis },
+            complete = true,
+            error = message,
+        )
+    }
+}

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -805,6 +805,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="meterlist">"Glucose Meters"</string>
     <string name="glucose_meters_desc">Падключэнне Bluetooth-глюкометраў</string>
     <string name="glucose_meters_journal_desc">Вынікі захоўваюцца як запісы глюкозы крыві ў дзённіку і могуць адпраўляцца ў Nightscout.</string>
+    <string name="satellite_meter_title">Глюкометр «Сателлит+»</string>
+    <string name="satellite_meter_code_label">PIN або код з этыкеткі</string>
+    <string name="satellite_meter_code_desc">Увядзіце 3-значны PIN або даўжэйшы код, надрукаваны пад QR/DataMatrix на глюкометры. Ён выкарыстоўваецца пры кожным Bluetooth-падключэнні.</string>
     <string name="glucose_meters_configured">Наладжаныя глюкометры</string>
     <string name="glucose_meters_none">Глюкометры не наладжаны</string>
     <string name="glucose_meters_none_desc">Знайдзіце глюкометр паблізу, каб пачаць імпарт вынікаў.</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -404,6 +404,9 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
 <string name="meterlist">"Blutzuckermessgeräte"</string>
 <string name="glucose_meters_desc">Bluetooth-Blutzuckermessgeräte verbinden</string>
 <string name="glucose_meters_journal_desc">Messwerte werden als Blutzuckereinträge im Tagebuch gespeichert und können an Nightscout gesendet werden.</string>
+<string name="satellite_meter_title">Satellite-Messgerät (Сателлит+)</string>
+<string name="satellite_meter_code_label">PIN oder Etikettencode</string>
+<string name="satellite_meter_code_desc">Gib die dreistellige PIN oder den längeren Code unter dem QR-/DataMatrix-Etikett am Messgerät ein. Er wird bei jeder Bluetooth-Verbindung verwendet.</string>
 <string name="glucose_meters_configured">Eingerichtete Messgeräte</string>
 <string name="glucose_meters_none">Keine Messgeräte eingerichtet</string>
 <string name="glucose_meters_none_desc">Ein Messgerät in der Nähe suchen, um Messwerte zu importieren.</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -780,6 +780,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="meterlist">"Glucose Meters"</string>
     <string name="glucose_meters_desc">Connecter des lecteurs de glycémie Bluetooth</string>
     <string name="glucose_meters_journal_desc">Les mesures sont enregistrées comme glycémies dans le journal et peuvent être envoyées à Nightscout.</string>
+    <string name="satellite_meter_title">Lecteur Satellite (Сателлит+)</string>
+    <string name="satellite_meter_code_label">PIN ou code de l’étiquette</string>
+    <string name="satellite_meter_code_desc">Saisissez le PIN à 3 chiffres ou le code plus long imprimé sous l’étiquette QR/DataMatrix du lecteur. Il est utilisé à chaque connexion Bluetooth.</string>
     <string name="glucose_meters_configured">Lecteurs configurés</string>
     <string name="glucose_meters_none">Aucun lecteur configuré</string>
     <string name="glucose_meters_none_desc">Recherchez un lecteur à proximité pour importer des mesures.</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -730,6 +730,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="meterlist">"Glucose Meters"</string>
     <string name="glucose_meters_desc">Collega glucometri Bluetooth</string>
     <string name="glucose_meters_journal_desc">Le misurazioni vengono salvate come glicemie nel diario e possono essere inviate a Nightscout.</string>
+    <string name="satellite_meter_title">Glucometro Satellite (Сателлит+)</string>
+    <string name="satellite_meter_code_label">PIN o codice etichetta</string>
+    <string name="satellite_meter_code_desc">Inserisci il PIN di 3 cifre o il codice più lungo stampato sotto l’etichetta QR/DataMatrix del glucometro. Viene usato a ogni connessione Bluetooth.</string>
     <string name="glucose_meters_configured">Glucometri configurati</string>
     <string name="glucose_meters_none">Nessun glucometro configurato</string>
     <string name="glucose_meters_none_desc">Trova un glucometro nelle vicinanze per iniziare a importare le misurazioni.</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -427,6 +427,9 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="meterlist">"Глюкоз хэмжигч төхөөрөмжүүд"</string>
     <string name="glucose_meters_desc">Bluetooth глюкоз хэмжигч холбоно уу</string>
     <string name="glucose_meters_journal_desc">Хэмжилтүүд өдрийн тэмдэглэлд цусан дахь глюкозын бичлэгээр хадгалагдаж, Nightscout руу илгээгдэх боломжтой.</string>
+    <string name="satellite_meter_title">Satellite (Сателлит+) глюкоз хэмжигч</string>
+    <string name="satellite_meter_code_label">PIN эсвэл шошгоны код</string>
+    <string name="satellite_meter_code_desc">3 оронтой PIN эсвэл хэмжигчийн QR/DataMatrix шошгоны доор хэвлэсэн урт кодыг оруулна уу. Энэ кодыг Bluetooth холболт бүрд ашиглана.</string>
     <string name="glucose_meters_configured">Тохируулсан хэмжигчүүд</string>
     <string name="glucose_meters_none">Хэмжигч тохируулаагүй</string>
     <string name="glucose_meters_none_desc">Хэмжилт импортлохын тулд ойролцоох хэмжигчийг олно уу.</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -397,6 +397,9 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
 <string name="meterlist">"Glucosemeters"</string>
 <string name="glucose_meters_desc">Bluetooth-glucosemeters verbinden</string>
 <string name="glucose_meters_journal_desc">Metingen worden als bloedglucose in het dagboek opgeslagen en kunnen naar Nightscout worden verzonden.</string>
+<string name="satellite_meter_title">Satellite-meter (Сателлит+)</string>
+<string name="satellite_meter_code_label">Pincode of labelcode</string>
+<string name="satellite_meter_code_desc">Voer de 3-cijferige pincode in of de langere code onder het QR-/DataMatrix-label op de meter. Deze wordt bij elke Bluetooth-verbinding gebruikt.</string>
 <string name="glucose_meters_configured">Ingestelde meters</string>
 <string name="glucose_meters_none">Geen meters ingesteld</string>
 <string name="glucose_meters_none_desc">Zoek een meter in de buurt om metingen te importeren.</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -863,6 +863,9 @@
     <string name="meterlist">"Glukometry"</string>
     <string name="glucose_meters_desc">Połącz glukometry Bluetooth</string>
     <string name="glucose_meters_journal_desc">Pomiary są zapisywane jako wpisy glikemii w dzienniku i mogą być wysyłane do Nightscout.</string>
+    <string name="satellite_meter_title">Glukometr Satellite (Сателлит+)</string>
+    <string name="satellite_meter_code_label">PIN lub kod z etykiety</string>
+    <string name="satellite_meter_code_desc">Wpisz 3-cyfrowy PIN lub dłuższy kod wydrukowany pod etykietą QR/DataMatrix na glukometrze. Jest używany przy każdym połączeniu Bluetooth.</string>
     <string name="glucose_meters_configured">Skonfigurowane glukometry</string>
     <string name="glucose_meters_none">Brak skonfigurowanych glukometrów</string>
     <string name="glucose_meters_none_desc">Znajdź pobliski glukometr, aby rozpocząć import pomiarów.</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -750,6 +750,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="meterlist">"Glucose Meters"</string>
     <string name="glucose_meters_desc">Ligar medidores de glicose Bluetooth</string>
     <string name="glucose_meters_journal_desc">As medições são guardadas como glicemia no diário e podem ser enviadas para o Nightscout.</string>
+    <string name="satellite_meter_title">Medidor Satellite (Сателлит+)</string>
+    <string name="satellite_meter_code_label">PIN ou código da etiqueta</string>
+    <string name="satellite_meter_code_desc">Introduza o PIN de 3 dígitos ou o código mais longo impresso sob a etiqueta QR/DataMatrix do medidor. É usado em cada ligação Bluetooth.</string>
     <string name="glucose_meters_configured">Medidores configurados</string>
     <string name="glucose_meters_none">Nenhum medidor configurado</string>
     <string name="glucose_meters_none_desc">Procure um medidor próximo para começar a importar medições.</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -868,6 +868,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="meterlist">"Глюкометры"</string>
     <string name="glucose_meters_desc">Подключение Bluetooth-глюкометров</string>
     <string name="glucose_meters_journal_desc">Измерения сохраняются в журнале как значения глюкозы крови и могут отправляться в Nightscout.</string>
+    <string name="satellite_meter_title">Глюкометр «Сателлит+»</string>
+    <string name="satellite_meter_code_label">PIN или код с этикетки</string>
+    <string name="satellite_meter_code_desc">Введите 3-значный PIN или более длинный код, напечатанный под QR/DataMatrix на глюкометре. Он используется при каждом Bluetooth-подключении.</string>
     <string name="glucose_meters_configured">Настроенные глюкометры</string>
     <string name="glucose_meters_none">Нет настроенных глюкометров</string>
     <string name="glucose_meters_none_desc">Найдите глюкометр поблизости, чтобы импортировать измерения.</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -449,6 +449,9 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
  <string name="meterlist">"Glucose mitir"</string>
  <string name="glucose_meters_desc">Ku xir mitirrada gulukoosta Bluetooth</string>
  <string name="glucose_meters_journal_desc">Cabbirrada waxaa loogu kaydiyaa gulukoosta dhiigga ee diiwaanka waxaana loo diri karaa Nightscout.</string>
+ <string name="satellite_meter_title">Mitirka Satellite (Сателлит+)</string>
+ <string name="satellite_meter_code_label">PIN ama koodhka summadda</string>
+ <string name="satellite_meter_code_desc">Geli PIN-ka 3 lambar ah ama koodhka dheer ee ku qoran hoosta summadda QR/DataMatrix ee mitirka. Waxa la isticmaalaa xiriir kasta oo Bluetooth ah.</string>
  <string name="glucose_meters_configured">Mitirrada la habeeyey</string>
  <string name="glucose_meters_none">Mitir lama habayn</string>
  <string name="glucose_meters_none_desc">Raadi mitir kuu dhow si aad u soo dejiso cabbirrada.</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -810,6 +810,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="meterlist">"Glucose Meters"</string>
     <string name="glucose_meters_desc">Anslut Bluetooth-blodsockermätare</string>
     <string name="glucose_meters_journal_desc">Mätvärden sparas som blodsockerposter i journalen och kan skickas till Nightscout.</string>
+    <string name="satellite_meter_title">Satellite-mätare (Сателлит+)</string>
+    <string name="satellite_meter_code_label">PIN eller etikettkod</string>
+    <string name="satellite_meter_code_desc">Ange den tresiffriga PIN-koden eller den längre koden under QR-/DataMatrix-etiketten på mätaren. Den används vid varje Bluetooth-anslutning.</string>
     <string name="glucose_meters_configured">Konfigurerade mätare</string>
     <string name="glucose_meters_none">Inga mätare konfigurerade</string>
     <string name="glucose_meters_none_desc">Hitta en mätare i närheten för att börja importera mätvärden.</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -845,6 +845,9 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="meterlist">"Glucose Meters"</string>
     <string name="glucose_meters_desc">Bluetooth glikoz ölçerleri bağlayın</string>
     <string name="glucose_meters_journal_desc">Ölçümler günlükte kan şekeri kaydı olarak saklanır ve Nightscout\'a gönderilebilir.</string>
+    <string name="satellite_meter_title">Satellite (Сателлит+) ölçüm cihazı</string>
+    <string name="satellite_meter_code_label">PIN veya etiket kodu</string>
+    <string name="satellite_meter_code_desc">3 haneli PIN’i veya cihazdaki QR/DataMatrix etiketinin altında yazan uzun kodu girin. Her Bluetooth bağlantısında kullanılır.</string>
     <string name="glucose_meters_configured">Yapılandırılmış ölçerler</string>
     <string name="glucose_meters_none">Yapılandırılmış ölçer yok</string>
     <string name="glucose_meters_none_desc">Ölçümleri içe aktarmak için yakındaki bir ölçeri bulun.</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -822,6 +822,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="meterlist">Глюкометри</string>
     <string name="glucose_meters_desc">Підключення Bluetooth-глюкометрів</string>
     <string name="glucose_meters_journal_desc">Вимірювання зберігаються в журналі як значення глюкози крові та можуть надсилатися до Nightscout.</string>
+    <string name="satellite_meter_title">Глюкометр «Сателлит+»</string>
+    <string name="satellite_meter_code_label">PIN або код з етикетки</string>
+    <string name="satellite_meter_code_desc">Введіть 3-значний PIN або довший код, надрукований під QR/DataMatrix на глюкометрі. Він використовується під час кожного Bluetooth-підключення.</string>
     <string name="glucose_meters_configured">Налаштовані глюкометри</string>
     <string name="glucose_meters_none">Немає налаштованих глюкометрів</string>
     <string name="glucose_meters_none_desc">Знайдіть глюкометр поблизу, щоб імпортувати вимірювання.</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -822,6 +822,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="meterlist">"Glucose Meters"</string>
     <string name="glucose_meters_desc">连接蓝牙血糖仪</string>
     <string name="glucose_meters_journal_desc">读数会作为血糖记录保存到日志中，并可发送到 Nightscout。</string>
+    <string name="satellite_meter_title">Satellite（Сателлит+）血糖仪</string>
+    <string name="satellite_meter_code_label">PIN 或标签代码</string>
+    <string name="satellite_meter_code_desc">输入 3 位 PIN，或血糖仪 QR/DataMatrix 标签下方印刷的较长代码。每次蓝牙连接时都会使用该代码。</string>
     <string name="glucose_meters_configured">已配置的血糖仪</string>
     <string name="glucose_meters_none">尚未配置血糖仪</string>
     <string name="glucose_meters_none_desc">查找附近的血糖仪以开始导入读数。</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -452,6 +452,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
  <string name="meterlist">"Glucose Meters"</string>
  <string name="glucose_meters_desc">Connect Bluetooth glucose meters</string>
  <string name="glucose_meters_journal_desc">Readings are saved as blood glucose entries in the Journal and can be sent to Nightscout.</string>
+ <string name="satellite_meter_title">Satellite (Сателлит+) meter</string>
+ <string name="satellite_meter_code_label">PIN or label code</string>
+ <string name="satellite_meter_code_desc">Enter the 3-digit PIN or the longer code printed below the QR/DataMatrix label on the meter. It is used for each Bluetooth connection.</string>
  <string name="glucose_meters_configured">Configured meters</string>
  <string name="glucose_meters_none">No meters configured</string>
  <string name="glucose_meters_none_desc">Find a nearby meter to start importing readings.</string>

--- a/Common/src/mobile/java/tk/glucodata/BluetoothGlucoseMeter.java
+++ b/Common/src/mobile/java/tk/glucodata/BluetoothGlucoseMeter.java
@@ -107,6 +107,11 @@ private static void removeReceivers() {
     }
 
 static  GlucoseMeterGatt[] meterGatts;
+public static void retrySatelliteSessions() {
+    final var gatts=meterGatts;
+    if(gatts==null) return;
+    for(final var gatt:gatts) gatt.retrySatelliteSession();
+}
 public static void getDevices() {
     final int[] devices=Natives.getActiveGlucoseMeters( );
     final int len=devices.length;

--- a/Common/src/mobile/java/tk/glucodata/GlucoseMeterGatt.java
+++ b/Common/src/mobile/java/tk/glucodata/GlucoseMeterGatt.java
@@ -52,7 +52,13 @@ import android.os.Build;
 
 import androidx.annotation.NonNull;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import tk.glucodata.glucosemeter.SatelliteMeterCredentials;
+import tk.glucodata.glucosemeter.SatelliteMeterProtocol;
+import tk.glucodata.glucosemeter.SatelliteMeterSession;
+import tk.glucodata.glucosemeter.SatelliteSessionUpdate;
 
 public  class GlucoseMeterGatt  extends BluetoothGattCallback {
     MeterList.MeterView view=null;
@@ -98,6 +104,8 @@ long foundtime=0L;
  private static final String RecordsCharUUID = "00002a52-0000-1000-8000-00805f9b34fb";
  private static final String DateTimeCharUUID = "00002a08-0000-1000-8000-00805f9b34fb";
  private static final String IsensTimeCharUUID ="0000fff1-0000-1000-8000-00805f9b34fb";
+ private static final String SatelliteRxCharUUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e";
+ private static final String SatelliteTxCharUUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e";
 
 
 
@@ -108,6 +116,10 @@ private  BluetoothGattCharacteristic GlucoseChar;
 private  BluetoothGattCharacteristic ContextChar;
 private  BluetoothGattCharacteristic RecordsChar;
 private  BluetoothGattCharacteristic ManufacturerNameChar;
+private BluetoothGattCharacteristic SatelliteRxChar;
+private BluetoothGattCharacteristic SatelliteTxChar;
+private SatelliteMeterSession satelliteSession;
+private boolean satelliteMode=false;
 
 
 
@@ -115,8 +127,13 @@ private boolean discovered=false;
 private boolean discover(BluetoothGatt bluetoothGatt) {
     var services=bluetoothGatt.getServices();
     boolean success=false;
+    satelliteMode=false;
+    SatelliteRxChar=null;
+    SatelliteTxChar=null;
+    satelliteSession=null;
     for(var ser:services) {
         if(doLog) Log.i(LOG_ID,"service: "+ser.getUuid().toString());
+        final boolean satelliteService=ser.getUuid().equals(SatelliteMeterProtocol.SERVICE_UUID);
         var chars=ser.getCharacteristics();
         for(var s:chars) {
             var uuid=s.getUuid().toString();
@@ -129,10 +146,18 @@ private boolean discover(BluetoothGatt bluetoothGatt) {
                 case GlucoseCharUUID: GlucoseChar=s;success=true;break;
                 case ContextCharUUID: ContextChar=s;break;
                 case RecordsCharUUID: RecordsChar=s;break;
+                case SatelliteRxCharUUID: if(satelliteService) SatelliteRxChar=s;break;
+                case SatelliteTxCharUUID: if(satelliteService) SatelliteTxChar=s;break;
                 }
             }
         }
-    if(success)  {
+    if(SatelliteRxChar!=null && SatelliteTxChar!=null) {
+        satelliteMode=true;
+        success=true;
+        if(doLog) Log.i(LOG_ID,"Satellite Nordic UART service discovered");
+        beginSatelliteSession(bluetoothGatt);
+    }
+    else if(success)  {
         if(doLog) Log.i(LOG_ID,"discover succesfull");
         tryer( ()->
             {
@@ -147,6 +172,18 @@ private boolean discover(BluetoothGatt bluetoothGatt) {
     return success;
     }
 
+private void beginSatelliteSession(BluetoothGatt gatt) {
+    final String pin=SatelliteMeterProtocol.resolvePin(SatelliteMeterCredentials.load());
+    if(pin==null) {
+        Log.e(LOG_ID,"Satellite meter code is missing or invalid");
+        return;
+    }
+    satelliteSession=new SatelliteMeterSession(pin,System.currentTimeMillis());
+    if(!enableNotification(gatt,SatelliteTxChar)) {
+        Log.e(LOG_ID,"Could not enable Satellite notifications");
+    }
+}
+
 long receivedTime=0L;
 boolean newvalues=false;
     @Override
@@ -156,6 +193,9 @@ boolean newvalues=false;
         if(doLog)
             Log.showbytes("Meter: onCharacteristicChanged "+uuid,value);
         switch(uuid) {
+            case SatelliteTxCharUUID:
+                processSatelliteResponse(gatt,value);
+                break;
             case GlucoseCharUUID:
                 final long[] saved = Natives.GlucoseMeterSaveResult(meterIndex,value);
                 if(saved != null && saved.length >= 2) {
@@ -181,6 +221,44 @@ boolean newvalues=false;
             }
 
     }
+
+private synchronized void processSatelliteResponse(BluetoothGatt gatt, byte[] value) {
+    final SatelliteMeterSession session=satelliteSession;
+    if(session==null) {
+        Log.e(LOG_ID,"Ignoring Satellite response without an active session");
+        return;
+    }
+    final SatelliteSessionUpdate update=session.onNotification(value);
+    if(update.getError()!=null) {
+        Log.e(LOG_ID,update.getError());
+    }
+    if(update.getComplete()) {
+        persistSatelliteReadings(update.getReadings());
+        satelliteSession=null;
+        return;
+    }
+    final byte[] command=update.getCommand();
+    if(command!=null) {
+        tryer(()->writeSatellite(gatt,command));
+    }
+}
+
+private void persistSatelliteReadings(List<SatelliteMeterProtocol.Reading> readings) {
+    boolean stored=false;
+    for(final SatelliteMeterProtocol.Reading reading:readings) {
+        final long[] saved=Natives.GlucoseMeterSaveDecodedResult(
+            meterIndex,reading.getTimestampMillis(),reading.getMgdlTenths());
+        if(saved==null || saved.length<2) continue;
+        stored=true;
+        GlucoseMeterJournalBridge.record(meterIndex,saved[0],saved[1]);
+        if(saved.length>=3 && saved[2]!=0L) newvalues=true;
+    }
+    if(stored) {
+        receivedTime=System.currentTimeMillis();
+        updateview();
+        Applic.app.redraw();
+    }
+}
 
 
 private boolean firstRecordonly=false;
@@ -320,6 +398,7 @@ boolean connected=false;
            disconnectedTime=tim;
            updateview();
            connected=false;
+           satelliteSession=null;
             if(bondstate == BluetoothDevice.BOND_BONDING) {
                    {if(doLog) {Log.i(LOG_ID, "BOND_BONDING");};};
                    }
@@ -368,6 +447,17 @@ static private          byte[] VerioGetTcounterCMD={0x20, 0x02};
         {if(doLog){Log.showbytes(LOG_ID + " writeCharacteristic: "+cha.getUuid().toString(), data);};}
         return true;
     }
+
+private boolean writeSatellite(BluetoothGatt gatt,byte[] command) {
+    final BluetoothGattCharacteristic characteristic=SatelliteRxChar;
+    if(characteristic==null || !characteristic.setValue(command)) {
+        Log.e(LOG_ID,"Could not prepare Satellite command");
+        return false;
+    }
+    final boolean written=gatt.writeCharacteristic(characteristic);
+    if(doLog) Log.i(LOG_ID,written ? "Satellite command written" : "Satellite command write failed");
+    return written;
+}
 //s/\<\([a-zA-Z0-9]*\).writeCharacteristic(\([^,]*\),\([^)]*\))/writer(\1,\2,\3)
 
 private void setCareSenseTime(BluetoothGatt bluetoothGatt) {
@@ -383,6 +473,18 @@ private void setCareSenseTime(BluetoothGatt bluetoothGatt) {
             {if(doLog){showbytes("GlucoseMeter: onDescriptorWrite char: " + uuid + " desc: " + bluetoothGattDescriptor.getUuid().toString() + " status=" + status, value);};}
             }
         switch(uuid) {
+           case SatelliteTxCharUUID:
+                if(status!=GATT_SUCCESS) {
+                    Log.e(LOG_ID,"Satellite notification descriptor failed: "+status);
+                    satelliteSession=null;
+                    break;
+                }
+                final SatelliteMeterSession session=satelliteSession;
+                if(session!=null) {
+                    final byte[] command=session.notificationsEnabled().getCommand();
+                    if(command!=null) tryer(()->writeSatellite(bluetoothGatt,command));
+                }
+                break;
            case GlucoseCharUUID:
                 tryer(()->enableIndication(bluetoothGatt, RecordsChar));
                 break;
@@ -547,6 +649,13 @@ public void disconnect() {
         {if(doLog) {Log.i(LOG_ID,"Disconnect mBluetoothGatt==null");};};
       }
     }
+
+void retrySatelliteSession() {
+    if(satelliteMode) {
+        satelliteSession=null;
+        disconnect();
+    }
+}
  public boolean connectActiveDevice(long delayMillis) {
     if(doLog) {Log.i(LOG_ID,"connectDevice("+delayMillis+") "+ meterIndex);};
     Runnable connect=getConnectDevice();

--- a/Common/src/mobile/java/tk/glucodata/GlucoseMeterManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/GlucoseMeterManager.kt
@@ -11,6 +11,7 @@ import tk.glucodata.data.journal.JournalEntryInput
 import tk.glucodata.data.journal.JournalEntrySource
 import tk.glucodata.data.journal.JournalEntryType
 import tk.glucodata.data.journal.JournalRepository
+import tk.glucodata.glucosemeter.SatelliteMeterCredentials
 
 data class GlucoseMeterSnapshot(
     val index: Int,
@@ -23,6 +24,17 @@ data class GlucoseMeterSnapshot(
 
 /** Compose-facing facade over the legacy, protocol-capable glucose meter runtime. */
 object GlucoseMeterManager {
+    fun satelliteCode(): String = SatelliteMeterCredentials.load()
+
+    fun isSatelliteCodeValid(code: String): Boolean = SatelliteMeterCredentials.isValid(code)
+
+    fun updateSatelliteCode(code: String) {
+        SatelliteMeterCredentials.save(code)
+        if (SatelliteMeterCredentials.isValid(code)) {
+            BluetoothGlucoseMeter.retrySatelliteSessions()
+        }
+    }
+
     fun configuredMeters(): List<GlucoseMeterSnapshot> =
         (0 until Natives.GlucoseMeterCount()).mapNotNull(::snapshot)
 

--- a/Common/src/mobile/java/tk/glucodata/ui/GlucoseMeterSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/GlucoseMeterSettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -67,6 +68,7 @@ import tk.glucodata.ui.util.BleDeviceScanner
 import tk.glucodata.ui.util.rememberBleScanner
 import java.text.DateFormat
 import java.util.Date
+import java.util.Locale
 import java.util.UUID
 
 private data class NearbyGlucoseMeter(
@@ -78,6 +80,7 @@ private data class NearbyGlucoseMeter(
 private val glucoseMeterServiceUuids = listOf(
     UUID.fromString("00001808-0000-1000-8000-00805f9b34fb"),
     UUID.fromString("af9df7a1-e595-11e3-96b4-0002a5d5c51b"),
+    UUID.fromString("6e400001-b5a3-f393-e0a9-e50e24dcca9e"),
 )
 
 @SuppressLint("MissingPermission")
@@ -89,6 +92,7 @@ fun GlucoseMeterSettingsScreen(navController: NavController) {
     var nearby by remember { mutableStateOf<List<NearbyGlucoseMeter>>(emptyList()) }
     var scanning by remember { mutableStateOf(false) }
     var scanRequest by remember { mutableIntStateOf(0) }
+    var satelliteCode by remember { mutableStateOf(GlucoseMeterManager.satelliteCode()) }
 
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
@@ -200,6 +204,47 @@ fun GlucoseMeterSettingsScreen(navController: NavController) {
                 }
             }
 
+            item("satellite_label") {
+                SectionLabel(stringResource(R.string.satellite_meter_title))
+            }
+            item("satellite_settings") {
+                Surface(
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    shape = RoundedCornerShape(20.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(18.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        Text(
+                            stringResource(R.string.satellite_meter_code_desc),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        OutlinedTextField(
+                            value = satelliteCode,
+                            onValueChange = { value ->
+                                satelliteCode = value.filter(Char::isLetterOrDigit)
+                                    .take(32)
+                                    .uppercase(Locale.US)
+                            },
+                            label = { Text(stringResource(R.string.satellite_meter_code_label)) },
+                            singleLine = true,
+                            isError = satelliteCode.isNotEmpty() &&
+                                !GlucoseMeterManager.isSatelliteCodeValid(satelliteCode),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Button(
+                            onClick = { GlucoseMeterManager.updateSatelliteCode(satelliteCode) },
+                            enabled = GlucoseMeterManager.isSatelliteCodeValid(satelliteCode),
+                            modifier = Modifier.align(Alignment.End),
+                        ) {
+                            Text(stringResource(R.string.save))
+                        }
+                    }
+                }
+            }
             item("configured_label") {
                 SectionLabel(stringResource(R.string.glucose_meters_configured))
             }

--- a/Common/src/test/java/tk/glucodata/glucosemeter/SatelliteMeterProtocolTests.kt
+++ b/Common/src/test/java/tk/glucodata/glucosemeter/SatelliteMeterProtocolTests.kt
@@ -1,0 +1,107 @@
+package tk.glucodata.glucosemeter
+
+import java.nio.charset.StandardCharsets
+import java.util.Calendar
+import java.util.TimeZone
+import java.util.Locale
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SatelliteMeterProtocolTests {
+    @Test
+    fun resolvesBarePinAndOfficialPrintedCodeDerivation() {
+        assertEquals("007", SatelliteMeterProtocol.resolvePin(" 007 "))
+        assertEquals("122", SatelliteMeterProtocol.resolvePin("D2502005885"))
+        assertEquals("122", SatelliteMeterProtocol.resolvePin("e2502005885"))
+        assertNull(SatelliteMeterProtocol.resolvePin("1234"))
+        assertNull(SatelliteMeterProtocol.resolvePin("A2502005885"))
+    }
+
+    @Test
+    fun buildsCommandsWithUtcMeterClock() {
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+            clear()
+            set(2026, Calendar.JULY, 15, 12, 34, 56)
+        }
+        assertArrayEquals(bytes("pin.007"), SatelliteMeterProtocol.pinCommand("007"))
+        assertArrayEquals(bytes("settime.260715123456"), SatelliteMeterProtocol.setTimeCommand(calendar.timeInMillis))
+        assertArrayEquals(bytes("rd.009"), SatelliteMeterProtocol.recordCommand(9))
+    }
+
+    @Test
+    fun parsesStrictUtcRecordAndConvertsCapillaryToPlasmaMgdl() {
+        val reading = SatelliteMeterProtocol.parseRecord("rd260715123456000055")!!
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+            clear()
+            set(2026, Calendar.JULY, 15, 12, 34, 56)
+        }
+        assertEquals(calendar.timeInMillis, reading.timestampMillis)
+        assertEquals(1_110, reading.mgdlTenths)
+        assertNull(SatelliteMeterProtocol.parseRecord("rd260231123456000055"))
+        assertNull(SatelliteMeterProtocol.parseRecord("rd260715123456000001"))
+        assertNull(SatelliteMeterProtocol.parseRecord("not-a-record"))
+    }
+
+    @Test
+    fun sessionAuthenticatesThenReturnsOldestFirstBoundedHistory() {
+        val session = SatelliteMeterSession("007", 1_800_000_000_000L)
+        assertEquals("pin.007", text(session.notificationsEnabled().command))
+        assertTrue(session.onNotification(bytes("pin.ok")).command?.let(::text)?.startsWith("settime.") == true)
+        assertEquals("rd.000", text(session.onNotification(bytes("settime.ok")).command))
+        assertEquals("rd.001", text(session.onNotification(bytes("rd260715123456000055")).command))
+        assertEquals("rd.002", text(session.onNotification(bytes("rd260714123456000060")).command))
+
+        val done = session.onNotification(bytes("rd000000000000000000"))
+        assertTrue(done.complete)
+        assertNull(done.error)
+        assertEquals(2, done.readings.size)
+        assertTrue(done.readings[0].timestampMillis < done.readings[1].timestampMillis)
+    }
+
+    @Test
+    fun sessionFailsClosedOnRejectedPinOrMalformedRecord() {
+        val rejected = SatelliteMeterSession("007", 1L).apply { notificationsEnabled() }
+            .onNotification(bytes("pin.bad"))
+        assertTrue(rejected.complete)
+        assertEquals("Satellite PIN rejected", rejected.error)
+
+        val malformed = SatelliteMeterSession("007", 1L)
+        malformed.notificationsEnabled()
+        malformed.onNotification(bytes("pin.ok"))
+        malformed.onNotification(bytes("time.ok"))
+        val failed = malformed.onNotification(bytes("rd-bad"))
+        assertTrue(failed.complete)
+        assertFalse(failed.error.isNullOrBlank())
+    }
+
+    @Test
+    fun sessionStopsAtTenRecordsAndRejectsFutureClockPoisoning() {
+        val bounded = SatelliteMeterSession("007", 1_800_000_000_000L)
+        bounded.notificationsEnabled()
+        bounded.onNotification(bytes("pin.ok"))
+        bounded.onNotification(bytes("time.ok"))
+        var update: SatelliteSessionUpdate? = null
+        repeat(10) { second ->
+            update = bounded.onNotification(
+                bytes(String.format(Locale.US, "rd2607151234%02d000055", second))
+            )
+        }
+        assertTrue(update!!.complete)
+        assertEquals(10, update!!.readings.size)
+
+        val future = SatelliteMeterSession("007", 1_600_000_000_000L)
+        future.notificationsEnabled()
+        future.onNotification(bytes("pin.ok"))
+        future.onNotification(bytes("time.ok"))
+        val rejected = future.onNotification(bytes("rd260715123456000055"))
+        assertTrue(rejected.complete)
+        assertEquals("Satellite record timestamp is in the future", rejected.error)
+    }
+
+    private fun bytes(value: String) = value.toByteArray(StandardCharsets.US_ASCII)
+    private fun text(value: ByteArray?) = value?.toString(StandardCharsets.US_ASCII)
+}


### PR DESCRIPTION
## Summary

- add Satellite (Сателлит+) discovery and Nordic UART Service transport to the Bluetooth glucose-meter flow
- implement credential derivation, PIN login, UTC clock synchronization, and bounded recent-reading backfill
- validate timestamps and glucose ranges, convert meter values to mg/dL, and persist accepted readings through the existing native meter journal path
- add settings UI and localized copy in all 15 resource locales
- add focused protocol and parsing tests

## Why

Satellite meters use a vendor text protocol over Nordic UART rather than the standard Bluetooth Glucose Service, so they need an explicit, contained meter backend.

## Verification

- `:Common:testMobileDebugUnitTest` with `SatelliteMeterProtocolTests` and `MeterJournalPolicyTests`
- mobile Kotlin and Java compilation passed as part of the focused test run
- Android arm64 NDK syntax check for `Common/src/main/cpp/meter/java.cpp`
- `xmllint` across all locale string files and 15-locale key-parity checks
- `git diff --check`

## Limits

No Satellite meter was available, so discovery, authentication, history transfer, and journal persistence are not hardware-verified. A full native link was not run; the changed C++ translation unit passed the targeted Android arm64 syntax check.