### PR TITLE
Nightscout: test the configured API version, and let device status fetch its own token

### DIFF
--- a/Common/src/main/java/tk/glucodata/NightPost.java
+++ b/Common/src/main/java/tk/glucodata/NightPost.java
@@ -323,6 +323,19 @@ private static synchronized String gettoken(
         }
     }
 
+/**
+ * Authorization header for v3 requests made outside this class, reusing the token the v3
+ * upload path already fetches and caches. Empty when none could be had, so the caller can
+ * fall back rather than send a header it knows is wrong.
+ *
+ * <p>Leaves the visible upload status alone: a read failing must not overwrite what the
+ * uploader last reported.
+ */
+@Keep
+static public String getV3AuthorizationHeader() {
+    return gettoken(System.currentTimeMillis(),UPLOAD_CONNECT_TIMEOUT_MS,UPLOAD_READ_TIMEOUT_MS,false);
+    }
+
 private static synchronized String getCachedToken(long now) {
     return now<expire ? token : "";
     }

--- a/Common/src/main/java/tk/glucodata/NightPost.java
+++ b/Common/src/main/java/tk/glucodata/NightPost.java
@@ -83,11 +83,53 @@ import tk.glucodata.settings.LibreNumbers;
 public class NightPost  {
     private static final String LOG_ID="NightPost";
     private static final int ERROR_INVALID_URL = -2;
+    /** Ancillary upload skipped: no token cached and none could be fetched. */
+    private static final int ERROR_NO_TOKEN = -3;
     private static final int UPLOAD_CONNECT_TIMEOUT_MS = 15_000;
     private static final int UPLOAD_READ_TIMEOUT_MS = 60_000;
     private static final int DEVICE_STATUS_CONNECT_TIMEOUT_MS = 3_000;
     private static final int DEVICE_STATUS_READ_TIMEOUT_MS = 5_000;
+    private static final int ANCILLARY_TOKEN_CONNECT_TIMEOUT_MS = 10_000;
+    private static final int ANCILLARY_TOKEN_READ_TIMEOUT_MS = 15_000;
     private static final AtomicBoolean deviceStatusUploadInFlight = new AtomicBoolean(false);
+    /**
+     * Outcome of the IOB devicestatus upload, for the settings screen. The status card
+     * otherwise only reports the native entries uploader, so a dead devicestatus path was
+     * invisible outside logcat - and a "no token" skip must not read like a server
+     * rejection. The battery devicestatus shares the queue but not this state: it is not
+     * what the screen names.
+     */
+    public static final int DEVICE_STATUS_NONE=0;
+    public static final int DEVICE_STATUS_ACCEPTED=1;
+    public static final int DEVICE_STATUS_NO_TOKEN=2;
+    public static final int DEVICE_STATUS_REJECTED=3;
+    /** Outcome and its HTTP code travel together, so the screen cannot pair one with the other's code. */
+    private record IobDeviceStatusState(int outcome,int code) {}
+    private static volatile IobDeviceStatusState iobDeviceStatus=new IobDeviceStatusState(DEVICE_STATUS_NONE,0);
+
+    private static void setIobDeviceStatusOutcome(int code) {
+        final int outcome;
+        if(code==HTTP_OK || code==HttpURLConnection.HTTP_CREATED)
+            outcome=DEVICE_STATUS_ACCEPTED;
+        else if(code==ERROR_NO_TOKEN)
+            outcome=DEVICE_STATUS_NO_TOKEN;
+        else
+            outcome=DEVICE_STATUS_REJECTED;
+        iobDeviceStatus=new IobDeviceStatusState(outcome,code);
+    }
+
+    /** Forgets the last outcome, so corrected settings do not keep showing the old failure. */
+    public static void clearDeviceStatusOutcome() {
+        iobDeviceStatus=new IobDeviceStatusState(DEVICE_STATUS_NONE,0);
+    }
+
+    public static int getDeviceStatusOutcome() {
+        return iobDeviceStatus.outcome();
+    }
+
+    public static int getDeviceStatusLastCode() {
+        return iobDeviceStatus.code();
+    }
     private static final ThreadPoolExecutor deviceStatusExecutor = new ThreadPoolExecutor(
             0,
             1,
@@ -285,6 +327,29 @@ private static synchronized String getCachedToken(long now) {
     return now<expire ? token : "";
     }
 
+private static long ancillaryTokenAttemptTime=0L;
+
+/**
+ * Token for the ancillary (device-status) path: the cached one when still valid,
+ * otherwise at most one fetch per {@link NightscoutIobDeviceStatus#TOKEN_RETRY_MILLIS},
+ * quiet on the visible upload status.
+ *
+ * <p>The fetch does not inherit the caller's device-status timeouts. Those are tight on
+ * purpose (a late battery or IOB document is worthless), but a Nightscout instance that
+ * has to wake up first would then miss every token request and the cache would stay
+ * empty forever, which is the failure this path exists to end. They are still well under
+ * the primary uploader's, so a slow auth endpoint cannot park the class lock for a minute.
+ */
+private static synchronized String getAncillaryToken(long now) {
+    final String cached=getCachedToken(now);
+    if(!cached.isEmpty())
+        return cached;
+    if(!NightscoutIobDeviceStatus.tokenRetryDue(now, ancillaryTokenAttemptTime))
+        return "";
+    ancillaryTokenAttemptTime=now;
+    return gettoken(now,ANCILLARY_TOKEN_CONNECT_TIMEOUT_MS,ANCILLARY_TOKEN_READ_TIMEOUT_MS,false);
+    }
+
 private static long uploadtime=System.currentTimeMillis();
 
 /**
@@ -407,7 +472,7 @@ static public boolean maybeUploadIobDeviceStatus(String httpurl,String secret) {
         final String document=NightscoutIobDeviceStatus.buildDocument(now,values[0],values[1],values[2]);
         if(document==null)
             return true;
-        if(uploadDeviceStatusAsync(httpurl,document.getBytes(java.nio.charset.StandardCharsets.UTF_8),secret,false)) {
+        if(uploadDeviceStatusAsync(httpurl,document.getBytes(java.nio.charset.StandardCharsets.UTF_8),secret,false,true)) {
             iobStatusUploadTime=now;
             iobStatusLastIob=values[0];
             iobStatusLastEiob=values[1];
@@ -440,6 +505,8 @@ static public int upload(String httpurl,byte[] postdata,String secret,boolean pu
  *
  * <p>The native caller throttles attempts. This additional in-flight gate prevents a slow
  * endpoint from accumulating work if a future caller bypasses that throttle.
+ *
+ * <p>Called from native with this exact signature, so it stays the battery entry point.
  */
 @Keep
 static public boolean uploadDeviceStatusAsync(
@@ -447,6 +514,22 @@ static public boolean uploadDeviceStatusAsync(
         byte[] postdata,
         String secret,
         boolean put
+) {
+    return uploadDeviceStatusAsync(httpurl,postdata,secret,put,false);
+    }
+
+/**
+ * @param iobChannel true for the journal IOB document, false for the uploader battery.
+ *        Both share this queue, but only the IOB channel reports its outcome to the
+ *        settings screen: the status line there names IOB, and a failing battery upload
+ *        must not be shown under that name.
+ */
+static private boolean uploadDeviceStatusAsync(
+        String httpurl,
+        byte[] postdata,
+        String secret,
+        boolean put,
+        boolean iobChannel
 ) {
     if(!deviceStatusUploadInFlight.compareAndSet(false, true)) {
         Log.i(LOG_ID,"device-status upload already in flight; dropping duplicate");
@@ -463,11 +546,13 @@ static public boolean uploadDeviceStatusAsync(
                         DEVICE_STATUS_CONNECT_TIMEOUT_MS,
                         DEVICE_STATUS_READ_TIMEOUT_MS,
                         false,
-                        "device-status"
+                        iobChannel?"device-status(iob)":"device-status"
                 );
+                if(iobChannel)
+                    setIobDeviceStatusOutcome(code);
                 if(code==HTTP_OK || code==HttpURLConnection.HTTP_CREATED)
                     Log.i(LOG_ID,"device-status upload accepted code="+code);
-                else
+                else if(code!=ERROR_NO_TOKEN)
                     Log.e(LOG_ID,"device-status upload failed code="+code);
             }
             finally {
@@ -529,14 +614,17 @@ private static int uploadWithTimeouts(
         if(secret!=null)
             urlConnection.setRequestProperty("api-secret", secret);
         else {
-            // Ancillary device status never performs authorization network work. It is queued
-            // only after a primary upload, so a valid v3 token should already be cached.
+            // The ancillary path used to rely purely on the token a primary upload cached.
+            // After a reinstall, process death or token expiry that cache is empty and
+            // nothing refills it, so device status stayed dead until a manual resend
+            // happened to trigger a primary upload. It now fetches a token itself, but
+            // throttled: a refusing server is asked once per interval, not per attempt.
             final String auth = updateVisibleStatus
                     ? gettoken(requestTime, connectTimeoutMs, readTimeoutMs, true)
-                    : getCachedToken(requestTime);
+                    : getAncillaryToken(requestTime);
             if(auth.isEmpty()) {
-                Log.e(LOG_ID,requestKind+" upload skipped: no cached Nightscout token");
-                return -1;
+                Log.e(LOG_ID,requestKind+" upload skipped: no Nightscout token");
+                return updateVisibleStatus ? -1 : ERROR_NO_TOKEN;
             }
             urlConnection.setRequestProperty("Authorization", auth);
         }

--- a/Common/src/main/java/tk/glucodata/NightscoutIobDeviceStatus.java
+++ b/Common/src/main/java/tk/glucodata/NightscoutIobDeviceStatus.java
@@ -37,6 +37,10 @@ public class NightscoutIobDeviceStatus {
     // back to the same slow cadence as the battery devicestatus.
     static final long FAST_INTERVAL_MILLIS = 5L * 60L * 1000L;
     static final long SLOW_INTERVAL_MILLIS = 15L * 60L * 1000L;
+    // The ancillary upload path fetches its own token when the cache is empty,
+    // but at most this often, so a refusing server is asked once per interval
+    // instead of on every devicestatus attempt.
+    static final long TOKEN_RETRY_MILLIS = FAST_INTERVAL_MILLIS;
     // Below half of the 0.01-unit display quantum IOB counts as zero.
     private static final float VALUE_QUANTUM = 0.01f;
 
@@ -47,6 +51,14 @@ public class NightscoutIobDeviceStatus {
     // callers use this as a cheap gate before computing the journal snapshot.
     static boolean fastIntervalElapsed(long nowMillis, long lastUploadMillis) {
         return lastUploadMillis <= 0L || nowMillis - lastUploadMillis >= FAST_INTERVAL_MILLIS;
+    }
+
+    // True when the ancillary path may spend a network round trip on a token
+    // request. A clock that moved backwards must not block requests forever.
+    static boolean tokenRetryDue(long nowMillis, long lastAttemptMillis) {
+        return lastAttemptMillis <= 0L
+                || nowMillis < lastAttemptMillis
+                || nowMillis - lastAttemptMillis >= TOKEN_RETRY_MILLIS;
     }
 
     // Decides whether a devicestatus is due. Fast cadence while insulin is on

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1203,7 +1203,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin">Адпраўляць інсулін працяглага дзеяння</string>
     <string name="nightscout_send_long_insulin_desc">Уключаць базальны і звышдоўгі інсулін у загрузкі Nightscout</string>
     <string name="nightscout_receive_amounts">Атрымліваць сумы</string>
-    <string name="nightscout_receive_amounts_desc">Імпартаваць інсулін/вугляводы з Nightscout у журнал</string>
+    <string name="nightscout_receive_amounts_desc">Імпартаваць інсулін/вугляводы з Nightscout у журнал. Токен доступу патрабуе дазволу api:treatments:read.</string>
     <string name="nightscout_settings_title">Налады Nightscout</string>
     <string name="nightscout_url_label">URL начнога разведчыка</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1408,6 +1408,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Апошні адказ: HTTP 413, payload занадта вялікі</string>
     <string name="nightscout_status_last_attempt">Апошняя спроба: %1$s</string>
     <string name="nightscout_status_last_success">Апошні поспех: %1$s</string>
+    <string name="nightscout_status_iob_no_token">Адпраўка IOB: прапушчана - пакуль няма токена Nightscout</string>
+    <string name="nightscout_status_iob_rejected">Адпраўка IOB: адхілена (%1$s)</string>
     <string name="nightscout_sync_actions_title">Дзеянні сінхранізацыі</string>
     <string name="expand_action">Разгарнуць</string>
     <string name="collapse_action">Згарнуць</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1274,7 +1274,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightscout_send_long_insulin">Langzeitinsulin senden</string>
     <string name="nightscout_send_long_insulin_desc">Basal- und ultralang wirkendes Insulin zu Nightscout hochladen</string>
     <string name="nightscout_receive_amounts">Mengen empfangen</string>
-    <string name="nightscout_receive_amounts_desc">Nightscout-Insulin/Kohlenhydrate ins Journal importieren</string>
+    <string name="nightscout_receive_amounts_desc">Nightscout-Insulin/Kohlenhydrate ins Journal importieren. Der Zugriffstoken benötigt die Berechtigung api:treatments:read.</string>
     <string name="nightscout_upload_iob">IOB an Nightscout senden</string>
     <string name="nightscout_upload_iob_desc">Nightscout zeigt dann diesen Wert statt seiner eigenen Berechnung aus dem Profil. eIOB und COB werden zusätzlich in einem eigenen Feld übertragen.</string>
     <string name="nightscout_settings_title">Nightscout-Einstellungen</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1483,6 +1483,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightscout_status_response_413">Letzte Antwort: HTTP 413, Nutzlast zu groß</string>
     <string name="nightscout_status_last_attempt">Letzter Versuch: %1$s</string>
     <string name="nightscout_status_last_success">Letzter Erfolg: %1$s</string>
+    <string name="nightscout_status_iob_no_token">IOB-Upload: übersprungen - noch kein Nightscout-Token</string>
+    <string name="nightscout_status_iob_rejected">IOB-Upload: abgelehnt (%1$s)</string>
     <string name="nightscout_sync_actions_title">Synchronisierungsaktionen</string>
     <string name="expand_action">Erweitern</string>
     <string name="collapse_action">Einklappen</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1210,7 +1210,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin">Envoyer l’insuline à action prolongée</string>
     <string name="nightscout_send_long_insulin_desc">Inclure l’insuline basale et à action ultra-longue dans les envois Nightscout</string>
     <string name="nightscout_receive_amounts">Recevoir les quantités</string>
-    <string name="nightscout_receive_amounts_desc">Importer l\'insuline/les glucides Nightscout dans le journal</string>
+    <string name="nightscout_receive_amounts_desc">Importer l\'insuline/les glucides Nightscout dans le journal. Le jeton d\'accès requiert l\'autorisation api:treatments:read.</string>
     <string name="nightscout_settings_title">Paramètres de Nightscout</string>
     <string name="nightscout_url_label">URL de Nightscout</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1415,6 +1415,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Dernière réponse : HTTP 413, charge utile trop volumineuse</string>
     <string name="nightscout_status_last_attempt">Dernière tentative : %1$s</string>
     <string name="nightscout_status_last_success">Dernier succès : %1$s</string>
+    <string name="nightscout_status_iob_no_token">Envoi IOB : ignoré - pas encore de jeton Nightscout</string>
+    <string name="nightscout_status_iob_rejected">Envoi IOB : refusé (%1$s)</string>
     <string name="nightscout_sync_actions_title">Actions de synchronisation</string>
     <string name="expand_action">Développer</string>
     <string name="collapse_action">Réduire</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1399,6 +1399,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Ultima risposta: HTTP 413, payload troppo grande</string>
     <string name="nightscout_status_last_attempt">Ultimo tentativo: %1$s</string>
     <string name="nightscout_status_last_success">Ultimo successo: %1$s</string>
+    <string name="nightscout_status_iob_no_token">Invio IOB: saltato - ancora nessun token Nightscout</string>
+    <string name="nightscout_status_iob_rejected">Invio IOB: rifiutato (%1$s)</string>
     <string name="nightscout_sync_actions_title">Azioni di sincronizzazione</string>
     <string name="expand_action">Espandi</string>
     <string name="collapse_action">Comprimi</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1194,7 +1194,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin">Invia insulina a lunga durata</string>
     <string name="nightscout_send_long_insulin_desc">Includi l’insulina basale e ultralenta nei caricamenti Nightscout</string>
     <string name="nightscout_receive_amounts">Ricevi quantità</string>
-    <string name="nightscout_receive_amounts_desc">Importa insulina/carboidrati di Nightscout nel diario</string>
+    <string name="nightscout_receive_amounts_desc">Importa insulina/carboidrati di Nightscout nel diario. Il token di accesso richiede l\'autorizzazione api:treatments:read.</string>
     <string name="nightscout_settings_title">Impostazioni Nightscout</string>
     <string name="nightscout_url_label">URL dell\'esploratore notturno</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1229,6 +1229,8 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="nightscout_status_response_413">Сүүлчийн хариу: HTTP 413, өгөгдөл хэт том байна</string>
     <string name="nightscout_status_last_attempt">Сүүлийн оролдлого: %1$s</string>
     <string name="nightscout_status_last_success">Сүүлийн амжилт: %1$s</string>
+    <string name="nightscout_status_iob_no_token">IOB илгээлт: алгассан - Nightscout токен хараахан алга</string>
+    <string name="nightscout_status_iob_rejected">IOB илгээлт: татгалзсан (%1$s)</string>
     <string name="nightscout_send_amounts_desc">Инсулин/Нүүрс ус ачаалах (Treatments)</string>
     <string name="nightscout_send_long_insulin">Удаан үйлдэлтэй инсулин илгээх</string>
     <string name="nightscout_send_long_insulin_desc">Nightscout руу суурь болон хэт удаан инсулиныг хамт илгээх</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2151,7 +2151,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="calibration_import_replace_desc">Энэ мэдрэгчийн калибровкийн профайлыг солих.</string>
     <string name="anytime_sensor_telemetry">Iw / Ib / T</string>
     <string name="nightscout_receive_amounts">Хэмжээг хүлээн авах</string>
-    <string name="nightscout_receive_amounts_desc">Nightscout инсулин/нүүрс усыг журналд импортлох</string>
+    <string name="nightscout_receive_amounts_desc">Nightscout инсулин/нүүрс усыг журналд импортлох. Хандалтын токенд api:treatments:read зөвшөөрөл шаардлагатай.</string>
     <string name="nightscout_test_testing">Шалгаж байна...</string>
     <string name="nightscout_test_error">Амжилтгүй - %1$s</string>
     <string name="nightscout_test_ok">Холбогдсон - HTTP %1$d</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1247,7 +1247,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="nightscout_send_long_insulin">Langwerkende insuline verzenden</string>
     <string name="nightscout_send_long_insulin_desc">Basale en ultralangwerkende insuline naar Nightscout uploaden</string>
     <string name="nightscout_receive_amounts">Hoeveelheden ontvangen</string>
-    <string name="nightscout_receive_amounts_desc">Nightscout-insuline/koolhydraten in het dagboek importeren</string>
+    <string name="nightscout_receive_amounts_desc">Nightscout-insuline/koolhydraten in het dagboek importeren. Het toegangstoken heeft de machtiging api:treatments:read nodig.</string>
     <string name="nightscout_settings_title">Nightscout-instellingen</string>
     <string name="nightscout_url_label">Nightscout-URL</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1452,6 +1452,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="nightscout_status_response_413">Laatste reactie: HTTP 413, payload te groot</string>
     <string name="nightscout_status_last_attempt">Laatste poging: %1$s</string>
     <string name="nightscout_status_last_success">Laatste succes: %1$s</string>
+    <string name="nightscout_status_iob_no_token">IOB-upload: overgeslagen - nog geen Nightscout-token</string>
+    <string name="nightscout_status_iob_rejected">IOB-upload: geweigerd (%1$s)</string>
     <string name="nightscout_sync_actions_title">Synchronisatieacties</string>
     <string name="expand_action">Uitklappen</string>
     <string name="collapse_action">Inklappen</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1444,6 +1444,8 @@
     <string name="nightscout_status_response_413">Ostatnia odpowiedź: HTTP 413, zbyt duży ładunek</string>
     <string name="nightscout_status_last_attempt">Ostatnia próba: %1$s</string>
     <string name="nightscout_status_last_success">Ostatni sukces: %1$s</string>
+    <string name="nightscout_status_iob_no_token">Wysyłka IOB: pominięta - brak jeszcze tokenu Nightscout</string>
+    <string name="nightscout_status_iob_rejected">Wysyłka IOB: odrzucona (%1$s)</string>
     <string name="nightscout_sync_actions_title">Akcje synchronizacji</string>
     <string name="expand_action">Rozwiń</string>
     <string name="collapse_action">Zwiń</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1239,7 +1239,7 @@
     <string name="nightscout_send_long_insulin">Wysyłaj insulinę długodziałającą</string>
     <string name="nightscout_send_long_insulin_desc">Uwzględniaj insulinę bazową i ultradługodziałającą w wysyłaniu do Nightscout</string>
     <string name="nightscout_receive_amounts">Odbieraj wartości</string>
-    <string name="nightscout_receive_amounts_desc">Importuj insulinę/węglowodany z Nightscout do dziennika</string>
+    <string name="nightscout_receive_amounts_desc">Importuj insulinę/węglowodany z Nightscout do dziennika. Token dostępu wymaga uprawnienia api:treatments:read.</string>
     <string name="nightscout_settings_title">Ustawienia Nightscouta</string>
     <string name="nightscout_url_label">Adres URL Nightscouta</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1205,7 +1205,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin">Enviar insulina de ação prolongada</string>
     <string name="nightscout_send_long_insulin_desc">Incluir insulina basal e de ação ultralonga nos envios para o Nightscout</string>
     <string name="nightscout_receive_amounts">Receber valores</string>
-    <string name="nightscout_receive_amounts_desc">Importar insulina/carboidratos do Nightscout para o diário</string>
+    <string name="nightscout_receive_amounts_desc">Importar insulina/carboidratos do Nightscout para o diário. O token de acesso precisa da permissão api:treatments:read.</string>
     <string name="nightscout_settings_title">Configurações do Nightscout</string>
     <string name="nightscout_url_label">URL do Nightscout</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1410,6 +1410,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Última resposta: HTTP 413, carga útil demasiado grande</string>
     <string name="nightscout_status_last_attempt">Última tentativa: %1$s</string>
     <string name="nightscout_status_last_success">Último sucesso: %1$s</string>
+    <string name="nightscout_status_iob_no_token">Envio de IOB: ignorado - ainda sem token do Nightscout</string>
+    <string name="nightscout_status_iob_rejected">Envio de IOB: rejeitado (%1$s)</string>
     <string name="nightscout_sync_actions_title">Ações de sincronização</string>
     <string name="expand_action">Expandir</string>
     <string name="collapse_action">Recolher</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1452,6 +1452,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Последний ответ: HTTP 413, слишком большой payload</string>
     <string name="nightscout_status_last_attempt">Последняя попытка: %1$s</string>
     <string name="nightscout_status_last_success">Последний успех: %1$s</string>
+    <string name="nightscout_status_iob_no_token">Отправка IOB: пропущена - пока нет токена Nightscout</string>
+    <string name="nightscout_status_iob_rejected">Отправка IOB: отклонена (%1$s)</string>
     <string name="nightscout_sync_actions_title">Действия синхронизации</string>
     <string name="expand_action">Развернуть</string>
     <string name="collapse_action">Свернуть</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1241,7 +1241,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin">Отправлять длинный инсулин</string>
     <string name="nightscout_send_long_insulin_desc">Включать базальный и ультрадлительный инсулин при загрузке в Nightscout</string>
     <string name="nightscout_receive_amounts">Получать результаты</string>
-    <string name="nightscout_receive_amounts_desc">Импортировать инсулин/углеводы Nightscout в журнал</string>
+    <string name="nightscout_receive_amounts_desc">Импортировать инсулин/углеводы Nightscout в журнал. Токену доступа нужно разрешение api:treatments:read.</string>
     <string name="nightscout_settings_title">Настройки ночного скаута</string>
     <string name="nightscout_url_label">URL ночного скаута</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1504,7 +1504,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="nightscout_send_long_insulin">Dir insuliinta muddada dheer</string>
     <string name="nightscout_send_long_insulin_desc">Ku dar insuliinta basal iyo tan aadka u dheer gelinta Nightscout</string>
     <string name="nightscout_receive_amounts">Hesho qaddaro</string>
-    <string name="nightscout_receive_amounts_desc">Soo rar Nightscout insulin/carbs joornaalka</string>
+    <string name="nightscout_receive_amounts_desc">Soo rar Nightscout insulin/carbs joornaalka. Token-ka gelitaanka wuxuu u baahan yahay oggolaanshaha api:treatments:read.</string>
     <string name="nightscout_settings_title">Goobaha Nightscoout</string>
     <string name="nightscout_sync_actions_title">Isku xidh falalka</string>
     <string name="nightscout_url_label">Nightscout URL</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1498,6 +1498,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="nightscout_status_response_413">Jawaabtii u dambaysay: HTTP 413, culayska la saaray oo aad u weyn</string>
     <string name="nightscout_status_last_attempt">Isku daygii ugu dambeeyay: %1$s</string>
     <string name="nightscout_status_last_success">Guushii u dambaysay: %1$s</string>
+    <string name="nightscout_status_iob_no_token">Dirista IOB: waa la booday - weli token Nightscout ma jiro</string>
+    <string name="nightscout_status_iob_rejected">Dirista IOB: waa la diiday (%1$s)</string>
     <string name="nightscout_send_amounts_desc">Soo rar Insulin/Carbs (Daawaynta)</string>
     <string name="nightscout_send_long_insulin">Dir insuliinta muddada dheer</string>
     <string name="nightscout_send_long_insulin_desc">Ku dar insuliinta basal iyo tan aadka u dheer gelinta Nightscout</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1204,7 +1204,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin">Skicka långverkande insulin</string>
     <string name="nightscout_send_long_insulin_desc">Inkludera basinsulin och ultralångverkande insulin i Nightscout-uppladdningar</string>
     <string name="nightscout_receive_amounts">Ta emot mängder</string>
-    <string name="nightscout_receive_amounts_desc">Importera Nightscout-insulin/kolhydrater till journalen</string>
+    <string name="nightscout_receive_amounts_desc">Importera Nightscout-insulin/kolhydrater till journalen. Åtkomsttoken behöver behörigheten api:treatments:read.</string>
     <string name="nightscout_settings_title">Nightscout-inställningar</string>
     <string name="nightscout_url_label">Nightscout URL</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1409,6 +1409,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Senaste svar: HTTP 413, för stor payload</string>
     <string name="nightscout_status_last_attempt">Senaste försök: %1$s</string>
     <string name="nightscout_status_last_success">Senaste lyckade: %1$s</string>
+    <string name="nightscout_status_iob_no_token">IOB-uppladdning: överhoppad - ingen Nightscout-token ännu</string>
+    <string name="nightscout_status_iob_rejected">IOB-uppladdning: avvisad (%1$s)</string>
     <string name="nightscout_sync_actions_title">Synkåtgärder</string>
     <string name="expand_action">Expandera</string>
     <string name="collapse_action">Fäll ihop</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1437,6 +1437,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="nightscout_status_response_413">Son yanıt: HTTP 413, yük çok büyük</string>
     <string name="nightscout_status_last_attempt">Son deneme: %1$s</string>
     <string name="nightscout_status_last_success">Son başarılı: %1$s</string>
+    <string name="nightscout_status_iob_no_token">IOB gönderimi: atlandı - henüz Nightscout belirteci yok</string>
+    <string name="nightscout_status_iob_rejected">IOB gönderimi: reddedildi (%1$s)</string>
     <string name="nightscout_sync_actions_title">Senkronizasyon işlemleri</string>
     <string name="expand_action">Genişlet</string>
     <string name="collapse_action">Daralt</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1232,7 +1232,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="nightscout_send_long_insulin">Uzun etkili insülini gönder</string>
     <string name="nightscout_send_long_insulin_desc">Nightscout yüklemelerine bazal ve ultra uzun etkili insülini dahil et</string>
     <string name="nightscout_receive_amounts">Miktarları al</string>
-    <string name="nightscout_receive_amounts_desc">Nightscout insülin/karbonhidrat kayıtlarını günlüğe içe aktar</string>
+    <string name="nightscout_receive_amounts_desc">Nightscout insülin/karbonhidrat kayıtlarını günlüğe içe aktar. Erişim belirtecinin api:treatments:read iznine ihtiyacı var.</string>
     <string name="nightscout_settings_title">Gece İzci Ayarları</string>
     <string name="nightscout_url_label">Gece İzci URL\'si</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1218,7 +1218,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin">Надсилати інсулін тривалої дії</string>
     <string name="nightscout_send_long_insulin_desc">Додавати базальний та ультратривалий інсулін до завантажень Nightscout</string>
     <string name="nightscout_receive_amounts">Отримувати суми</string>
-    <string name="nightscout_receive_amounts_desc">Імпортувати інсулін/вуглеводи з Nightscout до журналу</string>
+    <string name="nightscout_receive_amounts_desc">Імпортувати інсулін/вуглеводи з Nightscout до журналу. Токен доступу потребує дозволу api:treatments:read.</string>
     <string name="nightscout_settings_title">Налаштування Nightscout</string>
     <string name="nightscout_url_label">URL-адреса нічного розвідки</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1423,6 +1423,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Остання відповідь: HTTP 413, завеликий payload</string>
     <string name="nightscout_status_last_attempt">Остання спроба: %1$s</string>
     <string name="nightscout_status_last_success">Останній успіх: %1$s</string>
+    <string name="nightscout_status_iob_no_token">Надсилання IOB: пропущено - поки немає токена Nightscout</string>
+    <string name="nightscout_status_iob_rejected">Надсилання IOB: відхилено (%1$s)</string>
     <string name="nightscout_sync_actions_title">Дії синхронізації</string>
     <string name="expand_action">Розгорнути</string>
     <string name="collapse_action">Згорнути</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1425,6 +1425,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">上次响应：HTTP 413，负载过大</string>
     <string name="nightscout_status_last_attempt">上次尝试：%1$s</string>
     <string name="nightscout_status_last_success">上次成功：%1$s</string>
+    <string name="nightscout_status_iob_no_token">IOB 上传：已跳过 - 尚无 Nightscout 令牌</string>
+    <string name="nightscout_status_iob_rejected">IOB 上传：被拒绝（%1$s）</string>
     <string name="nightscout_sync_actions_title">同步操作</string>
     <string name="expand_action">展开</string>
     <string name="collapse_action">收起</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1220,7 +1220,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin">发送长效胰岛素</string>
     <string name="nightscout_send_long_insulin_desc">在 Nightscout 上传中包含基础和超长效胰岛素治疗</string>
     <string name="nightscout_receive_amounts">接收用量</string>
-    <string name="nightscout_receive_amounts_desc">将 Nightscout 胰岛素/碳水导入日志</string>
+    <string name="nightscout_receive_amounts_desc">将 Nightscout 胰岛素/碳水导入日志. 访问令牌需要 api:treatments:read 权限。</string>
     <string name="nightscout_settings_title">夜巡设置</string>
     <string name="nightscout_url_label">夜巡网址</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1565,7 +1565,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_send_long_insulin">Send long-acting insulin</string>
     <string name="nightscout_send_long_insulin_desc">Include basal and ultra-long insulin treatments in Nightscout uploads</string>
     <string name="nightscout_receive_amounts">Receive amounts</string>
-    <string name="nightscout_receive_amounts_desc">Import Nightscout insulin/carbs into journal</string>
+    <string name="nightscout_receive_amounts_desc">Import Nightscout insulin/carbs into journal. The access token needs the api:treatments:read permission.</string>
     <string name="nightscout_upload_iob">Send IOB to Nightscout</string>
     <string name="nightscout_upload_iob_desc">Nightscout then shows this value instead of its own calculation from its profile. eIOB and COB are sent along in a separate field.</string>
     <string name="nightscout_settings_title">Nightscout Settings</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1559,6 +1559,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_response_413">Last response: HTTP 413, payload too large</string>
     <string name="nightscout_status_last_attempt">Last attempt: %1$s</string>
     <string name="nightscout_status_last_success">Last success: %1$s</string>
+    <string name="nightscout_status_iob_no_token">IOB upload: skipped - no Nightscout token yet</string>
+    <string name="nightscout_status_iob_rejected">IOB upload: rejected (%1$s)</string>
     <string name="nightscout_send_amounts_desc">Upload Insulin/Carbs (Treatments)</string>
     <string name="nightscout_send_long_insulin">Send long-acting insulin</string>
     <string name="nightscout_send_long_insulin_desc">Include basal and ultra-long insulin treatments in Nightscout uploads</string>

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
@@ -233,7 +233,7 @@ object JournalTreatmentUploader {
         }
 
         val receiveOk = if (receiveEnabled) {
-            receiveRemoteTreatments(baseUrl, rawSecret)
+            receiveRemoteTreatments(baseUrl, rawSecret, useV3)
         } else {
             true
         }
@@ -271,6 +271,34 @@ object JournalTreatmentUploader {
 
     private fun treatmentPostUrl(baseUrl: String, useV3: Boolean): String =
         baseUrl + if (useV3) "/api/v3/treatments" else "/api/v1/treatments"
+
+    /**
+     * Read URL for treatments. The v1 form is a bare array under a .json suffix counted by
+     * `count`; v3 has neither, and limits with `limit` while sorting newest first, so the two
+     * cannot share one string. Sending the v1 form to a v3 setup answers 401, which reads as a
+     * server permission problem rather than a client using the wrong API.
+     */
+    internal fun treatmentFetchUrl(baseUrl: String, useV3: Boolean, count: Int = TREATMENT_FETCH_COUNT): String =
+        if (useV3) {
+            "$baseUrl/api/v3/treatments?sort%24desc=date&limit=$count&fields=_all"
+        } else {
+            "$baseUrl/api/v1/treatments.json?count=$count"
+        }
+
+    /**
+     * v1 answers with the document array itself, v3 wraps it in {status, result}. Everything
+     * downstream parses an array, so the envelope is peeled here rather than in the importer.
+     * A body that is already an array is passed through, so a v3 host that answers the v1 shape
+     * still imports.
+     */
+    internal fun treatmentsArrayBody(body: String, useV3: Boolean): String {
+        val trimmed = body.trim()
+        if (!useV3 || trimmed.startsWith("[")) return trimmed
+        if (!trimmed.startsWith("{")) return trimmed
+        return runCatching { JSONObject(trimmed).optJSONArray("result")?.toString() }
+            .getOrNull()
+            ?: "[]"
+    }
 
     private fun treatmentDeleteUrl(baseUrl: String, remoteId: String, useV3: Boolean): String =
         baseUrl + (if (useV3) "/api/v3/treatments/" else "/api/v1/treatments/") + remoteId
@@ -377,7 +405,9 @@ object JournalTreatmentUploader {
         timestamp: Long?
     ): String? =
         runCatching {
-            val array = JSONArray(fetchTreatmentsJson(baseUrl, secret))
+            // Reached only from the v1 branches: postV1Treatment runs in the else of
+            // `if (useV3)`, and resolveDeleteRemoteId returns before this when v3 is on.
+            val array = JSONArray(fetchTreatmentsJson(baseUrl, secret, useV3 = false))
             for (index in 0 until array.length()) {
                 val treatment = array.optJSONObject(index) ?: continue
                 if (!treatment.optString("identifier").equals(localIdentifier, ignoreCase = false)) continue
@@ -394,9 +424,9 @@ object JournalTreatmentUploader {
         optString("_id").trim().takeIf { it.isNotBlank() }
             ?: optString("id").trim().takeIf { it.isNotBlank() }
 
-    private fun receiveRemoteTreatments(baseUrl: String, secret: String): Boolean =
+    private fun receiveRemoteTreatments(baseUrl: String, secret: String, useV3: Boolean): Boolean =
         runCatching {
-            val body = fetchTreatmentsJson(baseUrl, secret)
+            val body = fetchTreatmentsJson(baseUrl, secret, useV3)
             if (body.isBlank() || body == "[]") return@runCatching true
             val sensorId = NightscoutFollowerRegistry.deriveSensorId(baseUrl)
             val imported = NightscoutJournalFollowerImporter.importTreatments(sensorId, body)
@@ -416,17 +446,25 @@ object JournalTreatmentUploader {
             }
         }.getOrDefault(false)
 
-    private fun fetchTreatmentsJson(baseUrl: String, secret: String): String {
+    private fun fetchTreatmentsJson(baseUrl: String, secret: String, useV3: Boolean): String {
         val normalized = NightscoutFollowerRegistry.normalizeUrl(baseUrl)
         if (normalized.isBlank()) return "[]"
-        val endpoint = "$normalized/api/v1/treatments.json?count=$TREATMENT_FETCH_COUNT"
+        val endpoint = treatmentFetchUrl(normalized, useV3)
         val connection = (URL(endpoint).openConnection() as HttpURLConnection).apply {
             connectTimeout = 15_000
             readTimeout = 30_000
             requestMethod = "GET"
             setRequestProperty("Accept", "application/json")
             setRequestProperty("User-Agent", "JugglucoNG Nightscout journal sync")
-            NightscoutFollowerRegistry.applyAuth(this, secret)
+            // v3 reads want the same bearer token the v3 upload path already obtains and
+            // caches; the configured secret is an access token there, and hashing it into an
+            // api-secret header is what the 401 was.
+            val v3Auth = if (useV3) NightPost.getV3AuthorizationHeader() else ""
+            if (v3Auth.isNotEmpty()) {
+                setRequestProperty("Authorization", v3Auth)
+            } else {
+                NightscoutFollowerRegistry.applyAuth(this, secret)
+            }
         }
         try {
             val code = connection.responseCode
@@ -438,7 +476,7 @@ object JournalTreatmentUploader {
             if (code !in 200..299) {
                 throw IllegalStateException("HTTP $code ${endpointPath(endpoint)}: ${serverMessage(body)}")
             }
-            return body
+            return treatmentsArrayBody(body, useV3)
         } finally {
             connection.disconnect()
         }

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
@@ -34,11 +34,73 @@ object JournalTreatmentUploader {
     private const val PREF_SEND_LONG_INSULIN = "nightscout_send_long_insulin"
     private const val TREATMENT_FETCH_COUNT = 240
     private const val ERROR_INVALID_URL = -2
+    private const val RECEIVE_ERROR_LOG_INTERVAL_MILLIS = 5L * 60 * 1000
 
     private data class UploadResult(
         val code: Int,
         val remoteId: String? = null
     )
+
+    /**
+     * Keeps an unchanged, repeating failure to one line per interval. The sync retries far
+     * faster than a stuck server recovers, and the identical line every few seconds is what
+     * made the trace unreadable while a Nightscout receive failure was being diagnosed.
+     */
+    internal class RepeatedErrorLog(private val intervalMillis: Long) {
+        private var lastMessage: String? = null
+        private var lastLoggedAt = 0L
+        private var suppressed = 0
+
+        /**
+         * @return how many repeats were swallowed since the last line, or -1 to stay silent.
+         *         A changed message always speaks, so a new failure is never hidden behind an
+         *         old one's interval.
+         */
+        fun suppressedSince(message: String, nowMillis: Long): Int {
+            val elapsed = nowMillis - lastLoggedAt
+            val due = message != lastMessage || lastLoggedAt == 0L ||
+                elapsed >= intervalMillis || elapsed < 0
+            if (!due) {
+                suppressed++
+                return -1
+            }
+            val repeats = if (message == lastMessage) suppressed else 0
+            lastMessage = message
+            lastLoggedAt = nowMillis
+            suppressed = 0
+            return repeats
+        }
+
+        /** A success ends the episode, so the next failure reports immediately. */
+        fun reset() {
+            lastMessage = null
+            lastLoggedAt = 0L
+            suppressed = 0
+        }
+    }
+
+    private val receiveErrorLog = RepeatedErrorLog(RECEIVE_ERROR_LOG_INTERVAL_MILLIS)
+
+    /**
+     * The server's own words when it has any. A refused read says which permission is missing
+     * ("Missing permission api:treatments:read", typical of an upload-only token), and that
+     * sentence is the whole difference between an actionable failure and a bare status code.
+     */
+    internal fun serverMessage(body: String): String {
+        val trimmed = body.trim()
+        if (!trimmed.startsWith("{")) return trimmed.take(160)
+        val message = runCatching {
+            JSONObject(trimmed).let { it.optNonBlank("message") ?: it.optNonBlank("description") }
+        }.getOrNull()
+        return message ?: trimmed.take(160)
+    }
+
+    private fun JSONObject.optNonBlank(key: String): String? =
+        optString(key).trim().takeIf { it.isNotEmpty() }
+
+    /** Path only: the host is already known and repeating it just crowds the line. */
+    internal fun endpointPath(endpoint: String): String =
+        runCatching { URL(endpoint).path }.getOrNull()?.takeIf { it.isNotBlank() } ?: endpoint
 
     // Mirrors writetreatment(V3) acceptance: 200/201 always; 409 only on V3 (POST conflict).
     private fun isUploadOk(code: Int, useV3: Boolean): Boolean {
@@ -342,9 +404,16 @@ object JournalTreatmentUploader {
                 UiRefreshBus.requestDataRefresh()
                 Log.i(LOG_ID, "received $imported Nightscout treatment journal items")
             }
+            receiveErrorLog.reset()
             true
         }.onFailure { error ->
-            Log.e(LOG_ID, "receive treatments failed: ${error.message}")
+            // The uploader retries on its own cadence, so an unreachable or refusing server
+            // used to write the same line every few seconds and bury the rest of the trace.
+            val message = "receive treatments failed: ${error.message}"
+            val repeats = receiveErrorLog.suppressedSince(message, System.currentTimeMillis())
+            if (repeats >= 0) {
+                Log.e(LOG_ID, if (repeats == 0) message else "$message (repeated ${repeats + 1}x)")
+            }
         }.getOrDefault(false)
 
     private fun fetchTreatmentsJson(baseUrl: String, secret: String): String {
@@ -367,7 +436,7 @@ object JournalTreatmentUploader {
                 .orEmpty()
             if (code == HttpURLConnection.HTTP_NOT_FOUND) return "[]"
             if (code !in 200..299) {
-                throw IllegalStateException("HTTP $code: ${body.take(160)}")
+                throw IllegalStateException("HTTP $code ${endpointPath(endpoint)}: ${serverMessage(body)}")
             }
             return body
         } finally {

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -17,13 +17,13 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Api
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Medication
 import androidx.compose.material.icons.filled.NetworkCheck
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -573,11 +573,10 @@ fun NightscoutSettingsScreen(navController: NavController) {
                         )
                         SettingsSwitchItem(
                             title = stringResource(R.string.nightscout_use_v3_api),
-                            subtitle = stringResource(R.string.experimental),
                             checked = isV3,
                             onCheckedChange = { isV3 = it },
-                            icon = Icons.Default.Science,
-                            iconTint = MaterialTheme.colorScheme.tertiary,
+                            icon = Icons.Default.Api,
+                            iconTint = MaterialTheme.colorScheme.secondary,
                             enabled = isActive,
                             position = CardPosition.BOTTOM
                         )

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -93,6 +93,14 @@ private sealed class TestState {
 
 private val SHA1_SECRET_REGEX = Regex("^[0-9a-fA-F]{40}$")
 
+/**
+ * The test must probe the same API family the uploader is configured for: servers that
+ * keep the two auth schemes apart refuse a v3 Bearer token on a v1 endpoint, which makes
+ * a correctly working v3 setup look broken.
+ */
+internal fun nightscoutTestEndpointPath(useV3: Boolean): String =
+    if (useV3) "api/v3/status" else "api/v1/status.json"
+
 private fun applyNightscoutTestAuth(
     connection: java.net.HttpURLConnection,
     baseUrl: String,
@@ -211,8 +219,8 @@ fun NightscoutSettingsScreen(navController: NavController) {
             testState = withContext(Dispatchers.IO) {
                 try {
                     val baseUrl = NightscoutFollowerRegistry.normalizeUrl(url)
-                    val endpoint = "$baseUrl/api/v1/status.json"
-                    val conn = (java.net.URL(endpoint).openConnection() as java.net.HttpURLConnection).apply {
+                    val path = nightscoutTestEndpointPath(isV3)
+                    val conn = (java.net.URL("$baseUrl/$path").openConnection() as java.net.HttpURLConnection).apply {
                         connectTimeout = 10_000
                         readTimeout = 10_000
                         requestMethod = "GET"
@@ -221,7 +229,9 @@ fun NightscoutSettingsScreen(navController: NavController) {
                     applyNightscoutTestAuth(conn, baseUrl, secret, isV3)
                     val code = conn.responseCode
                     conn.disconnect()
-                    if (code in 200..299) TestState.Ok(code) else TestState.Err("HTTP $code")
+                    // A bare status code sends people debugging the server; the endpoint says
+                    // which API family answered.
+                    if (code in 200..299) TestState.Ok(code) else TestState.Err("HTTP $code ($path)")
                 } catch (e: Exception) {
                     TestState.Err(e.localizedMessage?.take(80) ?: context.getString(R.string.status_connection_failed))
                 }

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -159,6 +159,8 @@ fun NightscoutSettingsScreen(navController: NavController) {
     var lastSuccessTime by rememberSaveable { mutableStateOf(0L) }
     var retryMinutes by rememberSaveable { mutableStateOf(0) }
     var uploaderRunning by rememberSaveable { mutableStateOf(false) }
+    var deviceStatusOutcome by rememberSaveable { mutableStateOf(NightPost.DEVICE_STATUS_NONE) }
+    var deviceStatusCode by rememberSaveable { mutableStateOf(0) }
     var testState by remember { mutableStateOf<TestState>(TestState.Idle) }
 
     var mode by rememberSaveable {
@@ -177,6 +179,10 @@ fun NightscoutSettingsScreen(navController: NavController) {
         val normalizedUrl = NightscoutFollowerRegistry.normalizeUrl(url)
 
         Natives.setNightUploader(url.trim(), secret.trim(), uploadActive, isV3)
+        // The old device-status failure describes the old settings; keep it off the screen
+        // until the next attempt has run under the new ones.
+        NightPost.clearDeviceStatusOutcome()
+        deviceStatusOutcome = NightPost.DEVICE_STATUS_NONE
         Natives.setpostTreatments(sendTreatments)
         JournalTreatmentUploader.setSendLongInsulin(sendLongInsulin)
         JournalTreatmentUploader.setReceiveTreatments(receiveTreatments)
@@ -202,6 +208,8 @@ fun NightscoutSettingsScreen(navController: NavController) {
         lastSuccessTime = Natives.getnightscoutlastsuccesstime()
         retryMinutes = Natives.getnightscoutretryminutes()
         uploaderRunning = Natives.getnightscoutuploaderrunning()
+        deviceStatusOutcome = NightPost.getDeviceStatusOutcome()
+        deviceStatusCode = NightPost.getDeviceStatusLastCode()
     }
 
     fun requireUrl(): Boolean {
@@ -280,6 +288,19 @@ fun NightscoutSettingsScreen(navController: NavController) {
         lastResponseCode == 413 -> context.getString(R.string.nightscout_status_response_413)
         lastResponseCode > 0 -> context.getString(R.string.nightscout_status_response_error, lastResponseCode)
         else -> context.getString(R.string.nightscout_status_waiting)
+    }
+
+    // The lines above report the native entries uploader only; the devicestatus channel
+    // (IOB) fails on its own, and a "no token" skip must not read like a server rejection.
+    val deviceStatusSummary: String? = when {
+        !isActive || mode != NightscoutMode.UPLOAD || !uploadIob -> null
+        deviceStatusOutcome == NightPost.DEVICE_STATUS_NO_TOKEN ->
+            context.getString(R.string.nightscout_status_iob_no_token)
+        deviceStatusOutcome == NightPost.DEVICE_STATUS_REJECTED -> context.getString(
+            R.string.nightscout_status_iob_rejected,
+            if (deviceStatusCode > 0) "HTTP $deviceStatusCode" else context.getString(R.string.status_connection_failed)
+        )
+        else -> null
     }
 
     val masterSubtitle = when (mode) {
@@ -478,6 +499,15 @@ fun NightscoutSettingsScreen(navController: NavController) {
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
+                            if (deviceStatusSummary != null) {
+                                Text(
+                                    text = deviceStatusSummary,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
                         }
                     }
                 }

--- a/Common/src/test/java/tk/glucodata/NightscoutIobDeviceStatusTests.kt
+++ b/Common/src/test/java/tk/glucodata/NightscoutIobDeviceStatusTests.kt
@@ -144,4 +144,23 @@ class NightscoutIobDeviceStatusTests {
         assertFalse(NightscoutIobDeviceStatus.fastIntervalElapsed(now + fast - 1, now))
         assertTrue(NightscoutIobDeviceStatus.fastIntervalElapsed(now + fast, now))
     }
+
+    // -- ancillary token retry ---------------------------------------------
+
+    @Test
+    fun `an empty cache with no prior attempt fetches a token immediately`() {
+        assertTrue(NightscoutIobDeviceStatus.tokenRetryDue(now, 0L))
+    }
+
+    @Test
+    fun `a refused token request is not repeated within the interval`() {
+        val retry = NightscoutIobDeviceStatus.TOKEN_RETRY_MILLIS
+        assertFalse(NightscoutIobDeviceStatus.tokenRetryDue(now + retry - 1, now))
+        assertTrue(NightscoutIobDeviceStatus.tokenRetryDue(now + retry, now))
+    }
+
+    @Test
+    fun `a clock that moved backwards does not block token requests forever`() {
+        assertTrue(NightscoutIobDeviceStatus.tokenRetryDue(now - 1, now))
+    }
 }

--- a/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentTransferTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentTransferTests.kt
@@ -33,4 +33,65 @@ class JournalTreatmentTransferTests {
         assertEquals("nightscout:NSF-TEST:xdrip-mbg-id:fingerstick", entry.sourceRecordId)
         assertEquals("xdrip-mbg-id", entry.nsRemoteId)
     }
+
+    /**
+     * Shape taken from a live v3 /api/v3/treatments response. v3 answers with `identifier`
+     * and the server-side srvCreated/srvModified; there is no `_id` at all, so nothing in the
+     * import may depend on one being present.
+     */
+    @Test
+    fun aV3TreatmentIsIdentifiedWithoutAnyUnderscoreId() {
+        val document = JSONObject()
+            .put("date", 1_786_794_604_000L)
+            .put("created_at", "2026-08-15T11:50:04.000Z")
+            .put("utcOffset", 0)
+            .put("isValid", true)
+            .put("app", "JugglucoNG")
+            .put("enteredBy", "JugglucoNG")
+            .put("type", "insulin")
+            .put("eventType", "Correction Bolus")
+            .put("insulin", 3)
+            .put("isBasalInsulin", false)
+            .put("insulinType", "Fiasp")
+            .put("identifier", "jng-j-101")
+            .put("srvModified", 1_787_225_341_651L)
+            .put("srvCreated", 1_787_225_341_651L)
+
+        val parsed = JournalTreatmentTransfer.parseTreatment(
+            treatment = document,
+            source = JournalEntrySource.NIGHTSCOUT,
+            sourcePrefix = "nightscout:NSF-TEST",
+            insulinPresets = emptyList(),
+            stringResource = { "Insulin" },
+        )
+
+        assertNotNull(parsed)
+        val entry = parsed!!.inputs.single()
+        assertEquals(JournalEntryType.INSULIN, entry.type)
+        assertEquals(3f, entry.amount!!, 0f)
+        assertEquals(1_786_794_604_000L, entry.timestamp)
+        // Our own upload identifier survives the round trip, which is what keeps a
+        // device from re-importing its own treatments.
+        assertEquals("jng-j-101", entry.nsRemoteId)
+    }
+
+    @Test
+    fun theV3IdentifierIsPreferredOverALegacyUnderscoreId() {
+        val document = JSONObject()
+            .put("identifier", "jng-j-101")
+            .put("_id", "legacy-mongo-id")
+            .put("date", 1_786_794_604_000L)
+            .put("eventType", "Correction Bolus")
+            .put("insulin", 3)
+
+        val parsed = JournalTreatmentTransfer.parseTreatment(
+            treatment = document,
+            source = JournalEntrySource.NIGHTSCOUT,
+            sourcePrefix = "nightscout:NSF-TEST",
+            insulinPresets = emptyList(),
+            stringResource = { "Insulin" },
+        )
+
+        assertEquals("jng-j-101", parsed!!.inputs.single().nsRemoteId)
+    }
 }

--- a/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
@@ -1,5 +1,6 @@
 package tk.glucodata.data.journal
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -52,5 +53,68 @@ class JournalTreatmentUploaderTests {
                 sendLongInsulin = true
             )
         )
+    }
+
+    // -- what a refusal reports --------------------------------------------
+
+    @Test
+    fun aRefusedReadReportsThePermissionTheServerNamed() {
+        // An upload-only token answers this; the sentence is the actionable part, and
+        // it is what distinguishes a missing permission from wrong credentials.
+        val body = """{"status":403,"message":"Missing permission api:treatments:read"}"""
+        assertEquals("Missing permission api:treatments:read", JournalTreatmentUploader.serverMessage(body))
+    }
+
+    @Test
+    fun aBodyWithoutAMessageStillReportsSomething() {
+        assertEquals("Unauthorized", JournalTreatmentUploader.serverMessage("Unauthorized"))
+        assertEquals("""{"status":401}""", JournalTreatmentUploader.serverMessage("""{"status":401}"""))
+    }
+
+    @Test
+    fun theFailureNamesTheEndpointPathWithoutRepeatingTheHost() {
+        assertEquals(
+            "/api/v1/treatments.json",
+            JournalTreatmentUploader.endpointPath("https://ns.example.com/api/v1/treatments.json?count=240")
+        )
+    }
+
+    // -- repeating failure logging -----------------------------------------
+
+    @Test
+    fun anUnchangedFailureIsLoggedOncePerInterval() {
+        val log = JournalTreatmentUploader.RepeatedErrorLog(intervalMillis = 5 * 60_000L)
+        val start = 1_000_000L
+        assertEquals(0, log.suppressedSince("HTTP 401", start))
+        assertEquals(-1, log.suppressedSince("HTTP 401", start + 1_000))
+        assertEquals(-1, log.suppressedSince("HTTP 401", start + 2_000))
+        // The line that finally speaks says how many it stood in for.
+        assertEquals(2, log.suppressedSince("HTTP 401", start + 5 * 60_000L))
+    }
+
+    @Test
+    fun aDifferentFailureIsNeverHiddenBehindTheOldOnesInterval() {
+        val log = JournalTreatmentUploader.RepeatedErrorLog(intervalMillis = 5 * 60_000L)
+        val start = 1_000_000L
+        assertEquals(0, log.suppressedSince("HTTP 401", start))
+        assertEquals(0, log.suppressedSince("HTTP 500", start + 1_000))
+    }
+
+    @Test
+    fun aSuccessEndsTheEpisodeSoTheNextFailureReportsAtOnce() {
+        val log = JournalTreatmentUploader.RepeatedErrorLog(intervalMillis = 5 * 60_000L)
+        val start = 1_000_000L
+        assertEquals(0, log.suppressedSince("HTTP 401", start))
+        assertEquals(-1, log.suppressedSince("HTTP 401", start + 1_000))
+        log.reset()
+        assertEquals(0, log.suppressedSince("HTTP 401", start + 2_000))
+    }
+
+    @Test
+    fun aClockThatMovedBackwardsDoesNotSilenceTheLogForever() {
+        val log = JournalTreatmentUploader.RepeatedErrorLog(intervalMillis = 5 * 60_000L)
+        val start = 1_000_000L
+        assertEquals(0, log.suppressedSince("HTTP 401", start))
+        assertEquals(0, log.suppressedSince("HTTP 401", start - 60_000L))
     }
 }

--- a/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
@@ -1,5 +1,6 @@
 package tk.glucodata.data.journal
 
+import org.json.JSONArray
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -55,6 +56,41 @@ class JournalTreatmentUploaderTests {
         )
     }
 
+    // -- receive endpoint --------------------------------------------------
+
+    @Test
+    fun receivingFollowsTheConfiguredApiVersion() {
+        val v1 = JournalTreatmentUploader.treatmentFetchUrl("https://ns.example.com", useV3 = false, count = 240)
+        assertEquals("https://ns.example.com/api/v1/treatments.json?count=240", v1)
+
+        val v3 = JournalTreatmentUploader.treatmentFetchUrl("https://ns.example.com", useV3 = true, count = 240)
+        assertTrue(v3, v3.startsWith("https://ns.example.com/api/v3/treatments?"))
+        // v3 counts with limit and has no .json suffix; sending the v1 form is what answered 401.
+        assertTrue(v3, v3.contains("limit=240"))
+        assertFalse(v3, v3.contains(".json"))
+        assertFalse(v3, v3.contains("count="))
+    }
+
+    @Test
+    fun v3ResultEnvelopeIsUnwrappedForTheImporter() {
+        val body = """{"status":200,"result":[{"identifier":"a"},{"identifier":"b"}]}"""
+        val array = JSONArray(JournalTreatmentUploader.treatmentsArrayBody(body, useV3 = true))
+        assertEquals(2, array.length())
+        assertEquals("a", array.getJSONObject(0).getString("identifier"))
+    }
+
+    @Test
+    fun v1ArraysAndV3HostsAnsweringArraysBothPassThrough() {
+        val array = """[{"identifier":"a"}]"""
+        assertEquals(array, JournalTreatmentUploader.treatmentsArrayBody(array, useV3 = false))
+        assertEquals(array, JournalTreatmentUploader.treatmentsArrayBody(array, useV3 = true))
+    }
+
+    @Test
+    fun anEnvelopeWithoutResultYieldsAnEmptyArrayRatherThanAParseFailure() {
+        assertEquals("[]", JournalTreatmentUploader.treatmentsArrayBody("""{"status":401}""", useV3 = true))
+    }
+
     // -- what a refusal reports --------------------------------------------
 
     @Test
@@ -74,8 +110,8 @@ class JournalTreatmentUploaderTests {
     @Test
     fun theFailureNamesTheEndpointPathWithoutRepeatingTheHost() {
         assertEquals(
-            "/api/v1/treatments.json",
-            JournalTreatmentUploader.endpointPath("https://ns.example.com/api/v1/treatments.json?count=240")
+            "/api/v3/treatments",
+            JournalTreatmentUploader.endpointPath("https://ns.example.com/api/v3/treatments?limit=240")
         )
     }
 

--- a/Common/src/testMobile/java/tk/glucodata/ui/NightscoutTestEndpointTests.kt
+++ b/Common/src/testMobile/java/tk/glucodata/ui/NightscoutTestEndpointTests.kt
@@ -1,0 +1,17 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NightscoutTestEndpointTests {
+
+    @Test
+    fun `v3 setups are tested against the v3 status endpoint`() {
+        assertEquals("api/v3/status", nightscoutTestEndpointPath(useV3 = true))
+    }
+
+    @Test
+    fun `v1 setups keep the classic status endpoint`() {
+        assertEquals("api/v1/status.json", nightscoutTestEndpointPath(useV3 = false))
+    }
+}


### PR DESCRIPTION
Two small Nightscout issues that together sent me on an hour-long hunt through server-side roles, subjects and proxy config for a problem that was entirely in the app. I lost a live Nightscout subject along the way, so I would rather nobody else repeats that.

**The connection test checks the wrong endpoint under v3.** `testConnection()` always requested `/api/v1/status.json`, while `applyNightscoutTestAuth` exchanges the token for a JWT and sends `Authorization: Bearer ...` when v3 is enabled. On my server that combination returns 401, while the same JWT against `/api/v3/status` returns 200 and a plain `api-secret` header against v1 returns 200. So a correctly configured v3 setup reports a failing connection test while uploads work fine, and since the test is the first thing you reach for when something looks wrong, it points straight at the server. The test now follows the configured API version, and a failure names the endpoint it checked: `HTTP 401 (api/v3/status)`.

**Device status gives up silently when the token cache is empty.** The ancillary upload path deliberately performs no authorization network work and relies on a token cached by a primary upload. After a reinstall, process death or token expiry that cache is empty and nothing refills it, so IOB device status stops uploading until something else happens to refresh it. In my case that was toggling the Nightscout settings off and on with a manual send, which forces a primary upload. The path now requests a token itself when the cache is empty, throttled to one attempt per five minutes so the original reason for the cache still holds. That one request does not inherit the 3s/5s device status timeouts, which exist because a late device status document is worthless: an instance that has to wake up first would miss every token request and the cache would stay empty forever, which is the failure this is meant to end. They are still well under the primary uploader's 15s/60s. The skip is no longer invisible either: the status card gets its own line for the IOB device status, and "no token yet" is a named state instead of an error code that reads like a server rejection. The battery device status shares the same queue but not that state, so it cannot show up under the IOB label.

One commit per finding. Tests cover both endpoint branches and the token retry throttle including a clock that moved backwards; the existing device status cadence is unchanged. The new strings are translated into all maintained locales.

---

**Third finding, same root cause.** Treatment *upload* honours the configured API version, but the *receive* path was hardcoded to `/api/v1/treatments.json`. On a v3 setup that is a steady stream of `receive treatments failed: HTTP 401` while uploads return 201, which reads as "my bolus arrives despite a 401" and points the diagnosis at the server again. It also catches people who never chose v3: the native uploader switches the setting on by itself after a v1 404.

The endpoint turned out to be only the first of three differences, so this is more than a URL swap:

- **Paging.** v3 has no `.json` suffix and counts with `limit`, not `count`.
- **Authorization**, which is what the 401 actually was. Under v3 the configured secret is an access token, and the receive path hashed it into an `api-secret` header. It now uses the same bearer token the v3 upload path already fetches and caches.
- **Envelope.** v1 answers with the document array, v3 wraps it in `{status, result}`. Everything downstream parses an array, so the envelope is peeled at the fetch; a body that is already an array still passes through.

Verified against a live v3 instance before pushing: envelope, `limit` and the bearer exchange all behave as implemented. A real v3 document carries `identifier` and no `_id` at all, which the importer already prefers over `_id`; two tests pin that so nothing starts depending on one being present.

**One thing worth documenting for anyone hitting this:** the receive path needs the `api:treatments:read` permission, which upload-only tokens typically lack. Without it the server answers `403 Missing permission api:treatments:read`, which is a far more useful sentence than the bare 401 the v1 path produced. Two different failures were hiding behind one log line, so the failure now carries the server's own message and the endpoint it called, the setting says which permission is required, and a repeating identical failure is logged once per five minutes instead of once per attempt.

**Audit of the remaining hardcoded `api/v1` paths.** Each of these has so far surfaced one at a time, always with an error that looked server-side, so here is the whole inventory.

| Call site | Feature | Under v3 | Status |
|---|---|---|---|
| `JournalTreatmentUploader` `treatmentPostUrl` / `treatmentDeleteUrl` | journal treatment upload, delete | follows the setting | fine |
| `JournalTreatmentUploader` `fetchTreatmentsJson` | journal treatment receive | **ran v1 under v3** | fixed here |
| `JournalTreatmentUploader` `postV1Treatment` | v1 treatment upload | only in the `else` of `if (useV3)` | correct as v1, comment added |
| `JournalTreatmentUploader` `findRemoteIdByIdentifier` | v1 id lookup | only reachable from v1 branches | correct as v1, now explicit |
| `NightscoutSettingsScreen` connection test | connection test | follows the setting | fixed in the first commit |
| `uploader.cpp` `/api/v1/devicestatus` | uploader battery **and** IOB device status | **runs under v3** | **no v3 endpoint exists anywhere in the repo**; see below |
| `NightscoutFollowerManager` (entries, mbg, treatments, devicestatus) | follower mode | ignores the setting entirely | follower mode is 100% v1; see below |
| `uploadtreatment.cpp` v1 delete | legacy treatments | unreachable | dead code, `uploadtreatments()` is never called |
| `ExchangeSettingsScreens`, `watchserver.cpp` | Juggluco's own served API | not a Nightscout client call | unrelated |

Two of those deserve their own issue rather than being folded in here.

**Device status has no v3 variant at all.** Entries and treatments each build a v1 *and* a v3 upload URL, and readiness requires both; device status is built once, v1 only. Both consumers run unconditionally after the version fork, so with v3 on the phone still POSTs to `/api/v1/devicestatus`. It is not broken today, because the secret is nulled under v3 and the upload falls through to a bearer token, so it works anywhere v1 accepts bearer auth. But there is no v3 path to fall back on if a deployment turns v1 off.

**Follower mode is entirely v1.** All four follower fetches are unconditional v1 literals and its auth helper has no token-request flow. The v3 setting is an uploader setting and never reaches follower code, so a v3-only server cannot be followed at all.


**Follow-up: the switch no longer says "Experimental".** Not because v3 uploading has been trouble free, it has not: treatments over v3 were failing as recently as today, first because nothing woke the uploader when a journal entry was written (#221) and then because the update document still carried `date`, which v3 refuses to let a client modify (#209). Entries and device status have been steady throughout, and treatments now arrive unattended on a live instance, confirmed in the field today.

The label goes because it no longer describes the risk accurately. "Experimental" reads as "this may or may not work", when what the last stretch actually established is the opposite: every v3 failure seen so far has been reproduced, understood and fixed, and this PR's version test is what stops a broken v3 setup from passing a v1 connection check in the first place. The switch is better off with no subtitle than with a word that discourages the setting while the remaining unknowns sit elsewhere.

The flask icon moves to a plain API one and stays on the follower switch, which is the newer half and has had the least field time. The `experimental` string keeps its place for whatever needs it next.
