### PR TITLE
API destinations: a token per insulin type

### DIFF
--- a/Common/src/main/java/tk/glucodata/OutboundApi.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApi.kt
@@ -538,22 +538,14 @@ object OutboundApi {
             DateFormat.SHORT,
             Locale.getDefault()
         ).format(Date(reading.timeMillis))
-        val journal = if (
-            template.contains("{journal") ||
-            template.contains("{iob}") ||
-            template.contains("{cob}")
-        ) {
-            reading.journal
-        } else {
-            JournalSnapshot()
-        }
+        val journal = if (needsJournalSnapshot(template)) reading.journal else JournalSnapshot()
         val effectiveIob = journal.iob.takeIf { it.isFinite() } ?: reading.iob
         val journalEvents = journalEventsJsonArray(journal)
         val effectiveStatus = status
             ?: destination?.rangeStatus(reading.mgdl)
             ?: OutboundApiSettings.TUNNEL_STATUS_IN_RANGE
         val statusEmojiValue = statusEmoji(effectiveStatus)
-        return template
+        val rendered = template
             .replace("{event_id}", reading.eventId)
             .replace("{recipient}", reading.recipient)
             .replace("{value}", reading.displayText)
@@ -593,7 +585,38 @@ object OutboundApi {
             .replace("{test}", reading.test.toString())
             .replace("{status}", effectiveStatus)
             .replace("{status_emoji}", statusEmojiValue)
+        return OutboundApiInsulinTokens.expand(
+            template = rendered,
+            types = OutboundApiInsulinTokens.parse(journal.json),
+            atMillis = reading.timeMillis,
+            formatTime = ::formatTimeOfDay
+        )
     }
+
+    private fun formatTimeOfDay(timeMillis: Long): String =
+        DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault()).format(Date(timeMillis))
+
+    /**
+     * Tokens that need no journal read. Anything else in a template — `{iob}`,
+     * `{cob}`, `{journal…}` or a per-insulin-type token, whose spelling depends
+     * on what the user named their insulin — means the snapshot has to be
+     * loaded, which costs a Room query per send.
+     */
+    private val STATIC_TOKENS = setOf(
+        "event_id", "recipient", "value", "unit", "mgdl", "mmol",
+        "auto", "auto_value", "auto_mgdl", "auto_mmol",
+        "raw", "raw_mgdl", "raw_mmol",
+        "trend", "trend_arrow", "rate_mgdl", "rate_mmol",
+        "timestamp", "time", "sensor", "sensor_gen", "alarm",
+        "test", "status", "status_emoji"
+    )
+
+    private val PLACEHOLDER = Regex("\\{[^{}\\s]+}")
+
+    internal fun needsJournalSnapshot(template: String): Boolean =
+        PLACEHOLDER.findAll(template).any { match ->
+            match.value.removeSurrounding("{", "}") !in STATIC_TOKENS
+        }
 
     internal fun statusEmoji(status: String): String = when (status) {
         OutboundApiSettings.TUNNEL_STATUS_HIGH -> "\uD83D\uDFE1"      // 🟡
@@ -1054,6 +1077,10 @@ class OutboundApiWorker(
                 .put("cob", journal.cob.takeIf { it.isFinite() })
                 .put("journal_cob", journal.cob.takeIf { it.isFinite() })
                 .put("journal_events", journalEvents)
+                .put(
+                    OutboundApiInsulinTokens.JSON_ARRAY,
+                    journal.json?.optJSONArray(OutboundApiInsulinTokens.JSON_ARRAY)
+                )
                 .put("journal", journal.json)
                 .put("message", message)
         }

--- a/Common/src/main/java/tk/glucodata/OutboundApiInsulinTokens.kt
+++ b/Common/src/main/java/tk/glucodata/OutboundApiInsulinTokens.kt
@@ -1,0 +1,168 @@
+package tk.glucodata
+
+import androidx.annotation.Keep
+import org.json.JSONObject
+import java.util.Locale
+
+/**
+ * Per-insulin-type template tokens for API destinations.
+ *
+ * `{iob}` cannot tell a basal shot from a bolus, so a Telegram chat watching a
+ * template had no way to say *which* insulin was just logged. Every insulin
+ * type the journal has active gets its own token family instead, named after
+ * the type itself — the stock English presets yield `{rapid_acting_insulin}`
+ * and `{long_acting_insulin}` — so a template can read
+ * "Long acting: {long_acting_insulin} U at {long_acting_insulin_time}".
+ *
+ * The slug is derived from the display name in whatever script it is written
+ * in (a Russian install gets `{инсулин_длительного_действия}`); the settings
+ * screen lists the live tokens as chips so nobody has to guess the spelling.
+ *
+ * The values come from the journal snapshot JSON, which is the only channel
+ * src/main has into the mobile-only journal.
+ */
+@Keep
+object OutboundApiInsulinTokens {
+
+    /** Array key inside the journal snapshot JSON. */
+    const val JSON_ARRAY = "insulin_types"
+
+    private const val KEY_SLUG = "slug"
+    private const val KEY_NAME = "name"
+    private const val KEY_IOB = "iob"
+    private const val KEY_LAST_UNITS = "last_units"
+    private const val KEY_LAST_TIMESTAMP = "last_timestamp"
+    private const val KEY_TODAY_UNITS = "today_units"
+
+    /** Used when a display name has no letters or digits to slug at all. */
+    private const val FALLBACK_SLUG = "insulin"
+
+    /**
+     * Suffixes appended to a type's slug, in the order the settings screen
+     * offers them. The bare slug (no suffix) is the last dose in units.
+     */
+    private val SUFFIXES = listOf("", "_time", "_ago", "_iob", "_today")
+
+    /** One insulin type as the template engine sees it. */
+    data class TypeSnapshot(
+        val slug: String,
+        val displayName: String,
+        val lastUnits: Float,
+        val lastTimestampMs: Long,
+        val iobUnits: Float,
+        val todayUnits: Float
+    )
+
+    /**
+     * Slug for one display name: letters and digits survive lowercased, every
+     * other run collapses into a single underscore. Works for any script, so
+     * localized preset names keep a usable token.
+     */
+    fun slugFor(displayName: String): String {
+        val slug = StringBuilder()
+        var pendingSeparator = false
+        displayName.lowercase().forEach { ch ->
+            if (ch.isLetterOrDigit()) {
+                if (pendingSeparator && slug.isNotEmpty()) slug.append('_')
+                pendingSeparator = false
+                slug.append(ch)
+            } else {
+                pendingSeparator = true
+            }
+        }
+        return slug.toString()
+    }
+
+    /**
+     * Slugs for a list of display names, in order, with collisions (two types
+     * named alike, or two names that slug the same) broken by a numeric suffix
+     * so every type keeps a token of its own.
+     */
+    fun assignSlugs(displayNames: List<String>): List<String> {
+        val used = mutableSetOf<String>()
+        return displayNames.map { name ->
+            val base = slugFor(name).ifEmpty { FALLBACK_SLUG }
+            var candidate = base
+            var index = 2
+            while (!used.add(candidate)) {
+                candidate = "${base}_$index"
+                index++
+            }
+            candidate
+        }
+    }
+
+    /** Every token one slug offers, brace-wrapped, for the settings chips. */
+    fun tokensForSlug(slug: String): List<String> = SUFFIXES.map { suffix -> "{$slug$suffix}" }
+
+    /** Every token a set of display names offers, in display order. */
+    fun tokensForNames(displayNames: List<String>): List<String> =
+        assignSlugs(displayNames).flatMap(::tokensForSlug)
+
+    /** Reads the `insulin_types` array out of a journal snapshot document. */
+    fun parse(journalJson: JSONObject?): List<TypeSnapshot> {
+        val array = journalJson?.optJSONArray(JSON_ARRAY) ?: return emptyList()
+        val types = ArrayList<TypeSnapshot>(array.length())
+        for (index in 0 until array.length()) {
+            val item = array.optJSONObject(index) ?: continue
+            val slug = item.optString(KEY_SLUG).takeIf { it.isNotBlank() } ?: continue
+            types.add(
+                TypeSnapshot(
+                    slug = slug,
+                    displayName = item.optString(KEY_NAME),
+                    lastUnits = item.optDouble(KEY_LAST_UNITS, Double.NaN).toFloat(),
+                    lastTimestampMs = item.optLong(KEY_LAST_TIMESTAMP, 0L),
+                    iobUnits = item.optDouble(KEY_IOB, Double.NaN).toFloat(),
+                    todayUnits = item.optDouble(KEY_TODAY_UNITS, Double.NaN).toFloat()
+                )
+            )
+        }
+        return types
+    }
+
+    /**
+     * Replaces every insulin-type token in [template].
+     *
+     * A type with no logged dose renders the dose tokens empty rather than
+     * "0" — the same way `{auto}` and `{raw}` stay empty when there is nothing
+     * to report — while the running totals render "0", matching `{iob}`.
+     */
+    fun expand(
+        template: String,
+        types: List<TypeSnapshot>,
+        atMillis: Long,
+        formatTime: (Long) -> String
+    ): String {
+        if (types.isEmpty()) return template
+        var rendered = template
+        types.forEach { type ->
+            val hasDose = type.lastTimestampMs > 0L && type.lastUnits.isFinite() && type.lastUnits > 0f
+            rendered = rendered
+                .replace("{${type.slug}}", if (hasDose) formatUnits(type.lastUnits) else "")
+                .replace("{${type.slug}_time}", if (hasDose) formatTime(type.lastTimestampMs) else "")
+                .replace(
+                    "{${type.slug}_ago}",
+                    if (hasDose) minutesSince(type.lastTimestampMs, atMillis).toString() else ""
+                )
+                .replace("{${type.slug}_iob}", formatUnits(type.iobUnits.orZero()))
+                .replace("{${type.slug}_today}", formatUnits(type.todayUnits.orZero()))
+        }
+        return rendered
+    }
+
+    private fun minutesSince(timestampMs: Long, atMillis: Long): Long =
+        ((atMillis - timestampMs) / 60_000L).coerceAtLeast(0L)
+
+    private fun Float.orZero(): Float = if (isFinite()) this else 0f
+
+    /** Whole units stay whole: "12", not "12.0"; halves keep one decimal. */
+    private fun formatUnits(units: Float): String {
+        if (!units.isFinite()) return "0"
+        val rounded = Math.round(units * 100f) / 100f
+        return if (rounded == rounded.toLong().toFloat()) {
+            rounded.toLong().toString()
+        } else {
+            "%.2f".format(Locale.US, rounded).trimEnd('0').trimEnd('.')
+        }
+    }
+}

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1912,6 +1912,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Шаблон паведамлення</string>
     <string name="outbound_api_template_desc">Націсніце токен ніжэй, каб уставіць яго.</string>
+    <string name="outbound_api_insulin_tokens">Тыпы інсуліну</string>
+    <string name="outbound_api_insulin_tokens_desc">Кожны актыўны тып інсуліну мае токены для апошняй дозы, яе часу, хвілін з таго моманту, астатніх адзінак і сумы за сёння.</string>
     <string name="outbound_api_min_interval">Мінімальны інтэрвал (хвіліны)</string>
     <string name="outbound_api_min_interval_desc">0 адпраўляе кожнае прынятае бягучае паказанне.</string>
     <string name="outbound_api_trigger">Трыгер</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1966,6 +1966,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Nachrichtenvorlage</string>
     <string name="outbound_api_template_desc">Tippe unten auf ein Token, um es einzufügen.</string>
+    <string name="outbound_api_insulin_tokens">Insulinarten</string>
+    <string name="outbound_api_insulin_tokens_desc">Jede aktive Insulinart hat Tokens für die letzte Dosis, deren Uhrzeit, die Minuten seitdem, die verbleibenden Einheiten und die heutige Summe.</string>
     <string name="outbound_api_min_interval">Mindestintervall (Minuten)</string>
     <string name="outbound_api_min_interval_desc">0 sendet jeden akzeptierten Live-Wert.</string>
     <string name="outbound_api_trigger">Auslöser</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1847,6 +1847,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Modèle de message</string>
     <string name="outbound_api_template_desc">Touchez un jeton ci-dessous pour l’insérer.</string>
+    <string name="outbound_api_insulin_tokens">Types d’insuline</string>
+    <string name="outbound_api_insulin_tokens_desc">Chaque type d’insuline actif dispose de jetons pour sa dernière dose, son heure, les minutes écoulées, les unités restantes et le total du jour.</string>
     <string name="outbound_api_min_interval">Intervalle minimal (minutes)</string>
     <string name="outbound_api_min_interval_desc">0 envoie chaque valeur en direct acceptée.</string>
     <string name="outbound_api_trigger">Déclencheur</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1831,6 +1831,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Modello messaggio</string>
     <string name="outbound_api_template_desc">Tocca un token sotto per inserirlo.</string>
+    <string name="outbound_api_insulin_tokens">Tipi di insulina</string>
+    <string name="outbound_api_insulin_tokens_desc">Ogni tipo di insulina attivo ha token per l’ultima dose, la sua ora, i minuti trascorsi, le unità rimanenti e il totale di oggi.</string>
     <string name="outbound_api_min_interval">Intervallo minimo (minuti)</string>
     <string name="outbound_api_min_interval_desc">0 invia ogni lettura live accettata.</string>
     <string name="outbound_api_trigger">Trigger</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1870,6 +1870,8 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Message template</string>
     <string name="outbound_api_template_desc">Tap a token below to insert it.</string>
+    <string name="outbound_api_insulin_tokens">Инсулины төрлүүд</string>
+    <string name="outbound_api_insulin_tokens_desc">Идэвхтэй инсулины төрөл бүр сүүлийн тун, түүний цаг, түүнээс хойших минут, үлдсэн нэгж, өнөөдрийн нийлбэрийн токентой.</string>
     <string name="outbound_api_min_interval">Minimum interval (minutes)</string>
     <string name="outbound_api_min_interval_desc">0 sends every accepted live reading.</string>
     <string name="outbound_api_trigger">Trigger</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1884,6 +1884,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Berichtsjabloon</string>
     <string name="outbound_api_template_desc">Tik hieronder op een token om het in te voegen.</string>
+    <string name="outbound_api_insulin_tokens">Insulinesoorten</string>
+    <string name="outbound_api_insulin_tokens_desc">Elke actieve insulinesoort heeft tokens voor de laatste dosis, het tijdstip, de minuten sindsdien, de resterende eenheden en het totaal van vandaag.</string>
     <string name="outbound_api_min_interval">Minimaal interval (minuten)</string>
     <string name="outbound_api_min_interval_desc">0 stuurt elke geaccepteerde live meting.</string>
     <string name="outbound_api_trigger">Trigger</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1876,6 +1876,8 @@
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Szablon wiadomości</string>
     <string name="outbound_api_template_desc">Dotknij tokenu poniżej, aby go wstawić.</string>
+    <string name="outbound_api_insulin_tokens">Rodzaje insuliny</string>
+    <string name="outbound_api_insulin_tokens_desc">Każdy aktywny rodzaj insuliny ma tokeny dla ostatniej dawki, jej godziny, minut od podania, pozostałych jednostek i dzisiejszej sumy.</string>
     <string name="outbound_api_min_interval">Minimalny interwał (minuty)</string>
     <string name="outbound_api_min_interval_desc">0 wysyła każdy zaakceptowany bieżący odczyt.</string>
     <string name="outbound_api_trigger">Wyzwalacz</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1842,6 +1842,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Modelo de mensagem</string>
     <string name="outbound_api_template_desc">Toque num token abaixo para inseri-lo.</string>
+    <string name="outbound_api_insulin_tokens">Tipos de insulina</string>
+    <string name="outbound_api_insulin_tokens_desc">Cada tipo de insulina ativo tem tokens para a última dose, a hora, os minutos decorridos, as unidades restantes e o total de hoje.</string>
     <string name="outbound_api_min_interval">Intervalo mínimo (minutos)</string>
     <string name="outbound_api_min_interval_desc">0 envia cada leitura ao vivo aceita.</string>
     <string name="outbound_api_trigger">Disparo</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1885,6 +1885,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Шаблон сообщения</string>
     <string name="outbound_api_template_desc">Нажмите токен ниже, чтобы вставить его.</string>
+    <string name="outbound_api_insulin_tokens">Типы инсулина</string>
+    <string name="outbound_api_insulin_tokens_desc">У каждого активного типа инсулина есть токены для последней дозы, её времени, минут с момента ввода, остатка единиц и суммы за сегодня.</string>
     <string name="outbound_api_min_interval">Минимальный интервал (минуты)</string>
     <string name="outbound_api_min_interval_desc">0 отправляет каждое принятое текущее показание.</string>
     <string name="outbound_api_trigger">Триггер</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2157,6 +2157,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="outbound_api_headers_placeholder">Oggolaanshaha: Calaamadda xanbaarsan</string>
     <string name="outbound_api_message_template">Qaabka fariinta</string>
     <string name="outbound_api_template_desc">Taabo calaamada hoose si aad u geliso</string>
+    <string name="outbound_api_insulin_tokens">Noocyada insuliinta</string>
+    <string name="outbound_api_insulin_tokens_desc">Nooc kasta oo insuliin ah oo firfircoon wuxuu leeyahay calaamado qiyaasta ugu dambeysay, waqtigeeda, daqiiqadaha laga soo bilaabo, cutubyada haray iyo wadarta maanta.</string>
     <string name="outbound_api_min_interval">Muddada ugu yar (daqiiqado)</string>
     <string name="outbound_api_min_interval_desc">0 waxay dirtaa akhriska tooska ah ee la aqbalo.</string>
     <string name="outbound_api_trigger">Kicin</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1841,6 +1841,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Meddelandemall</string>
     <string name="outbound_api_template_desc">Tryck på en token nedan för att infoga den.</string>
+    <string name="outbound_api_insulin_tokens">Insulintyper</string>
+    <string name="outbound_api_insulin_tokens_desc">Varje aktiv insulintyp har taggar för sin senaste dos, dess tid, minuter sedan, återstående enheter och dagens summa.</string>
     <string name="outbound_api_min_interval">Minsta intervall (minuter)</string>
     <string name="outbound_api_min_interval_desc">0 skickar varje accepterat livevärde.</string>
     <string name="outbound_api_trigger">Utlösare</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1869,6 +1869,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Mesaj şablonu</string>
     <string name="outbound_api_template_desc">Eklemek için aşağıdaki bir tokene dokunun.</string>
+    <string name="outbound_api_insulin_tokens">İnsülin türleri</string>
+    <string name="outbound_api_insulin_tokens_desc">Etkin her insülin türünün son dozu, saati, üzerinden geçen dakika, kalan ünite ve bugünkü toplam için kendi belirteçleri vardır.</string>
     <string name="outbound_api_min_interval">Minimum aralık (dakika)</string>
     <string name="outbound_api_min_interval_desc">0 kabul edilen her canlı ölçümü gönderir.</string>
     <string name="outbound_api_trigger">Tetikleyici</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1917,6 +1917,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Шаблон повідомлення</string>
     <string name="outbound_api_template_desc">Натисніть токен нижче, щоб вставити його.</string>
+    <string name="outbound_api_insulin_tokens">Типи інсуліну</string>
+    <string name="outbound_api_insulin_tokens_desc">Кожен активний тип інсуліну має токени для останньої дози, її часу, хвилин відтоді, залишку одиниць і суми за сьогодні.</string>
     <string name="outbound_api_min_interval">Мінімальний інтервал (хвилини)</string>
     <string name="outbound_api_min_interval_desc">0 надсилає кожне прийняте поточне показання.</string>
     <string name="outbound_api_trigger">Тригер</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1857,6 +1857,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">消息模板</string>
     <string name="outbound_api_template_desc">点按下方令牌即可插入。</string>
+    <string name="outbound_api_insulin_tokens">胰岛素类型</string>
+    <string name="outbound_api_insulin_tokens_desc">每种启用的胰岛素类型都有对应的标记：上次剂量、时间、距今分钟数、剩余单位和今日总量。</string>
     <string name="outbound_api_min_interval">最小间隔（分钟）</string>
     <string name="outbound_api_min_interval_desc">0 会发送每个已接受的实时读数。</string>
     <string name="outbound_api_trigger">触发条件</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2403,6 +2403,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="outbound_api_headers_placeholder">Authorization: Bearer token</string>
     <string name="outbound_api_message_template">Message template</string>
     <string name="outbound_api_template_desc">Tap a token below to insert it.</string>
+    <string name="outbound_api_insulin_tokens">Insulin types</string>
+    <string name="outbound_api_insulin_tokens_desc">Every active insulin type has tokens for its last dose, that dose time, minutes since, remaining units and the total so far today.</string>
     <string name="outbound_api_min_interval">Minimum interval (minutes)</string>
     <string name="outbound_api_min_interval_desc">0 sends every accepted live reading.</string>
     <string name="outbound_api_trigger">Trigger</string>

--- a/Common/src/mobile/java/tk/glucodata/OutboundApiJournalSnapshot.kt
+++ b/Common/src/mobile/java/tk/glucodata/OutboundApiJournalSnapshot.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import java.util.Calendar
 import org.json.JSONArray
 import org.json.JSONObject
 import tk.glucodata.data.HistoryDatabase
@@ -195,7 +196,64 @@ object OutboundApiJournalSnapshot {
             .put("journal_cob", finiteOrNull(cob))
             .put("events", events)
             .put("treatments", events)
+            .put(OutboundApiInsulinTokens.JSON_ARRAY, insulinTypesJson(presets, entries, atMillis))
     }
+
+    /**
+     * One entry per active insulin type, feeding the per-type template tokens
+     * (see [OutboundApiInsulinTokens]). Archived types are left out: they are
+     * the ones the user turned off, and their tokens would only clutter the
+     * settings chips — insulin already injected with one still counts toward
+     * the aggregate IOB, which is computed elsewhere from the full preset list.
+     *
+     * The per-type IOB deliberately ignores `countsTowardIob`: that switch says
+     * whether a type belongs in the single `{iob}` number, and a user asking
+     * for their basal by name wants what is actually left of it. The totals are
+     * bounded by the entry window buildSnapshot loaded, which always spans at
+     * least the last 24 hours.
+     */
+    private fun insulinTypesJson(
+        presets: List<JournalInsulinPreset>,
+        entries: List<JournalEntryEntity>,
+        atMillis: Long
+    ): JSONArray {
+        val active = presets.filterNot { it.isArchived }.sortedBy { it.sortOrder }
+        val slugs = OutboundApiInsulinTokens.assignSlugs(active.map { it.displayName })
+        val dayStartMillis = startOfDayMillis(atMillis)
+        val array = JSONArray()
+        active.forEachIndexed { index, preset ->
+            val doses = entries.mapNotNull { entry ->
+                if (JournalEntryType.fromStorage(entry.entryType) != JournalEntryType.INSULIN) return@mapNotNull null
+                if (entry.insulinPresetId != preset.id) return@mapNotNull null
+                if (entry.timestamp > atMillis) return@mapNotNull null
+                val units = entry.amount?.takeIf { it.isFinite() && it > 0f } ?: return@mapNotNull null
+                JournalIobCalculator.Dose(entry.timestamp, units, preset)
+            }
+            val last = doses.maxByOrNull { it.timestampMillis }
+            val todayUnits = doses
+                .filter { it.timestampMillis >= dayStartMillis }
+                .sumOf { it.amountUnits.toDouble() }
+            array.put(
+                JSONObject()
+                    .put("slug", slugs[index])
+                    .put("name", preset.displayName)
+                    .put("iob", finiteOrNull(JournalIobCalculator.compute(doses, atMillis).iobUnits))
+                    .put("last_units", finiteOrNull(last?.amountUnits))
+                    .put("last_timestamp", last?.timestampMillis ?: 0L)
+                    .put("today_units", todayUnits)
+            )
+        }
+        return array
+    }
+
+    private fun startOfDayMillis(atMillis: Long): Long =
+        Calendar.getInstance().apply {
+            timeInMillis = atMillis
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }.timeInMillis
 
     private suspend fun importJournal(raw: String, sourcePrefix: String): Int {
         val trimmed = raw.trim()

--- a/Common/src/mobile/java/tk/glucodata/ui/ApiSourceSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ApiSourceSettingsScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -66,6 +65,7 @@ import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.CompactSheetDragHandle
 import tk.glucodata.ui.components.SectionLabel
 import tk.glucodata.ui.components.StyledSwitch
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.components.cardShape
 
 @Composable
@@ -469,7 +469,7 @@ private fun SourcePresetPickerSheet(
     onPreset: (String) -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -39,6 +39,7 @@ import tk.glucodata.ui.theme.displayLargeExpressive
 import tk.glucodata.ui.theme.labelSmallPrim
 import tk.glucodata.ui.theme.labelLargeExpressive
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.collectAsState
@@ -2153,7 +2154,7 @@ private fun DashboardClearOptionsBottomSheet(
 ) {
     val sheetState = androidx.compose.material3.rememberModalBottomSheetState()
     
-    androidx.compose.material3.ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
@@ -1328,7 +1328,7 @@ fun NotificationSettingsSheet(
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },
@@ -1541,7 +1541,7 @@ fun AODSettingsSheet(onDismiss: () -> Unit, sheetState: SheetState, context: and
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/HistoryDataTransfer.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/HistoryDataTransfer.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetState
@@ -65,6 +64,7 @@ import tk.glucodata.data.ExportPackageExporter
 import tk.glucodata.data.GlucoseRepository
 import tk.glucodata.data.HistoryExporter
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import java.io.File
 import java.util.ArrayList
 import java.util.concurrent.TimeUnit
@@ -148,7 +148,7 @@ fun HistoryExportSheet(
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },
@@ -492,7 +492,7 @@ fun ExportDataSettingsSheet(
 
     val allSelected = includeSettings && includeHistory && includeCalibrations
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -37,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import tk.glucodata.ui.components.StableModalBottomSheet
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import tk.glucodata.InsulinPenManager
 import tk.glucodata.InsulinPenScanBus
@@ -72,7 +72,7 @@ fun InsulinPenScanSheetHost() {
         )
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = { InsulinPenScanBus.clear() },
         sheetState = sheetState,
     ) {

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.icons.filled.Contactless
 import androidx.compose.material.icons.filled.Vaccines
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -61,6 +60,7 @@ import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.MasterSwitchCard
 import tk.glucodata.ui.components.SectionLabel
 import tk.glucodata.ui.components.SettingsItem
+import tk.glucodata.ui.components.StableModalBottomSheet
 import java.text.DateFormat
 import java.util.Calendar
 import java.util.Date
@@ -249,7 +249,7 @@ private fun PenDetailSheet(
     onArmFullRead: () -> Unit,
     onForget: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    StableModalBottomSheet(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 16.dp)) {
             Text(
                 stringResource(R.string.insulin_pen_name, pen.serial),

--- a/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MirrorSettingsScreen.kt
@@ -796,7 +796,7 @@ fun MirrorEditSheet(pos: Int, sheetState: SheetState, onDismiss: () -> Unit) {
         return true
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -82,14 +83,18 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
 import kotlin.math.roundToInt
 import tk.glucodata.Applic
 import tk.glucodata.OutboundApi
+import tk.glucodata.OutboundApiInsulinTokens
 import tk.glucodata.OutboundApiSettings
 import tk.glucodata.R
+import tk.glucodata.data.journal.JournalRepository
 import tk.glucodata.sms.SmsWatchdog
 import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.CompactSheetDragHandle
@@ -1109,6 +1114,48 @@ private fun TemplateEditor(
             )
         }
     }
+
+    // Insulin-type tokens are spelled after the user's own preset names, which
+    // may be in any script — chips are the only practical way to enter them.
+    val insulinTokens = insulinTemplateTokens()
+    if (insulinTokens.isNotEmpty()) {
+        SettingsSubsectionTitle(stringResource(R.string.outbound_api_insulin_tokens))
+        Text(
+            text = stringResource(R.string.outbound_api_insulin_tokens_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            insulinTokens.forEach { token ->
+                AssistChip(
+                    onClick = { replaceSelection(token) },
+                    label = { Text(token) }
+                )
+            }
+        }
+    }
+}
+
+/** Tokens for the insulin types the journal currently has active, in display order. */
+@Composable
+private fun insulinTemplateTokens(): List<String> {
+    val tokens by produceState(initialValue = emptyList<String>()) {
+        value = withContext(Dispatchers.IO) {
+            runCatching {
+                OutboundApiInsulinTokens.tokensForNames(
+                    JournalRepository().getInsulinPresetsSnapshot()
+                        .filterNot { it.isArchived }
+                        .sortedBy { it.sortOrder }
+                        .map { it.displayName }
+                )
+            }.getOrDefault(emptyList())
+        }
+    }
+    return tokens
 }
 
 @Composable

--- a/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -96,6 +95,7 @@ import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.CompactSheetDragHandle
 import tk.glucodata.ui.components.SectionLabel
 import tk.glucodata.ui.components.SettingsItem
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.components.StyledSwitch
 import tk.glucodata.ui.components.cardShape
 
@@ -746,7 +746,7 @@ private fun TriggerEditorSheet(
     var highText by rememberSaveable(destination.id) {
         mutableStateOf(formatThreshold(destination.triggerHighMgdl))
     }
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }
@@ -1172,7 +1172,7 @@ private fun PresetPickerSheet(
     onPreset: (String) -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -66,6 +66,7 @@ import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.CompactSheetDragHandle
 import tk.glucodata.ui.components.SettingsItem
 import tk.glucodata.ui.components.SettingsSwitchItem
+import tk.glucodata.ui.components.StableModalBottomSheet
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import java.util.Locale
@@ -560,7 +561,7 @@ fun SensorCard(
     // Matches the destructive-action-sheet pattern from DashboardClearOptionsBottomSheet.
     if (showAiDexClearDialog) {
         @OptIn(ExperimentalMaterial3Api::class)
-        ModalBottomSheet(
+        StableModalBottomSheet(
             onDismissRequest = { showAiDexClearDialog = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             dragHandle = { BottomSheetDefaults.DragHandle() }
@@ -693,7 +694,7 @@ fun SensorCard(
     // Independent, immediately applied sensor-algorithm features.
     if (showSibionicsCalSheet && sensor.isSibionics && sensor.viewMode != 1) {
         @OptIn(ExperimentalMaterial3Api::class)
-        ModalBottomSheet(
+        StableModalBottomSheet(
             onDismissRequest = { showSibionicsCalSheet = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             dragHandle = { CompactSheetDragHandle() }
@@ -976,7 +977,7 @@ fun SensorCard(
 
     if (showMqRestoreSheet) {
         @OptIn(ExperimentalMaterial3Api::class)
-        ModalBottomSheet(
+        StableModalBottomSheet(
             onDismissRequest = { showMqRestoreSheet = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             dragHandle = { BottomSheetDefaults.DragHandle() }
@@ -1056,7 +1057,7 @@ fun SensorCard(
 
     if (showMqCalibrationSheet) {
         @OptIn(ExperimentalMaterial3Api::class)
-        ModalBottomSheet(
+        StableModalBottomSheet(
             onDismissRequest = {
                 showMqCalibrationSheet = false
                 mqCalibrationInputText = ""

--- a/Common/src/mobile/java/tk/glucodata/ui/calibration/CalibrationBottomSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/calibration/CalibrationBottomSheet.kt
@@ -67,6 +67,7 @@ import tk.glucodata.data.calibration.CalibrationEntity
 import tk.glucodata.data.calibration.CalibrationManager
 import tk.glucodata.logic.TrendEngine
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.theme.displayLargeExpressive
 import java.text.SimpleDateFormat
 import java.util.*
@@ -226,7 +227,7 @@ fun CalibrationBottomSheet(
     // Time State
     var isTimeExpanded by remember { mutableStateOf(false) }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/calibration/CalibrationListScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/calibration/CalibrationListScreen.kt
@@ -70,6 +70,7 @@ import tk.glucodata.data.HistoryRepository
 import tk.glucodata.data.calibration.CalibrationEntity
 import tk.glucodata.data.calibration.CalibrationManager
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.components.StyledSwitch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -1645,7 +1646,7 @@ private fun CalibrationImportExportBottomSheet(
 ) {
     val sheetState = rememberModalBottomSheetState()
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },
@@ -1789,7 +1790,7 @@ private fun ClearOptionsBottomSheet(
 ) {
     val sheetState = rememberModalBottomSheetState()
     
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/components/SensorTypePicker.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/SensorTypePicker.kt
@@ -125,7 +125,7 @@ fun SensorTypePicker(
         )
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         dragHandle = { CompactSheetDragHandle() },
         containerColor = MaterialTheme.colorScheme.surface

--- a/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
@@ -1,0 +1,106 @@
+package tk.glucodata.ui.components
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.contentColorFor
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * App-wide modal sheet entry point.
+ *
+ * Material 3 derives the expanded anchor from the sheet's measured height on every layout pass.
+ * A viewport-height sheet can otherwise become shorter while it is dragged because the framework
+ * dynamically consumes its top inset. That moves the expanded anchor during the gesture and makes
+ * the sheet appear to resist or jitter.
+ *
+ * Short sheets retain their intrinsic height. Once a sheet has measured at the viewport height,
+ * it remains viewport-height until it leaves composition, keeping its expanded anchor stable while
+ * nested scrolling continues to work normally.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StableModalBottomSheet(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(),
+    sheetMaxWidth: Dp = BottomSheetDefaults.SheetMaxWidth,
+    sheetGesturesEnabled: Boolean = true,
+    shape: Shape = BottomSheetDefaults.ExpandedShape,
+    containerColor: Color = BottomSheetDefaults.ContainerColor,
+    contentColor: Color = contentColorFor(containerColor),
+    tonalElevation: Dp = 0.dp,
+    scrimColor: Color = BottomSheetDefaults.ScrimColor,
+    dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
+    contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
+    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val heightPolicy = remember(sheetState) { StableSheetHeightPolicy() }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.stabilizeViewportHeight(heightPolicy),
+        sheetState = sheetState,
+        sheetMaxWidth = sheetMaxWidth,
+        sheetGesturesEnabled = sheetGesturesEnabled,
+        shape = shape,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        tonalElevation = tonalElevation,
+        scrimColor = scrimColor,
+        dragHandle = dragHandle,
+        contentWindowInsets = contentWindowInsets,
+        properties = properties,
+        content = content,
+    )
+}
+
+internal class StableSheetHeightPolicy {
+    var isViewportHeightLocked: Boolean = false
+        private set
+
+    fun minimumHeight(maxHeight: Int, hasBoundedHeight: Boolean): Int =
+        if (isViewportHeightLocked && hasBoundedHeight) maxHeight else 0
+
+    fun onMeasured(measuredHeight: Int, maxHeight: Int, hasBoundedHeight: Boolean) {
+        if (hasBoundedHeight && measuredHeight >= maxHeight) {
+            isViewportHeightLocked = true
+        }
+    }
+}
+
+private fun Modifier.stabilizeViewportHeight(policy: StableSheetHeightPolicy): Modifier =
+    layout { measurable, constraints ->
+        val minimumHeight = policy.minimumHeight(
+            maxHeight = constraints.maxHeight,
+            hasBoundedHeight = constraints.hasBoundedHeight,
+        )
+        val measurementConstraints = if (minimumHeight > constraints.minHeight) {
+            constraints.copy(minHeight = minimumHeight)
+        } else {
+            constraints
+        }
+        val placeable = measurable.measure(measurementConstraints)
+        policy.onMeasured(
+            measuredHeight = placeable.height,
+            maxHeight = constraints.maxHeight,
+            hasBoundedHeight = constraints.hasBoundedHeight,
+        )
+
+        layout(placeable.width, placeable.height) {
+            placeable.placeRelative(0, 0)
+        }
+    }

--- a/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
@@ -27,8 +27,9 @@ import androidx.compose.ui.unit.dp
  * the sheet appear to resist or jitter.
  *
  * Short sheets retain their intrinsic height. Once a sheet has measured at the viewport height,
- * it remains viewport-height until it leaves composition, keeping its expanded anchor stable while
- * nested scrolling continues to work normally.
+ * it remains viewport-height for the current [contentKey], keeping its expanded anchor stable while
+ * nested scrolling continues to work normally. Change [contentKey] when one sheet instance swaps
+ * between layouts with fundamentally different intrinsic heights.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,9 +47,10 @@ fun StableModalBottomSheet(
     dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
     contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
     properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
+    contentKey: Any? = Unit,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val heightPolicy = remember(sheetState) { StableSheetHeightPolicy() }
+    val heightPolicy = remember(sheetState, contentKey) { StableSheetHeightPolicy() }
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
@@ -71,7 +71,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -141,6 +140,7 @@ import tk.glucodata.data.prediction.PredictionModelProfile
 import tk.glucodata.data.journal.LegacyJournalFoodDatabase
 import tk.glucodata.ui.GlucosePoint
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.util.ConnectedButtonGroup
 import tk.glucodata.ui.util.GlucoseFormatter
 import kotlinx.coroutines.Dispatchers
@@ -478,7 +478,7 @@ fun JournalEntrySheet(
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
@@ -483,7 +483,8 @@ fun JournalEntrySheet(
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() },
         containerColor = MaterialTheme.colorScheme.surface,
-        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+        contentKey = draft.type,
     ) {
         LazyColumn(
             modifier = Modifier

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
@@ -64,7 +64,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -131,6 +130,7 @@ import tk.glucodata.ui.components.SectionLabel
 import tk.glucodata.ui.components.SettingsItem
 import tk.glucodata.ui.components.SettingsSwitchItem
 import tk.glucodata.ui.components.StyledSwitch
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.components.cardShape
 import tk.glucodata.ui.viewmodel.DashboardViewModel
 import kotlinx.coroutines.Dispatchers
@@ -1323,7 +1323,7 @@ private fun JournalFoodSheet(
         buildFoodInput(draft)?.let(onSave)
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }
@@ -1703,7 +1703,7 @@ private fun JournalInsulinPresetSheet(
         }
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = { dismissSheet() },
         sheetState = sheetState,
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/overlay/FloatingSettingsSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/overlay/FloatingSettingsSheet.kt
@@ -32,6 +32,7 @@ import tk.glucodata.ui.components.SettingsSwitchItem
 import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.CompactSheetDragHandle
 import tk.glucodata.ui.components.SectionLabel
+import tk.glucodata.ui.components.StableModalBottomSheet
 // import tk.glucodata.ui.components.StyledSwitch // Unused now
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -61,7 +62,7 @@ fun FloatingSettingsSheet(
         hasPermission = Settings.canDrawOverlays(context)
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false), // 1. Allow partial expansion
         dragHandle = { CompactSheetDragHandle() },

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsMetrics.kt
@@ -48,7 +48,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -86,6 +85,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import tk.glucodata.R
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.util.AdaptiveLayoutDensity
 import tk.glucodata.ui.util.AdaptiveWindowWidthClass
 import tk.glucodata.ui.util.ExpressiveMotion
@@ -1406,7 +1406,7 @@ private fun PinnedMetricPickerSheet(
     onTogglePinned: (StatsMetric) -> Unit,
     onDismiss: () -> Unit
 ) {
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         dragHandle = { CompactSheetDragHandle() }
     ) {

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsRangeControls.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsRangeControls.kt
@@ -21,12 +21,12 @@ import androidx.compose.material3.DateRangePickerState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Button
 import androidx.compose.material3.DateRangePicker
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.rememberDateRangePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -327,7 +327,7 @@ fun StatsDateRangeSheet(
         0
     }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsScreen.kt
@@ -94,7 +94,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.Surface
@@ -151,6 +150,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import tk.glucodata.R
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import tk.glucodata.ui.util.ConnectedButtonGroup
 import tk.glucodata.ui.util.GlucoseFormatter
 import java.text.SimpleDateFormat
@@ -473,7 +473,7 @@ fun StatsScreen(
 
         if (showShareSheet) {
             val parsedReportDays = reportDaysInput.toIntOrNull()?.coerceIn(1, 365)
-            ModalBottomSheet(
+            StableModalBottomSheet(
                 onDismissRequest = { showShareSheet = false },
                 dragHandle = { CompactSheetDragHandle() }
             ) {
@@ -804,7 +804,7 @@ private fun ArrangeSheet(
     // dismissing, and the animating height moved its drag anchors underneath it — so it
     // dismissed on an ordinary scroll, and on any scroll begun before the open animation
     // had settled.
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         dragHandle = { CompactSheetDragHandle() }
     ) {

--- a/Common/src/mobile/java/tk/glucodata/ui/stats/StatsSections.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/stats/StatsSections.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -57,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import tk.glucodata.R
 import tk.glucodata.ui.GlucosePoint
 import tk.glucodata.ui.components.CompactSheetDragHandle
+import tk.glucodata.ui.components.StableModalBottomSheet
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -648,7 +648,7 @@ internal fun DayDetailSheet(
     var selectedHour by remember(day.date) { mutableStateOf(-1) }
     val titleFormatter = remember { DateTimeFormatter.ofPattern("EEEE d MMMM", Locale.getDefault()) }
 
-    ModalBottomSheet(
+    StableModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         dragHandle = { CompactSheetDragHandle() }

--- a/Common/src/test/java/tk/glucodata/OutboundApiInsulinTokensTests.kt
+++ b/Common/src/test/java/tk/glucodata/OutboundApiInsulinTokensTests.kt
@@ -1,0 +1,178 @@
+package tk.glucodata
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The token vocabulary an API destination gets for insulin types (issue #196):
+ * one family per active type, named after the type, so a chat message can say
+ * which insulin was logged instead of only the aggregate IOB.
+ */
+class OutboundApiInsulinTokensTests {
+
+    private val atMillis = 1_700_000_000_000L
+
+    private fun time(millis: Long) = "T${millis / 1000}"
+
+    private fun typeJson(
+        slug: String,
+        name: String = slug,
+        lastUnits: Double? = null,
+        lastTimestamp: Long = 0L,
+        iob: Double? = null,
+        todayUnits: Double? = null
+    ): JSONObject = JSONObject()
+        .put("slug", slug)
+        .put("name", name)
+        .put("last_units", lastUnits)
+        .put("last_timestamp", lastTimestamp)
+        .put("iob", iob)
+        .put("today_units", todayUnits)
+
+    private fun snapshot(vararg types: JSONObject): JSONObject =
+        JSONObject().put(OutboundApiInsulinTokens.JSON_ARRAY, JSONArray().also { array ->
+            types.forEach(array::put)
+        })
+
+    @Test
+    fun stockPresetNamesSlugToTheTokensTheIssueAsksFor() {
+        assertEquals("long_acting_insulin", OutboundApiInsulinTokens.slugFor("Long acting insulin"))
+        assertEquals("rapid_acting_insulin", OutboundApiInsulinTokens.slugFor("Rapid acting insulin"))
+    }
+
+    @Test
+    fun punctuationCollapsesAndNeverLeadsOrTrails() {
+        assertEquals("humulin_r_novolin_r", OutboundApiInsulinTokens.slugFor("Humulin R/Novolin R"))
+        assertEquals("fiasp", OutboundApiInsulinTokens.slugFor("  Fiasp!  "))
+        assertEquals("nph_100", OutboundApiInsulinTokens.slugFor("NPH (100)"))
+    }
+
+    /** A localized preset name has to stay usable: the chips insert it verbatim. */
+    @Test
+    fun nonLatinNamesKeepTheirOwnScript() {
+        assertEquals(
+            "инсулин_длительного_действия",
+            OutboundApiInsulinTokens.slugFor("Инсулин длительного действия")
+        )
+    }
+
+    @Test
+    fun namesThatSlugAlikeStillGetDistinctTokens() {
+        val slugs = OutboundApiInsulinTokens.assignSlugs(listOf("Basal", "basal", "Basal!", "Bolus"))
+        assertEquals(listOf("basal", "basal_2", "basal_3", "bolus"), slugs)
+    }
+
+    @Test
+    fun aNameWithNothingToSlugStillGetsAToken() {
+        assertEquals(listOf("insulin", "insulin_2"), OutboundApiInsulinTokens.assignSlugs(listOf("***", "###")))
+    }
+
+    @Test
+    fun everyTypeOffersItsFullTokenFamily() {
+        assertEquals(
+            listOf("{basal}", "{basal_time}", "{basal_ago}", "{basal_iob}", "{basal_today}"),
+            OutboundApiInsulinTokens.tokensForSlug("basal")
+        )
+    }
+
+    @Test
+    fun aLoggedDoseFillsInEveryTokenOfItsType() {
+        val doseAt = atMillis - 90 * 60_000L
+        val types = OutboundApiInsulinTokens.parse(
+            snapshot(
+                typeJson(
+                    slug = "long_acting_insulin",
+                    lastUnits = 12.0,
+                    lastTimestamp = doseAt,
+                    iob = 9.5,
+                    todayUnits = 12.0
+                )
+            )
+        )
+        val rendered = OutboundApiInsulinTokens.expand(
+            template = "{long_acting_insulin} U at {long_acting_insulin_time} " +
+                "({long_acting_insulin_ago} min, {long_acting_insulin_iob} left, " +
+                "{long_acting_insulin_today} today)",
+            types = types,
+            atMillis = atMillis,
+            formatTime = ::time
+        )
+        assertEquals("12 U at ${time(doseAt)} (90 min, 9.5 left, 12 today)", rendered)
+    }
+
+    /** No dose is not a zero dose: the dose tokens go empty, the totals read 0. */
+    @Test
+    fun aTypeWithNoDoseRendersEmptyDoseTokens() {
+        val types = OutboundApiInsulinTokens.parse(snapshot(typeJson(slug = "rapid_acting_insulin")))
+        val rendered = OutboundApiInsulinTokens.expand(
+            template = "[{rapid_acting_insulin}][{rapid_acting_insulin_time}]" +
+                "[{rapid_acting_insulin_ago}][{rapid_acting_insulin_iob}][{rapid_acting_insulin_today}]",
+            types = types,
+            atMillis = atMillis,
+            formatTime = ::time
+        )
+        assertEquals("[][][][0][0]", rendered)
+    }
+
+    @Test
+    fun fractionalUnitsKeepTheirDecimalsAndWholeUnitsDoNotGrowAny() {
+        val types = OutboundApiInsulinTokens.parse(
+            snapshot(
+                typeJson(slug = "a", lastUnits = 2.5, lastTimestamp = atMillis, iob = 0.25, todayUnits = 8.0)
+            )
+        )
+        assertEquals(
+            "2.5|0.25|8",
+            OutboundApiInsulinTokens.expand("{a}|{a_iob}|{a_today}", types, atMillis, ::time)
+        )
+    }
+
+    /** One type's tokens must not be eaten by another whose slug is a prefix. */
+    @Test
+    fun aSlugThatPrefixesAnotherDoesNotSwallowIt() {
+        val types = OutboundApiInsulinTokens.parse(
+            snapshot(
+                typeJson(slug = "basal", lastUnits = 10.0, lastTimestamp = atMillis),
+                typeJson(slug = "basal_insulin", lastUnits = 4.0, lastTimestamp = atMillis)
+            )
+        )
+        assertEquals(
+            "10 4",
+            OutboundApiInsulinTokens.expand("{basal} {basal_insulin}", types, atMillis, ::time)
+        )
+    }
+
+    @Test
+    fun aDoseEnteredAheadOfTheReadingNeverReportsNegativeMinutes() {
+        val types = OutboundApiInsulinTokens.parse(
+            snapshot(typeJson(slug = "a", lastUnits = 3.0, lastTimestamp = atMillis + 5 * 60_000L))
+        )
+        assertEquals("0", OutboundApiInsulinTokens.expand("{a_ago}", types, atMillis, ::time))
+    }
+
+    @Test
+    fun unknownTokensAreLeftAloneWhenNoTypeClaimsThem() {
+        val types = OutboundApiInsulinTokens.parse(snapshot(typeJson(slug = "a")))
+        assertEquals("{b} {a_bogus}", OutboundApiInsulinTokens.expand("{b} {a_bogus}", types, atMillis, ::time))
+    }
+
+    @Test
+    fun aSnapshotWithoutTheArrayParsesToNothing() {
+        assertTrue(OutboundApiInsulinTokens.parse(null).isEmpty())
+        assertTrue(OutboundApiInsulinTokens.parse(JSONObject().put("iob", 1.0)).isEmpty())
+    }
+
+    /** The journal read costs a Room query per send, so only pay for it when asked. */
+    @Test
+    fun onlyTemplatesThatNeedTheJournalTriggerASnapshotRead() {
+        assertTrue(OutboundApi.needsJournalSnapshot("{long_acting_insulin} U"))
+        assertTrue(OutboundApi.needsJournalSnapshot("IOB {iob}"))
+        assertTrue(OutboundApi.needsJournalSnapshot("{journal_cob}"))
+        assertFalse(OutboundApi.needsJournalSnapshot("{value} {unit} {trend_arrow} {time}"))
+        assertFalse(OutboundApi.needsJournalSnapshot("no tokens at all"))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/ui/components/StableSheetHeightPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/components/StableSheetHeightPolicyTests.kt
@@ -1,0 +1,64 @@
+package tk.glucodata.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StableSheetHeightPolicyTests {
+    @Test
+    fun shortSheetKeepsIntrinsicHeight() {
+        val policy = StableSheetHeightPolicy()
+
+        policy.onMeasured(measuredHeight = 720, maxHeight = 1000, hasBoundedHeight = true)
+
+        assertFalse(policy.isViewportHeightLocked)
+        assertEquals(0, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
+    }
+
+    @Test
+    fun viewportHeightSheetLocksForLaterMeasurements() {
+        val policy = StableSheetHeightPolicy()
+
+        policy.onMeasured(measuredHeight = 1000, maxHeight = 1000, hasBoundedHeight = true)
+
+        assertTrue(policy.isViewportHeightLocked)
+        assertEquals(1000, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
+    }
+
+    @Test
+    fun lockedSheetTracksAChangedViewportHeight() {
+        val policy = StableSheetHeightPolicy()
+        policy.onMeasured(measuredHeight = 1000, maxHeight = 1000, hasBoundedHeight = true)
+
+        assertEquals(720, policy.minimumHeight(maxHeight = 720, hasBoundedHeight = true))
+    }
+
+    @Test
+    fun viewportHeightLockDoesNotReleaseWhenContentLaterMeasuresShorter() {
+        val policy = StableSheetHeightPolicy()
+        policy.onMeasured(measuredHeight = 1000, maxHeight = 1000, hasBoundedHeight = true)
+
+        policy.onMeasured(measuredHeight = 960, maxHeight = 1000, hasBoundedHeight = true)
+
+        assertTrue(policy.isViewportHeightLocked)
+        assertEquals(1000, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
+    }
+
+    @Test
+    fun unboundedMeasurementDoesNotLockOrInventAHeight() {
+        val policy = StableSheetHeightPolicy()
+
+        policy.onMeasured(
+            measuredHeight = 1000,
+            maxHeight = Int.MAX_VALUE,
+            hasBoundedHeight = false,
+        )
+
+        assertFalse(policy.isViewportHeightLocked)
+        assertEquals(
+            0,
+            policy.minimumHeight(maxHeight = Int.MAX_VALUE, hasBoundedHeight = false),
+        )
+    }
+}

--- a/docs/outbound-api.md
+++ b/docs/outbound-api.md
@@ -33,7 +33,8 @@ interval`. New presets plug in via three extension points (see §7).
 | `Common/src/main/java/tk/glucodata/SuperGattCallback.java` (line 577) | **Producer** — calls `OutboundApi.enqueueGlucose(...)` on every new CGM reading. |
 | `Common/src/main/java/tk/glucodata/OutboundApi.kt` | **Orchestrator + worker.** Object `OutboundApi` (queue, trigger gating, rate limit, network guard), data class `Reading` (post-render fields), data class `JournalSnapshot`, and `class OutboundApiWorker` (`runOnce`, `sendTelegram`, `sendVk`, `sendJson`, HTTP plumbing). |
 | `Common/src/main/java/tk/glucodata/OutboundApiSettings.kt` | **Persistence + destination model.** `Config`, `Destination`, presets, defaults, encode/decode to JSON, legacy migration. |
-| `Common/src/mobile/java/tk/glucodata/OutboundApiJournalSnapshot.kt` | **Journal data source.** Builds a JSON snapshot of recent insulin / carb entries for `{journal}`, `{iob}`, `{cob}` substitution. `mobile` flavour only. |
+| `Common/src/main/java/tk/glucodata/OutboundApiInsulinTokens.kt` | **Per-insulin-type tokens.** Slugs a preset display name into a token family and expands it (see §5.1). |
+| `Common/src/mobile/java/tk/glucodata/OutboundApiJournalSnapshot.kt` | **Journal data source.** Builds a JSON snapshot of recent insulin / carb entries for `{journal}`, `{iob}`, `{cob}` and the per-insulin-type tokens. `mobile` flavour only. |
 | `Common/src/mobile/java/tk/glucodata/ui/OutboundApiSettingsScreen.kt` | **UI.** Compose screen, preset picker, per-destination editor, status row, test button. |
 | `Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt` | **Wiring** — registers the route into the settings nav graph. |
 
@@ -165,6 +166,30 @@ state at the moment of send.
 
 The full list is also exposed at runtime in
 `templateTokens` (private val in `OutboundApiSettingsScreen.kt`).
+
+### 5.1 Per-insulin-type tokens
+
+`{iob}` cannot say *which* insulin moved, so every insulin type the journal has
+active also gets a token family of its own, named after the type
+(`OutboundApiInsulinTokens`). The slug is the display name lowercased with
+non-alphanumeric runs collapsed to `_`, in whatever script the name is written
+in; the stock English presets give `rapid_acting_insulin` and
+`long_acting_insulin`. Colliding slugs get a `_2`, `_3` suffix.
+
+| Token             | Renders                                              |
+|-------------------|------------------------------------------------------|
+| `{<slug>}`        | Last dose in units, empty when there is none         |
+| `{<slug>_time}`   | Locale-formatted short time of that dose             |
+| `{<slug>_ago}`    | Whole minutes since that dose                        |
+| `{<slug>_iob}`    | Units of that type still active (`0` when none)      |
+| `{<slug>_today}`  | Units of that type since local midnight              |
+
+The per-type `_iob` ignores the preset's `countsTowardIob` switch — that switch
+governs the single aggregate `{iob}`, while a token named after a type reports
+what is actually left of it. Values come from the `insulin_types` array in the
+journal snapshot, which the custom-JSON body also carries as a top-level field.
+The settings screen lists the live tokens as chips (`insulinTemplateTokens()`),
+which is the only practical way to enter a non-Latin slug.
 
 Default templates:
 


### PR DESCRIPTION
Closes #196.

`{iob}` is a single number, so a Telegram chat fed by an API destination could not tell a basal shot from a bolus. The issue asks for a template placeholder that fires specifically for long-acting insulin.

## What this adds

Every insulin type the journal has **active** now gets its own token family, slugged from that type's display name — the stock English presets give `{long_acting_insulin}` and `{rapid_acting_insulin}`:

| Token | Renders |
|---|---|
| `{<slug>}` | last dose in units, empty when there is none |
| `{<slug>_time}` | locale-formatted short time of that dose |
| `{<slug>_ago}` | whole minutes since that dose |
| `{<slug>_iob}` | units of that type still active (`0` when none) |
| `{<slug>_today}` | units of that type since local midnight |

So a template can read `Long acting: {long_acting_insulin} U at {long_acting_insulin_time}`.

The slug keeps whatever script the name is written in, so a Russian install gets `{инсулин_длительного_действия}`. Nobody should have to type that — the destination editor lists the live tokens as chips under a new **Insulin types** group, next to the existing ones. Types that slug alike get a `_2`/`_3` suffix so no type loses its token.

## How it is wired

- `OutboundApiInsulinTokens` (src/main) does the slugging and expansion — pure, and the bulk of the new tests.
- `OutboundApiJournalSnapshot` (src/mobile) adds an `insulin_types` array to the snapshot JSON, which is the only channel src/main has into the mobile-only journal. The custom-JSON destination body carries it as a top-level field too.
- `renderMessage`'s "do I need the journal?" check was a hardcoded `{iob}`/`{cob}`/`{journal` substring test; it now treats any non-static placeholder as needing the snapshot, since a per-type token's spelling depends on what the user named their insulin.

Two deliberate calls worth review:

- **The per-type `_iob` ignores `countsTowardIob`.** That switch decides what belongs in the single aggregate `{iob}`; the stock long-acting preset has it off. A token asked for by name should report what is actually left of *that* insulin, so `sum(per-type) != {iob}` by design. Documented in `docs/outbound-api.md` §5.1 and in the KDoc.
- **Archived types get no tokens** — they are the ones the user turned off, and their chips would only clutter the editor. Insulin already injected with an archived type still counts toward the aggregate `{iob}` as before.

## Testing

`Common/src/test/java/tk/glucodata/OutboundApiInsulinTokensTests.kt` — 13 tests covering slugging (stock names, punctuation, Cyrillic, collisions, unsluggable names), rendering (full family, no-dose emptiness, decimals, prefix slugs not swallowing each other, future-dated doses), and the journal-read gate. Full `:Common:testMobileDebugUnitTest` suite green.

Not exercised on a device: the settings chips are unrendered code review only.

Note: this branch also carries the two local `main` commits (`93d041914`, `c829aed23`) that were not yet pushed to `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)