### PR TITLE
Alerts: dismissing a full-screen alarm returns to the app you were using

### DIFF
--- a/Common/src/main/AndroidManifest.xml
+++ b/Common/src/main/AndroidManifest.xml
@@ -229,6 +229,9 @@
         <activity
             android:name=".ui.AlarmActivity"
             android:exported="false"
+            android:taskAffinity=""
+            android:excludeFromRecents="true"
+            android:autoRemoveFromRecents="true"
             android:showOnLockScreen="true"
             android:showWhenLocked="true"
             android:turnScreenOn="true"

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -2528,8 +2528,7 @@ public class Notify {
         try {
             Intent alarmIntent = buildAlarmActivityIntent(glucoseValue, alarmMessage, rate, alertTypeId,
                     customAlertId, deliveryMode);
-            alarmIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP
-                    | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            alarmIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
             Applic.app.startActivity(alarmIntent);
             return true;
         } catch (Throwable e) {

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -19,6 +19,7 @@ object AlertRepository {
     private const val PREFS_NAME = "tk.glucodata.alerts"
     private const val DEFAULT_THRESHOLD_MIGRATION_KEY = "alert_threshold_defaults_v3"
     private const val KEY_NOTIFICATION_DISMISS_ACTION = "notification_dismiss_action"
+    private const val KEY_RETURN_TO_PREVIOUS_APP_AFTER_ALARM = "alarm_return_to_previous_app"
     @Volatile
     private var hiddenLegacyAlertCleanupDone = false
     @Volatile
@@ -166,6 +167,17 @@ object AlertRepository {
     fun saveNotificationDismissAction(action: AlertNotificationDismissAction) {
         prefs.edit {
             putString(KEY_NOTIFICATION_DISMISS_ACTION, action.name)
+        }
+    }
+
+    /** After a full-screen alarm is dismissed or snoozed, return to the app that was open (default) instead of opening JugglucoNG. */
+    fun loadReturnToPreviousAppAfterAlarm(): Boolean {
+        return prefs.getBoolean(KEY_RETURN_TO_PREVIOUS_APP_AFTER_ALARM, true)
+    }
+
+    fun saveReturnToPreviousAppAfterAlarm(enabled: Boolean) {
+        prefs.edit {
+            putBoolean(KEY_RETURN_TO_PREVIOUS_APP_AFTER_ALARM, enabled)
         }
     }
     

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -618,6 +618,8 @@
     <string name="notification_dismiss_action_summary">Змахванне або закрыццё апавяшчэнняў</string>
     <string name="notification_dismiss_action_dismiss">Закрыць</string>
     <string name="notification_dismiss_action_snooze">Адкласці</string>
+    <string name="alarm_return_to_previous_app_title">Вяртацца да папярэдняй праграмы пасля сігналу</string>
+    <string name="alarm_return_to_previous_app_summary">Пасля поўнаэкраннага сігналу вяртацца да праграмы, якой вы карысталіся, замест адкрыцця JugglucoNG</string>
     <string name="realert_if_not_dismissed">Паўтараць, калі не адхілена</string>
     <string name="retry_every">Паўтараць кожныя</string>
     <string name="retry_if_no_reaction">Паўтараць пры адсутнасці рэакцыі</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -719,6 +719,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="notification_dismiss_action_summary">Benachrichtigungen wegwischen oder schließen</string>
     <string name="notification_dismiss_action_dismiss">Verwerfen</string>
     <string name="notification_dismiss_action_snooze">Schlummern</string>
+    <string name="alarm_return_to_previous_app_title">Nach Alarm zur vorherigen App zurückkehren</string>
+    <string name="alarm_return_to_previous_app_summary">Nach einem Vollbild-Alarm zur zuvor geöffneten App zurückkehren, statt JugglucoNG zu öffnen</string>
     <string name="realert_if_not_dismissed">Erneut alarmieren, wenn nicht verworfen</string>
     <string name="retry_every">Wiederholen alle</string>
     <string name="retry_if_no_reaction">Wiederholen bei keiner Reaktion</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -575,6 +575,8 @@
     <string name="notification_dismiss_action_summary">Balayage ou fermeture des notifications</string>
     <string name="notification_dismiss_action_dismiss">Ignorer</string>
     <string name="notification_dismiss_action_snooze">Répéter</string>
+    <string name="alarm_return_to_previous_app_title">Revenir à l\'application précédente après une alarme</string>
+    <string name="alarm_return_to_previous_app_summary">Après une alarme plein écran, revenir à l\'application que vous utilisiez au lieu d\'ouvrir JugglucoNG</string>
     <string name="realert_if_not_dismissed">Realerter si non ignoree</string>
     <string name="retry_every">Reessayer toutes les</string>
     <string name="retry_if_no_reaction">Reessayer si aucune reaction</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -501,6 +501,8 @@
     <string name="notification_dismiss_action_summary">Scorri o chiudi le notifiche</string>
     <string name="notification_dismiss_action_dismiss">Ignora</string>
     <string name="notification_dismiss_action_snooze">Posticipa</string>
+    <string name="alarm_return_to_previous_app_title">Torna all\'app precedente dopo l\'allarme</string>
+    <string name="alarm_return_to_previous_app_summary">Dopo un allarme a schermo intero, torna all\'app che stavi usando invece di aprire JugglucoNG</string>
     <string name="realert_if_not_dismissed">Ripeti se non ignorato</string>
     <string name="retry_every">Ripeti ogni</string>
     <string name="retry_if_no_reaction">Ripeti se nessuna reazione</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2086,6 +2086,8 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="notification_dismiss_action_summary">Мэдэгдлийг шудрах эсвэл хаах</string>
     <string name="notification_dismiss_action_dismiss">Хаах</string>
     <string name="notification_dismiss_action_snooze">Түр хойшлуулах</string>
+    <string name="alarm_return_to_previous_app_title">Дохионы дараа өмнөх апп руу буцах</string>
+    <string name="alarm_return_to_previous_app_summary">Бүтэн дэлгэцийн дохионы дараа JugglucoNG-г нээхийн оронд ашиглаж байсан апп руу буцна</string>
     <string name="calibrate_after_24h">24 цагийн дараа тохируулна</string>
     <string name="anytime_calibration_sent_status">Тохируулга илгээгдсэн; мэдрэгчийг хүлээж байна</string>
     <string name="anytime_calibration_accepted_status">Тохируулга зөвшөөрөгдсөн; #%1$d уншилтаас хэрэглэгдэнэ</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -716,6 +716,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="notification_dismiss_action_summary">Meldingen wegvegen of sluiten</string>
     <string name="notification_dismiss_action_dismiss">Sluiten</string>
     <string name="notification_dismiss_action_snooze">Snoozen</string>
+    <string name="alarm_return_to_previous_app_title">Na alarm terug naar vorige app</string>
+    <string name="alarm_return_to_previous_app_summary">Na een schermvullend alarm teruggaan naar de app die je gebruikte in plaats van JugglucoNG te openen</string>
     <string name="realert_if_not_dismissed">Opnieuw waarschuwen als niet weggeveegd</string>
     <string name="retry_every">Herhalen elke</string>
     <string name="retry_if_no_reaction">Herhalen bij geen reactie</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -703,6 +703,8 @@
     <string name="notification_dismiss_action_summary">Przesuniecie lub zamkniecie powiadomien</string>
     <string name="notification_dismiss_action_dismiss">Odrzuc</string>
     <string name="notification_dismiss_action_snooze">Odloz</string>
+    <string name="alarm_return_to_previous_app_title">Po alarmie wróć do poprzedniej aplikacji</string>
+    <string name="alarm_return_to_previous_app_summary">Po alarmie pełnoekranowym wróć do używanej aplikacji zamiast otwierać JugglucoNG</string>
     <string name="realert_if_not_dismissed">Ponow alarm, jesli nie odrzucono</string>
     <string name="retry_every">Ponow co</string>
     <string name="retry_if_no_reaction">Ponow przy braku reakcji</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -528,6 +528,8 @@
     <string name="notification_dismiss_action_summary">Deslizar ou fechar notificações</string>
     <string name="notification_dismiss_action_dismiss">Dispensar</string>
     <string name="notification_dismiss_action_snooze">Adiar</string>
+    <string name="alarm_return_to_previous_app_title">Voltar à app anterior após o alarme</string>
+    <string name="alarm_return_to_previous_app_summary">Após um alarme em ecrã inteiro, voltar à app que estava a usar em vez de abrir o JugglucoNG</string>
     <string name="realert_if_not_dismissed">Alertar novamente se nao descartado</string>
     <string name="retry_every">Repetir a cada</string>
     <string name="retry_if_no_reaction">Repetir se nao houver reacao</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -747,6 +747,8 @@
     <string name="notification_dismiss_action_summary">Смахивание или закрытие уведомлений</string>
     <string name="notification_dismiss_action_dismiss">Закрыть</string>
     <string name="notification_dismiss_action_snooze">Отложить</string>
+    <string name="alarm_return_to_previous_app_title">Возвращаться в предыдущее приложение после сигнала</string>
+    <string name="alarm_return_to_previous_app_summary">После полноэкранного сигнала возвращаться в приложение, которым вы пользовались, вместо открытия JugglucoNG</string>
     <string name="realert_if_not_dismissed">Повторять, если не отклонено</string>
     <string name="retry_every">Повторять каждые</string>
     <string name="retry_if_no_reaction">Повторять при отсутствии реакции</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1245,6 +1245,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="notification_dismiss_action_summary">Dhaq ama xidh ogeysiisyada digniinta</string>
     <string name="notification_dismiss_action_dismiss">Eryi</string>
     <string name="notification_dismiss_action_snooze">Hurdo</string>
+    <string name="alarm_return_to_previous_app_title">Digniinta ka dib ku noqo abka hore</string>
+    <string name="alarm_return_to_previous_app_summary">Digniin shaashad-buuxa ka dib, ku noqo abka aad isticmaalaysay halkii aad ka furi lahayd JugglucoNG</string>
     <string name="realert_if_not_dismissed">Dib-u-wargelinta haddii aan la dirin</string>
     <string name="retry_constantly">Si joogto ah</string>
     <string name="retry_every">Isku day mid kasta</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -628,6 +628,8 @@
     <string name="notification_dismiss_action_summary">Svep bort eller stäng aviseringar</string>
     <string name="notification_dismiss_action_dismiss">Avvisa</string>
     <string name="notification_dismiss_action_snooze">Snooza</string>
+    <string name="alarm_return_to_previous_app_title">Återgå till föregående app efter larm</string>
+    <string name="alarm_return_to_previous_app_summary">Efter ett helskärmslarm, gå tillbaka till appen du använde i stället för att öppna JugglucoNG</string>
     <string name="realert_if_not_dismissed">Varna igen om inte avvisad</string>
     <string name="retry_every">Upprepa var</string>
     <string name="retry_if_no_reaction">Upprepa vid ingen reaktion</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -680,6 +680,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="notification_dismiss_action_summary">Bildirimleri kaydirma veya kapatma</string>
     <string name="notification_dismiss_action_dismiss">Kapat</string>
     <string name="notification_dismiss_action_snooze">Ertele</string>
+    <string name="alarm_return_to_previous_app_title">Alarmdan sonra önceki uygulamaya dön</string>
+    <string name="alarm_return_to_previous_app_summary">Tam ekran alarmdan sonra JugglucoNG\'yi açmak yerine kullandığınız uygulamaya dönün</string>
     <string name="realert_if_not_dismissed">Kapatilmazsa tekrar uyar</string>
     <string name="retry_every">Su aralikla tekrarla</string>
     <string name="retry_if_no_reaction">Tepki yoksa tekrarla</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -640,6 +640,8 @@
     <string name="notification_dismiss_action_summary">Змахування або закриття сповіщень</string>
     <string name="notification_dismiss_action_dismiss">Закрити</string>
     <string name="notification_dismiss_action_snooze">Відкласти</string>
+    <string name="alarm_return_to_previous_app_title">Повертатися до попереднього застосунку після сигналу</string>
+    <string name="alarm_return_to_previous_app_summary">Після повноекранного сигналу повертатися до застосунку, яким ви користувалися, замість відкриття JugglucoNG</string>
     <string name="realert_if_not_dismissed">Повторювати, якщо не відхилено</string>
     <string name="retry_every">Повторювати кожні</string>
     <string name="retry_if_no_reaction">Повторювати, якщо немає реакції</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -640,6 +640,8 @@
     <string name="notification_dismiss_action_summary">滑动或关闭通知</string>
     <string name="notification_dismiss_action_dismiss">关闭</string>
     <string name="notification_dismiss_action_snooze">稍后提醒</string>
+    <string name="alarm_return_to_previous_app_title">警报后返回上一个应用</string>
+    <string name="alarm_return_to_previous_app_summary">全屏警报结束后返回您之前使用的应用，而不是打开 JugglucoNG</string>
     <string name="realert_if_not_dismissed">未关闭则再次提醒</string>
     <string name="retry_every">重试间隔</string>
     <string name="retry_if_no_reaction">无响应时重试</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1306,6 +1306,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_dismiss_action_summary">Swipe or close alert notifications</string>
     <string name="notification_dismiss_action_dismiss">Dismiss</string>
     <string name="notification_dismiss_action_snooze">Snooze</string>
+    <string name="alarm_return_to_previous_app_title">Return to previous app after alarm</string>
+    <string name="alarm_return_to_previous_app_summary">After a full-screen alarm, go back to the app you were using instead of opening JugglucoNG</string>
     <string name="realert_if_not_dismissed">Re-alert if not dismissed</string>
     <string name="retry_constantly">Constantly</string>
     <string name="retry_every">Retry every</string>

--- a/Common/src/mobile/java/tk/glucodata/receivers/AlarmLaunchReceiver.kt
+++ b/Common/src/mobile/java/tk/glucodata/receivers/AlarmLaunchReceiver.kt
@@ -12,7 +12,6 @@ class AlarmLaunchReceiver : BroadcastReceiver() {
             val alarmIntent = Intent(context.applicationContext, AlarmActivity::class.java).apply {
                 putExtras(intent)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or
-                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
                     Intent.FLAG_ACTIVITY_SINGLE_TOP or
                     Intent.FLAG_ACTIVITY_NO_USER_ACTION
             }

--- a/Common/src/mobile/java/tk/glucodata/ui/AlarmActivity.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/AlarmActivity.kt
@@ -16,6 +16,8 @@ import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.Locale
 import tk.glucodata.GlucosePoint
+import tk.glucodata.Log
+import tk.glucodata.MainActivity
 import tk.glucodata.Natives
 import tk.glucodata.Notify
 import tk.glucodata.SensorBluetooth
@@ -111,7 +113,7 @@ class AlarmActivity : ComponentActivity() {
                         Notify.cancelCurrentRetrySession("alarm-activity-snooze-after-stop")
                     }
                     cancelAlarmNotification()
-                    finish()
+                    leaveAlarmScreen()
                 },
                 onDismiss = {
                     Notify.cancelQueuedAlarmActivityLaunch(
@@ -131,7 +133,7 @@ class AlarmActivity : ComponentActivity() {
                         }
                     }
                     cancelAlarmNotification()
-                    finish()
+                    leaveAlarmScreen()
                 }
             )
         }
@@ -326,6 +328,31 @@ class AlarmActivity : ComponentActivity() {
         (getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager)?.cancel(81432)
     }
 
+    /**
+     * Called after snooze/dismiss has been fully handled. The activity lives in
+     * its own task (taskAffinity=""), so removing that task hands the screen back
+     * to whatever was visible before the alarm: the previous app, or the lock
+     * screen. Only the task goes away; the process, the foreground service and
+     * the alarm pipeline are untouched. With the setting off, JugglucoNG is
+     * brought to the front first, which is what the shared-task setup used to do.
+     */
+    private fun leaveAlarmScreen() {
+        if (!AlertRepository.loadReturnToPreviousAppAfterAlarm()) {
+            openMainApp()
+        }
+        finishAndRemoveTask()
+    }
+
+    private fun openMainApp() {
+        try {
+            val launch = packageManager.getLaunchIntentForPackage(packageName)
+                ?: Intent(this, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(launch)
+        } catch (t: Throwable) {
+            Log.stack(LOG_ID, "openMainApp", t)
+        }
+    }
+
     private fun turnScreenOnAndKeyguard() {
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         wakeHoldHandler.removeCallbacks(releaseWakeHold)
@@ -363,6 +390,7 @@ class AlarmActivity : ComponentActivity() {
         const val EXTRA_ALERT_TYPE_ID = "EXTRA_ALERT_TYPE_ID"
         const val EXTRA_RATE = "EXTRA_RATE"
         private const val ALARM_SCREEN_WAKE_HOLD_MS = 45_000L
+        private const val LOG_ID = "AlarmActivity"
 
         fun createIntent(
             context: Context,
@@ -378,7 +406,7 @@ class AlarmActivity : ComponentActivity() {
                 putExtra(EXTRA_ALARM_MESSAGE, alarmMessage)
                 putExtra(EXTRA_ALERT_TYPE_ID, alertTypeId)
                 putExtra(EXTRA_RATE, rate)
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
         }
     }

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.automirrored.filled.TrendingDown
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
@@ -187,6 +188,13 @@ fun AlertSettingsScreen(
     fun persistNotificationDismissAction(action: AlertNotificationDismissAction) {
         notificationDismissAction = action
         AlertRepository.saveNotificationDismissAction(action)
+    }
+    var returnToPreviousAppAfterAlarm by remember {
+        mutableStateOf(AlertRepository.loadReturnToPreviousAppAfterAlarm())
+    }
+    fun persistReturnToPreviousAppAfterAlarm(enabled: Boolean) {
+        returnToPreviousAppAfterAlarm = enabled
+        AlertRepository.saveReturnToPreviousAppAfterAlarm(enabled)
     }
 
     Scaffold(
@@ -508,6 +516,14 @@ fun AlertSettingsScreen(
                 NotificationDismissActionPreference(
                     action = notificationDismissAction,
                     onActionChange = { persistNotificationDismissAction(it) }
+                )
+            }
+
+            item(key = "alarm-return-to-previous-app") {
+                Spacer(Modifier.height(8.dp))
+                ReturnToPreviousAppPreference(
+                    enabled = returnToPreviousAppAfterAlarm,
+                    onEnabledChange = { persistReturnToPreviousAppAfterAlarm(it) }
                 )
             }
 
@@ -1611,6 +1627,62 @@ private fun NotificationDismissActionPreference(
                 selectedContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 unselectedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.56f),
                 unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReturnToPreviousAppPreference(
+    enabled: Boolean,
+    onEnabledChange: (Boolean) -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.24f)
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .clickable { onEnabledChange(!enabled) }
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Surface(
+                modifier = Modifier.size(40.dp),
+                shape = RoundedCornerShape(12.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerHighest
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ExitToApp,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.alarm_return_to_previous_app_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = stringResource(R.string.alarm_return_to_previous_app_summary),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            StyledSwitch(
+                checked = enabled,
+                onCheckedChange = onEnabledChange
             )
         }
     }


### PR DESCRIPTION
Dismissing a full-screen alarm leaves you in JugglucoNG rather than back in whatever app you were using. It happens with every full-screen alarm that fires over another app.

`AlarmActivity` declares no `taskAffinity`, so it runs inside NG's own task, on top of the dashboard. After `finish()` what is underneath is the dashboard, and that is what stays in front. The app you were using is still there, just in a task Android never returns to.

The activity now gets its own task: `taskAffinity=""`, excluded from recents, auto-removed. Snooze and dismiss end with `finishAndRemoveTask()`, so the task disappears and Android goes back to whatever was visible before: the previous app, or the lock screen if the device was locked. `FLAG_ACTIVITY_CLEAR_TOP` is dropped from the three launch sites (`Notify.showpopupalarm`, `AlarmLaunchReceiver`, `AlarmActivity.createIntent`); in a task that only ever holds this one `singleTask` activity there is nothing for it to clear.

**Setting.** "Return to previous app after alarm" under Alerts, on by default. Landing in NG was a side effect of the task setup rather than a choice, and anyone who wants NG after an alarm can tap the notification. With the setting off, the alarm screen brings JugglucoNG to the front before it closes, which is what you got before. The task affinity is a manifest attribute and cannot be switched at runtime, so this is how the old behaviour is kept.

**What does not change.**

- The alarm pipeline. `finishAndRemoveTask` removes only the activity's task, not the app, the foreground service or the retry session. Sound, vibration and the episode latch are still governed by `runstopalarm`. Snooze and dismiss handling (`SnoozeManager`, `AlertStateTracker`, `Notify.stopalarm`, `cancelCurrentRetrySession`) runs to completion in-process, synchronously, before the task goes away, so acknowledging an alarm cannot leave it ringing.
- Re-triggering while the alarm is up. `launchMode="singleTask"` and `onNewIntent` stay. With `taskAffinity=""` the system finds the existing alarm task by its root component, so a second alarm, or a tap on the notification's full-screen intent, lands in the same window. Nothing stacks.
- Lock screen. `showOnLockScreen`, `showWhenLocked` and `turnScreenOn` are untouched. With no previous app the lock screen comes back; NG does not open.
- Wear. The Wear manifest and its `AlarmActivity` are not touched.

The toggle's strings are in all maintained locales.

**On a device**

1. Alarm over another app, dismiss: you are back in that app.
2. Dismiss and snooze still take effect (sound stops, snooze is recorded) with the task removed right after.
3. Second alarm while the window is open: same window, no second one.
4. Tap the notification while the alarm is open: same window.
5. Alarm on the lock screen, dismiss: lock screen, not NG.
6. Setting off: NG opens after dismiss, as before.
7. Alarm while NG itself was in front: NG again after dismiss, no empty screen.

`:Common:testMobileReleaseUnitTest` passes. Not device-tested from here.

