### PR TITLE
LibreView: send the journal, and the values the app actually shows

### DIFF
--- a/Common/proguard-rules.my
+++ b/Common/proguard-rules.my
@@ -131,6 +131,22 @@
 # @Keep; keep the two in sync.
 -keep class tk.glucodata.NightscoutCalibration { *; }
 
+# Keep the LibreView journal bridge stable. journalentries.cpp resolves LibreviewJournal by
+# FindClass/GetStaticMethodID, and LibreviewJournal resolves the mobile-only
+# LibreviewJournalEntries by name -- neither is a reference R8 can see. Without these the
+# journal's food/insulin/notes silently stop reaching LibreView in minified builds only,
+# which is exactly how this feature looked before it existed.
+-keep class tk.glucodata.LibreviewJournal { *; }
+-keepnames class tk.glucodata.data.journal.LibreviewJournalEntries
+-keepclassmembers class tk.glucodata.data.journal.LibreviewJournalEntries {
+    public static int prepare(boolean);
+    public static java.lang.String foodEntries();
+    public static java.lang.String insulinEntries();
+    public static java.lang.String noteEntries();
+    public static void commit();
+    public static void discard();
+}
+
 # Keep notification/AOD predictive chart bridge stable. NotificationChartDrawer
 # resolves the mobile-only helper by name so main/wear source sets do not take a
 # direct dependency on mobile prediction/journal classes.

--- a/Common/src/main/cpp/CMakeLists.txt
+++ b/Common/src/main/cpp/CMakeLists.txt
@@ -63,7 +63,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
 set(BCRYPTDIR ${INCLUDESELF}/bcrypt/)
 set(BCRYPTFILES ${BCRYPTDIR}aes_encrypt.c ${BCRYPTDIR}bcrypt.cpp ${BCRYPTDIR}ccm_mode.c ${BCRYPTDIR}utils.c)
 
-set(EXTRAVIEW ${NETDIR}/libreview/putsensor.cpp ${NETDIR}/libreview/mkrealhistory.cpp ${NETDIR}/libreview/libreview.cpp ${NETDIR}/libreview/newlibre3.cpp ${NETDIR}/libreview/libreview.cpp )
+set(EXTRAVIEW ${NETDIR}/libreview/putsensor.cpp ${NETDIR}/libreview/mkrealhistory.cpp ${NETDIR}/libreview/libreview.cpp ${NETDIR}/libreview/newlibre3.cpp ${NETDIR}/libreview/journalentries.cpp ${NETDIR}/libreview/libreview.cpp )
 
 set(LIBRE3FILES ${INCLUDESELF}/libre3/bluetooth.cpp ${INCLUDESELF}/libre3/nfc.cpp)
 

--- a/Common/src/main/cpp/net/libreview/journalentries.cpp
+++ b/Common/src/main/cpp/net/libreview/journalentries.cpp
@@ -1,0 +1,145 @@
+/*      Part of JugglucoNG.                                                          */
+/*                                                                                   */
+/*      The journal's contribution to the LibreView measurement log.                 */
+/*                                                                                   */
+/*      LibreView's food, insulin and generic arrays used to be written only from the */
+/*      legacy native Numdata store. The Compose journal keeps its entries in Room and*/
+/*      never writes that store, so nothing a user recorded reached LibreView --      */
+/*      the "send amounts" switch was wired to an empty source. Nightscout was moved  */
+/*      off Numdata the same way (see JournalTreatmentUploader); this is the LibreView*/
+/*      half of that move.                                                            */
+/*                                                                                   */
+/*      The payload buffer is sized before it is filled, so the entries are fetched   */
+/*      once per document and held here: prepare() renders and caches them, write()   */
+/*      copies one array out, and commit()/discard() runs after the POST is answered. */
+
+#include <jni.h>
+#include <string>
+#include "libreview.hpp"
+#include "logs.hpp"
+
+extern JNIEnv *getenv();
+
+namespace {
+
+jclass journalclass = nullptr;
+bool journallookupfailed = false;
+
+std::string pendingfood, pendinginsulin, pendingnotes;
+
+bool ensurejournalclass(JNIEnv *env) {
+    if (journalclass != nullptr)
+        return true;
+    if (journallookupfailed)
+        return false;
+    constexpr const char classstr[] = "tk/glucodata/LibreviewJournal";
+    if (jclass cl = env->FindClass(classstr)) {
+        journalclass = (jclass)env->NewGlobalRef(cl);
+        env->DeleteLocalRef(cl);
+        if (journalclass != nullptr)
+            return true;
+        }
+    if (env->ExceptionCheck())
+        env->ExceptionClear();
+    journallookupfailed = true;
+    LOGGER("FindClass(%s) failed\n", classstr);
+    return false;
+    }
+
+//The rendered entries are ASCII by construction -- LibreviewJournalTransfer escapes every
+//non-ASCII character -- so JNI's modified UTF-8 and the bytes that go on the wire are the
+//same thing, and the length reported here is the length written later.
+std::string fetchfragment(JNIEnv *env, const char *name) {
+    jmethodID method = env->GetStaticMethodID(journalclass, name, "()Ljava/lang/String;");
+    if (method == nullptr) {
+        if (env->ExceptionCheck())
+            env->ExceptionClear();
+        return {};
+        }
+    auto jstr = (jstring)env->CallStaticObjectMethod(journalclass, method);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        return {};
+        }
+    if (jstr == nullptr)
+        return {};
+    std::string uit;
+    if (const char *chars = env->GetStringUTFChars(jstr, nullptr)) {
+        uit.assign(chars, env->GetStringUTFLength(jstr));
+        env->ReleaseStringUTFChars(jstr, chars);
+        }
+    env->DeleteLocalRef(jstr);
+    return uit;
+    }
+
+void callvoid(const char *name) {
+    auto env = getenv();
+    if (env == nullptr || !ensurejournalclass(env))
+        return;
+    jmethodID method = env->GetStaticMethodID(journalclass, name, "()V");
+    if (method == nullptr) {
+        if (env->ExceptionCheck())
+            env->ExceptionClear();
+        return;
+        }
+    env->CallStaticVoidMethod(journalclass, method);
+    if (env->ExceptionCheck())
+        env->ExceptionClear();
+    }
+
+} // namespace
+
+int libreviewJournalPrepare(bool libre3) {
+    pendingfood.clear();
+    pendinginsulin.clear();
+    pendingnotes.clear();
+    auto env = getenv();
+    if (env == nullptr || !ensurejournalclass(env))
+        return 0;
+    jmethodID prepare = env->GetStaticMethodID(journalclass, "prepare", "(Z)I");
+    if (prepare == nullptr) {
+        if (env->ExceptionCheck())
+            env->ExceptionClear();
+        return 0;
+        }
+    const int announced = env->CallStaticIntMethod(journalclass, prepare, (jboolean)libre3);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        return 0;
+        }
+    if (announced <= 0)
+        return 0;
+    pendingfood = fetchfragment(env, "foodEntries");
+    pendinginsulin = fetchfragment(env, "insulinEntries");
+    pendingnotes = fetchfragment(env, "noteEntries");
+    //Size from what was actually handed over, never from what Java announced: the buffer
+    //has to hold the bytes this file will copy, whatever the other side counted.
+    const int total = (int)(pendingfood.size() + pendinginsulin.size() + pendingnotes.size());
+    LOGGER("libreview journal entries: food=%zu insulin=%zu notes=%zu\n", pendingfood.size(),
+           pendinginsulin.size(), pendingnotes.size());
+    return total;
+    }
+
+int libreviewJournalWrite(char *out, const int kind) {
+    const std::string &from = kind == libreviewJournalFood     ? pendingfood
+                              : kind == libreviewJournalInsulin ? pendinginsulin
+                                                                : pendingnotes;
+    if (from.empty())
+        return 0;
+    memcpy(out, from.data(), from.size());
+    return (int)from.size();
+    }
+
+void libreviewJournalCommit() {
+    pendingfood.clear();
+    pendinginsulin.clear();
+    pendingnotes.clear();
+    callvoid("commit");
+    }
+
+void libreviewJournalDiscard() {
+    pendingfood.clear();
+    pendinginsulin.clear();
+    pendingnotes.clear();
+    callvoid("discard");
+    }

--- a/Common/src/main/cpp/net/libreview/libreview.cpp
+++ b/Common/src/main/cpp/net/libreview/libreview.cpp
@@ -153,8 +153,9 @@ static char *librehistel(const LibreHistEl *el, const int64_t histor,
     "timestamp": "2023-09-08T21:57:38.000+02:00"
  } */
 
-static char *libreScanel(const ScanData &scanel, const int16_t nr, char *ptr) {
-  const auto mgdL = scanel.getmgdL();
+static char *libreScanel(const SensorGlucoseData *sens, const ScanData &scanel,
+                         const int16_t nr, char *ptr) {
+  const auto mgdL = libreviewExportedMgdl(sens, scanel.gettime(), scanel.getmgdL());
   valuestart(ptr, mgdL);
   int mil = 0;
   ptr += TdatestringGMT(scanel.gettime(), mil, ptr);
@@ -301,6 +302,8 @@ static LibreHist librehistory(SensorGlucoseData *sensdata, uint32_t starttime,
   for (const ScanData *iter = found; iter <= laststream;) {
     uint64_t timesum = 0LL;
     double glusum = 0.0;
+    double rawsum = 0.0;
+    int rawnum = 0;
     int num = 0;
     const int nextid = id + periodright;
     if (nextid > laststreamid)
@@ -309,6 +312,10 @@ static LibreHist librehistory(SensorGlucoseData *sensdata, uint32_t starttime,
       //        LOGGER("id %d\n",iter->id);
       timesum += iter->t;
       glusum += iter->g;
+      if (const int raw = sensdata->getRawForPoll(iter); raw > 0) {
+        rawsum += raw;
+        ++rawnum;
+      }
       useddata = iter;
       ++num;
       do {
@@ -318,8 +325,14 @@ static LibreHist librehistory(SensorGlucoseData *sensdata, uint32_t starttime,
     }
   ENDINLOOP:
     if (num) {
-      list[datuit].ti = timesum / num;
-      list[datuit].mgdL = (int16_t)round(glusum / num);
+      //Average first, then calibrate, exactly as the Nightscout uploader does, so both
+      //destinations carry the same series rather than two roundings of it.
+      const uint32_t avgtime = timesum / num;
+      const int avgmgdl = (int)round(glusum / num);
+      const int avgraw = rawnum ? (int)lround(rawsum / rawnum) : 0;
+      list[datuit].ti = avgtime;
+      list[datuit].mgdL =
+          (int16_t)libreviewExportedMgdl(sensdata, avgtime, avgmgdl, avgraw);
       list[datuit++].id = id;
       //    LOGGER("in id=%d\n",id);
     }
@@ -444,9 +457,10 @@ bool putwhenneeded(bool libre3, SensorGlucoseData *sensdata) {
   }
 }
 extern int betweenviews;
-static char *onecurrent(const ScanData &scanel, const int nr, char *ptr,
-                        bool isviewed) {
-  const auto mgdL = scanel.getmgdL();
+static char *onecurrent(const SensorGlucoseData *sens, const ScanData &scanel,
+                        const int nr, char *ptr, bool isviewed) {
+  const auto mgdL = libreviewExportedMgdl(sens, scanel.gettime(), scanel.getmgdL(),
+                                          sens ? sens->getRawForPoll(&scanel) : 0);
   valuestart(ptr, mgdL);
   int mil = getmmsec();
   auto wastime = scanel.gettime();
@@ -472,7 +486,7 @@ static void addoldcurrents(char *&uitptr, const SensorGlucoseData *sens,
   for (int i : viewed) {
     if (i >= start && i < current) {
       const ScanData *el = startstream + i;
-      uitptr = onecurrent(*el, i, uitptr, true);
+      uitptr = onecurrent(sens, *el, i, uitptr, true);
       *uitptr++ = ',';
     }
   }
@@ -535,7 +549,7 @@ betweenviews
               }
            }*/
       }
-      uitptr = onecurrent(*el, i, uitptr, isViewed);
+      uitptr = onecurrent(sens, *el, i, uitptr, isViewed);
       *uitptr++ = ',';
       addoldcurrents(uitptr, sens, start, id);
       return ends;
@@ -662,7 +676,11 @@ bool sendlibreviewdata(const int newcurrent, const uint32_t nu) {
 #else
   constexpr const int bytesnumbers = 0;
 #endif
-  if (!nrscans && !histtotal && !bytesnumbers && !hasnewcurrent) {
+  //Journal entries are pending from the moment they are rendered until the document is
+  //answered, so the guard releases them on every path out of here that is not a success.
+  const int journalbytes = libreviewJournalPrepare(false);
+  destruct _journal([] { libreviewJournalDiscard(); });
+  if (!nrscans && !histtotal && !bytesnumbers && !journalbytes && !hasnewcurrent) {
     LOGAR("libreview not needed");
     return true;
   }
@@ -707,7 +725,7 @@ bool sendlibreviewdata(const int newcurrent, const uint32_t nu) {
       350 + timeuitlen + aftercurrents.size() + afterdevice2.size() +
       afterlocalstartime.size() + afterhists.size() + afterscans.size() +
       usertokenlen + aftertoken.size() + nrscans * scanelsize +
-      afterfood.size() + afterinsulin.size();
+      afterfood.size() + afterinsulin.size() + journalbytes;
 
 #ifndef NOLOG
 
@@ -779,9 +797,18 @@ bool sendlibreviewdata(const int newcurrent, const uint32_t nu) {
   uitptr += devicelen;
 
   addstrview(uitptr, afterdevice2);
-  uitptr += numbers.writeallfood(uitptr);
+  {
+    //Journal entries first, then the legacy store's. Each journal entry ends in a comma,
+    //writeallfood drops its own last one, so only a journal-only array needs trimming.
+    char *foodstart = uitptr;
+    uitptr += libreviewJournalWrite(uitptr, libreviewJournalFood);
+    uitptr += numbers.writeallfood(uitptr);
+    if (uitptr > foodstart && uitptr[-1] == ',')
+      --uitptr;
+  }
   addstrview(uitptr, afterfood);
   const char *startptr = uitptr;
+  uitptr += libreviewJournalWrite(uitptr, libreviewJournalNotes);
   uitptr += numbers.writeallnotes(uitptr);
   uitptr +=
       makesensorstarts(lists + startsensor, senslen - startsensor, uitptr);
@@ -789,7 +816,13 @@ bool sendlibreviewdata(const int newcurrent, const uint32_t nu) {
     --uitptr;
   addstrview(uitptr, afterlocalstartime);
   LOGAR("before numbers.writeallinsulin(uitptr)");
-  uitptr += numbers.writeallinsulin(uitptr);
+  {
+    char *insulinstart = uitptr;
+    uitptr += libreviewJournalWrite(uitptr, libreviewJournalInsulin);
+    uitptr += numbers.writeallinsulin(uitptr);
+    if (uitptr > insulinstart && uitptr[-1] == ',')
+      --uitptr;
+  }
   LOGAR("after numbers.writeallinsulin(uitptr)");
   addstrview(uitptr, afterinsulin);
 
@@ -825,7 +858,7 @@ bool sendlibreviewdata(const int newcurrent, const uint32_t nu) {
              ++iter) {
           ++id;
           if (iter->valid() && iter->gettime() > starttimeiter) {
-            uitptr = libreScanel(*iter, id, uitptr);
+            uitptr = libreScanel(sensdata, *iter, id, uitptr);
             *uitptr++ = ',';
             ++scansiter;
           }
@@ -851,7 +884,7 @@ bool sendlibreviewdata(const int newcurrent, const uint32_t nu) {
   //    write(STDOUT_FILENO,uitbuf,uitlen);
   LOGGER("uitlen=%d\n", uitlen);
   logwriter(uitbuf, uitlen);
-  if (!currentToSend && scansiter == 0 && !histtotal && !bytesnumbers) {
+  if (!currentToSend && scansiter == 0 && !histtotal && !bytesnumbers && !journalbytes) {
     LOGAR("Nothing to write to libreview");
     return true;
   }
@@ -864,6 +897,7 @@ bool sendlibreviewdata(const int newcurrent, const uint32_t nu) {
   if (datasend) {
     LOGAR("libresendmeasurements success");
     numbers.onSuccess();
+    libreviewJournalCommit();
     if (currentsend > 0) {
       currentsensor->getinfo()->libreCurrentIter = currentsend + 1;
       currentsensor->getinfo()->sendsensorstart = true;

--- a/Common/src/main/cpp/net/libreview/libreview.hpp
+++ b/Common/src/main/cpp/net/libreview/libreview.hpp
@@ -114,5 +114,33 @@ extern bool putwhenneeded(bool libre3,SensorGlucoseData *sensdata) ;
 extern bool	libresendmeasurements(bool libre3,const char *measurements,const int len);
 
 extern bool sendlibre3viewdata(bool,uint32_t);
+
+//The journal's contribution to the LibreView measurement log; see journalentries.cpp.
+//prepare() renders and caches the pending entries and returns their total size, write()
+//copies one array into the payload, and exactly one of commit()/discard() closes the pass.
+enum libreviewJournalKind { libreviewJournalFood=0, libreviewJournalInsulin=1, libreviewJournalNotes=2 };
+extern int libreviewJournalPrepare(bool libre3);
+extern int libreviewJournalWrite(char *out,const int kind);
+extern void libreviewJournalCommit();
+extern void libreviewJournalDiscard();
+
+//Every other exchange output -- Nightscout, the webserver, the watch, CSV export -- publishes
+//the value the app itself shows, the user's calibration and the exchange smoothing included.
+//LibreView was the one destination still sending the stored sensor lane, so a calibrated
+//user's LibreLinkUp followers saw numbers that matched nothing on their phone.
+extern int resolveExportedMgdlAt(const SensorGlucoseData *sens,const sensorname_t *sensorname,
+                                 const uint32_t tim,const int storedMgdl,const int rawCurrent);
+
+//rawCurrent stays 0 for records that are not polls -- scans and the 15-minute history --
+//because raw values only exist in the polls array and there is nothing to look them up by.
+//A raw-primary sensor then keeps its auto lane there rather than being calibrated against a
+//value that is not present.
+inline int libreviewExportedMgdl(const SensorGlucoseData *sens,const uint32_t tim,
+                                 const int storedMgdl,const int rawCurrent=0) {
+	if(!sens||storedMgdl<=0)
+		return storedMgdl;
+	const int exported=resolveExportedMgdlAt(sens,sens->shortsensorname(),tim,storedMgdl,rawCurrent);
+	return exported>0?exported:storedMgdl;
+	}
 #include "settings/mixpass.hpp"
 constexpr  const uint32_t day15secs=15*24*60*60;

--- a/Common/src/main/cpp/net/libreview/mkrealhistory.cpp
+++ b/Common/src/main/cpp/net/libreview/mkrealhistory.cpp
@@ -88,7 +88,9 @@ LibreHist  libreRealHistory(SensorGlucoseData *sens,uint32_t starttime,uint32_t 
 	for(;iter<endpos;iter++) {
 		const Glucose *gl=sens->getglucose(iter);
 		if(gl->valid()&&!info->isLibreSend(iter)) {
-			list[uitit++]={.ti=gl->gettime(),.mgdL=gl->getmgdL(),.id=(uint16_t)(gl->getid())};
+			list[uitit++]={.ti=gl->gettime(),
+			               .mgdL=(uint16_t)libreviewExportedMgdl(sens,gl->gettime(),gl->getmgdL()),
+			               .id=(uint16_t)(gl->getid())};
 			}
 		}
 	LOGGER("startit=%d nr=%d\n",startit,uitit);

--- a/Common/src/main/cpp/net/libreview/newlibre3.cpp
+++ b/Common/src/main/cpp/net/libreview/newlibre3.cpp
@@ -33,6 +33,7 @@
 #include "settings/settings.hpp"
 #include "SensorGlucoseData.hpp"
 #include "share/serial.hpp"
+#include "destruct.hpp"
 #include "libreview.hpp"
 #ifdef LIBRENUMBERS
 #include "librenumbers.hpp"
@@ -134,14 +135,15 @@ return sprintf(buf,entry, factime,num,stamp, value);
 #define EXTRATIME 0
 #endif
 static_assert(sizeof(long long)==sizeof(int64_t), "");
-static int histel3_2str(const Glucose *el,const int64_t histor,char *buf) {
+static int histel3_2str(const SensorGlucoseData *sens,const Glucose *el,const int64_t histor,char *buf) {
 	char gmttime[25+EXTRATIME];
 	auto tim=el->gettime();
 	int mil=getmmsec();
 	TdatestringGMT(tim,mil,gmttime);
 	char timestr[30+EXTRATIME];
 	Tdatestringlocal(tim,mil,timestr);
-	return historyformat(buf,gmttime,mkhistrecord(histor,el->getid()),timestr,(float)el->getmgdL());
+	return historyformat(buf,gmttime,mkhistrecord(histor,el->getid()),timestr,
+	                     (float)libreviewExportedMgdl(sens,tim,el->getmgdL()));
 	}
 
 
@@ -244,7 +246,7 @@ bool getisviewed(time_t wastime) {
 		}
 	return false;
 	}
-static int addcurrent(char *buf,int64_t histor,const ScanData *el,bool &viewed) {
+static int addcurrent(const SensorGlucoseData *sens,char *buf,int64_t histor,const ScanData *el,bool &viewed) {
 	char gmttime[25+EXTRATIME];
 	auto tim=el->gettime();
 	int mil=getmmsec();
@@ -254,7 +256,8 @@ static int addcurrent(char *buf,int64_t histor,const ScanData *el,bool &viewed) 
 	int64_t recordnum=mkhistrecord(histor,el->getid());
 	viewed=getisviewed(tim) ;
 	const char *isviewed=viewed?"true":"false";
-	return sprintf(buf,onecurrent, trendName[el->tr],isviewed,gmttime,recordnum,timestr,(float)el->getmgdL());
+	return sprintf(buf,onecurrent, trendName[el->tr],isviewed,gmttime,recordnum,timestr,
+	               (float)libreviewExportedMgdl(sens,tim,el->getmgdL(),sens?sens->getRawForPoll(el):0));
 	}
 //uint16_t lastLifeCountReceived;
 
@@ -281,7 +284,7 @@ static int sendallcurrent(uint32_t nu,SensorGlucoseData *sens,char *buf,int *las
 		const ScanData *el=startstream+i;
 		if(el->current(i)) {
 			int64_t histor=libreviewSensorNameID(sens);
-			int wrote=addcurrent(buf,histor,el,viewed);
+			int wrote=addcurrent(sens,buf,histor,el,viewed);
 			return wrote;
 			}
 		}
@@ -305,7 +308,7 @@ int allhistory(SensorGlucoseData *sens,char *buf,uint32_t *lasttime,int *nextnum
 	for(;iter<=endpos;iter++) {
 		const Glucose *gl=sens->getglucose(iter);
 		if(gl->valid()) {
-			pos+=histel3_2str(gl,histor,buf+pos);
+			pos+=histel3_2str(sens,gl,histor,buf+pos);
 			*lasttime=gl->gettime();
 			buf[pos++]=',';
 			}
@@ -405,11 +408,15 @@ LOGGER("numbers.spaceneeded()=%d\n",bytesnumbers);
 #else
 constexpr const int  bytesnumbers=0;
 #endif
+//Journal entries stay pending until this document is answered; the guard releases them on
+//every way out of here that is not a success.
+const int journalbytes=libreviewJournalPrepare(true);
+destruct _journal([] { libreviewJournalDiscard(); });
 	lastsensor=lastlibre3;
 LOGGER("startsensor=%d lastsensor=%d\n",startsensor,lastsensor);
 SensorGlucoseData *lastsensdata=(lastsensor<0)?nullptr:sensors->getSensorData(lastsensor); //TODO later?
 
-	if(bytesnumbers==0&&inhistory<=0) {
+	if(bytesnumbers==0&&journalbytes==0&&inhistory<=0) {
 		if(!hasnewcurrent)
 			return true;
 		}
@@ -424,7 +431,7 @@ const int usertokenlen= settings->data()->tokensize3;
 
 constexpr int restsize=2300;
 
-int totalsize= bytesnumbers+restsize+usertokenlen+incurrent*onecurrentsize+inhistory*onehistorysize+1;
+int totalsize= bytesnumbers+journalbytes+restsize+usertokenlen+incurrent*onecurrentsize+inhistory*onehistorysize+1;
 
 LOGGER("inhistory=%d incurrent=%d totalsize=%d\n",inhistory,incurrent,totalsize);
 char *buf= new(std::nothrow)  char[totalsize];
@@ -468,15 +475,26 @@ if(wrotecurrent>0) {
 	addarray(newline);
 	}
 addarray(afterentries);
+//Journal entries first, then the legacy store's. Each journal entry ends in a comma and
+//writeallfood drops its own last one, so only a journal-only array needs trimming.
+char *foodstart=uitptr;
+uitptr+=libreviewJournalWrite(uitptr,libreviewJournalFood);
 int wrotefood=numbers.writeallfood(uitptr);
-if(wrotefood>0) {
-	uitptr+=wrotefood;
+uitptr+=wrotefood;
+if(uitptr>foodstart) {
+	if(uitptr[-1]==',')
+		--uitptr;
 	addarray(newline);
 	}
 addarray(afterFoodentries);
 
-const int notelen=numbers.writeallnotes(uitptr);
-uitptr+=notelen;
+const int journalnotelen=libreviewJournalWrite(uitptr,libreviewJournalNotes);
+uitptr+=journalnotelen;
+const int nativenotelen=numbers.writeallnotes(uitptr);
+uitptr+=nativenotelen;
+//Both writers end every entry with a comma, so a non-zero total still means one is
+//trailing -- which is what the sensor-start block below decides whether to trim.
+const int notelen=journalnotelen+nativenotelen;
 
 int addsensorlen;
 if(wrotecurrent>0) {
@@ -495,9 +513,13 @@ else {
           }
 	}
 addarray(aftergeneric);
+char *insulinstart=uitptr;
+uitptr+=libreviewJournalWrite(uitptr,libreviewJournalInsulin);
 int wroteinsulin=numbers.writeallinsulin(uitptr);
-if(wroteinsulin>0) {
-	uitptr+=wroteinsulin;
+uitptr+=wroteinsulin;
+if(uitptr>insulinstart) {
+	if(uitptr[-1]==',')
+		--uitptr;
 	addarray(newline);
 	}
 addarray(afterinsulin);
@@ -539,6 +561,7 @@ bool datasend=libresendmeasurements(true,buf,uitlen);
 if(datasend) {
 	LOGSTRING("libresendmeasurements libre3 success\n");
 	numbers.onSuccess();
+	libreviewJournalCommit();
 //	int nextsensor=(wrotecurrent>0)?lastsensor:lastwrote;
 	if(nextsensor>=0) {
 		settings->data()->startlibre3view=nextsensor;

--- a/Common/src/main/cpp/net/watchserver/common.cpp
+++ b/Common/src/main/cpp/net/watchserver/common.cpp
@@ -17,6 +17,7 @@ extern jclass JNINightscoutCalibration;
 extern double getdelta(float change);
 extern std::string_view getdeltaname(float rate);
 extern double calibrateONE(const SensorGlucoseData *sens,const ScanData &value);
+extern double calibrateONE(const SensorGlucoseData *sens,const uint32_t time,const double value);
 
 static jclass exportvalueclass=nullptr;
 
@@ -39,13 +40,18 @@ static bool ensureexportvalueclass(JNIEnv *env) {
     return false;
     }
 
-int resolveExportedMgdl(const SensorGlucoseData *sens, const ScanData *val,
-                        const sensorname_t *sensorname) {
-    if(!sens||!val||!sensorname)
+//Value-based entry point, for outputs whose records are not ScanData: the LibreView
+//history stream carries Glucose records, which live outside the polls array and so have
+//no raw counterpart to look up. Those callers pass rawCurrent=0, which leaves a
+//raw-primary sensor on its auto lane rather than calibrating against a value that is not
+//there.
+int resolveExportedMgdlAt(const SensorGlucoseData *sens,const sensorname_t *sensorname,
+                          const uint32_t tim,const int storedMgdl,const int rawCurrent) {
+    if(!sens||!sensorname||storedMgdl<=0)
         return 0;
-    int autoMgdl=val->getmgdL();
+    int autoMgdl=storedMgdl;
     if(settings->data()->DoCalibrate) {
-        if(double calibrated=calibrateONE(sens,*val);!isnan(calibrated))
+        if(double calibrated=calibrateONE(sens,tim,(double)storedMgdl);!isnan(calibrated))
             autoMgdl=(int)round(calibrated);
         }
     auto env=getenv();
@@ -66,7 +72,6 @@ int resolveExportedMgdl(const SensorGlucoseData *sens, const ScanData *val,
     auto jsensor=env->NewStringUTF(sensornameStr);
     const auto *info=sens->getinfo();
     const int viewMode=info?info->viewMode:0;
-    const int rawCurrent=sens->getRawForPoll(val);
     const int resolved=env->CallStaticIntMethod(
         exportvalueclass,
         exportedValueMethod,
@@ -74,7 +79,7 @@ int resolveExportedMgdl(const SensorGlucoseData *sens, const ScanData *val,
         viewMode,
         autoMgdl,
         rawCurrent,
-        (jlong)val->gettime()*1000LL
+        (jlong)tim*1000LL
     );
     env->DeleteLocalRef(jsensor);
     if(env->ExceptionCheck()) {
@@ -82,6 +87,14 @@ int resolveExportedMgdl(const SensorGlucoseData *sens, const ScanData *val,
         return autoMgdl;
         }
     return resolved>0?resolved:autoMgdl;
+    }
+
+int resolveExportedMgdl(const SensorGlucoseData *sens, const ScanData *val,
+                        const sensorname_t *sensorname) {
+    if(!sens||!val||!sensorname)
+        return 0;
+    return resolveExportedMgdlAt(sens,sensorname,val->gettime(),val->getmgdL(),
+                                 sens->getRawForPoll(val));
     }
 
 const ScanData *makeExportedScan(const SensorGlucoseData *sens,

--- a/Common/src/main/cpp/net/watchserver/common.hpp
+++ b/Common/src/main/cpp/net/watchserver/common.hpp
@@ -209,6 +209,8 @@ inline void addjsonstring(char *&outptr,std::string_view value) {
 
 int resolveExportedMgdl(const SensorGlucoseData *sens, const ScanData *val,
                         const sensorname_t *sensorname);
+int resolveExportedMgdlAt(const SensorGlucoseData *sens, const sensorname_t *sensorname,
+                          const uint32_t tim, const int storedMgdl, const int rawCurrent);
 const ScanData *makeExportedScan(const SensorGlucoseData *sens,
                                  const ScanData *val,
                                  const sensorname_t *sensorname,

--- a/Common/src/main/java/tk/glucodata/LibreviewJournal.java
+++ b/Common/src/main/java/tk/glucodata/LibreviewJournal.java
@@ -1,0 +1,123 @@
+package tk.glucodata;
+
+import androidx.annotation.Keep;
+
+import java.lang.reflect.Method;
+
+/**
+ * Bridge between the native LibreView writer and the journal's LibreView entries.
+ *
+ * The LibreView payload is assembled in {@code net/libreview/libreview.cpp} and
+ * {@code newlibre3.cpp}, whose food/insulin/generic arrays were fed only by the legacy
+ * native {@code Numdata} store — a store the Compose journal never writes, so nothing a
+ * user recorded ever reached LibreView. This resolves the mobile-only journal by name, the
+ * same way {@link NightPost#uploadJournalTreatments(boolean)} does, so the wearable build
+ * (which has no journal database compiled in) simply contributes nothing.
+ *
+ * <p>The native side calls {@link #prepare(boolean)} while sizing its buffer, the three
+ * accessors while filling it, and exactly one of {@link #commit()} / {@link #discard()}
+ * once it knows whether LibreView accepted the document.
+ */
+@Keep
+public final class LibreviewJournal {
+    private static final String LOG_ID = "LibreviewJournal";
+    private static final String ENTRIES_CLASS = "tk.glucodata.data.journal.LibreviewJournalEntries";
+
+    private LibreviewJournal() {}
+
+    private static volatile Class<?> entriesClass;
+    private static volatile boolean unavailable;
+
+    private static Class<?> entries() {
+        if (unavailable) {
+            return null;
+        }
+        Class<?> cached = entriesClass;
+        if (cached != null) {
+            return cached;
+        }
+        try {
+            cached = Class.forName(ENTRIES_CLASS);
+            entriesClass = cached;
+            return cached;
+        } catch (ClassNotFoundException nfe) {
+            // Wearable build: no journal database. Nothing to contribute, and nothing wrong.
+            unavailable = true;
+            return null;
+        } catch (Throwable th) {
+            unavailable = true;
+            Log.e(LOG_ID, "journal entries unavailable:\n" + Log.stackline(th));
+            return null;
+        }
+    }
+
+    /** Renders what is pending and returns its size in bytes, or 0 when there is nothing. */
+    @Keep
+    public static int prepare(boolean libre3) {
+        final Class<?> cl = entries();
+        if (cl == null) {
+            return 0;
+        }
+        try {
+            Method method = cl.getMethod("prepare", boolean.class);
+            Object result = method.invoke(null, libre3);
+            return result instanceof Integer ? (Integer) result : 0;
+        } catch (Throwable th) {
+            Log.e(LOG_ID, "prepare failed:\n" + Log.stackline(th));
+            return 0;
+        }
+    }
+
+    @Keep
+    public static String foodEntries() {
+        return fragment("foodEntries");
+    }
+
+    @Keep
+    public static String insulinEntries() {
+        return fragment("insulinEntries");
+    }
+
+    @Keep
+    public static String noteEntries() {
+        return fragment("noteEntries");
+    }
+
+    /** Marks the prepared entries delivered. Only ever called after a successful upload. */
+    @Keep
+    public static void commit() {
+        call("commit");
+    }
+
+    /** Drops the prepared entries so the next pass rebuilds them. */
+    @Keep
+    public static void discard() {
+        call("discard");
+    }
+
+    private static String fragment(String name) {
+        final Class<?> cl = entries();
+        if (cl == null) {
+            return "";
+        }
+        try {
+            Object result = cl.getMethod(name).invoke(null);
+            return result instanceof String ? (String) result : "";
+        } catch (Throwable th) {
+            Log.e(LOG_ID, name + " failed:\n" + Log.stackline(th));
+            return "";
+        }
+    }
+
+    private static void call(String name) {
+        final Class<?> cl = entries();
+        if (cl == null) {
+            return;
+        }
+        try {
+            cl.getMethod(name).invoke(null);
+        } catch (Throwable th) {
+            Log.e(LOG_ID, name + " failed:\n" + Log.stackline(th));
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
@@ -39,7 +39,7 @@ import tk.glucodata.data.journal.JournalPendingDeleteEntity
         JournalInsulinPresetEntity::class,
         JournalPendingDeleteEntity::class
     ],
-    version = 12,
+    version = 13,
     exportSchema = false
 )
 abstract class HistoryDatabase : RoomDatabase() {
@@ -239,6 +239,17 @@ abstract class HistoryDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v12 -> v13: track LibreView delivery per journal row. Without its own column the
+         * LibreView uploader would have to share nsUploadedAt with Nightscout, and either
+         * destination succeeding would mark the entry sent to both.
+         */
+        private val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE journal_entries ADD COLUMN lvUploadedAt INTEGER")
+            }
+        }
+
         fun getInstance(context: Context): HistoryDatabase =
             INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
@@ -256,7 +267,8 @@ abstract class HistoryDatabase : RoomDatabase() {
                     MIGRATION_8_9,
                     MIGRATION_9_10,
                     MIGRATION_10_11,
-                    MIGRATION_11_12
+                    MIGRATION_11_12,
+                    MIGRATION_12_13
                 )
                 .fallbackToDestructiveMigration()  // Fallback if migration chain is broken
                 .build().also { INSTANCE = it }

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
@@ -115,6 +115,19 @@ interface JournalDao {
     @Query("SELECT nsRemoteId FROM journal_entries WHERE nsUploadedAt IS NOT NULL AND nsRemoteId IS NOT NULL")
     suspend fun getOwnUploadedNightscoutRemoteIds(): List<String>
 
+    @Query(
+        """
+        SELECT * FROM journal_entries
+         WHERE timestamp >= :sinceMillis
+           AND (lvUploadedAt IS NULL OR updatedAt > lvUploadedAt)
+         ORDER BY timestamp ASC, id ASC
+        """
+    )
+    suspend fun getEntriesNeedingLibreviewUpload(sinceMillis: Long): List<JournalEntryEntity>
+
+    @Query("UPDATE journal_entries SET lvUploadedAt = :uploadedAt WHERE id IN (:ids)")
+    suspend fun markEntriesUploadedToLibreview(ids: List<Long>, uploadedAt: Long)
+
     @Query("SELECT * FROM journal_pending_deletes ORDER BY deletedAt ASC")
     suspend fun getPendingNightscoutDeletes(): List<JournalPendingDeleteEntity>
 

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalEntryEntity.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalEntryEntity.kt
@@ -35,5 +35,11 @@ data class JournalEntryEntity(
     val createdAt: Long,
     val updatedAt: Long,
     val nsUploadedAt: Long? = null,
-    val nsRemoteId: String? = null
+    val nsRemoteId: String? = null,
+    /**
+     * When this row last went out to LibreView, so an unchanged entry is not resent on
+     * every upload pass. Tracked separately from [nsUploadedAt] because the two
+     * destinations succeed and fail independently.
+     */
+    val lvUploadedAt: Long? = null
 )

--- a/Common/src/mobile/java/tk/glucodata/data/journal/LibreviewJournalEntries.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/LibreviewJournalEntries.kt
@@ -1,0 +1,134 @@
+package tk.glucodata.data.journal
+
+import androidx.annotation.Keep
+import kotlinx.coroutines.runBlocking
+import tk.glucodata.Applic
+import tk.glucodata.Log
+import tk.glucodata.Natives
+import tk.glucodata.data.HistoryDatabase
+
+/**
+ * Supplies the LibreView payload with the journal's food, insulin and note entries.
+ *
+ * The native LibreView writer sizes its buffer before it fills it, so this works in three
+ * steps driven from `net/libreview/libreview.cpp` and `newlibre3.cpp`: [prepare] renders
+ * what is pending and reports how many bytes it needs, the three accessors hand over the
+ * rendered arrays, and [commit] runs only once the document has actually been accepted.
+ * A failed upload leaves every row pending, exactly as the native cursors behave.
+ *
+ * Entries carry a trailing comma each, which is what the native array writers emit; the
+ * caller strips the last one.
+ */
+@Keep
+object LibreviewJournalEntries {
+    private const val LOG_ID = "LibreviewJournal"
+
+    /** Mirrors the native LibreView send window: older entries are the cloud's problem. */
+    private const val LOOKBACK_MILLIS = 30L * 24 * 60 * 60 * 1000
+
+    /**
+     * A cap on one document's worth of journal entries. The native buffer is sized from
+     * what [prepare] reports, so this is not a safety limit but a fairness one: a first
+     * upload after a long gap should not push a megabyte of notes ahead of the glucose
+     * data. Whatever is left goes out on the next pass.
+     */
+    private const val MAX_ENTRIES = 300
+
+    private class Pending(
+        val food: String,
+        val insulin: String,
+        val generic: String,
+        val ids: List<Long>
+    )
+
+    @Volatile
+    private var pending: Pending? = null
+
+    /**
+     * Renders everything not yet delivered to LibreView and returns its size in bytes, or
+     * 0 when there is nothing to send. Always paired with [commit] or [discard].
+     */
+    @JvmStatic
+    @Keep
+    fun prepare(libre3: Boolean): Int {
+        pending = null
+        return try {
+            if (!Natives.getSendNumbers()) return 0
+            val prepared = runBlocking { load(libre3) } ?: return 0
+            pending = prepared
+            prepared.food.toByteArray(Charsets.UTF_8).size +
+                prepared.insulin.toByteArray(Charsets.UTF_8).size +
+                prepared.generic.toByteArray(Charsets.UTF_8).size
+        } catch (th: Throwable) {
+            Log.e(LOG_ID, "prepare failed: ${Log.stackline(th)}")
+            pending = null
+            0
+        }
+    }
+
+    @JvmStatic
+    @Keep
+    fun foodEntries(): String = pending?.food.orEmpty()
+
+    @JvmStatic
+    @Keep
+    fun insulinEntries(): String = pending?.insulin.orEmpty()
+
+    @JvmStatic
+    @Keep
+    fun noteEntries(): String = pending?.generic.orEmpty()
+
+    /** Marks the prepared rows delivered. Called only after LibreView accepted the document. */
+    @JvmStatic
+    @Keep
+    fun commit() {
+        val sent = pending ?: return
+        pending = null
+        if (sent.ids.isEmpty()) return
+        try {
+            val dao = HistoryDatabase.getInstance(Applic.app).journalDao()
+            runBlocking { dao.markEntriesUploadedToLibreview(sent.ids, System.currentTimeMillis()) }
+        } catch (th: Throwable) {
+            // Losing the mark costs one duplicate send under the same record numbers, which
+            // LibreView treats as an update of the entry it already has.
+            Log.e(LOG_ID, "commit failed: ${Log.stackline(th)}")
+        }
+    }
+
+    @JvmStatic
+    @Keep
+    fun discard() {
+        pending = null
+    }
+
+    private suspend fun load(libre3: Boolean): Pending? {
+        val app = Applic.app ?: return null
+        val dao = HistoryDatabase.getInstance(app).journalDao()
+        val since = System.currentTimeMillis() - LOOKBACK_MILLIS
+        val candidates = dao.getEntriesNeedingLibreviewUpload(since)
+            .asSequence()
+            .filter { it.timestamp > 0L }
+            .filter { !LibreviewJournalTransfer.isExternalMirrorSource(it.source) }
+            .filter { LibreviewJournalTransfer.isSendable(it) }
+            .take(MAX_ENTRIES)
+            .toList()
+        if (candidates.isEmpty()) return null
+
+        val presets = HashMap<Long, JournalInsulinPresetEntity>()
+        for (presetId in candidates.mapNotNull { it.insulinPresetId }.distinct()) {
+            dao.getInsulinPresetById(presetId)?.let { presets[presetId] = it }
+        }
+
+        val built = LibreviewJournalTransfer.build(candidates, presets, libre3)
+        if (built.isEmpty) return null
+        return Pending(
+            food = join(built.food),
+            insulin = join(built.insulin),
+            generic = join(built.generic),
+            ids = candidates.map { it.id }
+        )
+    }
+
+    private fun join(entries: List<String>): String =
+        if (entries.isEmpty()) "" else entries.joinToString(separator = ",", postfix = ",")
+}

--- a/Common/src/mobile/java/tk/glucodata/data/journal/LibreviewJournalTransfer.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/LibreviewJournalTransfer.kt
@@ -1,0 +1,270 @@
+package tk.glucodata.data.journal
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+/**
+ * Renders Journal entries as LibreView measurement-log entries.
+ *
+ * LibreView's payload is assembled in native code (`net/libreview/libreview.cpp` for the
+ * Libre 2 document, `newlibre3.cpp` for the Libre 3 one) and its food/insulin/generic
+ * arrays used to be filled only from the legacy `Numdata` store, which the Compose journal
+ * never writes. This builds the same entry shapes from the Room journal instead, so what
+ * the user records reaches LibreView the way it already reaches Nightscout.
+ *
+ * The two documents differ only in how timestamps are spelled: the Libre 3 flavour omits
+ * the milliseconds the Libre 2 flavour writes. Everything else here mirrors `writeentry`
+ * in `net/libreview/librenumbers.hpp`.
+ */
+object LibreviewJournalTransfer {
+
+    /** Record-type tags, the low byte of a recordNumber. Mirrors `RecordType` in librenumbers.hpp. */
+    private const val TYPE_RAPID = 1
+    private const val TYPE_LONG = 3
+    private const val TYPE_FOOD = 4
+    private const val TYPE_NOTE = 16
+
+    /**
+     * Journal record numbers start past this.
+     *
+     * A recordNumber is `id << 8 | type`, and the legacy Numdata writer builds its half of
+     * the same namespace from a counter that starts at 1. Room row ids also start at 1, so
+     * without an offset a user who has both would send two different entries under one
+     * record number and LibreView would keep whichever arrived last.
+     */
+    private const val RECORD_NUMBER_BASE = 1_000_000L
+
+    /** Rendered entries, grouped by the array each belongs to. */
+    data class Entries(
+        val food: List<String> = emptyList(),
+        val insulin: List<String> = emptyList(),
+        val generic: List<String> = emptyList()
+    ) {
+        val isEmpty: Boolean get() = food.isEmpty() && insulin.isEmpty() && generic.isEmpty()
+    }
+
+    /**
+     * Whether this entry has anything LibreView can represent.
+     *
+     * Fingersticks are deliberately absent: LibreView carries them in `bloodGlucoseEntries`,
+     * a channel this payload does not populate, and folding them into free-text notes would
+     * present a measurement as a comment.
+     */
+    fun isSendable(entry: JournalEntryEntity): Boolean = when (JournalEntryType.fromStorage(entry.entryType)) {
+        JournalEntryType.CARBS -> positive(entry.amount) != null
+        JournalEntryType.INSULIN -> positive(entry.amount) != null
+        JournalEntryType.NOTE, JournalEntryType.ACTIVITY -> noteText(entry).isNotEmpty()
+        else -> false
+    }
+
+    /**
+     * Entries that arrived from another system are not ours to forward: re-uploading them
+     * would bounce Nightscout's and AAPS's own records back out through a second cloud.
+     */
+    fun isExternalMirrorSource(source: String): Boolean =
+        source == JournalEntrySource.AAPS.storageValue ||
+            source == JournalEntrySource.NIGHTSCOUT.storageValue ||
+            source == JournalEntrySource.API.storageValue
+
+    fun build(
+        entries: List<JournalEntryEntity>,
+        presets: Map<Long, JournalInsulinPresetEntity>,
+        libre3: Boolean,
+        zone: ZoneId = ZoneId.systemDefault()
+    ): Entries {
+        val food = ArrayList<String>()
+        val insulin = ArrayList<String>()
+        val generic = ArrayList<String>()
+        for (entry in entries) {
+            if (entry.timestamp <= 0L) continue
+            if (isExternalMirrorSource(entry.source)) continue
+            when (JournalEntryType.fromStorage(entry.entryType)) {
+                JournalEntryType.CARBS -> foodEntry(entry, libre3, zone)?.let(food::add)
+                JournalEntryType.INSULIN ->
+                    insulinEntry(entry, presets[entry.insulinPresetId ?: -1L], libre3, zone)?.let(insulin::add)
+                JournalEntryType.NOTE, JournalEntryType.ACTIVITY ->
+                    noteEntry(entry, libre3, zone)?.let(generic::add)
+                else -> Unit
+            }
+        }
+        return Entries(food, insulin, generic)
+    }
+
+    fun recordNumber(entryId: Long, typeTag: Int): Long = ((RECORD_NUMBER_BASE + entryId) shl 8) or typeTag.toLong()
+
+    private fun foodEntry(entry: JournalEntryEntity, libre3: Boolean, zone: ZoneId): String? {
+        val grams = positive(entry.amount) ?: return null
+        return entryJson(
+            valueKey = "foodType",
+            valueName = mealType(grams, entry.timestamp, zone),
+            unitKey = "gramsCarbs",
+            unitValue = format(grams, decimals = 0),
+            text = null,
+            recordNumber = recordNumber(entry.id, TYPE_FOOD),
+            timestamp = entry.timestamp,
+            libre3 = libre3,
+            zone = zone
+        )
+    }
+
+    private fun insulinEntry(
+        entry: JournalEntryEntity,
+        preset: JournalInsulinPresetEntity?,
+        libre3: Boolean,
+        zone: ZoneId
+    ): String? {
+        val units = positive(entry.amount) ?: return null
+        // Same classification Nightscout uploads use: a preset that deliberately stays out
+        // of IOB is the basal one. An unknown preset counts as rapid rather than being
+        // dropped, so an entry whose preset was deleted still reaches LibreView.
+        val isLong = preset?.let { !it.countsTowardIob } ?: false
+        return entryJson(
+            valueKey = "insulinType",
+            valueName = if (isLong) "LongActing" else "RapidActing",
+            unitKey = "units",
+            unitValue = format(units, decimals = 1),
+            text = null,
+            recordNumber = recordNumber(entry.id, if (isLong) TYPE_LONG else TYPE_RAPID),
+            timestamp = entry.timestamp,
+            libre3 = libre3,
+            zone = zone
+        )
+    }
+
+    private fun noteEntry(entry: JournalEntryEntity, libre3: Boolean, zone: ZoneId): String? {
+        val text = noteText(entry).takeIf { it.isNotEmpty() } ?: return null
+        return entryJson(
+            valueKey = "type",
+            valueName = "com.abbottdiabetescare.informatics.customnote",
+            unitKey = null,
+            unitValue = null,
+            text = text,
+            recordNumber = recordNumber(entry.id, TYPE_NOTE),
+            timestamp = entry.timestamp,
+            libre3 = libre3,
+            zone = zone
+        )
+    }
+
+    /**
+     * One measurement-log entry.
+     *
+     * A note carries its wording in `extendedProperties.text` and no value field at all,
+     * which is the shape `writeentry` produces when it is handed zero units.
+     */
+    private fun entryJson(
+        valueKey: String,
+        valueName: String,
+        unitKey: String?,
+        unitValue: String?,
+        text: String?,
+        recordNumber: Long,
+        timestamp: Long,
+        libre3: Boolean,
+        zone: ZoneId
+    ): String {
+        val sb = StringBuilder(220)
+        sb.append('{').append('"').append(valueKey).append("\":\"").append(escape(valueName)).append('"')
+        if (unitKey != null && unitValue != null) {
+            sb.append(",\"").append(unitKey).append("\":").append(unitValue)
+        }
+        sb.append(",\"extendedProperties\":{\"factoryTimestamp\":\"")
+            .append(factoryTimestamp(timestamp, libre3))
+            .append('"')
+        if (text != null) {
+            sb.append(",\"text\":\"").append(escape(text)).append('"')
+        }
+        sb.append(",\"linkedGlucoseRecordNumber\":\"0\"}")
+        sb.append(",\"recordNumber\":").append(recordNumber)
+        sb.append(",\"timestamp\":\"").append(localTimestamp(timestamp, libre3)).append('"')
+        sb.append('}')
+        return sb.toString()
+    }
+
+    /**
+     * Meal naming, copied from `getmealtype`: only a portion big enough to be a meal gets
+     * named after the time of day, and anything outside normal meal hours stays a snack.
+     */
+    internal fun mealType(grams: Float, timestamp: Long, zone: ZoneId): String {
+        if (grams <= 50f) return "Snack"
+        val hour = ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp), zone).hour
+        return when {
+            hour <= 3 -> "Snack"
+            hour < 11 -> "Breakfast"
+            hour < 16 -> "Lunch"
+            hour < 22 -> "Dinner"
+            else -> "Snack"
+        }
+    }
+
+    private fun noteText(entry: JournalEntryEntity): String {
+        val title = entry.title.trim()
+        val note = entry.note?.trim().orEmpty()
+        return when {
+            title.isEmpty() -> note
+            note.isEmpty() || note == title -> title
+            else -> "$title: $note"
+        }
+    }
+
+    /** LibreView records to the minute, so the seconds are dropped rather than rounded. */
+    private fun minuteOf(timestamp: Long, zone: ZoneId): ZonedDateTime =
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp), zone).truncatedTo(ChronoUnit.MINUTES)
+
+    internal fun factoryTimestamp(timestamp: Long, libre3: Boolean): String {
+        val utc = minuteOf(timestamp, ZoneId.of("UTC"))
+        return String.format(
+            Locale.US,
+            if (libre3) "%04d-%02d-%02dT%02d:%02d:00Z" else "%04d-%02d-%02dT%02d:%02d:00.000Z",
+            utc.year, utc.monthValue, utc.dayOfMonth, utc.hour, utc.minute
+        )
+    }
+
+    internal fun localTimestamp(timestamp: Long, libre3: Boolean, zone: ZoneId = ZoneId.systemDefault()): String {
+        val local = minuteOf(timestamp, zone)
+        val offsetMinutes = local.offset.totalSeconds / 60
+        val sign = if (offsetMinutes < 0) '-' else '+'
+        val absMinutes = kotlin.math.abs(offsetMinutes)
+        return String.format(
+            Locale.US,
+            if (libre3) "%04d-%02d-%02dT%02d:%02d:00%c%02d:%02d" else "%04d-%02d-%02dT%02d:%02d:00.000%c%02d:%02d",
+            local.year, local.monthValue, local.dayOfMonth, local.hour, local.minute,
+            sign, absMinutes / 60, absMinutes % 60
+        )
+    }
+
+    private fun format(value: Float, decimals: Int): String =
+        String.format(Locale.US, "%.${decimals}f", value)
+
+    private fun positive(amount: Float?): Float? =
+        amount?.takeIf { it.isFinite() && it > 0f }
+
+    /**
+     * Escapes to pure ASCII, not just to valid JSON.
+     *
+     * The rendered entries cross into the native writer as a Java string, and JNI hands
+     * those over in modified UTF-8, which spells anything outside the BMP as a surrogate
+     * pair rather than as the four UTF-8 bytes an HTTP body needs. One emoji in a note
+     * would therefore have corrupted the whole LibreView document — glucose data included.
+     * Escaping every non-ASCII character sidesteps that, and makes the byte count the
+     * native buffer is sized from exactly the character count.
+     */
+    private fun escape(value: String): String {
+        val sb = StringBuilder(value.length + 8)
+        for (ch in value) {
+            when {
+                ch == '"' -> sb.append("\\\"")
+                ch == '\\' -> sb.append("\\\\")
+                ch == '\n' -> sb.append("\\n")
+                ch == '\r' -> sb.append("\\r")
+                ch == '\t' -> sb.append("\\t")
+                ch < ' ' || ch.code > 0x7E -> sb.append(String.format(Locale.US, "\\u%04x", ch.code))
+                else -> sb.append(ch)
+            }
+        }
+        return sb.toString()
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/ApiSourceSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ApiSourceSettingsScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -66,6 +65,7 @@ import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.CompactSheetDragHandle
 import tk.glucodata.ui.components.SectionLabel
 import tk.glucodata.ui.components.StyledSwitch
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.components.cardShape
 
 @Composable
@@ -469,7 +469,7 @@ private fun SourcePresetPickerSheet(
     onPreset: (String) -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -39,6 +39,7 @@ import tk.glucodata.ui.theme.displayLargeExpressive
 import tk.glucodata.ui.theme.labelSmallPrim
 import tk.glucodata.ui.theme.labelLargeExpressive
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.collectAsState
@@ -2153,7 +2154,7 @@ private fun DashboardClearOptionsBottomSheet(
 ) {
     val sheetState = androidx.compose.material3.rememberModalBottomSheetState()
     
-    androidx.compose.material3.ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
@@ -1328,7 +1328,7 @@ fun NotificationSettingsSheet(
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },
@@ -1541,7 +1541,7 @@ fun AODSettingsSheet(onDismiss: () -> Unit, sheetState: SheetState, context: and
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/HistoryDataTransfer.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/HistoryDataTransfer.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetState
@@ -65,6 +64,7 @@ import tk.glucodata.data.ExportPackageExporter
 import tk.glucodata.data.GlucoseRepository
 import tk.glucodata.data.HistoryExporter
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import java.io.File
 import java.util.ArrayList
 import java.util.concurrent.TimeUnit
@@ -148,7 +148,7 @@ fun HistoryExportSheet(
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },
@@ -492,7 +492,7 @@ fun ExportDataSettingsSheet(
 
     val allSelected = includeSettings && includeHistory && includeCalibrations
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -37,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import tk.glucodata.ui.components.StableModalBottomSheet
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import tk.glucodata.InsulinPenManager
 import tk.glucodata.InsulinPenScanBus
@@ -72,7 +72,7 @@ fun InsulinPenScanSheetHost() {
         )
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = { InsulinPenScanBus.clear() },
         sheetState = sheetState,
     ) {

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.icons.filled.Contactless
 import androidx.compose.material.icons.filled.Vaccines
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -61,6 +60,7 @@ import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.MasterSwitchCard
 import tk.glucodata.ui.components.SectionLabel
 import tk.glucodata.ui.components.SettingsItem
+import tk.glucodata.ui.components.StableModalBottomSheet
 import java.text.DateFormat
 import java.util.Calendar
 import java.util.Date
@@ -249,7 +249,7 @@ private fun PenDetailSheet(
     onArmFullRead: () -> Unit,
     onForget: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    StableModalBottomSheet(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 16.dp)) {
             Text(
                 stringResource(R.string.insulin_pen_name, pen.serial),

--- a/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
@@ -796,7 +796,7 @@ fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
         return true
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -96,6 +95,7 @@ import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.CompactSheetDragHandle
 import tk.glucodata.ui.components.SectionLabel
 import tk.glucodata.ui.components.SettingsItem
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.components.StyledSwitch
 import tk.glucodata.ui.components.cardShape
 
@@ -746,7 +746,7 @@ private fun TriggerEditorSheet(
     var highText by rememberSaveable(destination.id) {
         mutableStateOf(formatThreshold(destination.triggerHighMgdl))
     }
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }
@@ -1172,7 +1172,7 @@ private fun PresetPickerSheet(
     onPreset: (String) -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -66,6 +66,7 @@ import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.CompactSheetDragHandle
 import tk.glucodata.ui.components.SettingsItem
 import tk.glucodata.ui.components.SettingsSwitchItem
+import tk.glucodata.ui.components.StableModalBottomSheet
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import java.util.Locale
@@ -560,7 +561,7 @@ fun SensorCard(
     // Matches the destructive-action-sheet pattern from DashboardClearOptionsBottomSheet.
     if (showAiDexClearDialog) {
         @OptIn(ExperimentalMaterial3Api::class)
-        ModalBottomSheet(
+        StableModalBottomSheet(
             onDismissRequest = { showAiDexClearDialog = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             dragHandle = { BottomSheetDefaults.DragHandle() }
@@ -693,7 +694,7 @@ fun SensorCard(
     // Independent, immediately applied sensor-algorithm features.
     if (showSibionicsCalSheet && sensor.isSibionics && sensor.viewMode != 1) {
         @OptIn(ExperimentalMaterial3Api::class)
-        ModalBottomSheet(
+        StableModalBottomSheet(
             onDismissRequest = { showSibionicsCalSheet = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             dragHandle = { CompactSheetDragHandle() }
@@ -976,7 +977,7 @@ fun SensorCard(
 
     if (showMqRestoreSheet) {
         @OptIn(ExperimentalMaterial3Api::class)
-        ModalBottomSheet(
+        StableModalBottomSheet(
             onDismissRequest = { showMqRestoreSheet = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             dragHandle = { BottomSheetDefaults.DragHandle() }
@@ -1056,7 +1057,7 @@ fun SensorCard(
 
     if (showMqCalibrationSheet) {
         @OptIn(ExperimentalMaterial3Api::class)
-        ModalBottomSheet(
+        StableModalBottomSheet(
             onDismissRequest = {
                 showMqCalibrationSheet = false
                 mqCalibrationInputText = ""

--- a/Common/src/mobile/java/tk/glucodata/ui/calibration/CalibrationBottomSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/calibration/CalibrationBottomSheet.kt
@@ -67,6 +67,7 @@ import tk.glucodata.data.calibration.CalibrationEntity
 import tk.glucodata.data.calibration.CalibrationManager
 import tk.glucodata.logic.TrendEngine
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.theme.displayLargeExpressive
 import java.text.SimpleDateFormat
 import java.util.*
@@ -226,7 +227,7 @@ fun CalibrationBottomSheet(
     // Time State
     var isTimeExpanded by remember { mutableStateOf(false) }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/calibration/CalibrationListScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/calibration/CalibrationListScreen.kt
@@ -70,6 +70,7 @@ import tk.glucodata.data.HistoryRepository
 import tk.glucodata.data.calibration.CalibrationEntity
 import tk.glucodata.data.calibration.CalibrationManager
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.components.StyledSwitch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -1645,7 +1646,7 @@ private fun CalibrationImportExportBottomSheet(
 ) {
     val sheetState = rememberModalBottomSheetState()
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },
@@ -1789,7 +1790,7 @@ private fun ClearOptionsBottomSheet(
 ) {
     val sheetState = rememberModalBottomSheetState()
     
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/components/SensorTypePicker.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/SensorTypePicker.kt
@@ -125,7 +125,7 @@ fun SensorTypePicker(
         )
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         dragHandle = { CompactSheetDragHandle() },
         containerColor = MaterialTheme.colorScheme.surface

--- a/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
@@ -1,0 +1,106 @@
+package tk.glucodata.ui.components
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.contentColorFor
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * App-wide modal sheet entry point.
+ *
+ * Material 3 derives the expanded anchor from the sheet's measured height on every layout pass.
+ * A viewport-height sheet can otherwise become shorter while it is dragged because the framework
+ * dynamically consumes its top inset. That moves the expanded anchor during the gesture and makes
+ * the sheet appear to resist or jitter.
+ *
+ * Short sheets retain their intrinsic height. Once a sheet has measured at the viewport height,
+ * it remains viewport-height until it leaves composition, keeping its expanded anchor stable while
+ * nested scrolling continues to work normally.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StableModalBottomSheet(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(),
+    sheetMaxWidth: Dp = BottomSheetDefaults.SheetMaxWidth,
+    sheetGesturesEnabled: Boolean = true,
+    shape: Shape = BottomSheetDefaults.ExpandedShape,
+    containerColor: Color = BottomSheetDefaults.ContainerColor,
+    contentColor: Color = contentColorFor(containerColor),
+    tonalElevation: Dp = 0.dp,
+    scrimColor: Color = BottomSheetDefaults.ScrimColor,
+    dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
+    contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
+    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val heightPolicy = remember(sheetState) { StableSheetHeightPolicy() }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.stabilizeViewportHeight(heightPolicy),
+        sheetState = sheetState,
+        sheetMaxWidth = sheetMaxWidth,
+        sheetGesturesEnabled = sheetGesturesEnabled,
+        shape = shape,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        tonalElevation = tonalElevation,
+        scrimColor = scrimColor,
+        dragHandle = dragHandle,
+        contentWindowInsets = contentWindowInsets,
+        properties = properties,
+        content = content,
+    )
+}
+
+internal class StableSheetHeightPolicy {
+    var isViewportHeightLocked: Boolean = false
+        private set
+
+    fun minimumHeight(maxHeight: Int, hasBoundedHeight: Boolean): Int =
+        if (isViewportHeightLocked && hasBoundedHeight) maxHeight else 0
+
+    fun onMeasured(measuredHeight: Int, maxHeight: Int, hasBoundedHeight: Boolean) {
+        if (hasBoundedHeight && measuredHeight >= maxHeight) {
+            isViewportHeightLocked = true
+        }
+    }
+}
+
+private fun Modifier.stabilizeViewportHeight(policy: StableSheetHeightPolicy): Modifier =
+    layout { measurable, constraints ->
+        val minimumHeight = policy.minimumHeight(
+            maxHeight = constraints.maxHeight,
+            hasBoundedHeight = constraints.hasBoundedHeight,
+        )
+        val measurementConstraints = if (minimumHeight > constraints.minHeight) {
+            constraints.copy(minHeight = minimumHeight)
+        } else {
+            constraints
+        }
+        val placeable = measurable.measure(measurementConstraints)
+        policy.onMeasured(
+            measuredHeight = placeable.height,
+            maxHeight = constraints.maxHeight,
+            hasBoundedHeight = constraints.hasBoundedHeight,
+        )
+
+        layout(placeable.width, placeable.height) {
+            placeable.placeRelative(0, 0)
+        }
+    }

--- a/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
@@ -27,8 +27,9 @@ import androidx.compose.ui.unit.dp
  * the sheet appear to resist or jitter.
  *
  * Short sheets retain their intrinsic height. Once a sheet has measured at the viewport height,
- * it remains viewport-height until it leaves composition, keeping its expanded anchor stable while
- * nested scrolling continues to work normally.
+ * it remains viewport-height for the current [contentKey], keeping its expanded anchor stable while
+ * nested scrolling continues to work normally. Change [contentKey] when one sheet instance swaps
+ * between layouts with fundamentally different intrinsic heights.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,9 +47,10 @@ fun StableModalBottomSheet(
     dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
     contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
     properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
+    contentKey: Any? = Unit,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val heightPolicy = remember(sheetState) { StableSheetHeightPolicy() }
+    val heightPolicy = remember(sheetState, contentKey) { StableSheetHeightPolicy() }
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
@@ -71,7 +71,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -141,6 +140,7 @@ import tk.glucodata.data.prediction.PredictionModelProfile
 import tk.glucodata.data.journal.LegacyJournalFoodDatabase
 import tk.glucodata.ui.GlucosePoint
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.util.ConnectedButtonGroup
 import tk.glucodata.ui.util.GlucoseFormatter
 import kotlinx.coroutines.Dispatchers
@@ -478,7 +478,7 @@ fun JournalEntrySheet(
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
@@ -483,7 +483,8 @@ fun JournalEntrySheet(
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },
         containerColor = MaterialTheme.colorScheme.surface,
-        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+        contentKey = draft.type,
     ) {
         LazyColumn(
             modifier = Modifier

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
@@ -64,7 +64,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -131,6 +130,7 @@ import tk.glucodata.ui.components.SectionLabel
 import tk.glucodata.ui.components.SettingsItem
 import tk.glucodata.ui.components.SettingsSwitchItem
 import tk.glucodata.ui.components.StyledSwitch
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.components.cardShape
 import tk.glucodata.ui.viewmodel.DashboardViewModel
 import kotlinx.coroutines.Dispatchers
@@ -1323,7 +1323,7 @@ private fun JournalFoodSheet(
         buildFoodInput(draft)?.let(onSave)
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }
@@ -1703,7 +1703,7 @@ private fun JournalInsulinPresetSheet(
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = { dismissSheet() },
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/overlay/FloatingSettingsSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/overlay/FloatingSettingsSheet.kt
@@ -32,6 +32,7 @@ import tk.glucodata.ui.components.SettingsSwitchItem
 import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.CompactSheetDragHandle
 import tk.glucodata.ui.components.SectionLabel
+import tk.glucodata.ui.components.StableModalBottomSheet
 // import tk.glucodata.ui.components.StyledSwitch // Unused now
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -61,7 +62,7 @@ fun FloatingSettingsSheet(
         hasPermission = Settings.canDrawOverlays(context)
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false), // 1. Allow partial expansion
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
@@ -48,7 +48,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -86,6 +85,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import tk.glucodata.R
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.util.AdaptiveLayoutDensity
 import tk.glucodata.ui.util.AdaptiveWindowWidthClass
 import tk.glucodata.ui.util.ExpressiveMotion
@@ -1406,7 +1406,7 @@ private fun PinnedMetricPickerSheet(
     onTogglePinned: (StatsMetric) -> Unit,
     onDismiss: () -> Unit
 ) {
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         dragHandle = { CompactSheetDragHandle() }
     ) {

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsRangeControls.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsRangeControls.kt
@@ -21,12 +21,12 @@ import androidx.compose.material3.DateRangePickerState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Button
 import androidx.compose.material3.DateRangePicker
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.rememberDateRangePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -327,7 +327,7 @@ fun StatsDateRangeSheet(
         0
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsScreen.kt
@@ -94,7 +94,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.Surface
@@ -151,6 +150,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import tk.glucodata.R
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.util.ConnectedButtonGroup
 import tk.glucodata.ui.util.GlucoseFormatter
 import java.text.SimpleDateFormat
@@ -473,7 +473,7 @@ fun StatsScreen(
 
         if (showShareSheet) {
             val parsedReportDays = reportDaysInput.toIntOrNull()?.coerceIn(1, 365)
-            ModalBottomSheet(
+            StableModalBottomSheet(
                 onDismissRequest = { showShareSheet = false },
                 dragHandle = { CompactSheetDragHandle() }
             ) {
@@ -804,7 +804,7 @@ private fun ArrangeSheet(
     // dismissing, and the animating height moved its drag anchors underneath it — so it
     // dismissed on an ordinary scroll, and on any scroll begun before the open animation
     // had settled.
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         dragHandle = { CompactSheetDragHandle() }
     ) {

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsSections.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsSections.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -57,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import tk.glucodata.R
 import tk.glucodata.ui.GlucosePoint
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -648,7 +648,7 @@ internal fun DayDetailSheet(
     var selectedHour by remember(day.date) { mutableStateOf(-1) }
     val titleFormatter = remember { DateTimeFormatter.ofPattern("EEEE d MMMM", Locale.getDefault()) }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/test/java/tk/glucodata/ProguardKeepRulesTests.kt
+++ b/Common/src/test/java/tk/glucodata/ProguardKeepRulesTests.kt
@@ -67,6 +67,18 @@ class ProguardKeepRulesTests {
     }
 
     @Test
+    fun theLibreviewJournalBridgeIsKept() {
+        // Two name-based hops with nothing R8 can see: journalentries.cpp does FindClass on
+        // LibreviewJournal, and LibreviewJournal does Class.forName on LibreviewJournalEntries.
+        // Losing either sends LibreView an empty food/insulin array and says nothing.
+        val text = activeRules()
+        assertTrue(text.contains("-keep class tk.glucodata.LibreviewJournal { *; }"))
+        assertTrue(text.contains("-keepnames class tk.glucodata.data.journal.LibreviewJournalEntries"))
+        listOf("prepare(boolean)", "foodEntries()", "insulinEntries()", "noteEntries()", "commit()", "discard()")
+            .forEach { assertTrue("proguard-rules.my must keep $it", text.contains(it)) }
+    }
+
+    @Test
     fun theKeptCallbackIsStillDeclaredWithThatExactSignature() {
         // A rule that no longer matches the declaration is as good as no rule, and R8 does not
         // warn about a keep rule matching nothing.

--- a/Common/src/test/java/tk/glucodata/data/journal/LibreviewJournalTransferTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/LibreviewJournalTransferTests.kt
@@ -1,0 +1,186 @@
+package tk.glucodata.data.journal
+
+import java.time.ZoneId
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the shapes the LibreView measurement log expects.
+ *
+ * These entries are spliced into a document the native writer assembles, so a malformed
+ * one does not fail on its own — it takes the whole upload down, glucose data included.
+ */
+class LibreviewJournalTransferTests {
+
+    private val utc = ZoneId.of("UTC")
+
+    // 2026-03-14T09:26:53Z
+    private val noon = 1_773_480_413_000L
+
+    private fun entry(
+        id: Long = 1L,
+        type: JournalEntryType,
+        amount: Float? = null,
+        title: String = "",
+        note: String? = null,
+        source: JournalEntrySource = JournalEntrySource.MANUAL,
+        presetId: Long? = null,
+        timestamp: Long = noon
+    ) = JournalEntryEntity(
+        id = id,
+        timestamp = timestamp,
+        sensorSerial = null,
+        entryType = type.storageValue,
+        title = title,
+        note = note,
+        amount = amount,
+        glucoseValueMgDl = null,
+        durationMinutes = null,
+        intensity = null,
+        insulinPresetId = presetId,
+        source = source.storageValue,
+        sourceRecordId = null,
+        createdAt = timestamp,
+        updatedAt = timestamp
+    )
+
+    private fun preset(id: Long, countsTowardIob: Boolean) = JournalInsulinPresetEntity(
+        id = id,
+        displayName = "preset",
+        onsetMinutes = 15,
+        durationMinutes = 300,
+        accentColor = 0,
+        curveJson = "{}",
+        isBuiltIn = false,
+        isArchived = false,
+        countsTowardIob = countsTowardIob,
+        sortOrder = 0
+    )
+
+    private fun build(
+        entries: List<JournalEntryEntity>,
+        presets: Map<Long, JournalInsulinPresetEntity> = emptyMap(),
+        libre3: Boolean = true
+    ) = LibreviewJournalTransfer.build(entries, presets, libre3, utc)
+
+    @Test
+    fun carbsBecomeAFoodEntryWithWholeGrams() {
+        val built = build(listOf(entry(type = JournalEntryType.CARBS, amount = 42.4f)))
+        assertEquals(1, built.food.size)
+        val json = JSONObject(built.food.single())
+        assertEquals("Snack", json.getString("foodType"))
+        // gramsCarbs is written without decimals, exactly as writefood does.
+        assertEquals(42, json.getInt("gramsCarbs"))
+        assertTrue(built.insulin.isEmpty())
+        assertTrue(built.generic.isEmpty())
+    }
+
+    @Test
+    fun aRealMealIsNamedAfterTheTimeOfDay() {
+        // getmealtype only names a meal above 50g; anything smaller stays a snack.
+        assertEquals("Snack", LibreviewJournalTransfer.mealType(50f, noon, utc))
+        assertEquals("Breakfast", LibreviewJournalTransfer.mealType(60f, noon, utc))
+    }
+
+    @Test
+    fun insulinSplitsRapidFromLongByTheIobFlag() {
+        val entries = listOf(
+            entry(id = 1, type = JournalEntryType.INSULIN, amount = 4.5f, presetId = 7L),
+            entry(id = 2, type = JournalEntryType.INSULIN, amount = 12f, presetId = 8L)
+        )
+        val presets = mapOf(
+            7L to preset(7L, countsTowardIob = true),
+            8L to preset(8L, countsTowardIob = false)
+        )
+        val built = build(entries, presets)
+        assertEquals(2, built.insulin.size)
+        val rapid = JSONObject(built.insulin[0])
+        assertEquals("RapidActing", rapid.getString("insulinType"))
+        assertEquals(4.5, rapid.getDouble("units"), 0.001)
+        assertEquals("LongActing", JSONObject(built.insulin[1]).getString("insulinType"))
+    }
+
+    @Test
+    fun anUnknownPresetStillGoesOutAsRapidRatherThanBeingDropped() {
+        val built = build(listOf(entry(type = JournalEntryType.INSULIN, amount = 3f, presetId = 99L)))
+        assertEquals("RapidActing", JSONObject(built.insulin.single()).getString("insulinType"))
+    }
+
+    @Test
+    fun notesCarryTheirTextAndNoValueField() {
+        val built = build(listOf(entry(type = JournalEntryType.NOTE, title = "Walk", note = "30 min")))
+        val json = JSONObject(built.generic.single())
+        assertEquals("com.abbottdiabetescare.informatics.customnote", json.getString("type"))
+        assertEquals("Walk: 30 min", json.getJSONObject("extendedProperties").getString("text"))
+        assertFalse(json.has("units"))
+        assertFalse(json.has("gramsCarbs"))
+    }
+
+    @Test
+    fun recordNumbersCannotCollideWithTheLegacyNumdataCounter() {
+        // Numdata hands out small sequential ids into the same recordNumber namespace, so a
+        // row id of 1 must not produce the record number its counter would.
+        val journal = LibreviewJournalTransfer.recordNumber(1L, 4)
+        assertTrue("journal record numbers must sit far above the native counter", journal > (1L shl 27))
+        assertEquals(4L, journal and 0xFFL)
+        assertTrue(
+            LibreviewJournalTransfer.recordNumber(2L, 4) > LibreviewJournalTransfer.recordNumber(1L, 4)
+        )
+    }
+
+    @Test
+    fun theTwoDocumentFlavoursSpellTimestampsDifferently() {
+        assertEquals("2026-03-14T09:26:00Z", LibreviewJournalTransfer.factoryTimestamp(noon, libre3 = true))
+        assertEquals("2026-03-14T09:26:00.000Z", LibreviewJournalTransfer.factoryTimestamp(noon, libre3 = false))
+        assertEquals(
+            "2026-03-14T09:26:00+00:00",
+            LibreviewJournalTransfer.localTimestamp(noon, libre3 = true, zone = utc)
+        )
+    }
+
+    @Test
+    fun timestampsCarryTheZoneOffsetTheyWereRecordedIn() {
+        val kolkata = ZoneId.of("Asia/Kolkata")
+        assertEquals(
+            "2026-03-14T14:56:00+05:30",
+            LibreviewJournalTransfer.localTimestamp(noon, libre3 = true, zone = kolkata)
+        )
+    }
+
+    @Test
+    fun nonAsciiIsEscapedSoJniCannotCorruptTheDocument() {
+        // JNI hands strings over in modified UTF-8, which spells non-BMP characters as a
+        // surrogate pair rather than as UTF-8 bytes. Escaping keeps the payload valid.
+        val built = build(listOf(entry(type = JournalEntryType.NOTE, title = "café 🍎")))
+        val raw = built.generic.single()
+        assertTrue("entry must be pure ASCII, was: $raw", raw.all { it.code in 0x20..0x7E })
+        assertEquals("café 🍎", JSONObject(raw).getJSONObject("extendedProperties").getString("text"))
+    }
+
+    @Test
+    fun entriesMirroredInFromElsewhereAreNotForwardedOn() {
+        val entries = listOf(
+            entry(id = 1, type = JournalEntryType.CARBS, amount = 20f, source = JournalEntrySource.NIGHTSCOUT),
+            entry(id = 2, type = JournalEntryType.CARBS, amount = 20f, source = JournalEntrySource.AAPS),
+            entry(id = 3, type = JournalEntryType.CARBS, amount = 20f, source = JournalEntrySource.API),
+            entry(id = 4, type = JournalEntryType.CARBS, amount = 20f, source = JournalEntrySource.MANUAL)
+        )
+        assertEquals(1, build(entries).food.size)
+    }
+
+    @Test
+    fun entriesWithoutAValueAreLeftOut() {
+        val entries = listOf(
+            entry(id = 1, type = JournalEntryType.CARBS, amount = 0f),
+            entry(id = 2, type = JournalEntryType.INSULIN, amount = null),
+            entry(id = 3, type = JournalEntryType.NOTE, title = "", note = null),
+            // A fingerstick belongs in bloodGlucoseEntries, which this payload does not carry.
+            entry(id = 4, type = JournalEntryType.FINGERSTICK, amount = 5.5f)
+        )
+        assertTrue(build(entries).isEmpty)
+        entries.forEach { assertFalse(LibreviewJournalTransfer.isSendable(it)) }
+    }
+}

--- a/Common/src/test/java/tk/glucodata/ui/components/StableSheetHeightPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/components/StableSheetHeightPolicyTests.kt
@@ -1,0 +1,64 @@
+package tk.glucodata.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StableSheetHeightPolicyTests {
+    @Test
+    fun shortSheetKeepsIntrinsicHeight() {
+        val policy = StableSheetHeightPolicy()
+
+        policy.onMeasured(measuredHeight = 720, maxHeight = 1000, hasBoundedHeight = true)
+
+        assertFalse(policy.isViewportHeightLocked)
+        assertEquals(0, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
+    }
+
+    @Test
+    fun viewportHeightSheetLocksForLaterMeasurements() {
+        val policy = StableSheetHeightPolicy()
+
+        policy.onMeasured(measuredHeight = 1000, maxHeight = 1000, hasBoundedHeight = true)
+
+        assertTrue(policy.isViewportHeightLocked)
+        assertEquals(1000, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
+    }
+
+    @Test
+    fun lockedSheetTracksAChangedViewportHeight() {
+        val policy = StableSheetHeightPolicy()
+        policy.onMeasured(measuredHeight = 1000, maxHeight = 1000, hasBoundedHeight = true)
+
+        assertEquals(720, policy.minimumHeight(maxHeight = 720, hasBoundedHeight = true))
+    }
+
+    @Test
+    fun viewportHeightLockDoesNotReleaseWhenContentLaterMeasuresShorter() {
+        val policy = StableSheetHeightPolicy()
+        policy.onMeasured(measuredHeight = 1000, maxHeight = 1000, hasBoundedHeight = true)
+
+        policy.onMeasured(measuredHeight = 960, maxHeight = 1000, hasBoundedHeight = true)
+
+        assertTrue(policy.isViewportHeightLocked)
+        assertEquals(1000, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
+    }
+
+    @Test
+    fun unboundedMeasurementDoesNotLockOrInventAHeight() {
+        val policy = StableSheetHeightPolicy()
+
+        policy.onMeasured(
+            measuredHeight = 1000,
+            maxHeight = Int.MAX_VALUE,
+            hasBoundedHeight = false,
+        )
+
+        assertFalse(policy.isViewportHeightLocked)
+        assertEquals(
+            0,
+            policy.minimumHeight(maxHeight = Int.MAX_VALUE, hasBoundedHeight = false),
+        )
+    }
+}


### PR DESCRIPTION
Two gaps found by comparing a phone against what its LibreLinkUp followers see.

## LibreView was sending stored sensor values

Nightscout, the webserver, the watch and CSV export all publish through `resolveExportedMgdl`, which resolves the sensor's lane and applies the user's calibration and the exchange smoothing. The LibreView writers read `el->getmgdL()` straight from storage instead, so a calibrated user's followers saw numbers matching nothing on the phone.

All four value sites now go through the same bridge. `resolveExportedMgdl` is split so `resolveExportedMgdlAt` can serve the 15-minute history stream, whose records are `Glucose` rather than `ScanData`.

- That stream and the scan stream pass `rawCurrent=0` — raw values live only in the polls array, so there is nothing to look one up by. A raw-primary sensor keeps its auto lane there rather than being calibrated against a value that is not present.
- The history aggregate averages first and calibrates after, matching the Nightscout uploader, so both destinations carry one series rather than two roundings of it.

## The journal never reached LibreView at all

`foodEntries` / `insulinEntries` / `genericEntries` were filled only from the legacy native `Numdata` store, which the Compose journal never writes — the **send amounts** switch in LibreView settings was wired to an empty source. Nightscout was moved off `Numdata` with `JournalTreatmentUploader`; this is the LibreView half.

- `LibreviewJournalTransfer` renders journal rows in the entry shapes `writeentry` produces (the Libre 2 and Libre 3 documents differ only in how timestamps are spelled).
- `LibreviewJournalEntries` queries and caches what is pending, tracked by a new `lvUploadedAt` column so LibreView and Nightscout succeed and fail independently.
- `journalentries.cpp` splices the entries in ahead of the legacy store's own. The native writer sizes its buffer before filling it, so the pass is prepare → write → commit; rows are marked delivered only once LibreView accepted the document, and a failed upload leaves everything pending.

Decisions worth a look:

- **Record numbers** come from the Room row id, offset past anything the legacy counter will reach, so the two halves cannot collide in one account's namespace. An edited entry resends under its own number, which LibreView treats as an update.
- **Entries are escaped to pure ASCII.** They cross into native code as a Java string, and JNI hands those over in modified UTF-8, which spells non-BMP characters as a surrogate pair rather than UTF-8 bytes. One emoji in a note would have corrupted the whole document — glucose data included.
- **Fingersticks stay out.** LibreView carries them in `bloodGlucoseEntries`, a channel this payload does not populate; folding a measurement into a free-text note would misrepresent it.
- **Deletes are not propagated yet** — an entry deleted after it was sent stays in LibreView. Additions and edits both work.
- Entries mirrored in from Nightscout, AAPS or the HTTP API are not forwarded, so records do not bounce out through a second cloud.

Both name-based hops are invisible to R8, so `proguard-rules.my` keeps them and `ProguardKeepRulesTests` guards the rules.

## Not in this PR

The same report said Nightscout carries values that match neither the Raw nor the Auto lane. Nightscout **does** already call the exported-value bridge, so this is not the same defect; the likely explanation is the exchange-smoothing average added in 07bae1b64, which by design lands between the two lanes. Left alone deliberately — no obvious bug to fix from source, and it needs a log from the reporter.

## Testing

- `./gradlew :Common:testMobileDebugUnitTest` — 1623 tests, 0 failures, including 11 new ones over the entry shapes.
- `./gradlew :Common:externalNativeBuildMobileDebug` and `:Common:assembleMobileDebug` — green across all four ABIs.
- Not yet exercised against a live LibreView account; the entry shapes are covered by tests against `writeentry`, but the round trip is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)