### PR TITLE
Add inline sensor trace log

### DIFF
--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -756,6 +756,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Журнал злучэнняў</string>
     <string name="libre_setup_done">Гатова</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Наладзьце эксперыментальныя паводзіны сканавання Libre 3 перад спалучэннем.</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -858,6 +858,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="keep_auto_calibration">Autokalibrierungsdaten behalten</string>
     <string name="keep_data">Sensorinfo behalten</string>
     <string name="last_ble_status">Letzter BLE-Status</string>
+    <string name="sensor_connection_log">Verbindungsprotokoll</string>
     <string name="libre_setup_done">Fertig</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Experimentelles Scan-Verhalten für Libre 3 vor dem Koppeln anpassen.</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -730,6 +730,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Journal de connexion</string>
     <string name="libre_setup_done">Terminé</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Ajustez le comportement expérimental du scan Libre 3 avant l\'appairage.</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -674,6 +674,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Registro connessione</string>
     <string name="libre_setup_done">Fatto</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Regola il comportamento sperimentale della scansione Libre 3 prima dell\'associazione.</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -611,6 +611,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="enabled_status">Идэвхжсэн</string>
     <string name="disabled_status">Идэвхгүй болгосон</string>
     <string name="last_ble_status">Сүүлчийн BLE төлөв</string>
+    <string name="sensor_connection_log">Холболтын бүртгэл</string>
     <string name="sensor_address">Хаяг</string>
     <string name="sensor_started">Эхэлсэн</string>
     <string name="sensor_ends_officially">Албан ёсоор дуусах</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -829,6 +829,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="keep_auto_calibration">Keep auto-calibration data</string>
     <string name="keep_data">Keep sensor info</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Verbindingslogboek</string>
     <string name="libre_setup_done">Klaar</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Pas experimenteel Libre 3-scangedrag aan voordat je koppelt.</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -818,6 +818,7 @@
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Ostatni: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Dziennik połączenia</string>
     <string name="libre_setup_done">Gotowe</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Dostosuj eksperymentalne zachowanie skanowania Libre 3 przed parowaniem.</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -696,6 +696,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Registo de ligação</string>
     <string name="libre_setup_done">Concluído</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Ajuste o comportamento experimental da leitura do Libre 3 antes do emparelhamento.</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -493,6 +493,7 @@
     <string name="enabled_status">Включен</string>
     <string name="disabled_status">Отключен</string>
     <string name="last_ble_status">Статус BLE</string>
+    <string name="sensor_connection_log">Журнал подключений</string>
     <string name="sensor_address">Адрес</string>
     <string name="sensor_started">Запущен</string>
     <string name="sensor_ends_officially">Офиц. окончание</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -653,6 +653,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="enabled_status">Hawl gal</string>
     <string name="disabled_status">Dansan</string>
     <string name="last_ble_status">Heerka BLE ee u dambeeyay</string>
+    <string name="sensor_connection_log">Diiwaanka isku xirka</string>
     <string name="sensor_address">Cinwaanka</string>
     <string name="sensor_started">bilaabay</string>
     <string name="sensor_ends_officially">Si Rasmi Ah U Dhamaatay</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -761,6 +761,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Anslutningslogg</string>
     <string name="libre_setup_done">Klart</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Justera det experimentella Libre 3-skanningsbeteendet innan parkoppling.</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -799,6 +799,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Bağlantı günlüğü</string>
     <string name="libre_setup_done">Bitti</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Eşleştirmeden önce deneysel Libre 3 tarama davranışını ayarlayın.</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -773,6 +773,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Журнал підключень</string>
     <string name="libre_setup_done">Готово</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Налаштуйте експериментальну поведінку сканування Libre 3 перед сполученням.</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -773,6 +773,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">连接日志</string>
     <string name="libre_setup_done">完成</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">在配对前调整 Libre 3 的实验性扫描行为。</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -675,6 +675,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="enabled_status">Enabled</string>
     <string name="disabled_status">Disabled</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="sensor_connection_log">Connection log</string>
     <string name="sensor_address">Address</string>
     <string name="sensor_started">Started</string>
     <string name="sensor_ends_officially">Ends Officially</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -39,6 +39,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -47,6 +50,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.rotate
 
 import androidx.compose.material.icons.filled.AccessTime
 import tk.glucodata.CurrentDisplaySource
@@ -253,6 +257,7 @@ fun SensorCard(
     var showAiDexUnpairDialog by remember { mutableStateOf(false) }
     var showMqRestoreSheet by remember { mutableStateOf(false) }
     var showMqCalibrationSheet by remember { mutableStateOf(false) }
+    var connectionLogExpanded by remember(sensor.serial) { mutableStateOf(false) }
     var calibrationInputText by remember { mutableStateOf("") }
     var mqCalibrationInputText by remember { mutableStateOf("") }
     var mqQrInput by remember(context, sensor.serial) {
@@ -1616,6 +1621,46 @@ fun SensorCard(
                                 fontWeight = FontWeight.Bold
                             )
                         }
+                    }
+
+                    HorizontalDivider(
+                        modifier = Modifier.padding(top = 4.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 48.dp)
+                            .clickable { connectionLogExpanded = !connectionLogExpanded },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.History,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            text = stringResource(R.string.sensor_connection_log),
+                            style = MaterialTheme.typography.titleSmall,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Icon(
+                            imageVector = Icons.Default.ExpandMore,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .size(20.dp)
+                                .rotate(if (connectionLogExpanded) 180f else 0f),
+                        )
+                    }
+                    AnimatedVisibility(
+                        visible = connectionLogExpanded,
+                        enter = expandVertically() + fadeIn(),
+                        exit = shrinkVertically() + fadeOut(),
+                    ) {
+                        SensorTraceLog(sensor)
                     }
 
                 }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
@@ -1,0 +1,97 @@
+package tk.glucodata.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import tk.glucodata.R
+import tk.glucodata.SensorIdentity
+import tk.glucodata.ui.viewmodel.SensorInfo
+
+private const val TRACE_TAIL_BYTES = 64L * 1024L
+private const val TRACE_LINE_LIMIT = 10
+
+internal fun filterRecentSensorTraceLines(
+    lines: List<String>,
+    identifiers: Collection<String>,
+    limit: Int = TRACE_LINE_LIMIT,
+): List<String> {
+    val needles = identifiers.mapNotNull { value -> value.trim().takeIf { it.isNotEmpty() } }
+    if (needles.isEmpty()) return emptyList()
+    return lines.asReversed()
+        .filter { line -> needles.any { needle -> line.contains(needle, ignoreCase = true) } }
+        .take(limit)
+        .asReversed()
+}
+
+private fun readRecentSensorTraceLines(file: File, identifiers: Collection<String>): List<String> {
+    if (!file.exists()) return emptyList()
+    return runCatching {
+        val size = file.length()
+        file.inputStream().use { stream ->
+            if (size > TRACE_TAIL_BYTES) stream.skip(size - TRACE_TAIL_BYTES)
+            val lines = stream.bufferedReader().readLines()
+            filterRecentSensorTraceLines(
+                lines = if (size > TRACE_TAIL_BYTES) lines.drop(1) else lines,
+                identifiers = identifiers,
+            )
+        }
+    }.getOrDefault(emptyList())
+}
+
+@Composable
+internal fun SensorTraceLog(sensor: SensorInfo) {
+    val context = LocalContext.current
+    val identifiers = remember(sensor.serial, sensor.deviceAddress) {
+        buildSet {
+            add(sensor.serial)
+            sensor.deviceAddress.takeUnless { it.equals("Unknown", ignoreCase = true) }?.let(::add)
+            runCatching { SensorIdentity.resolveNativeHistorySensorNames(sensor.serial) }
+                .getOrDefault(emptyList())
+                .forEach(::add)
+        }
+    }
+    var lines by remember(sensor.serial) { mutableStateOf<List<String>>(emptyList()) }
+
+    LaunchedEffect(context, identifiers) {
+        val file = File(context.filesDir, "logs/trace.log")
+        while (isActive) {
+            lines = withContext(Dispatchers.IO) {
+                readRecentSensorTraceLines(file, identifiers)
+            }
+            delay(2_000L)
+        }
+    }
+
+    SelectionContainer {
+        Text(
+            text = if (lines.isEmpty()) {
+                stringResource(R.string.no_data_available)
+            } else {
+                lines.joinToString("\n")
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 32.dp, end = 8.dp, bottom = 8.dp),
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
@@ -1,0 +1,25 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SensorTraceLogTests {
+    @Test
+    fun filterRecentSensorTraceLines_matchesIdentifiersAndKeepsNewestLines() {
+        val lines = listOf(
+            "1 10 unrelated",
+            "2 10 sensor ABC123 connecting",
+            "3 10 address aa:bb:cc:dd:ee:ff",
+            "4 10 ABC123 connected",
+        )
+
+        assertEquals(
+            listOf(lines[2], lines[3]),
+            filterRecentSensorTraceLines(
+                lines = lines,
+                identifiers = listOf("ABC123", "AA:BB:CC:DD:EE:FF"),
+                limit = 2,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple inline expandable Connection log section to each sensor card
- tail trace.log and show the newest 10 lines matching the sensor serial, native aliases, or BLE address
- refresh only while the section is expanded; no BLE callbacks, persistence, or connection-policy changes

## Testing
- ./gradlew :Common:testMobileDebugUnitTest --tests 'tk.glucodata.ui.SensorTraceLogTests' --no-daemon --offline --console=plain
- xmllint --noout Common/src/main/res/values*/strings.xml
- git diff --check

## Validation boundaries
- mobile Kotlin/Java compilation, resource processing, and focused unit test passed
- not visually or device tested
