### PR TITLE
Nightscout: v3 endpoints for device status and follower mode

### DIFF
--- a/Common/src/main/cpp/net/watchserver/uploader.cpp
+++ b/Common/src/main/cpp/net/watchserver/uploader.cpp
@@ -46,6 +46,7 @@ jstring jnightuploadEntries3url=nullptr;
 jstring jnightuploadTreatmentsurl=nullptr;
 jstring jnightuploadTreatments3url=nullptr;
 jstring jnightuploadDevicestatusurl=nullptr;
+jstring jnightuploadDevicestatus3url=nullptr;
 jstring jnightuploadsecret= nullptr;
 jclass nightscoutcalibrationclass=nullptr;
 static int lastNightUploadCode = 0;
@@ -138,9 +139,11 @@ static bool makeuploadurls(JNIEnv *env) {
     const bool entriesv3=makeuploadurl(env,R"(/api/v3/entries)",jnightuploadEntries3url);
     const bool treatmentsv1=makeuploadurl(env,R"(/api/v1/treatments)",jnightuploadTreatmentsurl);
     const bool treatmentsv3=makeuploadurl(env,R"(/api/v3/treatments)",jnightuploadTreatments3url);
-    //devicestatus carries the uploader battery only. A failure here must not hold back glucose,
-    //so it is built but deliberately left out of the readiness check.
+    //devicestatus carries the uploader battery and the journal IOB. A failure here must not hold
+    //back glucose, so both forms are built but deliberately left out of the readiness check: they
+    //can only fail on the same base URL that entries and treatments already gate on.
     makeuploadurl(env,R"(/api/v1/devicestatus)",jnightuploadDevicestatusurl);
+    makeuploadurl(env,R"(/api/v3/devicestatus)",jnightuploadDevicestatus3url);
     return entriesv1&&entriesv3&&treatmentsv1&&treatmentsv3;
     }
 
@@ -387,8 +390,16 @@ int nightuploadTreatments(const char *data,int len) {
 int nightuploadTreatments3(const char *data,int len) {
     return nightupload(jnightuploadTreatments3url,data,len,false);
     }
+//The endpoint follows the configured API version, like entries and treatments do. v1 and v3
+//disagree on more than the path: v3 takes a single document rather than an array and rejects one
+//without an "app" field, so the callers build the matching shape for devicestatusIsV3().
+static bool devicestatusIsV3() {
+    return settings->data()->nightscoutV3 && jnightuploadDevicestatus3url!=nullptr;
+    }
+
 static bool queueNightuploadDevicestatus(const char *data,int len) {
-    if(jnightuploadDevicestatusurl==nullptr || nightpostclass==nullptr)
+    jstring url=devicestatusIsV3()?jnightuploadDevicestatus3url:jnightuploadDevicestatusurl;
+    if(url==nullptr || nightpostclass==nullptr)
         return false;
     auto env=getenv();
     if(env==nullptr)
@@ -416,7 +427,7 @@ static bool queueNightuploadDevicestatus(const char *data,int len) {
     const jboolean queued=env->CallStaticBooleanMethod(
         nightpostclass,
         uploadAsync,
-        jnightuploadDevicestatusurl,
+        url,
         payload,
         jnightuploadsecret,
         JNI_FALSE
@@ -472,11 +483,26 @@ static bool uploadDeviceStatus() {
         return true;
     char buf[256];
     char *ptr=buf;
-    addar(ptr,R"([{"device":"JugglucoNG","created_at":")");
+    const bool v3=devicestatusIsV3();
+    //Same battery document either way; only the wrapper differs. v3 takes the document on its
+    //own and refuses one without "app" ("Bad or missing app field"), where v1 takes an array
+    //and ignores the field.
+    if(v3) {
+        addar(ptr,R"({"app":"JugglucoNG","device":"JugglucoNG","date":)");
+        addjsonint(ptr,(long long)nu*1000LL);
+        addar(ptr,R"(,"utcOffset":0,"created_at":")");
+        }
+    else {
+        addar(ptr,R"([{"device":"JugglucoNG","created_at":")");
+        }
     addNightscoutDateStringGMT(ptr,time(nullptr));
     addar(ptr,R"(","uploader":{"battery":)");
     addjsonint(ptr,battery);
-    addar(ptr,R"(,"type":"PHONE"}}])");
+    //addar takes the literal by array reference, so the two shapes cannot share one call.
+    if(v3)
+        addar(ptr,R"(,"type":"PHONE"}})");
+    else
+        addar(ptr,R"(,"type":"PHONE"}}])");
     *ptr='\0';
     const bool queued=queueNightuploadDevicestatus(buf,ptr-buf);
     LOGGER("Nightscout device-status battery=%d queued=%d\n",battery,queued);

--- a/Common/src/main/java/tk/glucodata/NightPost.java
+++ b/Common/src/main/java/tk/glucodata/NightPost.java
@@ -404,7 +404,9 @@ static public boolean maybeUploadIobDeviceStatus(String httpurl,String secret) {
                 iobStatusLastEiob,
                 iobStatusLastCob))
             return true;
-        final String document=NightscoutIobDeviceStatus.buildDocument(now,values[0],values[1],values[2]);
+        //The endpoint the native side picks follows the same setting, so the document has to
+        //agree with it: v3 takes a single document with an "app" field, v1 an array.
+        final String document=NightscoutIobDeviceStatus.buildDocument(now,values[0],values[1],values[2],Natives.getnightscoutV3());
         if(document==null)
             return true;
         if(uploadDeviceStatusAsync(httpurl,document.getBytes(java.nio.charset.StandardCharsets.UTF_8),secret,false)) {

--- a/Common/src/main/java/tk/glucodata/NightscoutIobDeviceStatus.java
+++ b/Common/src/main/java/tk/glucodata/NightscoutIobDeviceStatus.java
@@ -86,11 +86,26 @@ public class NightscoutIobDeviceStatus {
     // the journal has data of that kind. All values are insulin units and
     // grams; glucose units play no role here.
     static String buildDocument(long nowMillis, float iob, float eiob, float cob) {
+        return buildDocument(nowMillis, iob, eiob, cob, false);
+    }
+
+    /**
+     * @param useV3 v3 stores one document rather than an array, and rejects one without an
+     *              "app" field ("Bad or missing app field"). The payload itself is the same
+     *              either way, so only the wrapper and those required fields differ.
+     */
+    static String buildDocument(long nowMillis, float iob, float eiob, float cob, boolean useV3) {
         if (!Float.isFinite(iob))
             return null;
         final String timestamp = isoTimestamp(nowMillis);
-        final StringBuilder out = new StringBuilder(224);
-        out.append("[{\"device\":\"JugglucoNG\",\"created_at\":\"").append(timestamp)
+        final StringBuilder out = new StringBuilder(256);
+        if (useV3) {
+            out.append("{\"app\":\"JugglucoNG\",\"date\":").append(nowMillis)
+                    .append(",\"utcOffset\":0,\"device\":\"JugglucoNG\",\"created_at\":\"").append(timestamp);
+        } else {
+            out.append("[{\"device\":\"JugglucoNG\",\"created_at\":\"").append(timestamp);
+        }
+        out
                 .append("\",\"openaps\":{\"iob\":{\"iob\":").append(formatUnits(iob))
                 .append(",\"timestamp\":\"").append(timestamp)
                 .append("\"}},\"jugglucong\":{\"iob\":").append(formatUnits(iob));
@@ -98,7 +113,7 @@ public class NightscoutIobDeviceStatus {
             out.append(",\"eiob\":").append(formatUnits(eiob));
         if (Float.isFinite(cob))
             out.append(",\"cob\":").append(formatUnits(cob));
-        out.append("}}]");
+        out.append(useV3 ? "}}" : "}}]");
         return out.toString();
     }
 

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
@@ -27,6 +27,7 @@ class NightscoutFollowerManager(
     serial: String,
     private val url: String,
     private val secret: String,
+    private val useV3: Boolean = false,
     dataptr: Long,
 ) : SuperGattCallback(serial, dataptr, SENSOR_GEN), ManagedBluetoothSensorDriver {
 
@@ -37,6 +38,7 @@ class NightscoutFollowerManager(
         private const val RETRY_INTERVAL_MS = 30_000L
         private const val PROBE_INTERVAL_MS = 59_000L
         private const val DEVICE_STATUS_COUNT = 5
+        private const val REFRESH_ERROR_LOG_INTERVAL_MS = 5L * 60_000L
         private const val MMOL_TO_MGDL = 18.0182f
     }
 
@@ -239,9 +241,18 @@ class NightscoutFollowerManager(
                 ),
             )
             UiRefreshBus.requestDataRefresh()
+            refreshErrorLog.reset()
             scheduleRefresh(POLL_INTERVAL_MS)
         } catch (t: Throwable) {
-            Log.stack(TAG, "refresh($reason)", t)
+            // The poll retries every 30s, far faster than a stuck server recovers, so an
+            // unchanged failure used to write a stack trace every half minute.
+            val message = "refresh($reason): ${t.message}"
+            val repeats = refreshErrorLog.suppressedSince(message, System.currentTimeMillis())
+            if (repeats == 0) {
+                Log.stack(TAG, "refresh($reason)", t)
+            } else if (repeats > 0) {
+                Log.w(TAG, "$message (repeated ${repeats + 1}x)")
+            }
             setStatus(Phase.IDLE, localizedString(R.string.nightscout_follow_status_sync_failed, "Nightscout sync failed"))
             scheduleRefresh(RETRY_INTERVAL_MS)
         }
@@ -337,6 +348,7 @@ class NightscoutFollowerManager(
             baseUrl = NightscoutFollowerRegistry.normalizeUrl(url),
             lowerBoundMs = lowerBoundMs,
             beforeExclusiveMs = beforeExclusiveMs,
+            useV3 = useV3,
         )
         val connection = (URL(endpoint).openConnection() as HttpURLConnection).apply {
             connectTimeout = 15_000
@@ -344,7 +356,7 @@ class NightscoutFollowerManager(
             requestMethod = "GET"
             setRequestProperty("Accept", "application/json")
             setRequestProperty("User-Agent", "JugglucoNG Nightscout follower")
-            NightscoutFollowerRegistry.applyAuth(this, secret)
+            applyFollowerAuth(this)
         }
         try {
             val code = connection.responseCode
@@ -353,9 +365,9 @@ class NightscoutFollowerManager(
                 ?.use { it.readText() }
                 .orEmpty()
             if (code !in 200..299) {
-                throw IllegalStateException("Nightscout HTTP $code: ${body.take(160)}")
+                throw IllegalStateException(failureText("entries", code, endpoint, body))
             }
-            val array = JSONArray(body)
+            val array = JSONArray(NightscoutFollowerV3.arrayBody(body))
             val readings = ArrayList<VirtualGlucoseSensorBridge.Reading>(array.length())
             for (index in 0 until array.length()) {
                 parseEntry(array.optJSONObject(index))?.let(readings::add)
@@ -411,14 +423,19 @@ class NightscoutFollowerManager(
     }
 
     private fun fetchDeviceStatusJson(): String {
-        val endpoint = "${NightscoutFollowerRegistry.normalizeUrl(url)}/api/v1/devicestatus.json?count=$DEVICE_STATUS_COUNT"
+        val baseUrl = NightscoutFollowerRegistry.normalizeUrl(url)
+        val endpoint = if (useV3) {
+            NightscoutFollowerV3.deviceStatusUrl(baseUrl, DEVICE_STATUS_COUNT)
+        } else {
+            "$baseUrl/api/v1/devicestatus.json?count=$DEVICE_STATUS_COUNT"
+        }
         val connection = (URL(endpoint).openConnection() as HttpURLConnection).apply {
             connectTimeout = 15_000
             readTimeout = 30_000
             requestMethod = "GET"
             setRequestProperty("Accept", "application/json")
             setRequestProperty("User-Agent", "JugglucoNG Nightscout follower")
-            NightscoutFollowerRegistry.applyAuth(this, secret)
+            applyFollowerAuth(this)
         }
         try {
             val code = connection.responseCode
@@ -428,9 +445,9 @@ class NightscoutFollowerManager(
                 .orEmpty()
             if (code == 404) return "[]"
             if (code !in 200..299) {
-                throw IllegalStateException("Nightscout devicestatus HTTP $code: ${body.take(160)}")
+                throw IllegalStateException(failureText("devicestatus", code, endpoint, body))
             }
-            return body
+            return NightscoutFollowerV3.arrayBody(body)
         } finally {
             connection.disconnect()
         }
@@ -454,6 +471,41 @@ class NightscoutFollowerManager(
         )
     }
 
+    /**
+     * v3 wants the bearer token exchanged from the access token; anything else, and any v1
+     * follower, keeps the existing header logic. Falling back rather than sending a header
+     * known to be wrong is what keeps a v1 follower behaving exactly as before.
+     */
+    private val refreshErrorLog = RepeatedFollowerError(REFRESH_ERROR_LOG_INTERVAL_MS)
+
+    private fun applyFollowerAuth(connection: HttpURLConnection) {
+        val bearer = if (useV3) {
+            NightscoutFollowerV3.authorizationHeader(
+                NightscoutFollowerRegistry.normalizeUrl(url),
+                secret,
+                System.currentTimeMillis(),
+            )
+        } else {
+            null
+        }
+        if (bearer != null) {
+            connection.setRequestProperty("Authorization", bearer)
+        } else {
+            NightscoutFollowerRegistry.applyAuth(connection, secret)
+        }
+    }
+
+    /**
+     * Names what was refused, where, and in the server's own words. A follower read needs
+     * api:entries:read, api:treatments:read and api:devicestatus:read; a token missing one
+     * answers "Missing permission ...", which is the sentence that stops this looking like a
+     * server problem.
+     */
+    private fun failureText(label: String, code: Int, endpoint: String, body: String): String {
+        val path = runCatching { URL(endpoint).path }.getOrNull()?.takeIf { it.isNotBlank() } ?: endpoint
+        return "Nightscout $label HTTP $code ($path): ${NightscoutFollowerV3.serverMessage(body)}"
+    }
+
     private fun fetchJournalJson(endpoint: String, label: String): String {
         val connection = (URL(endpoint).openConnection() as HttpURLConnection).apply {
             connectTimeout = 15_000
@@ -461,7 +513,7 @@ class NightscoutFollowerManager(
             requestMethod = "GET"
             setRequestProperty("Accept", "application/json")
             setRequestProperty("User-Agent", "JugglucoNG Nightscout follower")
-            NightscoutFollowerRegistry.applyAuth(this, secret)
+            applyFollowerAuth(this)
         }
         try {
             val code = connection.responseCode
@@ -471,9 +523,9 @@ class NightscoutFollowerManager(
                 .orEmpty()
             if (code == 404) return "[]"
             if (code !in 200..299) {
-                throw IllegalStateException("Nightscout $label HTTP $code: ${body.take(160)}")
+                throw IllegalStateException(failureText(label, code, endpoint, body))
             }
-            return body
+            return NightscoutFollowerV3.arrayBody(body)
         } finally {
             connection.disconnect()
         }
@@ -501,11 +553,13 @@ class NightscoutFollowerManager(
 internal object NightscoutFollowerJournalEndpoints {
     private const val JOURNAL_COUNT = 512
 
-    fun treatments(baseUrl: String): String =
-        "$baseUrl/api/v1/treatments.json?count=$JOURNAL_COUNT"
+    fun treatments(baseUrl: String, useV3: Boolean = false): String =
+        if (useV3) NightscoutFollowerV3.treatmentsUrl(baseUrl, JOURNAL_COUNT)
+        else "$baseUrl/api/v1/treatments.json?count=$JOURNAL_COUNT"
 
-    fun fingersticks(baseUrl: String): String =
-        "$baseUrl/api/v1/entries/mbg.json?count=$JOURNAL_COUNT"
+    fun fingersticks(baseUrl: String, useV3: Boolean = false): String =
+        if (useV3) NightscoutFollowerV3.entriesUrl(baseUrl, JOURNAL_COUNT, "mbg", null, null)
+        else "$baseUrl/api/v1/entries/mbg.json?count=$JOURNAL_COUNT"
 }
 
 internal object NightscoutFollowerHistoryPaging {
@@ -523,7 +577,11 @@ internal object NightscoutFollowerHistoryPaging {
         baseUrl: String,
         lowerBoundMs: Long?,
         beforeExclusiveMs: Long?,
+        useV3: Boolean = false,
     ): String {
+        if (useV3) {
+            return NightscoutFollowerV3.entriesUrl(baseUrl, PAGE_COUNT, "sgv", lowerBoundMs, beforeExclusiveMs)
+        }
         val parameters = buildList {
             add("count=$PAGE_COUNT")
             if (lowerBoundMs != null) {

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
@@ -16,6 +16,9 @@ object NightscoutFollowerRegistry {
     private const val PREF_ENABLED = "nightscout_follower_enabled"
     private const val PREF_URL = "nightscout_follower_url"
     private const val PREF_SECRET = "nightscout_follower_secret"
+    //The uploader's v3 flag is an uploader setting and never reaches here: a follower may point
+    //at an entirely different server than the one this phone uploads to.
+    private const val PREF_USE_V3 = "nightscout_follower_v3"
     private const val PREF_COMPLETE_HISTORY_PREFIX = "nightscout_follower_complete_history_v1_"
     const val SENSOR_PREFIX = "NSF-"
 
@@ -23,6 +26,7 @@ object NightscoutFollowerRegistry {
         val enabled: Boolean,
         val url: String,
         val secret: String,
+        val useV3: Boolean = false,
     ) {
         val sensorId: String get() = deriveSensorId(url)
         val isUsable: Boolean get() = enabled && url.isNotBlank()
@@ -61,13 +65,21 @@ object NightscoutFollowerRegistry {
             enabled = prefs(context).getBoolean(PREF_ENABLED, false),
             url = normalizeUrl(prefs(context).getString(PREF_URL, null)),
             secret = prefs(context).getString(PREF_SECRET, null).orEmpty(),
+            useV3 = prefs(context).getBoolean(PREF_USE_V3, false),
         )
 
-    fun saveConfig(context: Context, enabled: Boolean, url: String?, secret: String?) {
+    fun saveConfig(
+        context: Context,
+        enabled: Boolean,
+        url: String?,
+        secret: String?,
+        useV3: Boolean = loadConfig(context).useV3,
+    ) {
         prefs(context).edit()
             .putBoolean(PREF_ENABLED, enabled)
             .putString(PREF_URL, normalizeUrl(url).takeIf { it.isNotEmpty() })
             .putString(PREF_SECRET, secret?.trim()?.takeIf { it.isNotEmpty() })
+            .putBoolean(PREF_USE_V3, useV3)
             .apply()
         ManagedSensorUiSignals.markDeviceListDirty()
     }
@@ -93,14 +105,21 @@ object NightscoutFollowerRegistry {
             serial = config.sensorId,
             url = config.url,
             secret = config.secret,
+            useV3 = config.useV3,
             dataptr = dataptr,
         )
     }
 
-    fun enableFollowerSensor(context: Context, url: String?, secret: String?, connectNow: Boolean = true): String? {
+    fun enableFollowerSensor(
+        context: Context,
+        url: String?,
+        secret: String?,
+        connectNow: Boolean = true,
+        useV3: Boolean = loadConfig(context).useV3,
+    ): String? {
         val normalizedUrl = normalizeUrl(url)
         if (normalizedUrl.isEmpty()) return null
-        saveConfig(context, enabled = true, url = normalizedUrl, secret = secret)
+        saveConfig(context, enabled = true, url = normalizedUrl, secret = secret, useV3 = useV3)
         val sensorId = deriveSensorId(normalizedUrl)
         if (connectNow) {
             connectSensor(context, sensorId)

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
@@ -129,6 +129,7 @@ object NightscoutFollowerRegistry {
 
     fun disableFollowerSensor(context: Context) {
         val sensorId = loadConfig(context).sensorId
+        NightscoutFollowerDeviceStatus.clear()
         ManagedCurrentSensor.clearIfMatches(sensorId)
         saveConfig(context, enabled = false, url = loadConfig(context).url, secret = loadConfig(context).secret)
         SensorBluetooth.mygatts()

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerV3.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerV3.kt
@@ -1,0 +1,143 @@
+package tk.glucodata.drivers.nightscout
+
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+
+/**
+ * v3 support for follower mode: endpoint shapes, the response envelope, and the bearer token.
+ *
+ * The uploader's token cache in NightPost cannot be reused here. It mints its token from the
+ * uploader's own URL and secret and keeps it in a single field with no record of which host it
+ * came from, so a follower pointing at a different server would be handed a JWT signed by the
+ * wrong one. This keeps its own cache, keyed by the credentials it was minted from.
+ */
+internal object NightscoutFollowerV3 {
+    /** v3 pages with `limit` and has no `.json` suffix; `sort$desc=date` gives newest first. */
+    private const val SORT_NEWEST = "sort%24desc=date"
+
+    fun entriesUrl(baseUrl: String, count: Int, type: String, gteMillis: Long?, ltMillis: Long?): String {
+        val parameters = mutableListOf("limit=$count", SORT_NEWEST, "type%24eq=$type")
+        // Verified against a live instance: type$eq filters rather than being ignored.
+        if (gteMillis != null) parameters += "date%24gte=$gteMillis"
+        if (ltMillis != null) parameters += "date%24lt=$ltMillis"
+        return "$baseUrl/api/v3/entries?${parameters.joinToString("&")}"
+    }
+
+    fun treatmentsUrl(baseUrl: String, count: Int): String =
+        "$baseUrl/api/v3/treatments?limit=$count&$SORT_NEWEST&fields=_all"
+
+    fun deviceStatusUrl(baseUrl: String, count: Int): String =
+        "$baseUrl/api/v3/devicestatus?limit=$count&$SORT_NEWEST&fields=_all"
+
+    /**
+     * v1 answers with the document array itself, v3 wraps it in {status, result}. Every parser
+     * downstream expects an array, so the envelope comes off here. A body that is already an
+     * array passes through, so a host answering the v1 shape still works.
+     */
+    fun arrayBody(body: String): String {
+        val trimmed = body.trim()
+        if (trimmed.isEmpty() || trimmed.startsWith("[")) return trimmed
+        if (!trimmed.startsWith("{")) return trimmed
+        return runCatching { JSONObject(trimmed).optJSONArray("result")?.toString() }
+            .getOrNull()
+            ?: "[]"
+    }
+
+    /**
+     * The server's own words when it has any. A refused read names the permission it wanted
+     * ("Missing permission api:entries:read"), which is the difference between an actionable
+     * failure and a bare status code.
+     */
+    fun serverMessage(body: String): String {
+        val trimmed = body.trim()
+        if (!trimmed.startsWith("{")) return trimmed.take(160)
+        return runCatching {
+            JSONObject(trimmed).let { json ->
+                sequenceOf("message", "description")
+                    .map { json.optString(it).trim() }
+                    .firstOrNull { it.isNotEmpty() }
+            }
+        }.getOrNull() ?: trimmed.take(160)
+    }
+
+    /** A cached bearer token, remembering which credentials produced it. */
+    private data class CachedToken(val url: String, val secret: String, val header: String, val expiresAt: Long)
+
+    @Volatile
+    private var cached: CachedToken? = null
+
+    /** Clock skew guard: stop trusting the token slightly before the server does. */
+    private const val EXPIRY_MARGIN_MILLIS = 60_000L
+
+    @Synchronized
+    fun clearToken() {
+        cached = null
+    }
+
+    /**
+     * Authorization header for a v3 read, exchanging the access token for a bearer JWT and
+     * caching it until it expires. Returns null when the secret is already a header value or
+     * no token could be had, so the caller falls back to [NightscoutFollowerRegistry.applyAuth]
+     * rather than sending something it knows is wrong.
+     */
+    @Synchronized
+    fun authorizationHeader(baseUrl: String, secret: String, nowMillis: Long): String? {
+        val trimmed = secret.trim()
+        if (trimmed.isEmpty()) return null
+        // Already a header value: applyAuth handles these, and there is nothing to exchange.
+        if (trimmed.startsWith("Bearer ", ignoreCase = true) ||
+            trimmed.startsWith("token=", ignoreCase = true) ||
+            isSha1Hex(trimmed)
+        ) {
+            return null
+        }
+        cached?.let { hit ->
+            if (hit.url == baseUrl && hit.secret == trimmed && nowMillis < hit.expiresAt) {
+                return hit.header
+            }
+        }
+        val fetched = requestToken(baseUrl, trimmed, nowMillis) ?: return null
+        cached = fetched
+        return fetched.header
+    }
+
+    private fun requestToken(baseUrl: String, secret: String, nowMillis: Long): CachedToken? {
+        val encoded = URLEncoder.encode(secret, Charsets.UTF_8.name())
+        val connection = (URL("$baseUrl/api/v2/authorization/request/$encoded").openConnection()
+            as HttpURLConnection).apply {
+            connectTimeout = 15_000
+            readTimeout = 30_000
+            requestMethod = "GET"
+            setRequestProperty("Accept", "application/json")
+            setRequestProperty("User-Agent", "JugglucoNG Nightscout follower")
+        }
+        try {
+            if (connection.responseCode !in 200..299) return null
+            val body = connection.inputStream.bufferedReader().use { it.readText() }
+            val json = JSONObject(body)
+            val token = json.optString("token").trim()
+            if (token.isEmpty()) return null
+            // exp is seconds since the epoch, as in the uploader's own exchange.
+            val expSeconds = json.optLong("exp", 0L)
+            val expiresAt = if (expSeconds > 0L) {
+                expSeconds * 1000L - EXPIRY_MARGIN_MILLIS
+            } else {
+                nowMillis + 30 * 60_000L
+            }
+            return CachedToken(baseUrl, secret, "Bearer $token", expiresAt)
+        } catch (_: Throwable) {
+            return null
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    // Character loop rather than Regex: this runs on the follower HandlerThread, where the ICU
+    // matcher has been implicated in a native heap corruption (see NightscoutFollowerRegistry).
+    private fun isSha1Hex(s: String): Boolean {
+        if (s.length != 40) return false
+        return s.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutModePreference.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutModePreference.kt
@@ -1,0 +1,41 @@
+package tk.glucodata.drivers.nightscout
+
+import android.content.Context
+
+/** Upload/Follow selection, intentionally independent from the master enabled state. */
+object NightscoutModePreference {
+    enum class Mode { UPLOAD, FOLLOW }
+
+    private const val PREFS_NAME = "tk.glucodata_preferences"
+    private const val PREF_MODE = "nightscout_selected_mode_v1"
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun load(
+        context: Context,
+        legacyUploaderActive: Boolean,
+        legacyFollowerEnabled: Boolean,
+    ): Mode = resolve(
+        stored = prefs(context).getString(PREF_MODE, null),
+        legacyUploaderActive = legacyUploaderActive,
+        legacyFollowerEnabled = legacyFollowerEnabled,
+    )
+
+    fun save(context: Context, mode: Mode) {
+        prefs(context).edit().putString(PREF_MODE, mode.name).apply()
+    }
+
+    internal fun resolve(
+        stored: String?,
+        legacyUploaderActive: Boolean,
+        legacyFollowerEnabled: Boolean,
+    ): Mode {
+        Mode.entries.firstOrNull { it.name == stored }?.let { return it }
+        return when {
+            legacyUploaderActive -> Mode.UPLOAD
+            legacyFollowerEnabled -> Mode.FOLLOW
+            else -> Mode.UPLOAD
+        }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/RepeatedFollowerError.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/RepeatedFollowerError.kt
@@ -1,0 +1,40 @@
+package tk.glucodata.drivers.nightscout
+
+/**
+ * Keeps an unchanged, repeating failure to one line per interval.
+ *
+ * The follower retries every 30 seconds, far faster than an unreachable or refusing server
+ * recovers, so the same stack trace every half minute buries everything else in the trace.
+ */
+internal class RepeatedFollowerError(private val intervalMillis: Long) {
+    private var lastMessage: String? = null
+    private var lastLoggedAt = 0L
+    private var suppressed = 0
+
+    /**
+     * @return how many repeats were swallowed since the last line, or -1 to stay silent. A
+     *         changed message always speaks, so a new failure is never hidden behind an older
+     *         one's interval, and a clock that moved backwards cannot silence it for good.
+     */
+    fun suppressedSince(message: String, nowMillis: Long): Int {
+        val elapsed = nowMillis - lastLoggedAt
+        val due = message != lastMessage || lastLoggedAt == 0L ||
+            elapsed >= intervalMillis || elapsed < 0
+        if (!due) {
+            suppressed++
+            return -1
+        }
+        val repeats = if (message == lastMessage) suppressed else 0
+        lastMessage = message
+        lastLoggedAt = nowMillis
+        suppressed = 0
+        return repeats
+    }
+
+    /** A success ends the episode, so the next failure reports immediately. */
+    fun reset() {
+        lastMessage = null
+        lastLoggedAt = 0L
+        suppressed = 0
+    }
+}

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1399,6 +1399,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_title">Крыніца Nightscout</string>
     <string name="nightscout_follow_status_idle">Крыніца Nightscout чакае</string>
     <string name="nightscout_follow_status_following">Атрыманне з Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Выкарыстоўваць API v3 для сачэння</string>
+    <string name="nightscout_follow_use_v3_api_desc">Чытаць з /api/v3 замест /api/v1. Токен доступу патрабуе api:entries:read, api:treatments:read і api:devicestatus:read. Змены роляў дзейнічаюць толькі з наступным абменам токенаў, таму перазапусціце праграму, калі 403 захоўваецца.</string>
     <string name="nightscout_follow_status_syncing">Абнаўленне Nightscout</string>
     <string name="nightscout_follow_status_paused">Крыніца Nightscout прыпынена</string>
     <string name="nightscout_follow_status_config_needed">Увядзіце URL Nightscout</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1474,6 +1474,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightscout_follow_title">Nightscout-Follower</string>
     <string name="nightscout_follow_status_idle">Nightscout-Follower bereit</string>
     <string name="nightscout_follow_status_following">Folgt Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">v3-API zum Folgen verwenden</string>
+    <string name="nightscout_follow_use_v3_api_desc">Liest von /api/v3 statt /api/v1. Der Zugriffstoken benötigt api:entries:read, api:treatments:read und api:devicestatus:read. Geänderte Rollen wirken erst mit dem nächsten Token-Austausch: Bei anhaltendem 403 die App neu starten.</string>
     <string name="nightscout_follow_status_syncing">Nightscout wird aktualisiert</string>
     <string name="nightscout_follow_status_paused">Nightscout-Follower pausiert</string>
     <string name="nightscout_follow_status_config_needed">Nightscout-URL eingeben</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1406,6 +1406,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_title">Suivi Nightscout</string>
     <string name="nightscout_follow_status_idle">Suivi Nightscout inactif</string>
     <string name="nightscout_follow_status_following">Suivi de Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Utiliser l\'API v3 pour le suivi</string>
+    <string name="nightscout_follow_use_v3_api_desc">Lit /api/v3 au lieu de /api/v1. Le jeton d\'accès requiert api:entries:read, api:treatments:read et api:devicestatus:read. Les rôles modifiés ne prennent effet qu\'au prochain échange de jeton : redémarrez l\'application si un 403 persiste.</string>
     <string name="nightscout_follow_status_syncing">Actualisation de Nightscout</string>
     <string name="nightscout_follow_status_paused">Suivi Nightscout en pause</string>
     <string name="nightscout_follow_status_config_needed">Saisir l’URL Nightscout</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1390,6 +1390,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_title">Follower Nightscout</string>
     <string name="nightscout_follow_status_idle">Follower Nightscout inattivo</string>
     <string name="nightscout_follow_status_following">Connessione a Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Usa l\'API v3 per seguire</string>
+    <string name="nightscout_follow_use_v3_api_desc">Legge da /api/v3 invece di /api/v1. Il token di accesso richiede api:entries:read, api:treatments:read e api:devicestatus:read. I ruoli modificati hanno effetto solo al successivo scambio del token: riavvia l\'app se un 403 persiste.</string>
     <string name="nightscout_follow_status_syncing">Aggiornamento Nightscout</string>
     <string name="nightscout_follow_status_paused">Follower Nightscout in pausa</string>
     <string name="nightscout_follow_status_config_needed">Inserisci URL Nightscout</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1220,6 +1220,8 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="nightscout_follow_title">Nightscout дагагч</string>
     <string name="nightscout_follow_status_idle">Nightscout дагагч идэвхгүй байна</string>
     <string name="nightscout_follow_status_following">Nightscout-ийг дагаж байна</string>
+    <string name="nightscout_follow_use_v3_api">Дагахдаа v3 API ашиглах</string>
+    <string name="nightscout_follow_use_v3_api_desc">/api/v1-ийн оронд /api/v3-аас уншина. Хандалтын токенд api:entries:read, api:treatments:read, api:devicestatus:read шаардлагатай. Өөрчилсөн эрх зөвхөн дараагийн токен солилцоонд хүчинтэй тул 403 үргэлжилвэл аппыг дахин эхлүүлнэ үү.</string>
     <string name="nightscout_follow_status_syncing">Nightscout-ийг шинэчилж байна</string>
     <string name="nightscout_follow_status_paused">Nightscout дагагч түр зогссон</string>
     <string name="nightscout_follow_status_config_needed">Nightscout URL-г оруулна уу</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1443,6 +1443,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="nightscout_follow_title">Nightscout-volger</string>
     <string name="nightscout_follow_status_idle">Nightscout-volger inactief</string>
     <string name="nightscout_follow_status_following">Nightscout volgen</string>
+    <string name="nightscout_follow_use_v3_api">v3-API gebruiken om te volgen</string>
+    <string name="nightscout_follow_use_v3_api_desc">Leest van /api/v3 in plaats van /api/v1. Het toegangstoken heeft api:entries:read, api:treatments:read en api:devicestatus:read nodig. Gewijzigde rollen werken pas bij de volgende tokenuitwisseling: herstart de app als een 403 aanhoudt.</string>
     <string name="nightscout_follow_status_syncing">Nightscout vernieuwen</string>
     <string name="nightscout_follow_status_paused">Nightscout-volger gepauzeerd</string>
     <string name="nightscout_follow_status_config_needed">Nightscout-URL invoeren</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1435,6 +1435,8 @@
     <string name="nightscout_follow_title">Obserwator Nightscout</string>
     <string name="nightscout_follow_status_idle">Obserwator Nightscout bezczynny</string>
     <string name="nightscout_follow_status_following">Obserwowanie Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Używaj API v3 do śledzenia</string>
+    <string name="nightscout_follow_use_v3_api_desc">Czyta z /api/v3 zamiast /api/v1. Token dostępu wymaga api:entries:read, api:treatments:read i api:devicestatus:read. Zmienione role działają dopiero przy następnej wymianie tokenu: uruchom ponownie aplikację, jeśli 403 się utrzymuje.</string>
     <string name="nightscout_follow_status_syncing">Odświeżanie Nightscout</string>
     <string name="nightscout_follow_status_paused">Obserwator Nightscout wstrzymany</string>
     <string name="nightscout_follow_status_config_needed">Wprowadź adres URL Nightscout</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1401,6 +1401,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_title">Seguidor Nightscout</string>
     <string name="nightscout_follow_status_idle">Seguidor Nightscout inativo</string>
     <string name="nightscout_follow_status_following">A seguir Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Usar a API v3 para seguir</string>
+    <string name="nightscout_follow_use_v3_api_desc">Lê de /api/v3 em vez de /api/v1. O token de acesso precisa de api:entries:read, api:treatments:read e api:devicestatus:read. Funções alteradas só entram em vigor na próxima troca de token: reinicie a aplicação se um 403 persistir.</string>
     <string name="nightscout_follow_status_syncing">A atualizar Nightscout</string>
     <string name="nightscout_follow_status_paused">Seguidor Nightscout em pausa</string>
     <string name="nightscout_follow_status_config_needed">Introduza o URL do Nightscout</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1443,6 +1443,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_title">Источник Nightscout</string>
     <string name="nightscout_follow_status_idle">Источник Nightscout простаивает</string>
     <string name="nightscout_follow_status_following">Получение из Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Использовать API v3 для слежения</string>
+    <string name="nightscout_follow_use_v3_api_desc">Читает из /api/v3 вместо /api/v1. Токену доступа нужны api:entries:read, api:treatments:read и api:devicestatus:read. Изменённые роли действуют только со следующего обмена токенов: перезапустите приложение, если 403 сохраняется.</string>
     <string name="nightscout_follow_status_syncing">Обновление Nightscout</string>
     <string name="nightscout_follow_status_paused">Источник Nightscout приостановлен</string>
     <string name="nightscout_follow_status_config_needed">Введите URL Nightscout</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1489,6 +1489,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="nightscout_follow_title">Nightscoout raaca</string>
     <string name="nightscout_follow_status_idle">Nightscoout raaca</string>
     <string name="nightscout_follow_status_following">Ka dib Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Isticmaal API v3 raacitaanka</string>
+    <string name="nightscout_follow_use_v3_api_desc">Waxay ka akhridaa /api/v3 halkii /api/v1. Token-ka gelitaanka wuxuu u baahan yahay api:entries:read, api:treatments:read iyo api:devicestatus:read. Doorarka la beddelay waxay shaqeeyaan oo keliya beddelka token-ka ee xiga: dib u bilow abka haddii 403 sii socoto.</string>
     <string name="nightscout_follow_status_syncing">Nightscout oo soo kicinaysa</string>
     <string name="nightscout_follow_status_paused">Habeenimadii raacdayaashii waa hakad</string>
     <string name="nightscout_follow_status_config_needed">Geli Nightscout URL</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1400,6 +1400,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_title">Nightscout-följare</string>
     <string name="nightscout_follow_status_idle">Nightscout-följare inaktiv</string>
     <string name="nightscout_follow_status_following">Följer Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Använd v3-API för att följa</string>
+    <string name="nightscout_follow_use_v3_api_desc">Läser från /api/v3 i stället för /api/v1. Åtkomsttoken behöver api:entries:read, api:treatments:read och api:devicestatus:read. Ändrade roller börjar gälla först vid nästa tokenutbyte: starta om appen om ett 403 kvarstår.</string>
     <string name="nightscout_follow_status_syncing">Uppdaterar Nightscout</string>
     <string name="nightscout_follow_status_paused">Nightscout-följare pausad</string>
     <string name="nightscout_follow_status_config_needed">Ange Nightscout-URL</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1428,6 +1428,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="nightscout_follow_title">Nightscout takipçisi</string>
     <string name="nightscout_follow_status_idle">Nightscout takipçisi boşta</string>
     <string name="nightscout_follow_status_following">Nightscout takip ediliyor</string>
+    <string name="nightscout_follow_use_v3_api">Takip için v3 API kullan</string>
+    <string name="nightscout_follow_use_v3_api_desc">/api/v1 yerine /api/v3 okur. Erişim belirtecinin api:entries:read, api:treatments:read ve api:devicestatus:read izinleri gerekir. Değişen roller yalnızca sonraki belirteç değişiminde etkili olur: 403 sürerse uygulamayı yeniden başlatın.</string>
     <string name="nightscout_follow_status_syncing">Nightscout yenileniyor</string>
     <string name="nightscout_follow_status_paused">Nightscout takipçisi duraklatıldı</string>
     <string name="nightscout_follow_status_config_needed">Nightscout URL adresini girin</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1414,6 +1414,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_title">Джерело Nightscout</string>
     <string name="nightscout_follow_status_idle">Джерело Nightscout очікує</string>
     <string name="nightscout_follow_status_following">Отримання з Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Використовувати API v3 для стеження</string>
+    <string name="nightscout_follow_use_v3_api_desc">Читає з /api/v3 замість /api/v1. Токен доступу потребує api:entries:read, api:treatments:read і api:devicestatus:read. Змінені ролі діють лише з наступним обміном токенів: перезапустіть застосунок, якщо 403 не зникає.</string>
     <string name="nightscout_follow_status_syncing">Оновлення Nightscout</string>
     <string name="nightscout_follow_status_paused">Джерело Nightscout призупинено</string>
     <string name="nightscout_follow_status_config_needed">Введіть URL Nightscout</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1416,6 +1416,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_title">Nightscout 跟随器</string>
     <string name="nightscout_follow_status_idle">Nightscout 跟随器空闲</string>
     <string name="nightscout_follow_status_following">正在跟随 Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">使用 v3 API 跟随</string>
+    <string name="nightscout_follow_use_v3_api_desc">从 /api/v3 而非 /api/v1 读取。访问令牌需要 api:entries:read、api:treatments:read 和 api:devicestatus:read 权限。角色变更只在下次令牌交换后生效：若 403 持续出现，请重启应用。</string>
     <string name="nightscout_follow_status_syncing">正在刷新 Nightscout</string>
     <string name="nightscout_follow_status_paused">Nightscout 跟随器已暂停</string>
     <string name="nightscout_follow_status_config_needed">输入 Nightscout URL</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1550,6 +1550,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_title">Nightscout follower</string>
     <string name="nightscout_follow_status_idle">Nightscout follower idle</string>
     <string name="nightscout_follow_status_following">Following Nightscout</string>
+    <string name="nightscout_follow_use_v3_api">Use v3 API for following</string>
+    <string name="nightscout_follow_use_v3_api_desc">Read from /api/v3 instead of /api/v1. The access token needs api:entries:read, api:treatments:read and api:devicestatus:read. Changed roles only take effect with the next token exchange, so restart the app if a 403 persists.</string>
     <string name="nightscout_follow_status_syncing">Refreshing Nightscout</string>
     <string name="nightscout_follow_status_paused">Nightscout follower paused</string>
     <string name="nightscout_follow_status_config_needed">Enter Nightscout URL</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -75,13 +75,12 @@ import tk.glucodata.NightPost
 import tk.glucodata.R
 import tk.glucodata.data.journal.JournalTreatmentUploader
 import tk.glucodata.drivers.nightscout.NightscoutFollowerRegistry
+import tk.glucodata.drivers.nightscout.NightscoutModePreference
 import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.MasterSwitchCard
 import tk.glucodata.ui.components.SettingsSwitchItem
 import tk.glucodata.ui.components.cardShape
 import tk.glucodata.ui.util.ConnectedButtonGroup
-
-private enum class NightscoutMode { UPLOAD, FOLLOW }
 
 // Sealed result for test connection so we don't parse strings
 private sealed class TestState {
@@ -156,17 +155,18 @@ fun NightscoutSettingsScreen(navController: NavController) {
 
     var mode by rememberSaveable {
         mutableStateOf(
-            when {
-                initialUploaderActive -> NightscoutMode.UPLOAD
-                followerConfig.enabled -> NightscoutMode.FOLLOW
-                else -> NightscoutMode.UPLOAD
-            }
+            NightscoutModePreference.load(
+                context = context,
+                legacyUploaderActive = initialUploaderActive,
+                legacyFollowerEnabled = followerConfig.enabled,
+            )
         )
     }
 
     fun persistSettings(connectFollower: Boolean = false) {
-        val uploadActive = isActive && mode == NightscoutMode.UPLOAD
-        val followActive = isActive && mode == NightscoutMode.FOLLOW
+        NightscoutModePreference.save(context, mode)
+        val uploadActive = isActive && mode == NightscoutModePreference.Mode.UPLOAD
+        val followActive = isActive && mode == NightscoutModePreference.Mode.FOLLOW
         val normalizedUrl = NightscoutFollowerRegistry.normalizeUrl(url)
 
         Natives.setNightUploader(url.trim(), secret.trim(), uploadActive, isV3)
@@ -237,14 +237,14 @@ fun NightscoutSettingsScreen(navController: NavController) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             while (true) {
                 refreshStatus()
-                delay(if (isActive && mode == NightscoutMode.UPLOAD) 5_000L else 15_000L)
+                delay(if (isActive && mode == NightscoutModePreference.Mode.UPLOAD) 5_000L else 15_000L)
             }
         }
     }
 
     DisposableEffect(Unit) {
         refreshStatus()
-        onDispose { persistSettings(connectFollower = isActive && mode == NightscoutMode.FOLLOW) }
+        onDispose { persistSettings(connectFollower = isActive && mode == NightscoutModePreference.Mode.FOLLOW) }
     }
 
     fun formatStatusTime(epochSeconds: Long): String {
@@ -257,13 +257,13 @@ fun NightscoutSettingsScreen(navController: NavController) {
     }
 
     val uploaderSummary = when {
-        !isActive || mode != NightscoutMode.UPLOAD -> context.getString(R.string.nightscout_status_paused)
+        !isActive || mode != NightscoutModePreference.Mode.UPLOAD -> context.getString(R.string.nightscout_status_paused)
         uploaderRunning -> context.getString(R.string.nightscout_status_running)
         retryMinutes > 0 -> context.getString(R.string.nightscout_status_retry_in, retryMinutes)
         else -> context.getString(R.string.nightscout_status_waiting)
     }
     val responseSummary = when {
-        !isActive || mode != NightscoutMode.UPLOAD -> context.getString(R.string.nightscout_status_paused)
+        !isActive || mode != NightscoutModePreference.Mode.UPLOAD -> context.getString(R.string.nightscout_status_paused)
         lastResponseCode == 0 && lastAttemptTime <= 0L -> context.getString(R.string.nightscout_status_waiting)
         lastResponseCode == -2 -> context.getString(R.string.nightscout_status_response_invalid_url)
         lastResponseCode in 200..299 -> context.getString(R.string.nightscout_status_response_ok, lastResponseCode)
@@ -274,12 +274,12 @@ fun NightscoutSettingsScreen(navController: NavController) {
     }
 
     val masterSubtitle = when (mode) {
-        NightscoutMode.UPLOAD -> if (isActive) {
+        NightscoutModePreference.Mode.UPLOAD -> if (isActive) {
             context.getString(R.string.nightscout_upload_active)
         } else {
             context.getString(R.string.nightscout_upload_paused)
         }
-        NightscoutMode.FOLLOW -> when {
+        NightscoutModePreference.Mode.FOLLOW -> when {
             !isActive -> context.getString(R.string.nightscout_follow_status_paused)
             NightscoutFollowerRegistry.normalizeUrl(url).isBlank() -> context.getString(R.string.nightscout_follow_status_config_needed)
             else -> context.getString(R.string.nightscout_follow_status_following)
@@ -314,7 +314,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
                     checked = isActive,
                     onCheckedChange = { enabled ->
                         isActive = enabled
-                        persistSettings(connectFollower = enabled && mode == NightscoutMode.FOLLOW)
+                        persistSettings(connectFollower = enabled && mode == NightscoutModePreference.Mode.FOLLOW)
                     },
                     icon = Icons.Filled.CloudUpload
                 )
@@ -322,25 +322,25 @@ fun NightscoutSettingsScreen(navController: NavController) {
 
             item("nightscout_mode_group") {
                 ConnectedButtonGroup(
-                    options = listOf(NightscoutMode.UPLOAD, NightscoutMode.FOLLOW),
+                    options = listOf(NightscoutModePreference.Mode.UPLOAD, NightscoutModePreference.Mode.FOLLOW),
                     selectedOption = mode,
                     onOptionSelected = { selectedMode ->
                         if (selectedMode == mode) return@ConnectedButtonGroup
                         mode = selectedMode
-                        persistSettings(connectFollower = isActive && selectedMode == NightscoutMode.FOLLOW)
+                        persistSettings(connectFollower = isActive && selectedMode == NightscoutModePreference.Mode.FOLLOW)
                         testState = TestState.Idle
                     },
                     label = {},
                     labelText = { selectedMode ->
                         when (selectedMode) {
-                            NightscoutMode.UPLOAD -> context.getString(R.string.nightscout_mode_upload)
-                            NightscoutMode.FOLLOW -> context.getString(R.string.nightscout_mode_follow)
+                            NightscoutModePreference.Mode.UPLOAD -> context.getString(R.string.nightscout_mode_upload)
+                            NightscoutModePreference.Mode.FOLLOW -> context.getString(R.string.nightscout_mode_follow)
                         }
                     },
                     icon = { selectedMode ->
                         when (selectedMode) {
-                            NightscoutMode.UPLOAD -> Icons.Default.CloudUpload
-                            NightscoutMode.FOLLOW -> Icons.Default.Link
+                            NightscoutModePreference.Mode.UPLOAD -> Icons.Default.CloudUpload
+                            NightscoutModePreference.Mode.FOLLOW -> Icons.Default.Link
                         }
                     },
                     modifier = Modifier.fillMaxWidth(),
@@ -387,7 +387,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
                             leadingIcon = { Icon(Icons.Default.Key, contentDescription = null) },
                             visualTransformation = if (showSecret) VisualTransformation.None else PasswordVisualTransformation(),
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text, imeAction = ImeAction.Done),
-                            keyboardActions = KeyboardActions(onDone = { persistSettings(connectFollower = isActive && mode == NightscoutMode.FOLLOW) }),
+                            keyboardActions = KeyboardActions(onDone = { persistSettings(connectFollower = isActive && mode == NightscoutModePreference.Mode.FOLLOW) }),
                             trailingIcon = {
                                 IconButton(onClick = { showSecret = !showSecret }) {
                                     Icon(
@@ -440,7 +440,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
             }
 
             // Upload-only items
-            if (mode == NightscoutMode.UPLOAD) {
+            if (mode == NightscoutModePreference.Mode.UPLOAD) {
                 item("nightscout_status_card") {
                     Card(
                         modifier = Modifier
@@ -592,7 +592,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
 
             // Follow-only items. The uploader's v3 switch above is an uploader setting: a
             // follower may point at a different server, so it carries its own.
-            if (mode == NightscoutMode.FOLLOW) {
+            if (mode == NightscoutModePreference.Mode.FOLLOW) {
                 item("nightscout_follow_options_group") {
                     SettingsSwitchItem(
                         title = stringResource(R.string.nightscout_follow_use_v3_api),

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -145,6 +145,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
     var receiveTreatments by rememberSaveable { mutableStateOf(JournalTreatmentUploader.getReceiveTreatments()) }
     var uploadIob by rememberSaveable { mutableStateOf(NightPost.getUploadIob()) }
     var isV3 by rememberSaveable { mutableStateOf(Natives.getnightscoutV3()) }
+    var followerV3 by rememberSaveable { mutableStateOf(followerConfig.useV3) }
     var showSecret by rememberSaveable { mutableStateOf(false) }
     var lastResponseCode by rememberSaveable { mutableStateOf(0) }
     var lastAttemptTime by rememberSaveable { mutableStateOf(0L) }
@@ -174,17 +175,17 @@ fun NightscoutSettingsScreen(navController: NavController) {
         JournalTreatmentUploader.setReceiveTreatments(receiveTreatments)
         if (followActive) {
             if (normalizedUrl.isBlank()) {
-                NightscoutFollowerRegistry.saveConfig(context, enabled = true, url = normalizedUrl, secret = secret)
+                NightscoutFollowerRegistry.saveConfig(context, enabled = true, url = normalizedUrl, secret = secret, useV3 = followerV3)
             } else if (connectFollower) {
-                NightscoutFollowerRegistry.enableFollowerSensor(context, normalizedUrl, secret)
+                NightscoutFollowerRegistry.enableFollowerSensor(context, normalizedUrl, secret, useV3 = followerV3)
             } else {
-                NightscoutFollowerRegistry.saveConfig(context, enabled = true, url = normalizedUrl, secret = secret)
+                NightscoutFollowerRegistry.saveConfig(context, enabled = true, url = normalizedUrl, secret = secret, useV3 = followerV3)
             }
         } else {
             if (NightscoutFollowerRegistry.loadConfig(context).enabled) {
                 NightscoutFollowerRegistry.disableFollowerSensor(context)
             }
-            NightscoutFollowerRegistry.saveConfig(context, enabled = false, url = normalizedUrl, secret = secret)
+            NightscoutFollowerRegistry.saveConfig(context, enabled = false, url = normalizedUrl, secret = secret, useV3 = followerV3)
         }
     }
 
@@ -586,6 +587,26 @@ fun NightscoutSettingsScreen(navController: NavController) {
                         Spacer(modifier = Modifier.width(10.dp))
                         Text(stringResource(R.string.resend_data_reset))
                     }
+                }
+            }
+
+            // Follow-only items. The uploader's v3 switch above is an uploader setting: a
+            // follower may point at a different server, so it carries its own.
+            if (mode == NightscoutMode.FOLLOW) {
+                item("nightscout_follow_options_group") {
+                    SettingsSwitchItem(
+                        title = stringResource(R.string.nightscout_follow_use_v3_api),
+                        subtitle = stringResource(R.string.nightscout_follow_use_v3_api_desc),
+                        checked = followerV3,
+                        onCheckedChange = {
+                            followerV3 = it
+                            persistSettings(connectFollower = isActive)
+                        },
+                        icon = Icons.Default.Science,
+                        iconTint = MaterialTheme.colorScheme.tertiary,
+                        enabled = isActive,
+                        position = CardPosition.SINGLE
+                    )
                 }
             }
         }

--- a/Common/src/test/java/tk/glucodata/NightscoutIobDeviceStatusTests.kt
+++ b/Common/src/test/java/tk/glucodata/NightscoutIobDeviceStatusTests.kt
@@ -1,6 +1,7 @@
 package tk.glucodata
 
 import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -104,6 +105,38 @@ class NightscoutIobDeviceStatusTests {
         lastEiob: Float = eiob,
         lastCob: Float = cob
     ) = NightscoutIobDeviceStatus.shouldUpload(now + elapsed, now, iob, eiob, cob, lastIob, lastEiob, lastCob)
+
+    // -- v3 document shape -------------------------------------------------
+
+    @Test
+    fun `a v3 document is a single object carrying the app field the server requires`() {
+        val doc = NightscoutIobDeviceStatus.buildDocument(now, 1.8f, 1.5f, 24f, true)!!
+        // v3 refuses an array, and refuses a document without "app" ("Bad or missing app field").
+        assertTrue(doc, doc.startsWith("{"))
+        val entry = JSONObject(doc)
+        assertEquals("JugglucoNG", entry.getString("app"))
+        assertEquals(now, entry.getLong("date"))
+        assertEquals(1.8, entry.getJSONObject("openaps").getJSONObject("iob").getDouble("iob"), 1e-9)
+        assertEquals(24.0, entry.getJSONObject("jugglucong").getDouble("cob"), 1e-9)
+    }
+
+    @Test
+    fun `the v1 document keeps its array wrapper and needs no app field`() {
+        val doc = NightscoutIobDeviceStatus.buildDocument(now, 1.8f, 1.5f, 24f, false)!!
+        assertTrue(doc, doc.startsWith("["))
+        val entry = JSONArray(doc).getJSONObject(0)
+        assertFalse(entry.has("app"))
+        assertEquals(1.8, entry.getJSONObject("openaps").getJSONObject("iob").getDouble("iob"), 1e-9)
+    }
+
+    @Test
+    fun `both versions carry the same payload`() {
+        val v1 = JSONArray(NightscoutIobDeviceStatus.buildDocument(now, 1.8f, 1.5f, 24f, false)!!).getJSONObject(0)
+        val v3 = JSONObject(NightscoutIobDeviceStatus.buildDocument(now, 1.8f, 1.5f, 24f, true)!!)
+        assertEquals(v1.getJSONObject("jugglucong").toString(), v3.getJSONObject("jugglucong").toString())
+        assertEquals(v1.getJSONObject("openaps").toString(), v3.getJSONObject("openaps").toString())
+        assertEquals(v1.getString("created_at"), v3.getString("created_at"))
+    }
 
     @Test
     fun `first upload is always due`() {

--- a/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerV3Tests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerV3Tests.kt
@@ -1,0 +1,149 @@
+package tk.glucodata.drivers.nightscout
+
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NightscoutFollowerV3Tests {
+
+    private val baseUrl = "https://example.com"
+
+    // -- endpoints ---------------------------------------------------------
+
+    @Test
+    fun followingV3ReadsTheV3CollectionsWithLimitPaging() {
+        val treatments = NightscoutFollowerJournalEndpoints.treatments(baseUrl, useV3 = true)
+        assertTrue(treatments, treatments.startsWith("$baseUrl/api/v3/treatments?"))
+        // v3 pages with limit and has no .json suffix; sending the v1 form answers 401.
+        assertTrue(treatments, treatments.contains("limit=512"))
+        assertFalse(treatments, treatments.contains(".json"))
+        assertFalse(treatments, treatments.contains("count="))
+    }
+
+    @Test
+    fun v1FollowersKeepTheirExistingEndpointsExactly() {
+        assertEquals(
+            "$baseUrl/api/v1/treatments.json?count=512",
+            NightscoutFollowerJournalEndpoints.treatments(baseUrl),
+        )
+        assertEquals(
+            "$baseUrl/api/v1/entries/mbg.json?count=512",
+            NightscoutFollowerJournalEndpoints.fingersticks(baseUrl),
+        )
+        assertTrue(
+            NightscoutFollowerHistoryPaging.endpoint(baseUrl, null, null)
+                .endsWith("/api/v1/entries/sgv.json?count=1000"),
+        )
+    }
+
+    @Test
+    fun sgvAndMbgAreSeparatedByTypeFilterRatherThanBySeparatePaths() {
+        // v3 has no entries/sgv path; the collection is one, filtered by type.
+        val sgv = NightscoutFollowerHistoryPaging.endpoint(baseUrl, null, null, useV3 = true)
+        assertTrue(sgv, sgv.startsWith("$baseUrl/api/v3/entries?"))
+        assertTrue(sgv, sgv.contains("type%24eq=sgv"))
+
+        val mbg = NightscoutFollowerJournalEndpoints.fingersticks(baseUrl, useV3 = true)
+        assertTrue(mbg, mbg.startsWith("$baseUrl/api/v3/entries?"))
+        assertTrue(mbg, mbg.contains("type%24eq=mbg"))
+    }
+
+    @Test
+    fun pagingBoundsTravelAsV3DateFilters() {
+        val page = NightscoutFollowerHistoryPaging.endpoint(baseUrl, 1_000L, 5_000L, useV3 = true)
+        assertTrue(page, page.contains("date%24gte=1000"))
+        assertTrue(page, page.contains("date%24lt=5000"))
+        assertTrue(page, page.contains("limit=1000"))
+    }
+
+    @Test
+    fun deviceStatusFollowsTheSameV3Shape() {
+        val url = NightscoutFollowerV3.deviceStatusUrl(baseUrl, 5)
+        assertTrue(url, url.startsWith("$baseUrl/api/v3/devicestatus?"))
+        assertTrue(url, url.contains("limit=5"))
+        assertFalse(url, url.contains(".json"))
+    }
+
+    // -- envelope ----------------------------------------------------------
+
+    @Test
+    fun theV3ResultEnvelopeIsPeeledForParsersThatExpectAnArray() {
+        val body = """{"status":200,"result":[{"identifier":"a"},{"identifier":"b"}]}"""
+        val array = JSONArray(NightscoutFollowerV3.arrayBody(body))
+        assertEquals(2, array.length())
+        assertEquals("a", array.getJSONObject(0).getString("identifier"))
+    }
+
+    @Test
+    fun aBodyThatIsAlreadyAnArrayPassesThrough() {
+        val array = """[{"identifier":"a"}]"""
+        assertEquals(array, NightscoutFollowerV3.arrayBody(array))
+    }
+
+    @Test
+    fun anEnvelopeWithoutResultBecomesEmptyRatherThanAParseFailure() {
+        assertEquals("[]", NightscoutFollowerV3.arrayBody("""{"status":403}"""))
+    }
+
+    // -- what a refusal reports --------------------------------------------
+
+    @Test
+    fun aRefusedReadReportsThePermissionTheServerNamed() {
+        // A follower token without the read role answers exactly this.
+        assertEquals(
+            "Missing permission api:entries:read",
+            NightscoutFollowerV3.serverMessage("""{"status":403,"message":"Missing permission api:entries:read"}"""),
+        )
+    }
+
+    @Test
+    fun aBodyWithoutAMessageStillReportsSomething() {
+        assertEquals("Unauthorized", NightscoutFollowerV3.serverMessage("Unauthorized"))
+    }
+
+    // -- auth --------------------------------------------------------------
+
+    @Test
+    fun secretsThatAreAlreadyHeaderValuesAreLeftToTheExistingAuthPath() {
+        val now = 1_000_000L
+        // No exchange to make, so the caller falls back to applyAuth rather than
+        // spending a round trip or sending a header it cannot build.
+        assertNull(NightscoutFollowerV3.authorizationHeader(baseUrl, "Bearer abc", now))
+        assertNull(NightscoutFollowerV3.authorizationHeader(baseUrl, "token=abc", now))
+        assertNull(NightscoutFollowerV3.authorizationHeader(baseUrl, "a".repeat(40), now))
+        assertNull(NightscoutFollowerV3.authorizationHeader(baseUrl, "   ", now))
+    }
+
+    // -- repeating failure logging -----------------------------------------
+
+    @Test
+    fun anUnchangedFailureIsLoggedOncePerInterval() {
+        val log = RepeatedFollowerError(intervalMillis = 5 * 60_000L)
+        val start = 1_000_000L
+        assertEquals(0, log.suppressedSince("HTTP 403", start))
+        assertEquals(-1, log.suppressedSince("HTTP 403", start + 30_000L))
+        assertEquals(-1, log.suppressedSince("HTTP 403", start + 60_000L))
+        assertEquals(2, log.suppressedSince("HTTP 403", start + 5 * 60_000L))
+    }
+
+    @Test
+    fun aDifferentFailureIsNeverHiddenBehindTheOldOnesInterval() {
+        val log = RepeatedFollowerError(intervalMillis = 5 * 60_000L)
+        val start = 1_000_000L
+        assertEquals(0, log.suppressedSince("HTTP 403", start))
+        assertEquals(0, log.suppressedSince("HTTP 500", start + 1_000L))
+    }
+
+    @Test
+    fun aSuccessEndsTheEpisodeAndABackwardsClockDoesNotSilenceIt() {
+        val log = RepeatedFollowerError(intervalMillis = 5 * 60_000L)
+        val start = 1_000_000L
+        assertEquals(0, log.suppressedSince("HTTP 403", start))
+        log.reset()
+        assertEquals(0, log.suppressedSince("HTTP 403", start + 1_000L))
+        assertEquals(0, log.suppressedSince("HTTP 403", start - 60_000L))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutModePreferenceTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutModePreferenceTests.kt
@@ -1,0 +1,38 @@
+package tk.glucodata.drivers.nightscout
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NightscoutModePreferenceTests {
+    @Test
+    fun savedFollowModeSurvivesBothServicesBeingDisabled() {
+        assertEquals(
+            NightscoutModePreference.Mode.FOLLOW,
+            NightscoutModePreference.resolve(
+                stored = "FOLLOW",
+                legacyUploaderActive = false,
+                legacyFollowerEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun legacyInstallInfersTheOnlyActiveService() {
+        assertEquals(
+            NightscoutModePreference.Mode.FOLLOW,
+            NightscoutModePreference.resolve(
+                stored = null,
+                legacyUploaderActive = false,
+                legacyFollowerEnabled = true,
+            ),
+        )
+        assertEquals(
+            NightscoutModePreference.Mode.UPLOAD,
+            NightscoutModePreference.resolve(
+                stored = null,
+                legacyUploaderActive = true,
+                legacyFollowerEnabled = false,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Follow-up to #202, which inventoried the remaining hardcoded `api/v1` paths and deliberately left two of them out as separate work. This is that work. It does not depend on #202 and can land in either order.

**Device status has no v3 variant at all.** Entries and treatments each build a v1 and a v3 upload URL and pick between them by the configured API version. Device status is built once, v1 only, and both consumers, the uploader battery and the journal IOB, run unconditionally after that fork. It works today because the secret is nulled under v3 and the upload falls through to a bearer token, so it succeeds anywhere v1 accepts bearer auth, but there is no v3 path to fall back on if a deployment turns v1 off.

The endpoint now follows the setting. v1 and v3 disagree on more than the path, so both document builders branch as well: v3 stores a single document rather than an array, and rejects one without an `app` field. The payload is unchanged in both directions, and the cadence, the throttle and the token acquisition are untouched.

One deliberate deviation worth flagging: device status stays out of the readiness check. Its comment says it is excluded so a failure there cannot hold back glucose, and since `makeuploadurl` can only fail on the same base URL that entries and treatments already gate on, adding it would gain nothing and could only cost.

**Follower mode is entirely v1.** All four follower fetches are unconditional v1 literals, and the follower's auth helper has no token exchange: anything that is not already a bearer or `token=` value gets SHA-1'd into an `api-secret` header, the same construction that caused the 401 in #202. So a v3-only server cannot be followed at all.

Two design points came out of tracing rather than from the plan:

- **The follower carries its own API version.** The existing v3 flag is an uploader setting and never reaches follower code, and a follower may point at a different server than the phone uploads to, so reusing it would be wrong the moment those differ. It is a new follower preference, off by default, so existing installs are untouched.
- **The token cannot be shared with the uploader.** `NightPost.gettoken` mints its token from the uploader's own URL and secret and caches it in a single field with no record of which host it came from, so a follower on another server would be handed a JWT signed by the wrong one. The follower does its own exchange and caches the result against the credentials that produced it.

Beyond the endpoints, v3 pages with `limit` and has no `.json` suffix, has no `entries/sgv` path so sgv and mbg are separated by a `type$eq` filter on one collection, and wraps documents in `{status, result}`, which is peeled before every parser that expects an array.

Failures now name the endpoint and the server's own words. A follower needs `api:entries:read`, `api:treatments:read` and `api:devicestatus:read`; a token missing one answers `Missing permission ...`, which is the sentence that stops this looking like a server fault. Repeating identical failures are logged once per five minutes rather than a stack trace every thirty seconds. The required permissions are documented next to the setting, along with the fact that role changes only take effect at the next token exchange, since Nightscout carries permissions in the JWT and a cached token can be hours old.

Verified against a live v3 instance (Nightscout 15.0.7): the `{status, result}` envelope, `limit` paging, bearer auth from `/api/v2/authorization/request/<token>`, that `type$eq` filtering actually applies, that device status documents carry `identifier` and no `_id`, and that a device status POST without `app` returns `400 Bad or missing app field` while one with it returns `201`.

Two commits, one per area. 113 follower tests pass, including the 99 that already existed, plus the device status document tests. Both new strings are translated into all maintained locales.

Not in scope: the upload format, the cadence, the paths #202 fixes, Juggluco's own served API, and the dead v1 delete in `uploadtreatment.cpp`.

## Mode persistence

The latest follow-up keeps the selected Nightscout mode independent of the master enabled switch. A phone configured as a follower now returns to Follow after Nightscout is disabled and re-enabled instead of silently defaulting to Upload.

Existing installs infer the active mode once, then persist the explicit Upload or Follow choice. Disabling Follow also clears cached follower device status so stale IOB cannot remain visible while the receiver is off.

The preference resolution tests are included in the full mobile unit-test pass.
