### PR TITLE
Nightscout: a refused delete costs deletes, not every later upload

### DIFF
--- a/Common/src/main/java/tk/glucodata/NightPost.java
+++ b/Common/src/main/java/tk/glucodata/NightPost.java
@@ -83,6 +83,8 @@ import tk.glucodata.settings.LibreNumbers;
 public class NightPost  {
     private static final String LOG_ID="NightPost";
     private static final int ERROR_INVALID_URL = -2;
+    /** No HTTP status to report: the request never left, or no answer came back. */
+    public static final int ERROR_NO_RESPONSE = -1;
     private static final int UPLOAD_CONNECT_TIMEOUT_MS = 15_000;
     private static final int UPLOAD_READ_TIMEOUT_MS = 60_000;
     private static final int DEVICE_STATUS_CONNECT_TIMEOUT_MS = 3_000;
@@ -147,18 +149,31 @@ private static  String getstart(HttpURLConnection con,int max)  throws IOExcepti
 final  static String nothing=Applic.getContext().getString(R.string.triednothing).intern();
 final static String success=Applic.getContext().getString(R.string.success).intern();
 static private String uploadstatus=nothing;
+/**
+ * Called from native (uploadtreatment.cpp) via JNI, so the signature stays boolean.
+ * New callers should prefer {@link #deleteUrlCode}, which keeps the status apart
+ * from "already gone" and from a network failure worth retrying.
+ */
 @Keep
 static public boolean deleteUrl(String urlstring,String secret) {
+    final int code=deleteUrlCode(urlstring,secret);
+    return code==HTTP_OK || code==HttpURLConnection.HTTP_NO_CONTENT;
+    }
+
+/**
+ * DELETEs a Nightscout document and reports the HTTP status.
+ *
+ * @return the response code, {@link #ERROR_NO_RESPONSE} when the request could not be
+ *         made or answered at all (bad URL, missing token, network failure).
+ */
+@Keep
+static public int deleteUrlCode(String urlstring,String secret) {
     patch();
     uploadtime=System.currentTimeMillis();
     {if(doLog) {Log.i(LOG_ID,"deleteUrl "+urlstring);};};
     HttpURLConnection urlConnection=null;
     try {
         URL url = new URL(urlstring);
-        if(url==null)  {
-            uploadstatus="URL("+urlstring+")==null";
-            return false;
-            }
     uploadstatus=" start deleteURL "+urlstring;
         urlConnection = (HttpURLConnection) url.openConnection();
         urlConnection.setConnectTimeout(UPLOAD_CONNECT_TIMEOUT_MS);
@@ -173,7 +188,7 @@ static public boolean deleteUrl(String urlstring,String secret) {
                     true
             );
             if(auth.isEmpty()) {
-                return false;
+                return ERROR_NO_RESPONSE;
             }
             urlConnection.setRequestProperty("Authorization", auth);
         }
@@ -185,21 +200,19 @@ static public boolean deleteUrl(String urlstring,String secret) {
         if(code==HTTP_OK || code==HttpURLConnection.HTTP_NO_CONTENT) {
             {if(doLog) {Log.i(LOG_ID,"deleteUrl success "+res);};};
             uploadstatus=success;
-            return true;
             }
         else {
             String delerror="deleteUrl "+urlstring+" failure code="+code+'\n'+res;
             Log.e(LOG_ID,delerror);
             uploadstatus=delerror;
-            return false;
             }
-
+        return code;
         }
     catch(Throwable th) {
         String error ="deleteUrl error:\n"+stackline(th);
         uploadstatus=error;
         Log.e(LOG_ID,error);
-        return false;
+        return ERROR_NO_RESPONSE;
         }
     finally {
         if(urlConnection!=null)

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1408,6 +1408,11 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Апошні адказ: HTTP 413, payload занадта вялікі</string>
     <string name="nightscout_status_last_attempt">Апошняя спроба: %1$s</string>
     <string name="nightscout_status_last_success">Апошні поспех: %1$s</string>
+    <string name="nightscout_status_treatments_never">Лячэнне: пакуль нічога не адпраўлена</string>
+    <string name="nightscout_status_treatments_ok">Лячэнне: апошняя адпраўка %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Лячэнне: адпраўка не праходзіць з %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Лячэнне: выдаленні адхіляюцца з %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">няма адказу</string>
     <string name="nightscout_sync_actions_title">Дзеянні сінхранізацыі</string>
     <string name="expand_action">Разгарнуць</string>
     <string name="collapse_action">Згарнуць</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1483,6 +1483,11 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightscout_status_response_413">Letzte Antwort: HTTP 413, Nutzlast zu groß</string>
     <string name="nightscout_status_last_attempt">Letzter Versuch: %1$s</string>
     <string name="nightscout_status_last_success">Letzter Erfolg: %1$s</string>
+    <string name="nightscout_status_treatments_never">Behandlungen: noch nichts gesendet</string>
+    <string name="nightscout_status_treatments_ok">Behandlungen: zuletzt gesendet %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Behandlungen: Senden schlägt seit %1$s fehl (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Behandlungen: Löschungen seit %1$s abgelehnt (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">keine Antwort</string>
     <string name="nightscout_sync_actions_title">Synchronisierungsaktionen</string>
     <string name="expand_action">Erweitern</string>
     <string name="collapse_action">Einklappen</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1415,6 +1415,11 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Dernière réponse : HTTP 413, charge utile trop volumineuse</string>
     <string name="nightscout_status_last_attempt">Dernière tentative : %1$s</string>
     <string name="nightscout_status_last_success">Dernier succès : %1$s</string>
+    <string name="nightscout_status_treatments_never">Traitements : rien envoyé pour le moment</string>
+    <string name="nightscout_status_treatments_ok">Traitements : dernier envoi %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Traitements : envoi en échec depuis %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Traitements : suppressions refusées depuis %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">pas de réponse</string>
     <string name="nightscout_sync_actions_title">Actions de synchronisation</string>
     <string name="expand_action">Développer</string>
     <string name="collapse_action">Réduire</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1399,6 +1399,11 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Ultima risposta: HTTP 413, payload troppo grande</string>
     <string name="nightscout_status_last_attempt">Ultimo tentativo: %1$s</string>
     <string name="nightscout_status_last_success">Ultimo successo: %1$s</string>
+    <string name="nightscout_status_treatments_never">Trattamenti: ancora nulla inviato</string>
+    <string name="nightscout_status_treatments_ok">Trattamenti: ultimo invio %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Trattamenti: invio non riuscito da %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Trattamenti: eliminazioni rifiutate da %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">nessuna risposta</string>
     <string name="nightscout_sync_actions_title">Azioni di sincronizzazione</string>
     <string name="expand_action">Espandi</string>
     <string name="collapse_action">Comprimi</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1229,6 +1229,11 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="nightscout_status_response_413">Сүүлчийн хариу: HTTP 413, өгөгдөл хэт том байна</string>
     <string name="nightscout_status_last_attempt">Сүүлийн оролдлого: %1$s</string>
     <string name="nightscout_status_last_success">Сүүлийн амжилт: %1$s</string>
+    <string name="nightscout_status_treatments_never">Эмчилгээ: одоогоор юу ч илгээгээгүй</string>
+    <string name="nightscout_status_treatments_ok">Эмчилгээ: сүүлд илгээсэн %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Эмчилгээ: %1$s-с хойш илгээлт амжилтгүй (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Эмчилгээ: %1$s-с хойш устгал татгалзсан (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">хариу алга</string>
     <string name="nightscout_send_amounts_desc">Инсулин/Нүүрс ус ачаалах (Treatments)</string>
     <string name="nightscout_send_long_insulin">Удаан үйлдэлтэй инсулин илгээх</string>
     <string name="nightscout_send_long_insulin_desc">Nightscout руу суурь болон хэт удаан инсулиныг хамт илгээх</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1452,6 +1452,11 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="nightscout_status_response_413">Laatste reactie: HTTP 413, payload te groot</string>
     <string name="nightscout_status_last_attempt">Laatste poging: %1$s</string>
     <string name="nightscout_status_last_success">Laatste succes: %1$s</string>
+    <string name="nightscout_status_treatments_never">Behandelingen: nog niets verzonden</string>
+    <string name="nightscout_status_treatments_ok">Behandelingen: laatst verzonden %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Behandelingen: verzenden mislukt sinds %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Behandelingen: verwijderingen geweigerd sinds %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">geen antwoord</string>
     <string name="nightscout_sync_actions_title">Synchronisatieacties</string>
     <string name="expand_action">Uitklappen</string>
     <string name="collapse_action">Inklappen</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1444,6 +1444,11 @@
     <string name="nightscout_status_response_413">Ostatnia odpowiedź: HTTP 413, zbyt duży ładunek</string>
     <string name="nightscout_status_last_attempt">Ostatnia próba: %1$s</string>
     <string name="nightscout_status_last_success">Ostatni sukces: %1$s</string>
+    <string name="nightscout_status_treatments_never">Leczenia: nic jeszcze nie wysłano</string>
+    <string name="nightscout_status_treatments_ok">Leczenia: ostatnio wysłano %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Leczenia: wysyłanie nie działa od %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Leczenia: usunięcia odrzucane od %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">brak odpowiedzi</string>
     <string name="nightscout_sync_actions_title">Akcje synchronizacji</string>
     <string name="expand_action">Rozwiń</string>
     <string name="collapse_action">Zwiń</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1410,6 +1410,11 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Última resposta: HTTP 413, carga útil demasiado grande</string>
     <string name="nightscout_status_last_attempt">Última tentativa: %1$s</string>
     <string name="nightscout_status_last_success">Último sucesso: %1$s</string>
+    <string name="nightscout_status_treatments_never">Tratamentos: ainda nada enviado</string>
+    <string name="nightscout_status_treatments_ok">Tratamentos: último envio %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Tratamentos: envio a falhar desde %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Tratamentos: eliminações recusadas desde %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">sem resposta</string>
     <string name="nightscout_sync_actions_title">Ações de sincronização</string>
     <string name="expand_action">Expandir</string>
     <string name="collapse_action">Recolher</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1452,6 +1452,11 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Последний ответ: HTTP 413, слишком большой payload</string>
     <string name="nightscout_status_last_attempt">Последняя попытка: %1$s</string>
     <string name="nightscout_status_last_success">Последний успех: %1$s</string>
+    <string name="nightscout_status_treatments_never">Лечение: пока ничего не отправлено</string>
+    <string name="nightscout_status_treatments_ok">Лечение: последняя отправка %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Лечение: отправка не проходит с %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Лечение: удаления отклоняются с %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">нет ответа</string>
     <string name="nightscout_sync_actions_title">Действия синхронизации</string>
     <string name="expand_action">Развернуть</string>
     <string name="collapse_action">Свернуть</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1498,6 +1498,11 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="nightscout_status_response_413">Jawaabtii u dambaysay: HTTP 413, culayska la saaray oo aad u weyn</string>
     <string name="nightscout_status_last_attempt">Isku daygii ugu dambeeyay: %1$s</string>
     <string name="nightscout_status_last_success">Guushii u dambaysay: %1$s</string>
+    <string name="nightscout_status_treatments_never">Daawaynta: weli waxba lama dirin</string>
+    <string name="nightscout_status_treatments_ok">Daawaynta: markii ugu dambeysay la diray %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Daawaynta: dirista way fashilmaysaa tan iyo %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Daawaynta: tirtiridda waa la diiday tan iyo %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">jawaab ma jirto</string>
     <string name="nightscout_send_amounts_desc">Soo rar Insulin/Carbs (Daawaynta)</string>
     <string name="nightscout_send_long_insulin">Dir insuliinta muddada dheer</string>
     <string name="nightscout_send_long_insulin_desc">Ku dar insuliinta basal iyo tan aadka u dheer gelinta Nightscout</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1409,6 +1409,11 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Senaste svar: HTTP 413, för stor payload</string>
     <string name="nightscout_status_last_attempt">Senaste försök: %1$s</string>
     <string name="nightscout_status_last_success">Senaste lyckade: %1$s</string>
+    <string name="nightscout_status_treatments_never">Behandlingar: inget skickat än</string>
+    <string name="nightscout_status_treatments_ok">Behandlingar: senast skickat %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Behandlingar: sändning misslyckas sedan %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Behandlingar: raderingar nekas sedan %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">inget svar</string>
     <string name="nightscout_sync_actions_title">Synkåtgärder</string>
     <string name="expand_action">Expandera</string>
     <string name="collapse_action">Fäll ihop</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1437,6 +1437,11 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="nightscout_status_response_413">Son yanıt: HTTP 413, yük çok büyük</string>
     <string name="nightscout_status_last_attempt">Son deneme: %1$s</string>
     <string name="nightscout_status_last_success">Son başarılı: %1$s</string>
+    <string name="nightscout_status_treatments_never">Tedaviler: henüz bir şey gönderilmedi</string>
+    <string name="nightscout_status_treatments_ok">Tedaviler: son gönderim %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Tedaviler: %1$s tarihinden beri gönderim başarısız (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Tedaviler: %1$s tarihinden beri silmeler reddediliyor (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">yanıt yok</string>
     <string name="nightscout_sync_actions_title">Senkronizasyon işlemleri</string>
     <string name="expand_action">Genişlet</string>
     <string name="collapse_action">Daralt</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1423,6 +1423,11 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Остання відповідь: HTTP 413, завеликий payload</string>
     <string name="nightscout_status_last_attempt">Остання спроба: %1$s</string>
     <string name="nightscout_status_last_success">Останній успіх: %1$s</string>
+    <string name="nightscout_status_treatments_never">Лікування: поки нічого не надіслано</string>
+    <string name="nightscout_status_treatments_ok">Лікування: останнє надсилання %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Лікування: надсилання не працює з %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Лікування: видалення відхиляються з %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">немає відповіді</string>
     <string name="nightscout_sync_actions_title">Дії синхронізації</string>
     <string name="expand_action">Розгорнути</string>
     <string name="collapse_action">Згорнути</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1425,6 +1425,11 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">上次响应：HTTP 413，负载过大</string>
     <string name="nightscout_status_last_attempt">上次尝试：%1$s</string>
     <string name="nightscout_status_last_success">上次成功：%1$s</string>
+    <string name="nightscout_status_treatments_never">治疗：尚未发送任何内容</string>
+    <string name="nightscout_status_treatments_ok">治疗：上次发送 %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">治疗：自 %1$s 起发送失败（%2$s）</string>
+    <string name="nightscout_status_treatments_delete_failing">治疗：自 %1$s 起删除被拒绝（%2$s）</string>
+    <string name="nightscout_status_treatments_no_response">无响应</string>
     <string name="nightscout_sync_actions_title">同步操作</string>
     <string name="expand_action">展开</string>
     <string name="collapse_action">收起</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1559,6 +1559,11 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Last response: HTTP 413, payload too large</string>
     <string name="nightscout_status_last_attempt">Last attempt: %1$s</string>
     <string name="nightscout_status_last_success">Last success: %1$s</string>
+    <string name="nightscout_status_treatments_never">Treatments: nothing sent yet</string>
+    <string name="nightscout_status_treatments_ok">Treatments: last sent %1$s</string>
+    <string name="nightscout_status_treatments_upload_failing">Treatments: sending has failed since %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_delete_failing">Treatments: deletions refused since %1$s (%2$s)</string>
+    <string name="nightscout_status_treatments_no_response">no response</string>
     <string name="nightscout_send_amounts_desc">Upload Insulin/Carbs (Treatments)</string>
     <string name="nightscout_send_long_insulin">Send long-acting insulin</string>
     <string name="nightscout_send_long_insulin_desc">Include basal and ultra-long insulin treatments in Nightscout uploads</string>

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
@@ -29,6 +29,7 @@ import tk.glucodata.data.journal.JournalPendingDeleteEntity
  *   v10 — Nightscout sync columns on journal entries + tombstone table for journal deletes
  *   v11 — journal food library and macro metadata for carb entries
  *   v12 — per-preset dose-calculation eligibility
+ *   v13 — retry accounting on journal delete tombstones
  */
 @Database(
     entities = [
@@ -39,7 +40,7 @@ import tk.glucodata.data.journal.JournalPendingDeleteEntity
         JournalInsulinPresetEntity::class,
         JournalPendingDeleteEntity::class
     ],
-    version = 12,
+    version = 13,
     exportSchema = false
 )
 abstract class HistoryDatabase : RoomDatabase() {
@@ -239,6 +240,17 @@ abstract class HistoryDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE journal_pending_deletes ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0"
+                )
+                db.execSQL(
+                    "ALTER TABLE journal_pending_deletes ADD COLUMN lastAttemptAt INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         fun getInstance(context: Context): HistoryDatabase =
             INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
@@ -256,7 +268,8 @@ abstract class HistoryDatabase : RoomDatabase() {
                     MIGRATION_8_9,
                     MIGRATION_9_10,
                     MIGRATION_10_11,
-                    MIGRATION_11_12
+                    MIGRATION_11_12,
+                    MIGRATION_12_13
                 )
                 .fallbackToDestructiveMigration()  // Fallback if migration chain is broken
                 .build().also { INSTANCE = it }

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
@@ -123,4 +123,10 @@ interface JournalDao {
 
     @Query("DELETE FROM journal_pending_deletes WHERE entryId = :entryId")
     suspend fun clearPendingNightscoutDelete(entryId: Long)
+
+    @Query(
+        "UPDATE journal_pending_deletes SET attempts = :attempts, lastAttemptAt = :attemptedAt " +
+            "WHERE entryId = :entryId"
+    )
+    suspend fun recordFailedNightscoutDelete(entryId: Long, attempts: Int, attemptedAt: Long)
 }

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalPendingDeleteEntity.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalPendingDeleteEntity.kt
@@ -3,10 +3,20 @@ package tk.glucodata.data.journal
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+/**
+ * A journal entry that was deleted locally and still has to be deleted on Nightscout.
+ *
+ * [attempts] counts the deletes the server refused. A document the server will never
+ * let us delete (a token without `api:treatments:delete`, say) would otherwise be
+ * retried on every upload cycle forever, so the tombstone is dropped past
+ * [JournalTreatmentUploader.MAX_DELETE_ATTEMPTS].
+ */
 @Entity(tableName = "journal_pending_deletes")
 data class JournalPendingDeleteEntity(
     @PrimaryKey
     val entryId: Long,
     val nsRemoteId: String,
-    val deletedAt: Long
+    val deletedAt: Long,
+    val attempts: Int = 0,
+    val lastAttemptAt: Long = 0L
 )

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalSyncStatus.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalSyncStatus.kt
@@ -1,0 +1,105 @@
+package tk.glucodata.data.journal
+
+import android.content.Context
+import tk.glucodata.Applic
+
+/** Which half of a treatment sync cycle broke, so the UI can name it. */
+enum class JournalSyncFailure(val storageValue: Int) {
+    NONE(0),
+    UPLOAD(1),
+    DELETE(2);
+
+    companion object {
+        fun fromStorage(value: Int): JournalSyncFailure =
+            entries.firstOrNull { it.storageValue == value } ?: NONE
+    }
+}
+
+/**
+ * @param lastSuccessAt when Nightscout last accepted a treatment document from us.
+ * @param failingSince the start of the current run of failures, 0 while healthy.
+ */
+data class JournalSyncState(
+    val lastSuccessAt: Long = 0L,
+    val failingSince: Long = 0L,
+    val failureCode: Int = 0,
+    val failure: JournalSyncFailure = JournalSyncFailure.NONE
+) {
+    val isFailing: Boolean get() = failure != JournalSyncFailure.NONE
+}
+
+internal fun applySyncSuccess(
+    state: JournalSyncState,
+    now: Long,
+    acceptedDocument: Boolean
+): JournalSyncState = JournalSyncState(
+    // A cycle with nothing pending proves the path is not broken, but it is not a send:
+    // leaving lastSuccessAt alone keeps "last sent" honest.
+    lastSuccessAt = if (acceptedDocument) now else state.lastSuccessAt,
+    failingSince = 0L,
+    failureCode = 0,
+    failure = JournalSyncFailure.NONE
+)
+
+internal fun applySyncFailure(
+    state: JournalSyncState,
+    now: Long,
+    code: Int,
+    failure: JournalSyncFailure
+): JournalSyncState = state.copy(
+    // Keep the first failure of the run: "failing since" is the number that shows
+    // a sync path has been dead for days rather than for one cycle.
+    failingSince = if (state.isFailing && state.failingSince > 0L) state.failingSince else now,
+    failureCode = code,
+    failure = failure
+)
+
+/**
+ * Last known health of the Nightscout *treatment* path, which is the JVM-side uploader and
+ * therefore invisible to the native uploader status the settings screen otherwise reports
+ * (issue #191: that line can read HTTP 200 while treatments have been failing for days).
+ *
+ * Persisted, because "failing since" is only worth anything if it survives a restart.
+ */
+object JournalSyncStatus {
+    private const val PREFS_NAME = "tk.glucodata_preferences"
+    private const val KEY_LAST_SUCCESS = "journal_sync_last_success"
+    private const val KEY_FAILING_SINCE = "journal_sync_failing_since"
+    private const val KEY_FAILURE_CODE = "journal_sync_failure_code"
+    private const val KEY_FAILURE_KIND = "journal_sync_failure_kind"
+
+    @Volatile
+    private var cached: JournalSyncState? = null
+
+    private fun prefs() =
+        Applic.app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun state(): JournalSyncState = cached ?: load().also { cached = it }
+
+    private fun load(): JournalSyncState = with(prefs()) {
+        JournalSyncState(
+            lastSuccessAt = getLong(KEY_LAST_SUCCESS, 0L),
+            failingSince = getLong(KEY_FAILING_SINCE, 0L),
+            failureCode = getInt(KEY_FAILURE_CODE, 0),
+            failure = JournalSyncFailure.fromStorage(getInt(KEY_FAILURE_KIND, 0))
+        )
+    }
+
+    fun recordSuccess(now: Long, acceptedDocument: Boolean) {
+        store(applySyncSuccess(state(), now, acceptedDocument))
+    }
+
+    fun recordFailure(now: Long, code: Int, failure: JournalSyncFailure) {
+        store(applySyncFailure(state(), now, code, failure))
+    }
+
+    private fun store(next: JournalSyncState) {
+        cached = next
+        prefs().edit()
+            .putLong(KEY_LAST_SUCCESS, next.lastSuccessAt)
+            .putLong(KEY_FAILING_SINCE, next.failingSince)
+            .putInt(KEY_FAILURE_CODE, next.failureCode)
+            .putInt(KEY_FAILURE_KIND, next.failure.storageValue)
+            .apply()
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
@@ -35,10 +35,39 @@ object JournalTreatmentUploader {
     private const val TREATMENT_FETCH_COUNT = 240
     private const val ERROR_INVALID_URL = -2
 
+    /**
+     * Refused deletes the tombstone survives before it is dropped. A document Nightscout
+     * will never let us delete (a token without `api:treatments:delete` answers 403 forever)
+     * must not stay queued for the rest of the install's life.
+     */
+    internal const val MAX_DELETE_ATTEMPTS = 20
+
+    internal enum class TombstoneAction { CLEAR, RETRY, GIVE_UP }
+
     private data class UploadResult(
         val code: Int,
         val remoteId: String? = null
     )
+
+    /** True only when the server actually removed the document for us. */
+    internal fun isDeleteAccepted(code: Int): Boolean =
+        code == HttpURLConnection.HTTP_OK || code == HttpURLConnection.HTTP_NO_CONTENT
+
+    /**
+     * What to do with a tombstone after a delete answered [code]. 404/410 count as done:
+     * the document we wanted gone is gone, and the old code kept retrying those forever.
+     */
+    internal fun tombstoneAction(code: Int, attemptsSoFar: Int): TombstoneAction = when (code) {
+        HttpURLConnection.HTTP_OK,
+        HttpURLConnection.HTTP_NO_CONTENT,
+        HttpURLConnection.HTTP_NOT_FOUND,
+        HttpURLConnection.HTTP_GONE -> TombstoneAction.CLEAR
+        else -> if (attemptsSoFar + 1 >= MAX_DELETE_ATTEMPTS) {
+            TombstoneAction.GIVE_UP
+        } else {
+            TombstoneAction.RETRY
+        }
+    }
 
     // Mirrors writetreatment(V3) acceptance: 200/201 always; 409 only on V3 (POST conflict).
     private fun isUploadOk(code: Int, useV3: Boolean): Boolean {
@@ -100,23 +129,50 @@ object JournalTreatmentUploader {
         val presetCache = HashMap<Long, JournalInsulinPresetEntity?>()
         val foodCache = HashMap<Long, JournalFoodEntity?>()
         var uploadOk = true
+        var acceptedDocument = false
+        var deleteFailureCode: Int? = null
+        var uploadFailureCode: Int? = null
 
+        // Deletes and creates are independent, so a refused delete must not cost us the
+        // pending entries: it used to break out of the whole run and, since the tombstone
+        // was never cleared, wedge every later cycle at the same document (issue #191).
         if (sendEnabled) {
             for (tomb in dao.getPendingNightscoutDeletes()) {
                 val deleteRemoteId = resolveDeleteRemoteId(baseUrl, rawSecret, tomb.nsRemoteId, useV3)
                 val deleteUrl = treatmentDeleteUrl(baseUrl, deleteRemoteId, useV3)
-                if (NightPost.deleteUrl(deleteUrl, secretHashed)) {
-                    dao.clearPendingNightscoutDelete(tomb.entryId)
-                } else {
-                    Log.e(LOG_ID, "tombstone delete failed for entryId=${tomb.entryId} remoteId=$deleteRemoteId")
-                    uploadOk = false
-                    break
+                val code = NightPost.deleteUrlCode(deleteUrl, secretHashed)
+                val attempts = tomb.attempts + 1
+                when (tombstoneAction(code, tomb.attempts)) {
+                    TombstoneAction.CLEAR -> {
+                        dao.clearPendingNightscoutDelete(tomb.entryId)
+                        // A 404 also clears the tombstone, but it is not proof that the
+                        // server took anything from us, so it must not move "last sent".
+                        if (isDeleteAccepted(code)) acceptedDocument = true
+                    }
+                    TombstoneAction.RETRY -> {
+                        Log.e(
+                            LOG_ID,
+                            "tombstone delete failed for entryId=${tomb.entryId} " +
+                                "remoteId=$deleteRemoteId code=$code attempt=$attempts"
+                        )
+                        dao.recordFailedNightscoutDelete(tomb.entryId, attempts, System.currentTimeMillis())
+                        deleteFailureCode = code
+                    }
+                    TombstoneAction.GIVE_UP -> {
+                        Log.e(
+                            LOG_ID,
+                            "giving up on tombstone entryId=${tomb.entryId} remoteId=$deleteRemoteId " +
+                                "after $attempts refused deletes (last code=$code); dropping it"
+                        )
+                        dao.clearPendingNightscoutDelete(tomb.entryId)
+                        deleteFailureCode = code
+                    }
                 }
             }
         }
 
         val sinceMillis = System.currentTimeMillis() - LOOKBACK_MILLIS
-        if (sendEnabled && uploadOk) {
+        if (sendEnabled) {
             val pending = dao.getEntriesNeedingNightscoutUpload(sinceMillis)
             for (entry in pending) {
                 if (!isSendableType(entry.entryType)) continue
@@ -159,6 +215,7 @@ object JournalTreatmentUploader {
                 }
                 if (!isUploadOk(result.code, useV3)) {
                     Log.e(LOG_ID, "upload failed entry id=${entry.id} code=${result.code}")
+                    uploadFailureCode = result.code
                     uploadOk = false
                     break
                 }
@@ -167,7 +224,12 @@ object JournalTreatmentUploader {
                     result.remoteId ?: remoteId,
                     System.currentTimeMillis()
                 )
+                acceptedDocument = true
             }
+        }
+
+        if (sendEnabled) {
+            recordSendStatus(uploadFailureCode, deleteFailureCode, acceptedDocument)
         }
 
         val receiveOk = if (receiveEnabled) {
@@ -175,7 +237,29 @@ object JournalTreatmentUploader {
         } else {
             true
         }
+        // A refused delete is deliberately not folded in here. Returning false makes the native
+        // loop back off and skip the IOB device status, which is exactly the collateral damage
+        // this path used to cause; the tombstone is retried on the next cycle either way.
         return uploadOk && receiveOk
+    }
+
+    /**
+     * Publishes the outcome of one send cycle so the settings screen can show a treatment
+     * path that has been failing while the native entries uploader kept reporting HTTP 200.
+     */
+    private fun recordSendStatus(
+        uploadFailureCode: Int?,
+        deleteFailureCode: Int?,
+        acceptedDocument: Boolean
+    ) {
+        val now = System.currentTimeMillis()
+        when {
+            uploadFailureCode != null ->
+                JournalSyncStatus.recordFailure(now, uploadFailureCode, JournalSyncFailure.UPLOAD)
+            deleteFailureCode != null ->
+                JournalSyncStatus.recordFailure(now, deleteFailureCode, JournalSyncFailure.DELETE)
+            else -> JournalSyncStatus.recordSuccess(now, acceptedDocument)
+        }
     }
 
     private fun isSendableType(entryType: String): Boolean {

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -73,6 +73,8 @@ import kotlinx.coroutines.withContext
 import tk.glucodata.Natives
 import tk.glucodata.NightPost
 import tk.glucodata.R
+import tk.glucodata.data.journal.JournalSyncFailure
+import tk.glucodata.data.journal.JournalSyncStatus
 import tk.glucodata.data.journal.JournalTreatmentUploader
 import tk.glucodata.drivers.nightscout.NightscoutFollowerRegistry
 import tk.glucodata.ui.components.CardPosition
@@ -92,6 +94,14 @@ private sealed class TestState {
 }
 
 private val SHA1_SECRET_REGEX = Regex("^[0-9a-fA-F]{40}$")
+
+/** "HTTP 403" reads the same in every locale; a request that never got an answer does not. */
+private fun failureDetail(context: android.content.Context, code: Int): String =
+    if (code > 0) {
+        "HTTP $code"
+    } else {
+        context.getString(R.string.nightscout_status_treatments_no_response)
+    }
 
 private fun applyNightscoutTestAuth(
     connection: java.net.HttpURLConnection,
@@ -151,6 +161,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
     var lastSuccessTime by rememberSaveable { mutableStateOf(0L) }
     var retryMinutes by rememberSaveable { mutableStateOf(0) }
     var uploaderRunning by rememberSaveable { mutableStateOf(false) }
+    var treatmentSync by remember { mutableStateOf(JournalSyncStatus.state()) }
     var testState by remember { mutableStateOf<TestState>(TestState.Idle) }
 
     var mode by rememberSaveable {
@@ -194,6 +205,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
         lastSuccessTime = Natives.getnightscoutlastsuccesstime()
         retryMinutes = Natives.getnightscoutretryminutes()
         uploaderRunning = Natives.getnightscoutuploaderrunning()
+        treatmentSync = JournalSyncStatus.state()
     }
 
     fun requireUrl(): Boolean {
@@ -255,6 +267,9 @@ fun NightscoutSettingsScreen(navController: NavController) {
         ).format(java.util.Date(epochSeconds * 1000L))
     }
 
+    // The native uploader reports seconds; the journal sync status is in millis.
+    fun formatStatusMillis(epochMillis: Long): String = formatStatusTime(epochMillis / 1000L)
+
     val uploaderSummary = when {
         !isActive || mode != NightscoutMode.UPLOAD -> context.getString(R.string.nightscout_status_paused)
         uploaderRunning -> context.getString(R.string.nightscout_status_running)
@@ -270,6 +285,27 @@ fun NightscoutSettingsScreen(navController: NavController) {
         lastResponseCode == 413 -> context.getString(R.string.nightscout_status_response_413)
         lastResponseCode > 0 -> context.getString(R.string.nightscout_status_response_error, lastResponseCode)
         else -> context.getString(R.string.nightscout_status_waiting)
+    }
+
+    // The lines above report the native entries uploader only, so they can read HTTP 200 while
+    // the JVM-side treatment path has been rejected for days (issue #191).
+    val treatmentSummary: String? = when {
+        !isActive || mode != NightscoutMode.UPLOAD || !sendTreatments -> null
+        treatmentSync.failure == JournalSyncFailure.UPLOAD -> context.getString(
+            R.string.nightscout_status_treatments_upload_failing,
+            formatStatusMillis(treatmentSync.failingSince),
+            failureDetail(context, treatmentSync.failureCode)
+        )
+        treatmentSync.failure == JournalSyncFailure.DELETE -> context.getString(
+            R.string.nightscout_status_treatments_delete_failing,
+            formatStatusMillis(treatmentSync.failingSince),
+            failureDetail(context, treatmentSync.failureCode)
+        )
+        treatmentSync.lastSuccessAt > 0L -> context.getString(
+            R.string.nightscout_status_treatments_ok,
+            formatStatusMillis(treatmentSync.lastSuccessAt)
+        )
+        else -> context.getString(R.string.nightscout_status_treatments_never)
     }
 
     val masterSubtitle = when (mode) {
@@ -468,6 +504,19 @@ fun NightscoutSettingsScreen(navController: NavController) {
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
+                            if (treatmentSummary != null) {
+                                Text(
+                                    text = treatmentSummary,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = if (treatmentSync.isFailing) {
+                                        MaterialTheme.colorScheme.error
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                    },
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
                         }
                     }
                 }

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
@@ -544,16 +544,21 @@ internal fun metricSpec(
             tone = bandTone(summary.avgMgDl)
         )
 
-        StatsMetric.GMI -> spec(
-            value = String.format(Locale.getDefault(), "%.1f%%", summary.gmiPercent),
-            status = if (summary.gmiPercent <= 7.0f) targetWord else highWord,
-            meta = "$targetWord $targetValue",
-            tone = when {
-                summary.gmiPercent < 5.7f -> TirInRangeColor
-                summary.gmiPercent < 6.5f -> TirHighColor
-                else -> TirVeryHighColor
-            }
-        )
+        StatsMetric.GMI -> {
+            // Status word and tone both read [GmiBand], so the tile cannot call a
+            // number "target" and colour it like the worst one at the same time.
+            val band = GmiBand.of(summary.gmiPercent)
+            spec(
+                value = String.format(Locale.getDefault(), "%.1f%%", summary.gmiPercent),
+                status = if (band == GmiBand.AT_TARGET) targetWord else highWord,
+                meta = "$targetWord $targetValue",
+                tone = when (band) {
+                    GmiBand.AT_TARGET -> TirInRangeColor
+                    GmiBand.ABOVE_TARGET -> TirHighColor
+                    GmiBand.WELL_ABOVE_TARGET -> TirVeryHighColor
+                }
+            )
+        }
 
         StatsMetric.CV -> spec(
             value = String.format(Locale.getDefault(), "%.1f%%", summary.cvPercent),

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsModels.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsModels.kt
@@ -130,6 +130,35 @@ enum class GriZone(@param:StringRes val labelResId: Int) {
     }
 }
 
+/**
+ * Where a GMI reading sits relative to the therapy target the A1c tile prints.
+ *
+ * The tile used to word its status against the target (< 7.0 %) and colour itself
+ * against 5.7 and 6.5 — the population thresholds for prediabetes and for diagnosing
+ * diabetes. Those answer "does this person have diabetes", which is not the question
+ * this screen is for, so a 6.6 % reading read "target" on the tone reserved for the
+ * worst band. Word and colour now come from this one place and cannot drift apart.
+ */
+enum class GmiBand {
+    AT_TARGET,
+    ABOVE_TARGET,
+    WELL_ABOVE_TARGET;
+
+    companion object {
+        /** The consensus target for most adults on therapy; `R.string.gmi_target_value` prints it. */
+        const val TARGET_PERCENT = 7.0f
+
+        /** Half a point over target is a miss worth flagging, not yet the worst band. */
+        const val WELL_ABOVE_TARGET_PERCENT = 7.5f
+
+        fun of(gmiPercent: Float): GmiBand = when {
+            gmiPercent <= TARGET_PERCENT -> AT_TARGET
+            gmiPercent < WELL_ABOVE_TARGET_PERCENT -> ABOVE_TARGET
+            else -> WELL_ABOVE_TARGET
+        }
+    }
+}
+
 data class GlycemiaRiskIndex(
     val value: Float = 0f,
     val zone: GriZone = GriZone.A,

--- a/Common/src/test/java/tk/glucodata/data/journal/JournalSyncStatusTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/JournalSyncStatusTests.kt
@@ -1,0 +1,77 @@
+package tk.glucodata.data.journal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The state machine behind the treatment line on the Nightscout settings screen (issue #191).
+ * What matters is that a failure run keeps its *first* timestamp, so a path that has been dead
+ * for days says so instead of resetting to "just now" on every cycle.
+ */
+class JournalSyncStatusTests {
+    private val firstFailure = 1_000_000L
+    private val laterFailure = firstFailure + 3 * 24 * 60 * 60 * 1000L
+
+    @Test
+    fun aHealthyStateReportsNoFailure() {
+        assertFalse(JournalSyncState().isFailing)
+    }
+
+    @Test
+    fun theStartOfAFailureRunSurvivesLaterFailures() {
+        val first = applySyncFailure(
+            JournalSyncState(lastSuccessAt = 500L),
+            now = firstFailure,
+            code = 403,
+            failure = JournalSyncFailure.DELETE
+        )
+        val later = applySyncFailure(first, laterFailure, code = 401, failure = JournalSyncFailure.UPLOAD)
+
+        assertEquals(firstFailure, later.failingSince)
+        assertEquals(401, later.failureCode)
+        assertEquals(JournalSyncFailure.UPLOAD, later.failure)
+        // A stale success time is worth keeping: it is the "and it last worked then" half.
+        assertEquals(500L, later.lastSuccessAt)
+        assertTrue(later.isFailing)
+    }
+
+    @Test
+    fun anAcceptedDocumentEndsTheFailureRun() {
+        val failing = applySyncFailure(
+            JournalSyncState(),
+            now = firstFailure,
+            code = 403,
+            failure = JournalSyncFailure.DELETE
+        )
+        val healthy = applySyncSuccess(failing, now = laterFailure, acceptedDocument = true)
+
+        assertFalse(healthy.isFailing)
+        assertEquals(0L, healthy.failingSince)
+        assertEquals(0, healthy.failureCode)
+        assertEquals(laterFailure, healthy.lastSuccessAt)
+    }
+
+    @Test
+    fun anIdleCycleClearsTheFailureWithoutFakingASend() {
+        val failing = applySyncFailure(
+            JournalSyncState(lastSuccessAt = 500L),
+            now = firstFailure,
+            code = 403,
+            failure = JournalSyncFailure.DELETE
+        )
+        val idle = applySyncSuccess(failing, now = laterFailure, acceptedDocument = false)
+
+        assertFalse(idle.isFailing)
+        assertEquals(500L, idle.lastSuccessAt)
+    }
+
+    @Test
+    fun failureKindsRoundTripThroughStorage() {
+        for (failure in JournalSyncFailure.entries) {
+            assertEquals(failure, JournalSyncFailure.fromStorage(failure.storageValue))
+        }
+        assertEquals(JournalSyncFailure.NONE, JournalSyncFailure.fromStorage(99))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
@@ -1,8 +1,12 @@
 package tk.glucodata.data.journal
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import tk.glucodata.data.journal.JournalTreatmentUploader.MAX_DELETE_ATTEMPTS
+import tk.glucodata.data.journal.JournalTreatmentUploader.TombstoneAction
+import tk.glucodata.data.journal.JournalTreatmentUploader.tombstoneAction
 
 class JournalTreatmentUploaderTests {
     private fun preset(countsTowardIob: Boolean) = JournalInsulinPresetEntity(
@@ -52,5 +56,43 @@ class JournalTreatmentUploaderTests {
                 sendLongInsulin = true
             )
         )
+    }
+
+    @Test
+    fun acceptedDeleteClearsTheTombstone() {
+        assertEquals(TombstoneAction.CLEAR, tombstoneAction(code = 200, attemptsSoFar = 0))
+        assertEquals(TombstoneAction.CLEAR, tombstoneAction(code = 204, attemptsSoFar = 3))
+    }
+
+    @Test
+    fun aDocumentTheServerNoLongerHasCountsAsDeleted() {
+        // The old boolean path retried these forever: the delete can never succeed,
+        // and there is nothing left on the server to delete either.
+        assertEquals(TombstoneAction.CLEAR, tombstoneAction(code = 404, attemptsSoFar = 0))
+        assertEquals(TombstoneAction.CLEAR, tombstoneAction(code = 410, attemptsSoFar = 0))
+    }
+
+    @Test
+    fun aRefusedDeleteIsRetriedUntilTheAttemptCapIsReached() {
+        // 403 is the reported case: a role with api:treatments:create but not :delete.
+        assertEquals(TombstoneAction.RETRY, tombstoneAction(code = 403, attemptsSoFar = 0))
+        assertEquals(
+            TombstoneAction.RETRY,
+            tombstoneAction(code = 403, attemptsSoFar = MAX_DELETE_ATTEMPTS - 2)
+        )
+        assertEquals(
+            TombstoneAction.GIVE_UP,
+            tombstoneAction(code = 403, attemptsSoFar = MAX_DELETE_ATTEMPTS - 1)
+        )
+        assertEquals(
+            TombstoneAction.GIVE_UP,
+            tombstoneAction(code = 403, attemptsSoFar = MAX_DELETE_ATTEMPTS)
+        )
+    }
+
+    @Test
+    fun aDeleteThatNeverGotAnAnswerIsRetriedToo() {
+        assertEquals(TombstoneAction.RETRY, tombstoneAction(code = -1, attemptsSoFar = 0))
+        assertEquals(TombstoneAction.RETRY, tombstoneAction(code = 500, attemptsSoFar = 0))
     }
 }

--- a/Common/src/test/java/tk/glucodata/ui/stats/StatsAnalyticsTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/stats/StatsAnalyticsTests.kt
@@ -143,6 +143,27 @@ class StatsAnalyticsTests {
         assertTrue(defaultGri.value > 40f)
     }
 
+    // -------------------------------------------------------------------- GMI
+
+    @Test
+    fun gmiBandsSplitOnTheTherapyTargetTheTilePrints() {
+        // 7.0 is the target itself, so it still counts as meeting it.
+        assertEquals(GmiBand.AT_TARGET, GmiBand.of(6.6f))
+        assertEquals(GmiBand.AT_TARGET, GmiBand.of(GmiBand.TARGET_PERCENT))
+        assertEquals(GmiBand.ABOVE_TARGET, GmiBand.of(7.1f))
+        assertEquals(GmiBand.WELL_ABOVE_TARGET, GmiBand.of(GmiBand.WELL_ABOVE_TARGET_PERCENT))
+        assertEquals(GmiBand.WELL_ABOVE_TARGET, GmiBand.of(9f))
+    }
+
+    @Test
+    fun gmiDoesNotJudgeTherapyByTheDiagnosticThresholds() {
+        // 5.7 and 6.5 screen an undiagnosed population; on this screen they are not a
+        // scale at all, so nothing below the target may land in a warning band.
+        listOf(5.6f, 5.7f, 6.4f, 6.5f, 6.9f).forEach { gmi ->
+            assertEquals("GMI $gmi is within target", GmiBand.AT_TARGET, GmiBand.of(gmi))
+        }
+    }
+
     // ---------------------------------------------------------------- cadence
 
     @Test


### PR DESCRIPTION
Fixes #191 — both halves of it: the tombstone loop that wedges the whole treatment path, and the fact that nothing outside `Log.e` ever said so.

## 1 + 2 — a failed delete no longer aborts the run

`JournalTreatmentUploader.uploadInternal` broke out of the tombstone loop on the first refused delete and gated the entry upload on `uploadOk`. The tombstone was never cleared, so every later cycle failed at the same document: a Nightscout role with `api:treatments:create` but not `api:treatments:delete` stopped **all** treatment uploads from the first deleted or edited journal entry onwards. Returning `false` also makes the native loop `continue`, which skips `uploadIobDeviceStatus()` — that is the "and IOB" in the issue title.

Now:

- deletes and creates are independent; a refused delete is recorded against the tombstone and the run carries on to the pending entries;
- **404/410 clear the tombstone.** The document we wanted gone is gone. The old boolean path treated these as failures and retried them forever — a second latent wedge, since deleting an entry Nightscout never had could never resolve;
- a tombstone refused `MAX_DELETE_ATTEMPTS` (20) times is dropped with a loud log, so one undeletable document can't accumulate work for the life of the install;
- delete failures no longer decide the return value, so the IOB device status keeps flowing while a delete is stuck. A failed *entry* upload still returns false — that is a systemic signal (auth, endpoint) worth backing off on.

`journal_pending_deletes` gains `attempts` / `lastAttemptAt` (Room v13, additive migration).

## 3 — the failure is visible

`JournalSyncStatus` records the outcome of each send cycle (persisted, because "failing since" is only worth anything across a restart) and the Nightscout settings status card gains a treatments line:

| state | line |
|---|---|
| healthy | `Treatments: last sent 14/08 09:12` |
| upload failing | `Treatments: sending has failed since 14/08 09:12 (HTTP 401)` — error colour |
| delete refused | `Treatments: deletions refused since 14/08 09:12 (HTTP 403)` — error colour |
| nothing sent yet | `Treatments: nothing sent yet` |

The four lines above it come from the native entries uploader, which is exactly why they could read HTTP 200 while this path had been dead for days. It covers the reported API-v3/401 case too: that shows as `sending has failed since … (HTTP 401)` instead of only appearing in logcat.

`failingSince` keeps the *first* failure of a run, so a path dead for days says so rather than resetting to "just now" each cycle. An idle cycle with nothing pending clears the failure but does not move "last sent".

## Notes

- `NightPost.deleteUrlCode` reports the HTTP status; `deleteUrl` keeps its boolean signature and `@Keep`, because `uploadtreatment.cpp` calls it over JNI.
- New strings are in `values/` and all 14 `values-*` locales.

## Verification

`./gradlew :Common:testMobileDebugUnitTest` green, including 9 new tests over the tombstone policy (`tombstoneAction`) and the sync-status state machine. `git diff --check` clean. Not run on a device — the Room migration and the settings line have not been exercised on hardware.