### PR TITLE
Readiness: full-screen alarm permission is checked on every start

### DIFF
--- a/Common/src/main/java/tk/glucodata/alerts/FullScreenIntentReadiness.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/FullScreenIntentReadiness.kt
@@ -1,0 +1,43 @@
+package tk.glucodata.alerts
+
+import tk.glucodata.AlertDeliveryPolicy
+
+/**
+ * Pure rules for the "full-screen alarms" readiness check.
+ *
+ * Since Android 14 the USE_FULL_SCREEN_INTENT permission is no longer granted
+ * just because the manifest declares it: for apps whose core function is not
+ * calling or alarms it can be missing after install and is taken away again
+ * with app updates, and only the user can re-grant it from system settings.
+ * Without it a full-screen alarm silently degrades to a plain notification on
+ * a locked screen. The readiness card only matters when at least one alert
+ * actually uses full-screen delivery.
+ */
+object FullScreenIntentReadiness {
+    /** Build.VERSION_CODES.UPSIDE_DOWN_CAKE, kept as a plain int so tests need no Android stubs. */
+    const val FIRST_ENFORCED_SDK = 34
+
+    fun isEnforced(sdkInt: Int): Boolean = sdkInt >= FIRST_ENFORCED_SDK
+
+    fun usesFullScreenDelivery(config: AlertConfig): Boolean {
+        return config.enabled &&
+            AlertDeliveryPolicy.shouldAttachFullScreenIntent(AlertDeliveryPolicy.normalize(config.deliveryMode.name))
+    }
+
+    fun usesFullScreenDelivery(config: CustomAlertConfig): Boolean {
+        return config.enabled &&
+            AlertDeliveryPolicy.shouldAttachFullScreenIntent(AlertDeliveryPolicy.normalize(config.style))
+    }
+
+    fun anyAlertUsesFullScreen(
+        alerts: Collection<AlertConfig>,
+        customAlerts: Collection<CustomAlertConfig>
+    ): Boolean {
+        return alerts.any(::usesFullScreenDelivery) || customAlerts.any(::usesFullScreenDelivery)
+    }
+
+    /** The readiness item is shown only where the permission can actually be missing and matters. */
+    fun shouldCheck(sdkInt: Int, anyAlertUsesFullScreen: Boolean): Boolean {
+        return isEnforced(sdkInt) && anyAlertUsesFullScreen
+    }
+}

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1761,6 +1761,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_open_location_action">Адкрыць геалакацыю</string>
     <string name="cgm_readiness_open_notifications_action">Адкрыць апавяшчэнні</string>
     <string name="cgm_readiness_open_alarm_action">Адкрыць доступ будзільнікаў</string>
+    <string name="cgm_readiness_open_full_screen_action">Дазволіць поўнаэкранныя трывогі</string>
     <string name="cgm_readiness_open_battery_action">Адкрыць налады батарэі</string>
     <string name="cgm_readiness_open_dnd_action">Адкрыць доступ DND</string>
     <string name="cgm_readiness_open_overlay_action">Адкрыць доступ накладання</string>
@@ -1788,6 +1789,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_exact_alarm_title">Дакладныя будзільнікі</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Планаванне дакладных будзільнікаў дазволена.</string>
     <string name="cgm_readiness_exact_alarm_detail">Дазвольце дакладныя будзільнікі для надзейных напамінаў, праверак перападключэння і тэрміновых трывог.</string>
+    <string name="cgm_readiness_full_screen_title">Поўнаэкранныя трывогі</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Трывогі могуць абуджаць заблакаваны экран.</string>
+    <string name="cgm_readiness_full_screen_detail">Без гэтага дазволу трывогі больш не абуджаюць заблакаваны экран і паказваюцца толькі як апавяшчэнне. Android можа адклікаць яго пры кожным абнаўленні праграмы — правярайце пасля абнаўленняў.</string>
     <string name="cgm_readiness_battery_title">Батарэя без абмежаванняў</string>
     <string name="cgm_readiness_battery_ready_detail">Аптымізацыя батарэі Android выключана для гэтай праграмы.</string>
     <string name="cgm_readiness_battery_detail">Выключыце аптымізацыю батарэі, каб фонавыя BLE, трывогі і сеткавая сінхранізацыя не спыняліся.</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1812,6 +1812,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="cgm_readiness_open_location_action">Standort öffnen</string>
     <string name="cgm_readiness_open_notifications_action">Benachrichtigungen öffnen</string>
     <string name="cgm_readiness_open_alarm_action">Alarmzugriff öffnen</string>
+    <string name="cgm_readiness_open_full_screen_action">Vollbild-Alarme erlauben</string>
     <string name="cgm_readiness_open_battery_action">Akku-Einstellungen öffnen</string>
     <string name="cgm_readiness_open_dnd_action">DND-Zugriff öffnen</string>
     <string name="cgm_readiness_open_overlay_action">Overlay-Zugriff öffnen</string>
@@ -1839,6 +1840,9 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="cgm_readiness_exact_alarm_title">Exakte Alarme</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Exakte Alarmplanung ist erlaubt.</string>
     <string name="cgm_readiness_exact_alarm_detail">Exakte Alarme für zuverlässige Erinnerungen, Wiederverbindungsprüfungen und zeitkritische Alarme erlauben.</string>
+    <string name="cgm_readiness_full_screen_title">Vollbild-Alarme</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Alarme dürfen den gesperrten Bildschirm aufwecken.</string>
+    <string name="cgm_readiness_full_screen_detail">Ohne diese Berechtigung wecken Alarme den gesperrten Bildschirm nicht mehr auf und erscheinen nur als Benachrichtigung. Android kann sie bei jedem App-Update wieder entziehen – nach Updates prüfen.</string>
     <string name="cgm_readiness_battery_title">Akku uneingeschränkt</string>
     <string name="cgm_readiness_battery_ready_detail">Android-Akkuoptimierung ist für diese App deaktiviert.</string>
     <string name="cgm_readiness_battery_detail">Akkuoptimierung deaktivieren, damit Hintergrund-BLE, Alarme und Netzwerksync nicht gestoppt werden.</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1693,6 +1693,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_open_location_action">Ouvrir Localisation</string>
     <string name="cgm_readiness_open_notifications_action">Ouvrir Notifications</string>
     <string name="cgm_readiness_open_alarm_action">Ouvrir accès alarmes</string>
+    <string name="cgm_readiness_open_full_screen_action">Autoriser les alarmes plein écran</string>
     <string name="cgm_readiness_open_battery_action">Ouvrir paramètres batterie</string>
     <string name="cgm_readiness_open_dnd_action">Ouvrir accès NPD</string>
     <string name="cgm_readiness_open_overlay_action">Ouvrir accès superposition</string>
@@ -1720,6 +1721,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_exact_alarm_title">Alarmes exactes</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Planification des alarmes exactes autorisée.</string>
     <string name="cgm_readiness_exact_alarm_detail">Autorisez les alarmes exactes pour rappels fiables, contrôles de reconnexion et alertes urgentes.</string>
+    <string name="cgm_readiness_full_screen_title">Alarmes plein écran</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Les alarmes peuvent réveiller l’écran verrouillé.</string>
+    <string name="cgm_readiness_full_screen_detail">Sans cette autorisation, les alarmes ne réveillent plus l’écran verrouillé et n’apparaissent que comme notification. Android peut la retirer à chaque mise à jour de l’app : vérifiez-la après une mise à jour.</string>
     <string name="cgm_readiness_battery_title">Batterie sans restriction</string>
     <string name="cgm_readiness_battery_ready_detail">Optimisation batterie Android désactivée pour cette app.</string>
     <string name="cgm_readiness_battery_detail">Désactivez l’optimisation batterie pour éviter l’arrêt du BLE arrière-plan, des alarmes et de la synchro réseau.</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1677,6 +1677,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_open_location_action">Apri Posizione</string>
     <string name="cgm_readiness_open_notifications_action">Apri Notifiche</string>
     <string name="cgm_readiness_open_alarm_action">Apri accesso allarmi</string>
+    <string name="cgm_readiness_open_full_screen_action">Consenti allarmi a schermo intero</string>
     <string name="cgm_readiness_open_battery_action">Apri impostazioni batteria</string>
     <string name="cgm_readiness_open_dnd_action">Apri accesso DND</string>
     <string name="cgm_readiness_open_overlay_action">Apri accesso overlay</string>
@@ -1704,6 +1705,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_exact_alarm_title">Allarmi esatti</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Pianificazione allarmi esatti consentita.</string>
     <string name="cgm_readiness_exact_alarm_detail">Consenti allarmi esatti per promemoria affidabili, controlli di riconnessione e avvisi urgenti.</string>
+    <string name="cgm_readiness_full_screen_title">Allarmi a schermo intero</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Gli allarmi possono riattivare lo schermo bloccato.</string>
+    <string name="cgm_readiness_full_screen_detail">Senza questa autorizzazione gli allarmi non riattivano più lo schermo bloccato e compaiono solo come notifica. Android può revocarla a ogni aggiornamento dell’app: controllala dopo gli aggiornamenti.</string>
     <string name="cgm_readiness_battery_title">Batteria senza restrizioni</string>
     <string name="cgm_readiness_battery_ready_detail">Ottimizzazione batteria Android disattivata per questa app.</string>
     <string name="cgm_readiness_battery_detail">Disattiva ottimizzazione batteria per non fermare BLE in background, allarmi e sincronizzazione rete.</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1722,6 +1722,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="cgm_readiness_open_location_action">Open Location</string>
     <string name="cgm_readiness_open_notifications_action">Open Notifications</string>
     <string name="cgm_readiness_open_alarm_action">Open Alarm access</string>
+    <string name="cgm_readiness_open_full_screen_action">Allow full-screen alarms</string>
     <string name="cgm_readiness_open_battery_action">Open Battery settings</string>
     <string name="cgm_readiness_open_dnd_action">Open DND access</string>
     <string name="cgm_readiness_open_overlay_action">Open Overlay access</string>
@@ -1749,6 +1750,9 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="cgm_readiness_exact_alarm_title">Exact alarms</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Exact alarm scheduling is allowed.</string>
     <string name="cgm_readiness_exact_alarm_detail">Allow exact alarms for reliable reminders, reconnect checks, and time-critical alerts.</string>
+    <string name="cgm_readiness_full_screen_title">Full-screen alarms</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Alarms are allowed to wake the locked screen.</string>
+    <string name="cgm_readiness_full_screen_detail">Without this permission alarms no longer wake a locked screen and only show as a notification. Android can take it away again with every app update, so check it after updating.</string>
     <string name="cgm_readiness_battery_title">Battery unrestricted</string>
     <string name="cgm_readiness_battery_ready_detail">Android battery optimization is disabled for this app.</string>
     <string name="cgm_readiness_battery_detail">Disable battery optimization so background BLE, alarms, and network sync are not stopped.</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1730,6 +1730,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="cgm_readiness_open_location_action">Locatie openen</string>
     <string name="cgm_readiness_open_notifications_action">Meldingen openen</string>
     <string name="cgm_readiness_open_alarm_action">Alarmtoegang openen</string>
+    <string name="cgm_readiness_open_full_screen_action">Schermvullende alarmen toestaan</string>
     <string name="cgm_readiness_open_battery_action">Batterij-instellingen openen</string>
     <string name="cgm_readiness_open_dnd_action">Niet storen-toegang openen</string>
     <string name="cgm_readiness_open_overlay_action">Overlay-toegang openen</string>
@@ -1757,6 +1758,9 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="cgm_readiness_exact_alarm_title">Exacte alarmen</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Exacte alarmplanning is toegestaan.</string>
     <string name="cgm_readiness_exact_alarm_detail">Sta exacte alarmen toe voor betrouwbare herinneringen, reconnect-controles en tijdkritieke alarmen.</string>
+    <string name="cgm_readiness_full_screen_title">Schermvullende alarmen</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Alarmen mogen het vergrendelde scherm wekken.</string>
+    <string name="cgm_readiness_full_screen_detail">Zonder deze toestemming wekken alarmen het vergrendelde scherm niet meer en verschijnen ze alleen als melding. Android kan haar bij elke app-update weer intrekken; controleer dit na een update.</string>
     <string name="cgm_readiness_battery_title">Batterij onbeperkt</string>
     <string name="cgm_readiness_battery_ready_detail">Android-batterijoptimalisatie is uitgeschakeld voor deze app.</string>
     <string name="cgm_readiness_battery_detail">Schakel batterijoptimalisatie uit zodat achtergrond-BLE, alarmen en netwerksync niet worden gestopt.</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1722,6 +1722,7 @@
     <string name="cgm_readiness_open_location_action">Otwórz lokalizację</string>
     <string name="cgm_readiness_open_notifications_action">Otwórz powiadomienia</string>
     <string name="cgm_readiness_open_alarm_action">Otwórz dostęp alarmów</string>
+    <string name="cgm_readiness_open_full_screen_action">Zezwól na alarmy pełnoekranowe</string>
     <string name="cgm_readiness_open_battery_action">Otwórz ustawienia baterii</string>
     <string name="cgm_readiness_open_dnd_action">Otwórz dostęp DND</string>
     <string name="cgm_readiness_open_overlay_action">Otwórz dostęp nakładki</string>
@@ -1749,6 +1750,9 @@
     <string name="cgm_readiness_exact_alarm_title">Dokładne alarmy</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Planowanie dokładnych alarmów jest dozwolone.</string>
     <string name="cgm_readiness_exact_alarm_detail">Zezwól na dokładne alarmy dla niezawodnych przypomnień, kontroli ponownego połączenia i pilnych alertów.</string>
+    <string name="cgm_readiness_full_screen_title">Alarmy pełnoekranowe</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Alarmy mogą wybudzać zablokowany ekran.</string>
+    <string name="cgm_readiness_full_screen_detail">Bez tego uprawnienia alarmy nie wybudzają już zablokowanego ekranu i pojawiają się tylko jako powiadomienie. Android może je odbierać przy każdej aktualizacji aplikacji – sprawdź je po aktualizacji.</string>
     <string name="cgm_readiness_battery_title">Bateria bez ograniczeń</string>
     <string name="cgm_readiness_battery_ready_detail">Optymalizacja baterii Androida jest wyłączona dla tej aplikacji.</string>
     <string name="cgm_readiness_battery_detail">Wyłącz optymalizację baterii, aby BLE w tle, alarmy i synchronizacja sieci nie były zatrzymywane.</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1688,6 +1688,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_open_location_action">Abrir Localização</string>
     <string name="cgm_readiness_open_notifications_action">Abrir Notificações</string>
     <string name="cgm_readiness_open_alarm_action">Abrir acesso a alarmes</string>
+    <string name="cgm_readiness_open_full_screen_action">Permitir alarmes em ecrã inteiro</string>
     <string name="cgm_readiness_open_battery_action">Abrir configurações de bateria</string>
     <string name="cgm_readiness_open_dnd_action">Abrir acesso DND</string>
     <string name="cgm_readiness_open_overlay_action">Abrir acesso de sobreposição</string>
@@ -1715,6 +1716,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_exact_alarm_title">Alarmes exatos</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Agendamento de alarmes exatos permitido.</string>
     <string name="cgm_readiness_exact_alarm_detail">Permita alarmes exatos para lembretes confiáveis, checagens de reconexão e alertas críticos.</string>
+    <string name="cgm_readiness_full_screen_title">Alarmes em ecrã inteiro</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Os alarmes podem acordar o ecrã bloqueado.</string>
+    <string name="cgm_readiness_full_screen_detail">Sem esta permissão, os alarmes deixam de acordar o ecrã bloqueado e aparecem apenas como notificação. O Android pode retirá-la a cada atualização da app; verifique após atualizar.</string>
     <string name="cgm_readiness_battery_title">Bateria irrestrita</string>
     <string name="cgm_readiness_battery_ready_detail">Otimização de bateria do Android desativada para este app.</string>
     <string name="cgm_readiness_battery_detail">Desative otimização de bateria para não parar BLE em segundo plano, alarmes e sincronização de rede.</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1734,6 +1734,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_open_location_action">Открыть геолокацию</string>
     <string name="cgm_readiness_open_notifications_action">Открыть уведомления</string>
     <string name="cgm_readiness_open_alarm_action">Открыть доступ будильников</string>
+    <string name="cgm_readiness_open_full_screen_action">Разрешить полноэкранные тревоги</string>
     <string name="cgm_readiness_open_battery_action">Открыть настройки батареи</string>
     <string name="cgm_readiness_open_dnd_action">Открыть доступ DND</string>
     <string name="cgm_readiness_open_overlay_action">Открыть доступ наложения</string>
@@ -1761,6 +1762,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_exact_alarm_title">Точные будильники</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Планирование точных будильников разрешено.</string>
     <string name="cgm_readiness_exact_alarm_detail">Разрешите точные будильники для надежных напоминаний, проверок переподключения и срочных тревог.</string>
+    <string name="cgm_readiness_full_screen_title">Полноэкранные тревоги</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Тревоги могут будить заблокированный экран.</string>
+    <string name="cgm_readiness_full_screen_detail">Без этого разрешения тревоги больше не будят заблокированный экран и показываются только как уведомление. Android может отзывать его при каждом обновлении приложения — проверяйте после обновлений.</string>
     <string name="cgm_readiness_battery_title">Батарея без ограничений</string>
     <string name="cgm_readiness_battery_ready_detail">Оптимизация батареи Android отключена для этого приложения.</string>
     <string name="cgm_readiness_battery_detail">Отключите оптимизацию батареи, чтобы фоновые BLE, тревоги и сетевая синхронизация не останавливались.</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2009,6 +2009,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="cgm_readiness_open_location_action">Goobta Furan</string>
     <string name="cgm_readiness_open_notifications_action">Ogeysiisyada Furan</string>
     <string name="cgm_readiness_open_alarm_action">Fur gelida alaarmiga</string>
+    <string name="cgm_readiness_open_full_screen_action">Ogolow digniinaha shaashadda buuxda</string>
     <string name="cgm_readiness_open_battery_action">Fur goobaha baytariyada</string>
     <string name="cgm_readiness_open_dnd_action">Furo gelitaanka DND</string>
     <string name="cgm_readiness_open_overlay_action">Furan gelitaanka dulsaar</string>
@@ -2036,6 +2037,9 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="cgm_readiness_exact_alarm_title">Alaarmiga saxda ah</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Jadwalka digniinta saxda ah waa la oggol yahay.</string>
     <string name="cgm_readiness_exact_alarm_detail">Oggolow digniinaha saxda ah ee xasuusinta la isku halayn karo, jeegaga dib ugu xidhka, iyo digniinaha wakhtiga muhiimka ah.</string>
+    <string name="cgm_readiness_full_screen_title">Digniinaha shaashadda buuxda</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Digniinuhu waxay toosin karaan shaashadda xiran.</string>
+    <string name="cgm_readiness_full_screen_detail">Ogolaansho la’aanteed digniinuhu ma toosiyaan shaashadda xiran, waxayna u muuqdaan oo keliya sida ogeysiis. Android wuu dib u qaadi karaa cusboonaysiin kasta oo appka ah – ka dib cusboonaysiinta hubi.</string>
     <string name="cgm_readiness_battery_title">Batarigu ma xadidna</string>
     <string name="cgm_readiness_battery_ready_detail">Hagaajinta batteriga Android waa la damiyay abkan.</string>
     <string name="cgm_readiness_battery_detail">Dami hagaajinta baytariga si BLE-gii hore, alaarmiga, iyo isku xidhka shabakada aan loo joojin.</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1687,6 +1687,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_open_location_action">Öppna Plats</string>
     <string name="cgm_readiness_open_notifications_action">Öppna Aviseringar</string>
     <string name="cgm_readiness_open_alarm_action">Öppna larmåtkomst</string>
+    <string name="cgm_readiness_open_full_screen_action">Tillåt helskärmslarm</string>
     <string name="cgm_readiness_open_battery_action">Öppna batteriinställningar</string>
     <string name="cgm_readiness_open_dnd_action">Öppna Stör ej-åtkomst</string>
     <string name="cgm_readiness_open_overlay_action">Öppna överläggsåtkomst</string>
@@ -1714,6 +1715,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_exact_alarm_title">Exakta larm</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Schemaläggning av exakta larm är tillåten.</string>
     <string name="cgm_readiness_exact_alarm_detail">Tillåt exakta larm för pålitliga påminnelser, återanslutningskontroller och tidskritiska larm.</string>
+    <string name="cgm_readiness_full_screen_title">Helskärmslarm</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Larm får väcka den låsta skärmen.</string>
+    <string name="cgm_readiness_full_screen_detail">Utan denna behörighet väcker larm inte längre en låst skärm utan visas bara som en avisering. Android kan ta bort den vid varje appuppdatering – kontrollera efter uppdateringar.</string>
     <string name="cgm_readiness_battery_title">Obegränsat batteri</string>
     <string name="cgm_readiness_battery_ready_detail">Androids batterioptimering är avstängd för appen.</string>
     <string name="cgm_readiness_battery_detail">Stäng av batterioptimering så att BLE i bakgrunden, larm och nätverkssynk inte stoppas.</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1715,6 +1715,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="cgm_readiness_open_location_action">Konumu aç</string>
     <string name="cgm_readiness_open_notifications_action">Bildirimleri aç</string>
     <string name="cgm_readiness_open_alarm_action">Alarm erişimini aç</string>
+    <string name="cgm_readiness_open_full_screen_action">Tam ekran alarmlara izin ver</string>
     <string name="cgm_readiness_open_battery_action">Pil ayarlarını aç</string>
     <string name="cgm_readiness_open_dnd_action">DND erişimini aç</string>
     <string name="cgm_readiness_open_overlay_action">Yer paylaşımı erişimini aç</string>
@@ -1742,6 +1743,9 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="cgm_readiness_exact_alarm_title">Kesin alarmlar</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Kesin alarm planlama izinli.</string>
     <string name="cgm_readiness_exact_alarm_detail">Güvenilir hatırlatmalar, yeniden bağlanma kontrolleri ve zaman kritik uyarılar için kesin alarmlara izin verin.</string>
+    <string name="cgm_readiness_full_screen_title">Tam ekran alarmlar</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Alarmlar kilitli ekranı uyandırabilir.</string>
+    <string name="cgm_readiness_full_screen_detail">Bu izin olmadan alarmlar kilitli ekranı artık uyandırmaz ve yalnızca bildirim olarak görünür. Android her uygulama güncellemesinde izni geri alabilir; güncellemeden sonra kontrol edin.</string>
     <string name="cgm_readiness_battery_title">Pil sınırsız</string>
     <string name="cgm_readiness_battery_ready_detail">Bu uygulama için Android pil optimizasyonu kapalı.</string>
     <string name="cgm_readiness_battery_detail">Arka plan BLE, alarmlar ve ağ eşitlemesi durmasın diye pil optimizasyonunu kapatın.</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1766,6 +1766,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_open_location_action">Відкрити геолокацію</string>
     <string name="cgm_readiness_open_notifications_action">Відкрити сповіщення</string>
     <string name="cgm_readiness_open_alarm_action">Відкрити доступ будильників</string>
+    <string name="cgm_readiness_open_full_screen_action">Дозволити повноекранні тривоги</string>
     <string name="cgm_readiness_open_battery_action">Відкрити налаштування батареї</string>
     <string name="cgm_readiness_open_dnd_action">Відкрити доступ DND</string>
     <string name="cgm_readiness_open_overlay_action">Відкрити доступ накладання</string>
@@ -1793,6 +1794,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_exact_alarm_title">Точні будильники</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Планування точних будильників дозволено.</string>
     <string name="cgm_readiness_exact_alarm_detail">Дозвольте точні будильники для надійних нагадувань, перевірок перепідключення та термінових тривог.</string>
+    <string name="cgm_readiness_full_screen_title">Повноекранні тривоги</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Тривоги можуть будити заблокований екран.</string>
+    <string name="cgm_readiness_full_screen_detail">Без цього дозволу тривоги більше не будять заблокований екран і показуються лише як сповіщення. Android може відкликати його під час кожного оновлення застосунку — перевіряйте після оновлень.</string>
     <string name="cgm_readiness_battery_title">Батарея без обмежень</string>
     <string name="cgm_readiness_battery_ready_detail">Оптимізацію батареї Android вимкнено для цього застосунку.</string>
     <string name="cgm_readiness_battery_detail">Вимкніть оптимізацію батареї, щоб фонові BLE, тривоги та мережева синхронізація не зупинялися.</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1703,6 +1703,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_open_location_action">打开位置信息</string>
     <string name="cgm_readiness_open_notifications_action">打开通知</string>
     <string name="cgm_readiness_open_alarm_action">打开闹钟权限</string>
+    <string name="cgm_readiness_open_full_screen_action">允许全屏警报</string>
     <string name="cgm_readiness_open_battery_action">打开电池设置</string>
     <string name="cgm_readiness_open_dnd_action">打开勿扰权限</string>
     <string name="cgm_readiness_open_overlay_action">打开悬浮窗权限</string>
@@ -1730,6 +1731,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_exact_alarm_title">精确闹钟</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">已允许精确闹钟调度。</string>
     <string name="cgm_readiness_exact_alarm_detail">允许精确闹钟，用于可靠提醒、重连检查和时间关键警报。</string>
+    <string name="cgm_readiness_full_screen_title">全屏警报</string>
+    <string name="cgm_readiness_full_screen_ready_detail">警报可以唤醒锁定的屏幕。</string>
+    <string name="cgm_readiness_full_screen_detail">没有此权限，警报将无法唤醒锁定的屏幕，只会显示为通知。Android 可能会在每次应用更新时收回该权限，请在更新后检查。</string>
     <string name="cgm_readiness_battery_title">电池不受限制</string>
     <string name="cgm_readiness_battery_ready_detail">已为此应用关闭 Android 电池优化。</string>
     <string name="cgm_readiness_battery_detail">关闭电池优化，避免后台 BLE、警报和网络同步被停止。</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2255,6 +2255,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_open_location_action">Open Location</string>
     <string name="cgm_readiness_open_notifications_action">Open Notifications</string>
     <string name="cgm_readiness_open_alarm_action">Open Alarm access</string>
+    <string name="cgm_readiness_open_full_screen_action">Allow full-screen alarms</string>
     <string name="cgm_readiness_open_battery_action">Open Battery settings</string>
     <string name="cgm_readiness_open_dnd_action">Open DND access</string>
     <string name="cgm_readiness_open_overlay_action">Open Overlay access</string>
@@ -2282,6 +2283,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="cgm_readiness_exact_alarm_title">Exact alarms</string>
     <string name="cgm_readiness_exact_alarm_ready_detail">Exact alarm scheduling is allowed.</string>
     <string name="cgm_readiness_exact_alarm_detail">Allow exact alarms for reliable reminders, reconnect checks, and time-critical alerts.</string>
+    <string name="cgm_readiness_full_screen_title">Full-screen alarms</string>
+    <string name="cgm_readiness_full_screen_ready_detail">Alarms are allowed to wake the locked screen.</string>
+    <string name="cgm_readiness_full_screen_detail">Without this permission alarms no longer wake a locked screen and only show as a notification. Android can take it away again with every app update, so check it after updating.</string>
     <string name="cgm_readiness_battery_title">Battery unrestricted</string>
     <string name="cgm_readiness_battery_ready_detail">Android battery optimization is disabled for this app.</string>
     <string name="cgm_readiness_battery_detail">Disable battery optimization so background BLE, alarms, and network sync are not stopped.</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/CgmReadiness.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/CgmReadiness.kt
@@ -63,6 +63,7 @@ import androidx.compose.material.icons.filled.DoNotDisturbOn
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Nfc
 import androidx.compose.material.icons.filled.NotificationsActive
@@ -114,6 +115,8 @@ import tk.glucodata.R
 import tk.glucodata.SensorSourceResolver
 import tk.glucodata.alerts.AlertRepository
 import tk.glucodata.alerts.AlertType
+import tk.glucodata.alerts.CustomAlertRepository
+import tk.glucodata.alerts.FullScreenIntentReadiness
 import tk.glucodata.data.settings.FloatingSettingsRepository
 
 private const val CGM_READINESS_PREFS = "cgm_readiness"
@@ -135,6 +138,7 @@ private enum class CgmReadinessAction {
     EnableBluetooth,
     OpenBatteryOptimization,
     OpenExactAlarmSettings,
+    OpenFullScreenIntentSettings,
     OpenNotificationSettings,
     OpenDndSettings,
     OpenLocationSettings,
@@ -778,6 +782,7 @@ private fun buildCgmReadinessSnapshot(
             notificationPermissionItem(appContext),
             appNotificationItem(appContext),
             exactAlarmItem(appContext),
+            fullScreenIntentItem(appContext),
             batteryOptimizationItem(appContext),
             dndItem(appContext),
             overlayItem(appContext),
@@ -954,6 +959,37 @@ private fun exactAlarmItem(context: Context): CgmReadinessItem? {
     )
 }
 
+private fun fullScreenIntentItem(context: Context): CgmReadinessItem? {
+    // Since Android 14 the manifest declaration alone no longer grants
+    // USE_FULL_SCREEN_INTENT; it can be missing after install and is taken away
+    // again by app updates, so it is re-checked on every snapshot, not cached.
+    if (!FullScreenIntentReadiness.shouldCheck(Build.VERSION.SDK_INT, isFullScreenDeliveryEnabledForAnyAlert())) {
+        return null
+    }
+    val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+    val ready = Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE ||
+        manager?.canUseFullScreenIntent() != false
+    return CgmReadinessItem(
+        id = "full_screen_intent",
+        titleRes = R.string.cgm_readiness_full_screen_title,
+        detailRes = if (ready) {
+            R.string.cgm_readiness_full_screen_ready_detail
+        } else {
+            R.string.cgm_readiness_full_screen_detail
+        },
+        status = if (ready) CgmReadinessStatus.Ready else CgmReadinessStatus.Critical,
+        icon = Icons.Filled.Fullscreen,
+        action = if (ready) null else CgmReadinessAction.OpenFullScreenIntentSettings,
+        actionLabelRes = if (ready) null else R.string.cgm_readiness_open_full_screen_action
+    )
+}
+
+private fun isFullScreenDeliveryEnabledForAnyAlert(): Boolean {
+    val alerts = AlertType.settingsEntries.map { AlertRepository.loadConfig(it) }
+    val customAlerts = runCatching { CustomAlertRepository.getAll() }.getOrDefault(emptyList())
+    return FullScreenIntentReadiness.anyAlertUsesFullScreen(alerts, customAlerts)
+}
+
 private fun batteryOptimizationItem(context: Context): CgmReadinessItem? {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return null
     val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
@@ -1109,6 +1145,13 @@ private fun Context.startReadinessSettingsActivity(action: CgmReadinessAction) {
         CgmReadinessAction.OpenExactAlarmSettings -> {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, packageUri)
+            } else {
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, packageUri)
+            }
+        }
+        CgmReadinessAction.OpenFullScreenIntentSettings -> {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT, packageUri)
             } else {
                 Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, packageUri)
             }

--- a/Common/src/test/java/tk/glucodata/alerts/FullScreenIntentReadinessTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/FullScreenIntentReadinessTests.kt
@@ -1,0 +1,64 @@
+package tk.glucodata.alerts
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FullScreenIntentReadinessTests {
+
+    private fun alert(mode: AlertDeliveryMode, enabled: Boolean = true): AlertConfig {
+        return AlertConfig(type = AlertType.LOW, enabled = enabled, deliveryMode = mode)
+    }
+
+    private fun custom(style: String, enabled: Boolean = true): CustomAlertConfig {
+        return CustomAlertConfig(enabled = enabled, style = style)
+    }
+
+    @Test
+    fun permissionIsOnlyEnforcedFromAndroid14() {
+        assertFalse(FullScreenIntentReadiness.isEnforced(33))
+        assertTrue(FullScreenIntentReadiness.isEnforced(34))
+        assertTrue(FullScreenIntentReadiness.isEnforced(35))
+    }
+
+    @Test
+    fun alarmSurfacesUseFullScreenDelivery() {
+        assertTrue(FullScreenIntentReadiness.usesFullScreenDelivery(alert(AlertDeliveryMode.SYSTEM_ALARM)))
+        assertTrue(FullScreenIntentReadiness.usesFullScreenDelivery(alert(AlertDeliveryMode.BOTH)))
+        assertFalse(FullScreenIntentReadiness.usesFullScreenDelivery(alert(AlertDeliveryMode.NOTIFICATION_ONLY)))
+    }
+
+    @Test
+    fun disabledAlertsDoNotCount() {
+        assertFalse(FullScreenIntentReadiness.usesFullScreenDelivery(alert(AlertDeliveryMode.SYSTEM_ALARM, enabled = false)))
+        assertFalse(FullScreenIntentReadiness.usesFullScreenDelivery(custom("alarm", enabled = false)))
+    }
+
+    @Test
+    fun customAlertStylesFollowTheSameRule() {
+        assertTrue(FullScreenIntentReadiness.usesFullScreenDelivery(custom("alarm")))
+        assertTrue(FullScreenIntentReadiness.usesFullScreenDelivery(custom("both")))
+        assertFalse(FullScreenIntentReadiness.usesFullScreenDelivery(custom("notification")))
+    }
+
+    @Test
+    fun checkIsSkippedWhenNoAlertUsesFullScreen() {
+        val notificationOnly = listOf(alert(AlertDeliveryMode.NOTIFICATION_ONLY))
+        val noCustom = emptyList<CustomAlertConfig>()
+        assertFalse(FullScreenIntentReadiness.anyAlertUsesFullScreen(notificationOnly, noCustom))
+        assertFalse(FullScreenIntentReadiness.shouldCheck(34, false))
+    }
+
+    @Test
+    fun checkRunsOnAndroid14WhenAnyAlertUsesFullScreen() {
+        val alerts = listOf(alert(AlertDeliveryMode.NOTIFICATION_ONLY), alert(AlertDeliveryMode.SYSTEM_ALARM))
+        assertTrue(FullScreenIntentReadiness.anyAlertUsesFullScreen(alerts, emptyList()))
+        assertTrue(FullScreenIntentReadiness.anyAlertUsesFullScreen(emptyList(), listOf(custom("both"))))
+        assertTrue(FullScreenIntentReadiness.shouldCheck(34, true))
+    }
+
+    @Test
+    fun checkNeverRunsBelowAndroid14() {
+        assertFalse(FullScreenIntentReadiness.shouldCheck(33, true))
+    }
+}


### PR DESCRIPTION
`USE_FULL_SCREEN_INTENT` is declared in the manifest but never checked and never requested. Since Android 14 that is not enough: the permission is only granted by default to apps whose core function is calling or alarm clocks. For everything else it can be missing after install and is taken away again with app updates, and only the user can grant it back from system settings. So after an update, full-screen alarms stop waking a locked screen and come through as a plain notification, and nothing in the app says so. For an alarm app that is the worst kind of failure, because it only shows up in exactly the situation the alarm exists for: locked phone, at night.

This adds it to the existing `CgmReadiness` checks, next to exact alarms, battery optimisation and DND. State comes from `NotificationManager.canUseFullScreenIntent()`, the action opens `ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT` for the package. Nothing is cached: the item is rebuilt with every readiness snapshot, which already happens on start, on resume and on the refresh button, so revoking the permission in system settings and coming back to the app shows the card without a restart, and so does the next app update.

When it is missing the card is `Critical`, same as exact alarms. It stays hidden when no enabled alert, standard or custom, uses full-screen delivery (`SYSTEM_ALARM` or `BOTH`), since then the permission changes nothing, and below API 34, where the manifest declaration still suffices. The card text says what the permission does for a locked screen and that updates take it away again, rather than naming it.

The rules (which API levels, which delivery modes count, whether the check applies) live in a plain object, `FullScreenIntentReadiness`, with 7 unit tests. The four new strings are translated into all maintained locales.

Not touched: the manifest declaration (still needed), `AlertDeliveryPolicy`, the full-screen intent attached in `Notify`, the other readiness items, Wear.

**Worth checking on a device (Android 14+)**

1. Permission off in system settings, at least one alert on Alarm or Both: the card shows as critical and its action lands on the full-screen intent page for NG.
2. Permission on: no card.
3. Every alert on Notification only: no card.
4. Revoke the permission in settings while NG is running, return to NG: the card appears without a restart.

`:Common:testMobileReleaseUnitTest` passes (the 11 pre-existing `SibionicsExact*` failures are unchanged from `main`). Not device-tested from here.
