### PR TITLE
iCan: reject challenge-less glucose during warm-up

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthParser.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthParser.kt
@@ -167,7 +167,7 @@ object ICanHealthParser {
             authChallenge = authChallenge,
             usesNewBundledCrypto = usesNewBundledCrypto,
             warmupMinutes = warmupMinutes,
-        )
+        ) ?: return null
         val directGlucoseEncoding =
             ICanHealthConstants.usesDirectSnHistoryGlucoseEncoding(onboardingDeviceSn)
         val glucLo = glucoseBytes[0].toInt() and 0xFF
@@ -689,7 +689,7 @@ object ICanHealthParser {
                     authChallenge = authChallenge,
                     usesNewBundledCrypto = usesNewBundledCrypto,
                     warmupMinutes = warmupMinutes,
-                )
+                ) ?: return null
                 val low = glucoseBytes[0].toInt() and 0xFF
                 val high = glucoseBytes[1].toInt() and 0xFF
                 val dataState = if (directGlucoseEncoding) 0 else (high ushr 4) and 0x0F
@@ -724,10 +724,19 @@ object ICanHealthParser {
         authChallenge: ByteArray?,
         usesNewBundledCrypto: Boolean,
         warmupMinutes: Int,
-    ): ByteArray {
-        val challenge = authChallenge
-        if (sequenceNumber >= warmupMinutes || challenge == null || challenge.isEmpty()) {
+    ): ByteArray? {
+        if (sequenceNumber >= warmupMinutes) {
             return byteArrayOf(low, high)
+        }
+        val challenge = authChallenge
+        if (challenge == null || challenge.size < 4) {
+            // During warm-up these bytes are challenge-dependent XOR data. Without all four
+            // challenge bytes they cannot be decoded safely; accepting them verbatim can turn
+            // the encoded value into plausible but dangerously wrong glucose.
+            logWarn(
+                "decodeGlucose: rejecting warm-up seq=$sequenceNumber without a 4-byte auth challenge"
+            )
+            return null
         }
         val table = if (usesNewBundledCrypto) {
             ICanHealthConstants.LEGACY_HISTORY_GLUCOSE_XOR_TABLE_NEW

--- a/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthParserTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthParserTests.kt
@@ -69,6 +69,34 @@ class ICanHealthParserTests {
         assertEquals(4.50f, reading!!.glucoseMmolL, 0.001f)
     }
 
+    @Test
+    fun parseGlucoseNotification_rejectsWarmupFrameWithoutChallenge() {
+        val sequence = 60
+        val data = encryptedNotification(
+            sequence = sequence,
+            plaintext = glucosePlaintext(sequence = sequence, glucoseRaw = 2960)
+        )
+
+        assertNull(parse(data, authChallenge = null, warmupMinutes = 120))
+    }
+
+    @Test
+    fun parseGlucoseNotification_rejectsWarmupFrameWithShortChallenge() {
+        val sequence = 60
+        val data = encryptedNotification(
+            sequence = sequence,
+            plaintext = glucosePlaintext(sequence = sequence, glucoseRaw = 2960)
+        )
+
+        assertNull(
+            parse(
+                data,
+                authChallenge = byteArrayOf(0x01, 0x02, 0x03),
+                warmupMinutes = 120,
+            )
+        )
+    }
+
     private fun parse(
         data: ByteArray,
         authChallenge: ByteArray? = null,


### PR DESCRIPTION
## Summary

- Reject iCan glucose samples inside the configured warm-up window when the four-byte authentication challenge is unavailable.
- Keep post-warm-up behavior unchanged.
- Add regression coverage for missing and truncated challenges.

## Why

Before the iCan warm-up boundary, the two glucose bytes are challenge-dependent XOR data. `decodeHistoryGlucoseBytes()` previously returned those bytes unchanged when `authChallenge` was null or empty. They were then interpreted as centi-mmol/L, which can produce plausible but severely inflated readings rather than a parse failure.

I observed this with a Chinese iCan i3 (`iCGM-t3`, firmware `v3.2.8`) on an Honor Magic 6 Pro. During the first hour the displayed readings were roughly 25.6–29.9 mmol/L. After the phone was rebooted, the fresh BLE/auth session began producing usable readings. That behavior is consistent with the four-byte challenge becoming available after reconnect.

This is not safely correctable with a fixed `/4` scale. If the challenge is absent, the warm-up field is not decodable, so rejecting the sample is safer than applying a numeric correction.

## Behavior

- `sequenceNumber >= warmupMinutes`: unchanged; raw glucose bytes are accepted.
- `sequenceNumber < warmupMinutes` and challenge length is at least four bytes: unchanged; challenge-dependent XOR decoding is applied.
- `sequenceNumber < warmupMinutes` and challenge is missing or truncated: reject the sample and emit a warning.

## Current-build workaround

During the 120-minute i3 warm-up, force a fresh BLE/auth session by rebooting the phone or toggling Bluetooth off and on. Do **not** remove or disconnect the sensor. Alternatively, wait until the warm-up window has ended.

Anomalous CGM readings should be verified with a blood glucose meter and must not be used for treatment decisions.

## Tests

- `./gradlew :Common:testMobileDebugUnitTest --tests tk.glucodata.drivers.icanhealth.ICanHealthParserTests --tests tk.glucodata.drivers.icanhealth.ICanHealthConstantsTests`
- `./gradlew :Common:assembleMobileDebug`

Related: #91 and Discussion #42.