### PR TITLE
Journal: an entry shows where it came from

### DIFF
--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1692,6 +1692,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_type_fingerstick">Вымярэнне з пальца</string>
     <string name="journal_type_activity">Актыўнасць</string>
     <string name="journal_type_note">Нататка</string>
+    <string name="journal_source_pen">Счытана з ручкі</string>
+    <string name="journal_source_nightscout">Атрымана з Nightscout</string>
+    <string name="journal_source_aaps">Атрымана з AAPS</string>
+    <string name="journal_source_api">Атрымана праз API</string>
+    <string name="journal_source_health_connect">З Health Connect</string>
+    <string name="journal_source_meter">З глюкометра</string>
     <string name="journal_note_label">Нататка</string>
     <string name="journal_onset_label">Пачатак дзеяння</string>
     <string name="journal_add_preset">Дадаць тып інсуліну</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1747,6 +1747,12 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="journal_type_fingerstick">Fingerstick</string>
     <string name="journal_type_activity">Aktivität</string>
     <string name="journal_type_note">Notiz</string>
+    <string name="journal_source_pen">Aus Pen gelesen</string>
+    <string name="journal_source_nightscout">Von Nightscout empfangen</string>
+    <string name="journal_source_aaps">Von AAPS empfangen</string>
+    <string name="journal_source_api">Über API empfangen</string>
+    <string name="journal_source_health_connect">Aus Health Connect</string>
+    <string name="journal_source_meter">Vom Messgerät</string>
     <string name="journal_note_label">Notiz</string>
     <string name="journal_onset_label">Wirkbeginn</string>
     <string name="journal_add_preset">Insulintyp hinzufügen</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1628,6 +1628,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_type_fingerstick">Mesure capillaire</string>
     <string name="journal_type_activity">Activité</string>
     <string name="journal_type_note">Note</string>
+    <string name="journal_source_pen">Lu depuis le stylo</string>
+    <string name="journal_source_nightscout">Reçu de Nightscout</string>
+    <string name="journal_source_aaps">Reçu d\'AAPS</string>
+    <string name="journal_source_api">Reçu via l\'API</string>
+    <string name="journal_source_health_connect">Depuis Health Connect</string>
+    <string name="journal_source_meter">Depuis le lecteur</string>
     <string name="journal_note_label">Note</string>
     <string name="journal_onset_label">Début d\'action</string>
     <string name="journal_add_preset">Ajouter un type d\'insuline</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1612,6 +1612,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_type_fingerstick">Puntura dito</string>
     <string name="journal_type_activity">Attività</string>
     <string name="journal_type_note">Nota</string>
+    <string name="journal_source_pen">Letto dalla penna</string>
+    <string name="journal_source_nightscout">Ricevuto da Nightscout</string>
+    <string name="journal_source_aaps">Ricevuto da AAPS</string>
+    <string name="journal_source_api">Ricevuto tramite API</string>
+    <string name="journal_source_health_connect">Da Health Connect</string>
+    <string name="journal_source_meter">Dal glucometro</string>
     <string name="journal_note_label">Nota</string>
     <string name="journal_onset_label">Inizio azione</string>
     <string name="journal_add_preset">Aggiungi tipo di insulina</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1639,6 +1639,12 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="journal_type_fingerstick">Fingerstick</string>
     <string name="journal_type_activity">Activity</string>
     <string name="journal_type_note">Note</string>
+    <string name="journal_source_pen">Үзгээс уншсан</string>
+    <string name="journal_source_nightscout">Nightscout-оос хүлээн авсан</string>
+    <string name="journal_source_aaps">AAPS-оос хүлээн авсан</string>
+    <string name="journal_source_api">API-аар хүлээн авсан</string>
+    <string name="journal_source_health_connect">Health Connect-оос</string>
+    <string name="journal_source_meter">Хэмжигчээс</string>
     <string name="journal_note_label">Note</string>
     <string name="journal_onset_label">Onset</string>
     <string name="journal_add_preset">Add insulin type</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1665,6 +1665,12 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="journal_type_fingerstick">Vingerprik</string>
     <string name="journal_type_activity">Activiteit</string>
     <string name="journal_type_note">Notitie</string>
+    <string name="journal_source_pen">Uit pen gelezen</string>
+    <string name="journal_source_nightscout">Ontvangen van Nightscout</string>
+    <string name="journal_source_aaps">Ontvangen van AAPS</string>
+    <string name="journal_source_api">Ontvangen via API</string>
+    <string name="journal_source_health_connect">Uit Health Connect</string>
+    <string name="journal_source_meter">Van meter</string>
     <string name="journal_note_label">Notitie</string>
     <string name="journal_onset_label">Werking start</string>
     <string name="journal_add_preset">Insulinetype toevoegen</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1657,6 +1657,12 @@
     <string name="journal_type_fingerstick">Pomiar z palca</string>
     <string name="journal_type_activity">Aktywność</string>
     <string name="journal_type_note">Notatka</string>
+    <string name="journal_source_pen">Odczytano ze wstrzykiwacza</string>
+    <string name="journal_source_nightscout">Odebrano z Nightscout</string>
+    <string name="journal_source_aaps">Odebrano z AAPS</string>
+    <string name="journal_source_api">Odebrano przez API</string>
+    <string name="journal_source_health_connect">Z Health Connect</string>
+    <string name="journal_source_meter">Z glukometru</string>
     <string name="journal_note_label">Notatka</string>
     <string name="journal_onset_label">Początek działania</string>
     <string name="journal_add_preset">Dodaj typ insuliny</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1623,6 +1623,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_type_fingerstick">Ponta de dedo</string>
     <string name="journal_type_activity">Atividade</string>
     <string name="journal_type_note">Nota</string>
+    <string name="journal_source_pen">Lido da caneta</string>
+    <string name="journal_source_nightscout">Recebido do Nightscout</string>
+    <string name="journal_source_aaps">Recebido do AAPS</string>
+    <string name="journal_source_api">Recebido via API</string>
+    <string name="journal_source_health_connect">Do Health Connect</string>
+    <string name="journal_source_meter">Do medidor</string>
     <string name="journal_note_label">Nota</string>
     <string name="journal_onset_label">Início da ação</string>
     <string name="journal_add_preset">Adicionar tipo de insulina</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1665,6 +1665,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_type_fingerstick">Пальцевый замер</string>
     <string name="journal_type_activity">Активность</string>
     <string name="journal_type_note">Заметка</string>
+    <string name="journal_source_pen">Считано с ручки</string>
+    <string name="journal_source_nightscout">Получено из Nightscout</string>
+    <string name="journal_source_aaps">Получено из AAPS</string>
+    <string name="journal_source_api">Получено через API</string>
+    <string name="journal_source_health_connect">Из Health Connect</string>
+    <string name="journal_source_meter">С глюкометра</string>
     <string name="journal_note_label">Заметка</string>
     <string name="journal_onset_label">Начало действия</string>
     <string name="journal_add_preset">Добавить тип инсулина</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1926,6 +1926,12 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="journal_type_fingerstick">Farta gacanta</string>
     <string name="journal_type_activity">Hawsha</string>
     <string name="journal_type_note">Ogow</string>
+    <string name="journal_source_pen">Laga akhriyay qalinka</string>
+    <string name="journal_source_nightscout">Laga helay Nightscout</string>
+    <string name="journal_source_aaps">Laga helay AAPS</string>
+    <string name="journal_source_api">Lagu helay API</string>
+    <string name="journal_source_health_connect">Ka yimid Health Connect</string>
+    <string name="journal_source_meter">Ka yimid qalabka cabbirka</string>
     <string name="journal_note_label">Ogow</string>
     <string name="journal_onset_label">Bilawga</string>
     <string name="journal_add_preset">Ku dar nooca insulin</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1622,6 +1622,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_type_fingerstick">Fingerstick</string>
     <string name="journal_type_activity">Aktivitet</string>
     <string name="journal_type_note">Anteckning</string>
+    <string name="journal_source_pen">Läst från pennan</string>
+    <string name="journal_source_nightscout">Mottaget från Nightscout</string>
+    <string name="journal_source_aaps">Mottaget från AAPS</string>
+    <string name="journal_source_api">Mottaget via API</string>
+    <string name="journal_source_health_connect">Från Health Connect</string>
+    <string name="journal_source_meter">Från mätaren</string>
     <string name="journal_note_label">Anteckning</string>
     <string name="journal_onset_label">Verkan startar</string>
     <string name="journal_add_preset">Lägg till insulintyp</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1650,6 +1650,12 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="journal_type_fingerstick">Parmak ölçümü</string>
     <string name="journal_type_activity">Aktivite</string>
     <string name="journal_type_note">Not</string>
+    <string name="journal_source_pen">Kalemden okundu</string>
+    <string name="journal_source_nightscout">Nightscout\'tan alındı</string>
+    <string name="journal_source_aaps">AAPS\'ten alındı</string>
+    <string name="journal_source_api">API üzerinden alındı</string>
+    <string name="journal_source_health_connect">Health Connect\'ten</string>
+    <string name="journal_source_meter">Ölçüm cihazından</string>
     <string name="journal_note_label">Not</string>
     <string name="journal_onset_label">Etki başlangıcı</string>
     <string name="journal_add_preset">İnsülin türü ekle</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1697,6 +1697,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_type_fingerstick">Пальцевий замір</string>
     <string name="journal_type_activity">Активність</string>
     <string name="journal_type_note">Нотатка</string>
+    <string name="journal_source_pen">Зчитано з ручки</string>
+    <string name="journal_source_nightscout">Отримано з Nightscout</string>
+    <string name="journal_source_aaps">Отримано з AAPS</string>
+    <string name="journal_source_api">Отримано через API</string>
+    <string name="journal_source_health_connect">З Health Connect</string>
+    <string name="journal_source_meter">З глюкометра</string>
     <string name="journal_note_label">Нотатка</string>
     <string name="journal_onset_label">Початок дії</string>
     <string name="journal_add_preset">Додати тип інсуліну</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1638,6 +1638,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_type_fingerstick">指尖血糖</string>
     <string name="journal_type_activity">活动</string>
     <string name="journal_type_note">备注</string>
+    <string name="journal_source_pen">从胰岛素笔读取</string>
+    <string name="journal_source_nightscout">来自 Nightscout</string>
+    <string name="journal_source_aaps">来自 AAPS</string>
+    <string name="journal_source_api">通过 API 接收</string>
+    <string name="journal_source_health_connect">来自 Health Connect</string>
+    <string name="journal_source_meter">来自血糖仪</string>
     <string name="journal_note_label">备注</string>
     <string name="journal_onset_label">起效时间</string>
     <string name="journal_add_preset">添加胰岛素类型</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2167,6 +2167,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_type_fingerstick">Fingerstick</string>
     <string name="journal_type_activity">Activity</string>
     <string name="journal_type_note">Note</string>
+    <string name="journal_source_pen">Read from pen</string>
+    <string name="journal_source_nightscout">Received from Nightscout</string>
+    <string name="journal_source_aaps">Received from AAPS</string>
+    <string name="journal_source_api">Received via API</string>
+    <string name="journal_source_health_connect">From Health Connect</string>
+    <string name="journal_source_meter">From meter</string>
     <string name="journal_note_label">Note</string>
     <string name="journal_onset_label">Onset</string>
     <string name="journal_add_preset">Add insulin type</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCompose.kt
@@ -510,6 +510,26 @@ fun JournalEntrySheet(
                             style = MaterialTheme.typography.headlineSmall,
                             fontWeight = FontWeight.SemiBold
                         )
+                        existingEntry?.source?.presentation()?.let { source ->
+                            // The icon on the row only explains itself for NFC; here the
+                            // origin is spelled out.
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(6.dp)
+                            ) {
+                                Icon(
+                                    imageVector = source.icon,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Text(
+                                    text = stringResource(source.labelRes),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
 //                        Text(
 //                            text = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT)
 //                                .format(Date(draft.timestamp)),
@@ -2681,6 +2701,18 @@ fun JournalInlineChip(
                         overflow = TextOverflow.Ellipsis
                     )
                 }
+                entry.source.presentation()?.let { source ->
+                    // Where the number came from, in the colour of secondary text so it never
+                    // competes with the amount. Manual entries draw nothing here.
+                    Icon(
+                        imageVector = source.icon,
+                        contentDescription = stringResource(source.labelRes),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .padding(top = if (expanded) 3.dp else 0.dp)
+                            .size(if (expanded) 14.dp else 12.dp)
+                    )
+                }
             }
         }
     }
@@ -2836,6 +2868,15 @@ private fun JournalEntryChip(
                 )
             }
             Spacer(modifier = Modifier.width(8.dp))
+            entry.source.presentation()?.let { source ->
+                Icon(
+                    imageVector = source.icon,
+                    contentDescription = stringResource(source.labelRes),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+            }
             Text(
                 text = DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(entry.timestamp)),
                 style = MaterialTheme.typography.labelMedium,

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSourcePresentation.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSourcePresentation.kt
@@ -1,0 +1,38 @@
+package tk.glucodata.ui.journal
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.HealthAndSafety
+import androidx.compose.material.icons.filled.Nfc
+import androidx.compose.material.icons.filled.WaterDrop
+import androidx.compose.ui.graphics.vector.ImageVector
+import tk.glucodata.R
+import tk.glucodata.data.journal.JournalEntrySource
+
+/**
+ * How a journal entry's origin is shown: a small icon on the row, plain words in the detail.
+ *
+ * A dose read off a pen over NFC and one typed from memory make the same entry with the same
+ * insulin and the same units; the origin is what says whether the number came from a device.
+ * The icon alone only carries that for NFC, which people know from paying and ticketing, so
+ * every source also has a label, and the row's icon uses it as its content description.
+ */
+internal data class JournalSourcePresentation(
+    val icon: ImageVector,
+    @StringRes val labelRes: Int,
+)
+
+/**
+ * Null for [JournalEntrySource.MANUAL]: typing an entry in is the normal case, and marking
+ * every row would drown the marks that mean something.
+ */
+internal fun JournalEntrySource.presentation(): JournalSourcePresentation? = when (this) {
+    JournalEntrySource.MANUAL -> null
+    JournalEntrySource.PEN -> JournalSourcePresentation(Icons.Default.Nfc, R.string.journal_source_pen)
+    JournalEntrySource.NIGHTSCOUT -> JournalSourcePresentation(Icons.Default.CloudDownload, R.string.journal_source_nightscout)
+    JournalEntrySource.AAPS -> JournalSourcePresentation(Icons.Default.CloudDownload, R.string.journal_source_aaps)
+    JournalEntrySource.API -> JournalSourcePresentation(Icons.Default.CloudDownload, R.string.journal_source_api)
+    JournalEntrySource.HEALTH_CONNECT -> JournalSourcePresentation(Icons.Default.HealthAndSafety, R.string.journal_source_health_connect)
+    JournalEntrySource.METER -> JournalSourcePresentation(Icons.Default.WaterDrop, R.string.journal_source_meter)
+}

--- a/Common/src/test/java/tk/glucodata/ui/journal/JournalSourcePresentationTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/journal/JournalSourcePresentationTests.kt
@@ -1,0 +1,42 @@
+package tk.glucodata.ui.journal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import tk.glucodata.data.journal.JournalEntrySource
+
+class JournalSourcePresentationTests {
+
+    @Test
+    fun manualEntriesCarryNoMark() {
+        assertNull(JournalEntrySource.MANUAL.presentation())
+    }
+
+    @Test
+    fun everyOtherSourceHasAnIconAndALabel() {
+        JournalEntrySource.entries
+            .filter { it != JournalEntrySource.MANUAL }
+            .forEach { source ->
+                val shown = source.presentation()
+                assertNotNull("$source should be shown", shown)
+                assertNotNull(shown!!.icon)
+            }
+    }
+
+    @Test
+    fun labelsTellTheSourcesApart() {
+        // The icon is shared between the three "received from elsewhere" sources, so the
+        // label is what distinguishes them in the detail view.
+        val labels = JournalEntrySource.entries.mapNotNull { it.presentation()?.labelRes }
+
+        assertEquals(labels.size, labels.toSet().size)
+    }
+
+    @Test
+    fun anUnknownStoredValueIsShownAsManual() {
+        // fromStorage falls back to MANUAL, so an entry written by a newer build with a
+        // source this one does not know draws no mark rather than crashing.
+        assertNull(JournalEntrySource.fromStorage("telepathy").presentation())
+    }
+}


### PR DESCRIPTION
Journal entries already record where they came from. `JournalEntrySource` has manual, Health Connect, meter, pen, AAPS, Nightscout and API, and the value travels all the way into the Nightscout upload as `journalSource`. Nothing in the journal UI ever showed it, so a dose read from a pen over NFC and one typed from memory looked identical in the list: same insulin, same units, no way to tell which number came from a device. That matters for how far a number can be trusted, and for tracing an import that behaves oddly.

### What changes

The entry chip (compact and expanded, the one `ReadingRow` and the timeline draw) and the quick-dock entry card carry a small icon in the colour of secondary text, so it never competes with the amount. The entry sheet spells the origin out in words under the title: "Read from pen", "Received from Nightscout", "Received via API" and so on.

Manual entries stay unmarked, since typing an entry in is the normal case and marking every row would devalue the ones that matter. NFC stands for the pen because that symbol is already learned from payments and ticketing. The three received-from-elsewhere sources (Nightscout, AAPS, API) share a cloud icon and lean on the sheet's line to tell them apart; the icon's content description is that same label, so a screen reader gets the words rather than an unexplained picture. Health Connect uses the health icon, the meter a drop.

The pen serial is deliberately not shown: the insulin preset already ties the insulin to the pen, and the insulin name is on the row.

Display only. No schema change, no migration, nothing new is stored, and `JournalEntrySource`, the storage and the Nightscout upload are untouched. The six labels are in all fifteen locales.

### Tests

`JournalSourcePresentationTests`: manual draws nothing, every other source has an icon and a label, the labels are distinct (the cloud is shared), and an unknown stored value falls back to manual without a mark. What a unit test cannot cover and is worth a look on a device: the compact chip with a long insulin name at a large font size should still show the amount, and TalkBack should read the source on the row.
