### PR TITLE
Fix smoothing lag at live-series edges

### DIFF
--- a/Common/src/main/cpp/net/watchserver/uploader.cpp
+++ b/Common/src/main/cpp/net/watchserver/uploader.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <climits>
 #include <cmath>
 #include <ctime>
 #include <memory>
@@ -517,20 +518,20 @@ extern double getdelta(float change);
 extern std::string_view getdeltaname(float change);
 extern int mkv1streamid(char *outiter,const sensorname_t *name,int num);
 
-//Every other exchange output gets the data-smoothing average applied in Java, by
+//Every other exchange output gets data smoothing applied in Java, by
 //CurrentDisplaySource.resolveCurrentForExchange. The Nightscout uploader builds its
-//entries here, straight from the stored polls, so it has to run the same average
+//entries here, straight from the stored polls, so it has to run the same filter
 //itself or Nightscout stays the one destination carrying unsmoothed values.
 //Read/written by the uploader thread only, refreshed once per upload pass so a
 //120-item backfill chunk does not cross into Java per sample.
 static int uploadSmoothingSeconds=0;
 
-//Mirrors DataSmoothing.smoothNativePoints: an unweighted mean of every stored
-//sample within +/-window/2 of the sample's own timestamp. Returns 0 (meaning
-//"keep the stored value") when smoothing is off or nothing else falls in the
-//window. The newest sample therefore only averages older neighbours, exactly as
-//the live value does on the Java side. Polls are time-ordered, so an empty slot
-//or a sample past the window ends the walk.
+//Mirrors GlucoseSmoothing.smoothLane: complete windows use their centred mean;
+//when a series boundary clips the window, a degree-1 time regression is evaluated
+//at the sample timestamp and clamped to the measured range. Returns 0 (meaning
+//"keep the stored value") when smoothing is off or fewer than two valid samples
+//fall in the window. Polls are time-ordered, so an empty slot or a sample past the
+//window ends the walk.
 template <class Getvalue>
 static int smoothPollWindow(std::span<const ScanData> gdata,const int pos,Getvalue getvalue) {
     if(uploadSmoothingSeconds<=0||pos<0||pos>=(int)gdata.size())
@@ -539,27 +540,74 @@ static int smoothPollWindow(std::span<const ScanData> gdata,const int pos,Getval
     const uint32_t half=(uint32_t)uploadSmoothingSeconds/2;
     if(!tim||!half||getvalue(pos)<=0)
         return 0;
-    double sum=0.0;
+    const uint64_t minTime=tim>=half?tim-half:0;
+    const uint64_t maxTime=(uint64_t)tim+half;
+    double sumX=0.0;
+    double sumY=0.0;
+    double sumXX=0.0;
+    double sumXY=0.0;
     int count=0;
-    for(int i=pos;i>=0;--i) {
+    int measuredMin=INT_MAX;
+    int measuredMax=INT_MIN;
+    bool leftClipped=false;
+    bool rightClipped=false;
+    int i=pos;
+    for(;i>=0;--i) {
         const uint32_t eltime=gdata[i].gettime();
-        if(!eltime||eltime+half<tim)
+        if(!eltime) {
+            leftClipped=true;
+            break;
+            }
+        if(eltime<minTime)
             break;
         if(const int val=getvalue(i);val>0) {
-            sum+=val;
+            const double x=(double)((int64_t)eltime-(int64_t)tim);
+            sumX+=x;
+            sumY+=val;
+            sumXX+=x*x;
+            sumXY+=x*val;
+            measuredMin=std::min(measuredMin,val);
+            measuredMax=std::max(measuredMax,val);
             ++count;
             }
         }
-    for(int i=pos+1;i<(int)gdata.size();++i) {
+    if(i<0)
+        leftClipped=gdata.empty()||gdata.front().gettime()>minTime;
+    i=pos+1;
+    for(;i<(int)gdata.size();++i) {
         const uint32_t eltime=gdata[i].gettime();
-        if(!eltime||eltime>tim+half)
+        if(!eltime) {
+            rightClipped=true;
+            break;
+            }
+        if(eltime>maxTime)
             break;
         if(const int val=getvalue(i);val>0) {
-            sum+=val;
+            const double x=(double)((int64_t)eltime-(int64_t)tim);
+            sumX+=x;
+            sumY+=val;
+            sumXX+=x*x;
+            sumXY+=x*val;
+            measuredMin=std::min(measuredMin,val);
+            measuredMax=std::max(measuredMax,val);
             ++count;
             }
         }
-    return count>1?(int)lround(sum/count):0;
+    if(i>=(int)gdata.size())
+        rightClipped=gdata.empty()||gdata.back().gettime()<maxTime;
+    if(count<=1)
+        return 0;
+    if(!leftClipped&&!rightClipped)
+        return (int)lround(sumY/count);
+
+    const double denominator=count*sumXX-sumX*sumX;
+    if(denominator<=1e-12)
+        return (int)lround(sumY/count);
+    const double slope=(count*sumXY-sumX*sumY)/denominator;
+    const double fitted=(sumY-slope*sumX)/count;
+    if(!std::isfinite(fitted))
+        return (int)lround(sumY/count);
+    return (int)lround(std::clamp(fitted,(double)measuredMin,(double)measuredMax));
     }
 
 //Deliberately never calls ScanData::valid(): that patches a zero timestamp from the

--- a/Common/src/main/java/tk/glucodata/DataSmoothing.kt
+++ b/Common/src/main/java/tk/glucodata/DataSmoothing.kt
@@ -215,51 +215,12 @@ object DataSmoothing {
         points: List<GlucosePoint>,
         halfWindowMs: Long,
         useRawValue: Boolean
-    ): FloatArray {
-        val size = points.size
-        val prefixSums = DoubleArray(size + 1)
-        val prefixCounts = IntArray(size + 1)
-
-        for (index in 0 until size) {
-            val point = points[index]
-            val value = if (useRawValue) point.rawValue else point.value
-            val valid = value.isFinite() && value >= 0.1f
-            prefixSums[index + 1] = prefixSums[index] + if (valid) value.toDouble() else 0.0
-            prefixCounts[index + 1] = prefixCounts[index] + if (valid) 1 else 0
-        }
-
-        val result = FloatArray(size)
-        var windowStart = 0
-        var windowEndExclusive = 0
-
-        for (index in 0 until size) {
-            val point = points[index]
-            val original = if (useRawValue) point.rawValue else point.value
-            if (!original.isFinite() || original < 0.1f) {
-                result[index] = original
-                continue
-            }
-
-            val minTime = point.timestamp - halfWindowMs
-            val maxTime = point.timestamp + halfWindowMs
-
-            while (windowStart < size && points[windowStart].timestamp < minTime) {
-                windowStart++
-            }
-            while (windowEndExclusive < size && points[windowEndExclusive].timestamp <= maxTime) {
-                windowEndExclusive++
-            }
-
-            val count = prefixCounts[windowEndExclusive] - prefixCounts[windowStart]
-            result[index] = if (count > 0) {
-                ((prefixSums[windowEndExclusive] - prefixSums[windowStart]) / count).toFloat()
-            } else {
-                original
-            }
-        }
-
-        return result
-    }
+    ): FloatArray = GlucoseSmoothing.smoothLane(
+        points = points,
+        halfWindowMs = halfWindowMs,
+        timestamp = { it.timestamp },
+        selector = { if (useRawValue) it.rawValue else it.value },
+    )
 
     internal fun collapsePointsForDisplay(
         points: List<GlucosePoint>,

--- a/Common/src/main/java/tk/glucodata/GlucoseSmoothing.kt
+++ b/Common/src/main/java/tk/glucodata/GlucoseSmoothing.kt
@@ -10,7 +10,8 @@ package tk.glucodata
  * Three steps, in order, matching what [DataSmoothing]'s settings describe:
  *  1. split the series wherever the data has a real hole or changes sensor, so
  *     nothing is averaged across a gap;
- *  2. run a centred moving average over each segment, both lanes independently;
+ *  2. run a centred mean in complete windows and a local linear fit where a
+ *     segment boundary clips the window, both lanes independently;
  *  3. optionally collapse each segment into one reading per interval.
  *
  * It is generic over the point type because the phone's chart carries a richer
@@ -56,8 +57,8 @@ object GlucoseSmoothing {
             val smoothed = if (segment.size < MIN_POINTS) {
                 segment
             } else {
-                val autoLane = movingAverage(segment, halfWindowMs, timestamp, value)
-                val rawLane = movingAverage(segment, halfWindowMs, timestamp, rawValue)
+                val autoLane = smoothLane(segment, halfWindowMs, timestamp, value)
+                val rawLane = smoothLane(segment, halfWindowMs, timestamp, rawValue)
                 segment.mapIndexed { index, point ->
                     withValues(point, autoLane[index], rawLane[index])
                 }
@@ -106,10 +107,15 @@ object GlucoseSmoothing {
     }
 
     /**
-     * Centred moving average over a time window, carrying holes through
-     * untouched so a missing lane does not get invented from its neighbours.
+     * Time-window smoother shared with [DataSmoothing]. Complete interior
+     * windows keep the centred mean. At a segment boundary, where that window
+     * is necessarily one-sided, a degree-1 local regression is evaluated at
+     * the point's own timestamp so linear movement is not shifted in time.
+     *
+     * Invalid samples do not contribute and an invalid point stays invalid.
+     * Degenerate timestamps fall back to the same mean used by the old filter.
      */
-    private fun <T> movingAverage(
+    internal fun <T> smoothLane(
         points: List<T>,
         halfWindowMs: Long,
         timestamp: (T) -> Long,
@@ -142,13 +148,74 @@ object GlucoseSmoothing {
                 windowEndExclusive++
             }
             val count = prefixCounts[windowEndExclusive] - prefixCounts[windowStart]
-            result[index] = if (count > 0) {
-                ((prefixSums[windowEndExclusive] - prefixSums[windowStart]) / count).toFloat()
+            if (count <= 0) {
+                result[index] = original
+                continue
+            }
+
+            val mean = (prefixSums[windowEndExclusive] - prefixSums[windowStart]) / count
+            val clippedByBoundary = minTime < timestamp(points.first()) ||
+                maxTime > timestamp(points.last())
+            result[index] = if (clippedByBoundary) {
+                boundaryLinearEstimate(
+                    points = points,
+                    windowStart = windowStart,
+                    windowEndExclusive = windowEndExclusive,
+                    at = at,
+                    selector = selector,
+                    timestamp = timestamp,
+                    fallbackMean = mean,
+                ).toFloat()
             } else {
-                original
+                mean.toFloat()
             }
         }
         return result
+    }
+
+    private fun <T> boundaryLinearEstimate(
+        points: List<T>,
+        windowStart: Int,
+        windowEndExclusive: Int,
+        at: Long,
+        selector: (T) -> Float,
+        timestamp: (T) -> Long,
+        fallbackMean: Double,
+    ): Double {
+        var count = 0
+        var sumX = 0.0
+        var sumY = 0.0
+        var sumXX = 0.0
+        var sumXY = 0.0
+        var measuredMin = Double.POSITIVE_INFINITY
+        var measuredMax = Double.NEGATIVE_INFINITY
+
+        for (index in windowStart until windowEndExclusive) {
+            val sample = points[index]
+            val sampleValue = selector(sample)
+            if (!sampleValue.isFinite() || sampleValue < MIN_VALID_VALUE) continue
+
+            val xMinutes = (timestamp(sample) - at) / 60_000.0
+            val y = sampleValue.toDouble()
+            count++
+            sumX += xMinutes
+            sumY += y
+            sumXX += xMinutes * xMinutes
+            sumXY += xMinutes * y
+            measuredMin = minOf(measuredMin, y)
+            measuredMax = maxOf(measuredMax, y)
+        }
+
+        val denominator = count * sumXX - sumX * sumX
+        if (count < 2 || denominator <= 1e-12) return fallbackMean
+
+        val slope = (count * sumXY - sumX * sumY) / denominator
+        val fittedAtPoint = (sumY - slope * sumX) / count
+        return if (fittedAtPoint.isFinite()) {
+            fittedAtPoint.coerceIn(measuredMin, measuredMax)
+        } else {
+            fallbackMean
+        }
     }
 
     /**

--- a/Common/src/main/java/tk/glucodata/GlucoseSmoothing.kt
+++ b/Common/src/main/java/tk/glucodata/GlucoseSmoothing.kt
@@ -173,6 +173,18 @@ object GlucoseSmoothing {
         return result
     }
 
+    /**
+     * Two distinct timestamps are intentionally sufficient. A 5-minute sensor
+     * often has only two samples at the edge of a 10/13-minute window; using
+     * their mean would reintroduce the phase lag this estimator removes. With
+     * only two samples the fit leaves the endpoint unchanged, while larger
+     * boundary windows still provide denoising.
+     *
+     * Clamping is deliberately conservative: an exact linear trace evaluated
+     * at an observed timestamp already lands on that sample. A fit outside the
+     * window's measured range therefore reflects noise or curvature, and must
+     * not invent a new glucose extreme.
+     */
     private fun <T> boundaryLinearEstimate(
         points: List<T>,
         windowStart: Int,

--- a/Common/src/test/java/tk/glucodata/CurrentDisplaySourceTests.kt
+++ b/Common/src/test/java/tk/glucodata/CurrentDisplaySourceTests.kt
@@ -110,7 +110,7 @@ class CurrentDisplaySourceTests {
     }
 
     @Test
-    fun prepareRecentPointsForCurrent_smoothsLivePointBeforeTrendResolution() {
+    fun prepareRecentPointsForCurrent_preservesLinearLiveEdgeBeforeTrendResolution() {
         val minute = 60_000L
         val recentPoints = listOf(
             GlucosePoint(0L * minute, 100f, 90f),
@@ -140,7 +140,7 @@ class CurrentDisplaySourceTests {
         )
 
         assertEquals(15L * minute, processed.last().timestamp)
-        assertEquals(115f, processed.last().value, 0.001f)
+        assertEquals(130f, processed.last().value, 0.001f)
     }
 
     @Test

--- a/Common/src/test/java/tk/glucodata/DataSmoothingTests.kt
+++ b/Common/src/test/java/tk/glucodata/DataSmoothingTests.kt
@@ -6,6 +6,27 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DataSmoothingTests {
+    private val minute = 60_000L
+
+    @Test
+    fun nativePointsUseTheSharedBoundaryRegressionForBothLanes() {
+        val points = (0..12).map { index ->
+            GlucosePoint(
+                index * minute,
+                160f - 2f * index,
+                120f - index,
+            )
+        }
+
+        for (window in listOf(5, 10, 13)) {
+            val smoothed = DataSmoothing.smoothNativePoints(points, window, collapseChunks = false)
+            points.indices.forEach { index ->
+                assertEquals(points[index].value, smoothed[index].value, 1e-3f)
+                assertEquals(points[index].rawValue, smoothed[index].rawValue, 1e-3f)
+            }
+        }
+    }
+
     @Test
     fun collapsePointsForDisplaySkipsOpenBucket() {
         val points = (0..7).map { minute ->

--- a/Common/src/test/java/tk/glucodata/GlucoseSmoothingTests.kt
+++ b/Common/src/test/java/tk/glucodata/GlucoseSmoothingTests.kt
@@ -62,6 +62,67 @@ class GlucoseSmoothingTests {
     }
 
     @Test
+    fun constantAndLinearBoundariesStayOnTheTraceAtSupportedCadences() {
+        val windows = listOf(5, 10, 13)
+        val cadences = listOf(minute, 5 * minute)
+
+        for (cadence in cadences) {
+            val constant = (0..12).map { P(it * cadence, 123f, 77f) }
+            val rising = (0..12).map { index ->
+                val at = index * cadence
+                val minutes = at / minute
+                P(at, 90f + 2f * minutes, 60f + minutes)
+            }
+            for (window in windows) {
+                val constantSmoothed = smooth(constant, minutes = window)
+                constantSmoothed.forEach {
+                    assertEquals(123f, it.value, 1e-3f)
+                    assertEquals(77f, it.rawValue, 1e-3f)
+                }
+
+                val risingSmoothed = smooth(rising, minutes = window)
+                assertEquals(rising.first().value, risingSmoothed.first().value, 1e-3f)
+                assertEquals(rising.last().value, risingSmoothed.last().value, 1e-3f)
+                assertEquals(rising.first().rawValue, risingSmoothed.first().rawValue, 1e-3f)
+                assertEquals(rising.last().rawValue, risingSmoothed.last().rawValue, 1e-3f)
+            }
+        }
+    }
+
+    @Test
+    fun irregularCadenceBoundariesStayOnAnExactLine() {
+        val timestamps = listOf(0L, 70_000L, 190_000L, 310_000L, 590_000L, 760_000L)
+        val points = timestamps.map { at ->
+            val minutes = at / 60_000.0
+            P(at, (100.0 + 1.5 * minutes).toFloat(), (80.0 - 0.5 * minutes).toFloat())
+        }
+
+        for (window in listOf(5, 10, 13)) {
+            val smoothed = smooth(points, minutes = window)
+            assertEquals(points.first().value, smoothed.first().value, 1e-3f)
+            assertEquals(points.last().value, smoothed.last().value, 1e-3f)
+            assertEquals(points.first().rawValue, smoothed.first().rawValue, 1e-3f)
+            assertEquals(points.last().rawValue, smoothed.last().rawValue, 1e-3f)
+        }
+    }
+
+    @Test
+    fun noisyEndpointIsReducedAndBoundaryFitCannotExceedMeasuredRange() {
+        val spike = smooth(series(100f, 100f, 100f, 100f, 200f), minutes = 5).last().value
+        assertTrue("endpoint spike $spike should be reduced", spike >= 100f && spike < 200f)
+
+        val wouldOvershoot = smooth(series(100f, 200f, 200f), minutes = 5).last().value
+        assertEquals(200f, wouldOvershoot, 1e-3f)
+    }
+
+    @Test
+    fun duplicateTimestampsUseTheMeanFallback() {
+        val points = listOf(P(0L, 100f), P(0L, 110f), P(0L, 120f))
+        val smoothed = smooth(points, minutes = 5)
+        smoothed.forEach { assertEquals(110f, it.value, 1e-3f) }
+    }
+
+    @Test
     fun bothLanesSmoothIndependently() {
         val points = listOf(
             P(0, 100f, 50f),

--- a/Common/src/test/java/tk/glucodata/SmoothingConsumerRegressionTests.kt
+++ b/Common/src/test/java/tk/glucodata/SmoothingConsumerRegressionTests.kt
@@ -1,0 +1,65 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import tk.glucodata.alerts.DeltaAlarmState
+import tk.glucodata.logic.TrendEngine
+
+class SmoothingConsumerRegressionTests {
+    private val minute = 60_000L
+
+    @Test
+    fun exactFallKeepsTrendDeltaAndFallingFastCheckpoint() {
+        val raw = (0..20).map { index ->
+            GlucosePoint(index * minute, 150f - 2f * index, 0f)
+        }
+        val smoothed = DataSmoothing.smoothNativePoints(
+            points = raw,
+            smoothingMinutes = 13,
+            collapseChunks = false,
+        )
+
+        val rawTrend = TrendEngine.calculateTrend(raw, useRaw = false, isMmol = false)
+        val smoothedTrend = TrendEngine.calculateTrend(smoothed, useRaw = false, isMmol = false)
+        assertEquals(rawTrend.velocity, smoothedTrend.velocity, 1e-4f)
+
+        fun fiveMinuteDelta(points: List<GlucosePoint>): Float {
+            val newest = points.last()
+            val previous = points[points.lastIndex - 5]
+            return GlucoseDelta.fiveMinuteDelta(
+                newest.timestamp,
+                newest.value,
+                previous.timestamp,
+                previous.value,
+            )
+        }
+        assertEquals(fiveMinuteDelta(raw), fiveMinuteDelta(smoothed), 1e-4f)
+
+        fun fallingFastCheckpoint(points: List<GlucosePoint>): Long {
+            val state = DeltaAlarmState(falling = true)
+            var firedAt = -1L
+            for (point in points) {
+                if (state.shouldTrigger(
+                        enabled = true,
+                        activeNow = true,
+                        snoozed = false,
+                        value = point.value,
+                        readingTimeMs = point.timestamp,
+                        deltaThreshold = 10f,
+                        deltaCount = 3,
+                        deltaBorder = 120f,
+                        intervalMinutes = 5,
+                        earlyTriggerEnabled = false,
+                    )
+                ) {
+                    firedAt = point.timestamp
+                    break
+                }
+            }
+            return firedAt
+        }
+
+        assertEquals(15 * minute, fallingFastCheckpoint(raw))
+        assertEquals(fallingFastCheckpoint(raw), fallingFastCheckpoint(smoothed))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/SmoothingConsumerRegressionTests.kt
+++ b/Common/src/test/java/tk/glucodata/SmoothingConsumerRegressionTests.kt
@@ -10,22 +10,9 @@ class SmoothingConsumerRegressionTests {
 
     @Test
     fun exactFallKeepsTrendDeltaAndFallingFastCheckpoint() {
-        val raw = (0..20).map { index ->
-            GlucosePoint(index * minute, 150f - 2f * index, 0f)
-        }
-        val smoothed = DataSmoothing.smoothNativePoints(
-            points = raw,
-            smoothingMinutes = 13,
-            collapseChunks = false,
-        )
-
-        val rawTrend = TrendEngine.calculateTrend(raw, useRaw = false, isMmol = false)
-        val smoothedTrend = TrendEngine.calculateTrend(smoothed, useRaw = false, isMmol = false)
-        assertEquals(rawTrend.velocity, smoothedTrend.velocity, 1e-4f)
-
         fun fiveMinuteDelta(points: List<GlucosePoint>): Float {
             val newest = points.last()
-            val previous = points[points.lastIndex - 5]
+            val previous = points.last { it.timestamp == newest.timestamp - 5 * minute }
             return GlucoseDelta.fiveMinuteDelta(
                 newest.timestamp,
                 newest.value,
@@ -33,8 +20,6 @@ class SmoothingConsumerRegressionTests {
                 previous.value,
             )
         }
-        assertEquals(fiveMinuteDelta(raw), fiveMinuteDelta(smoothed), 1e-4f)
-
         fun fallingFastCheckpoint(points: List<GlucosePoint>): Long {
             val state = DeltaAlarmState(falling = true)
             var firedAt = -1L
@@ -59,7 +44,28 @@ class SmoothingConsumerRegressionTests {
             return firedAt
         }
 
-        assertEquals(15 * minute, fallingFastCheckpoint(raw))
-        assertEquals(fallingFastCheckpoint(raw), fallingFastCheckpoint(smoothed))
+        for (cadenceMinutes in listOf(1, 5)) {
+            val raw = (0..20 step cadenceMinutes).map { atMinute ->
+                GlucosePoint(atMinute * minute, 150f - 2f * atMinute, 0f)
+            }
+            val rawTrend = TrendEngine.calculateTrend(raw, useRaw = false, isMmol = false)
+            val rawDelta = fiveMinuteDelta(raw)
+            val rawCheckpoint = fallingFastCheckpoint(raw)
+            assertEquals(15 * minute, rawCheckpoint)
+
+            for (windowMinutes in listOf(5, 10, 13)) {
+                val smoothed = DataSmoothing.smoothNativePoints(
+                    points = raw,
+                    smoothingMinutes = windowMinutes,
+                    collapseChunks = false,
+                )
+                val context = "cadence=$cadenceMinutes window=$windowMinutes"
+                val smoothedTrend = TrendEngine.calculateTrend(smoothed, useRaw = false, isMmol = false)
+
+                assertEquals(context, rawTrend.velocity, smoothedTrend.velocity, 1e-4f)
+                assertEquals(context, rawDelta, fiveMinuteDelta(smoothed), 1e-4f)
+                assertEquals(context, rawCheckpoint, fallingFastCheckpoint(smoothed))
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- keep the centred mean for complete smoothing windows
- use a timestamp-based degree-1 local regression when a segment boundary clips the window
- clamp boundary estimates to the valid samples' measured range and retain the mean fallback for duplicate timestamps
- share the Kotlin primitive across chart/current/exchange smoothing and mirror its estimator and rounding in the native Nightscout uploader
- preserve smoothing scopes, holes, timestamps, segment/chunk behavior, raw/auto independence, TrendEngine, delta alarms, and PR #83 behavior outside this estimator defect

Addresses #187.

## Deterministic validation

- Focused smoothing/current-display/trend/delta/alarm tests: **passed**
  - `:Common:testMobileDebugUnitTest` filtered to the touched consumers
- Native build: **passed**
  - `:Common:externalNativeBuildMobileDebug` for armeabi-v7a, arm64-v8a, x86, and x86_64
- APK build: **passed**
  - `:Common:assembleMobileDebug`
- `git diff --check`: **passed**
- Canonical unit suite: **1,601 passed, 11 fixture-gated failures**
  - all failures are in `SibionicsExactV115GCoreTest` / `SibionicsExactV116ACoreTest`
  - they fail during setup because `sibionics_exact_v115g_replay.csv` and `sibionics_exact_v116a_startup.csv` are absent from this checkout, before assertions run

The regression coverage pins constant and exact-linear traces at 1-minute, 5-minute, and irregular cadences for 5/10/13-minute windows; endpoint spike reduction and clamping; invalid-lane, gap, sensor, and collapse behavior; and unchanged TrendEngine velocity, five-minute delta, and falling-fast checkpoint timing on an exact fall.

## Hardware validation

Libre 3 hardware behavior was **not tested** in this change. The evidence above is deterministic unit and build validation only.