### PR TITLE
Stats: colour the A1c tile by the target it prints, not by a diagnosis

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
@@ -544,16 +544,21 @@ internal fun metricSpec(
             tone = bandTone(summary.avgMgDl)
         )
 
-        StatsMetric.GMI -> spec(
-            value = String.format(Locale.getDefault(), "%.1f%%", summary.gmiPercent),
-            status = if (summary.gmiPercent <= 7.0f) targetWord else highWord,
-            meta = "$targetWord $targetValue",
-            tone = when {
-                summary.gmiPercent < 5.7f -> TirInRangeColor
-                summary.gmiPercent < 6.5f -> TirHighColor
-                else -> TirVeryHighColor
-            }
-        )
+        StatsMetric.GMI -> {
+            // Status word and tone both read [GmiBand], so the tile cannot call a
+            // number "target" and colour it like the worst one at the same time.
+            val band = GmiBand.of(summary.gmiPercent)
+            spec(
+                value = String.format(Locale.getDefault(), "%.1f%%", summary.gmiPercent),
+                status = if (band == GmiBand.AT_TARGET) targetWord else highWord,
+                meta = "$targetWord $targetValue",
+                tone = when (band) {
+                    GmiBand.AT_TARGET -> TirInRangeColor
+                    GmiBand.ABOVE_TARGET -> TirHighColor
+                    GmiBand.WELL_ABOVE_TARGET -> TirVeryHighColor
+                }
+            )
+        }
 
         StatsMetric.CV -> spec(
             value = String.format(Locale.getDefault(), "%.1f%%", summary.cvPercent),

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsModels.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsModels.kt
@@ -130,6 +130,35 @@ enum class GriZone(@param:StringRes val labelResId: Int) {
     }
 }
 
+/**
+ * Where a GMI reading sits relative to the therapy target the A1c tile prints.
+ *
+ * The tile used to word its status against the target (< 7.0 %) and colour itself
+ * against 5.7 and 6.5 — the population thresholds for prediabetes and for diagnosing
+ * diabetes. Those answer "does this person have diabetes", which is not the question
+ * this screen is for, so a 6.6 % reading read "target" on the tone reserved for the
+ * worst band. Word and colour now come from this one place and cannot drift apart.
+ */
+enum class GmiBand {
+    AT_TARGET,
+    ABOVE_TARGET,
+    WELL_ABOVE_TARGET;
+
+    companion object {
+        /** The consensus target for most adults on therapy; `R.string.gmi_target_value` prints it. */
+        const val TARGET_PERCENT = 7.0f
+
+        /** Half a point over target is a miss worth flagging, not yet the worst band. */
+        const val WELL_ABOVE_TARGET_PERCENT = 7.5f
+
+        fun of(gmiPercent: Float): GmiBand = when {
+            gmiPercent <= TARGET_PERCENT -> AT_TARGET
+            gmiPercent < WELL_ABOVE_TARGET_PERCENT -> ABOVE_TARGET
+            else -> WELL_ABOVE_TARGET
+        }
+    }
+}
+
 data class GlycemiaRiskIndex(
     val value: Float = 0f,
     val zone: GriZone = GriZone.A,

--- a/Common/src/test/java/tk/glucodata/ui/stats/StatsAnalyticsTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/stats/StatsAnalyticsTests.kt
@@ -143,6 +143,27 @@ class StatsAnalyticsTests {
         assertTrue(defaultGri.value > 40f)
     }
 
+    // -------------------------------------------------------------------- GMI
+
+    @Test
+    fun gmiBandsSplitOnTheTherapyTargetTheTilePrints() {
+        // 7.0 is the target itself, so it still counts as meeting it.
+        assertEquals(GmiBand.AT_TARGET, GmiBand.of(6.6f))
+        assertEquals(GmiBand.AT_TARGET, GmiBand.of(GmiBand.TARGET_PERCENT))
+        assertEquals(GmiBand.ABOVE_TARGET, GmiBand.of(7.1f))
+        assertEquals(GmiBand.WELL_ABOVE_TARGET, GmiBand.of(GmiBand.WELL_ABOVE_TARGET_PERCENT))
+        assertEquals(GmiBand.WELL_ABOVE_TARGET, GmiBand.of(9f))
+    }
+
+    @Test
+    fun gmiDoesNotJudgeTherapyByTheDiagnosticThresholds() {
+        // 5.7 and 6.5 screen an undiagnosed population; on this screen they are not a
+        // scale at all, so nothing below the target may land in a warning band.
+        listOf(5.6f, 5.7f, 6.4f, 6.5f, 6.9f).forEach { gmi ->
+            assertEquals("GMI $gmi is within target", GmiBand.AT_TARGET, GmiBand.of(gmi))
+        }
+    }
+
     // ---------------------------------------------------------------- cadence
 
     @Test


### PR DESCRIPTION
Fixes #190.

The A1c (GMI) tile answered two different questions at once. Its status word was measured against the therapy target it prints on its own meta line (`<7.0%`); its tone was measured against 5.7 and 6.5 — the population screening thresholds for prediabetes and for diagnosing diabetes. A GMI of 6.6 therefore read **target** on the tone reserved for very high.

For someone already diagnosed, the diagnostic scale isn't a scale at all: it answers "does this person have diabetes", which is not what this screen is for. The tile now judges by the number it already shows the user.

**Bands** (`GmiBand` in `StatsModels.kt`, one source for both halves):

| GMI | Band | Tone |
| --- | --- | --- |
| ≤ 7.0 | `AT_TARGET` | in-range |
| 7.0 – 7.5 | `ABOVE_TARGET` | high |
| ≥ 7.5 | `WELL_ABOVE_TARGET` | very high |

The `AT_TARGET` boundary is `<=`, matching the status word's existing `<= 7.0f` exactly, so no reading changes its word — only readings between 5.7 and 7.0 change colour, from a warning tone to in-range, which is the bug.

`R.string.gmi_target_value` stays a translated literal rather than a format arg — several locales place the percent sign before the number (`tr` is `<%7,0`), so threading the constant through `getString` would break formatting there. `TARGET_PERCENT` carries a KDoc note pointing at it.

Tests in `StatsAnalyticsTests.kt` pin the boundaries and assert that nothing below the target lands in a warning band. `./gradlew :Common:testMobileDebugUnitTest` is green.
