### PR TITLE
History: the reading rows show the dashboard's delta

### DIFF
--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2176,7 +2176,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_cob_desc">Паказваць COB журнала ў радку стану</string>
     <string name="notification_show_delta_minutes_desc">Паказваць змену за %1$d хв каля стрэлкі</string>
     <string name="dashboard_rows_show_delta_title">Дэльта ў спісе значэнняў</string>
-    <string name="dashboard_rows_show_delta_desc">Паказваць змену каля кожнага значэння</string>
+    <string name="dashboard_rows_show_delta_desc">Паказваць змену каля кожнага значэння на панэлі і ў гісторыі</string>
     <string name="glucose_range_colors_title">Колер значэнняў паводле дыяпазону</string>
     <string name="glucose_range_colors_desc">Выкарыстоўваць колеры дыяпазонаў на галоўнай і ў апавяшчэнні</string>
     <string name="very_range_title">Вельмі нізкі / вельмі высокі</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1696,7 +1696,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="dashboard_show_delta_title">Delta (Δ) auf dem Dashboard</string>
     <string name="dashboard_show_delta_desc">Gemessene Änderung über das Delta-Intervall, unter dem Trendpfeil</string>
     <string name="dashboard_rows_show_delta_title">Delta in der Messwertliste</string>
-    <string name="dashboard_rows_show_delta_desc">Änderung neben jedem Messwert anzeigen</string>
+    <string name="dashboard_rows_show_delta_desc">Änderung neben jedem Messwert anzeigen, im Dashboard und in der Historie</string>
     <string name="delta_interval_title">Delta-Intervall (Δ)</string>
     <string name="delta_interval_desc">Zeitfenster für die Δ-Anzeige; die Schnell-fallend/steigend-Alarme folgen ihm, solange kein eigenes Fenster gesetzt ist</string>
     <string name="delta_interval_1min">1 Min</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2115,7 +2115,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_cob_desc">Afficher le COB du journal dans la ligne d’état</string>
     <string name="notification_show_delta_minutes_desc">Afficher la variation sur %1$d min près de la flèche</string>
     <string name="dashboard_rows_show_delta_title">Delta dans la liste</string>
-    <string name="dashboard_rows_show_delta_desc">Afficher la variation près de chaque valeur</string>
+    <string name="dashboard_rows_show_delta_desc">Afficher la variation près de chaque valeur, sur le tableau de bord et dans l’historique</string>
     <string name="glucose_range_colors_title">Colorer les valeurs par plage</string>
     <string name="glucose_range_colors_desc">Utiliser les couleurs de plage sur le tableau de bord et la notification</string>
     <string name="very_range_title">Très basse / très haute</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2099,7 +2099,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_cob_desc">Mostra COB del diario nella riga di stato</string>
     <string name="notification_show_delta_minutes_desc">Mostra la variazione di %1$d min accanto alla freccia</string>
     <string name="dashboard_rows_show_delta_title">Delta nell’elenco letture</string>
-    <string name="dashboard_rows_show_delta_desc">Mostra la variazione accanto a ogni lettura</string>
+    <string name="dashboard_rows_show_delta_desc">Mostra la variazione accanto a ogni lettura, nella dashboard e nella cronologia</string>
     <string name="glucose_range_colors_title">Colora i valori per intervallo</string>
     <string name="glucose_range_colors_desc">Usa i colori degli intervalli nella dashboard e nella notifica</string>
     <string name="very_range_title">Molto basso / molto alto</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2224,7 +2224,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="notification_show_cob_desc">Журналын COB-г төлөвийн мөрөнд харуулна</string>
     <string name="notification_show_delta_minutes_desc">%1$d минутын өөрчлөлтийг сумны хажууд харуулна</string>
     <string name="dashboard_rows_show_delta_title">Уншилтын жагсаалтын дельта</string>
-    <string name="dashboard_rows_show_delta_desc">Уншилт бүрийн хажууд өөрчлөлтийг харуулна</string>
+    <string name="dashboard_rows_show_delta_desc">Уншилт бүрийн хажууд өөрчлөлтийг хянах самбар болон түүхэнд харуулна</string>
     <string name="glucose_range_colors_title">Утгыг хязгаараар будах</string>
     <string name="glucose_range_colors_desc">Хяналтын самбар болон мэдэгдэлд хязгаарын өнгө ашиглана</string>
     <string name="very_range_title">Маш бага / маш өндөр</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2152,7 +2152,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="notification_show_cob_desc">Toon COB uit het journaal in de statusregel</string>
     <string name="notification_show_delta_minutes_desc">Toon de verandering over %1$d min naast de pijl</string>
     <string name="dashboard_rows_show_delta_title">Delta in meetwaardenlijst</string>
-    <string name="dashboard_rows_show_delta_desc">Toon de verandering naast elke meetwaarde</string>
+    <string name="dashboard_rows_show_delta_desc">Toon de verandering naast elke meetwaarde, op het dashboard en in de geschiedenis</string>
     <string name="glucose_range_colors_title">Waarden kleuren per bereik</string>
     <string name="glucose_range_colors_desc">Gebruik bereikkleuren op het dashboard en in meldingen</string>
     <string name="very_range_title">Zeer laag / zeer hoog</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2143,7 +2143,7 @@
     <string name="notification_show_cob_desc">Pokaż COB z Dziennika w wierszu stanu</string>
     <string name="notification_show_delta_minutes_desc">Pokaż zmianę z %1$d min obok strzałki</string>
     <string name="dashboard_rows_show_delta_title">Delta na liście odczytów</string>
-    <string name="dashboard_rows_show_delta_desc">Pokaż zmianę obok każdego odczytu</string>
+    <string name="dashboard_rows_show_delta_desc">Pokaż zmianę obok każdego odczytu, na pulpicie i w historii</string>
     <string name="glucose_range_colors_title">Koloruj wartości według zakresu</string>
     <string name="glucose_range_colors_desc">Użyj kolorów zakresu na pulpicie i w powiadomieniu</string>
     <string name="very_range_title">Bardzo niski / bardzo wysoki</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2110,7 +2110,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_cob_desc">Mostrar COB do Diário na linha de estado</string>
     <string name="notification_show_delta_minutes_desc">Mostrar a variação de %1$d min junto à seta</string>
     <string name="dashboard_rows_show_delta_title">Delta na lista de leituras</string>
-    <string name="dashboard_rows_show_delta_desc">Mostrar a variação junto a cada leitura</string>
+    <string name="dashboard_rows_show_delta_desc">Mostrar a variação junto a cada leitura, no painel e no histórico</string>
     <string name="glucose_range_colors_title">Colorir valores por intervalo</string>
     <string name="glucose_range_colors_desc">Usar cores de intervalo no painel e na notificação</string>
     <string name="very_range_title">Muito baixo / muito alto</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2154,7 +2154,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_cob_desc">Показывать COB журнала в строке состояния</string>
     <string name="notification_show_delta_minutes_desc">Показывать изменение за %1$d мин рядом со стрелкой</string>
     <string name="dashboard_rows_show_delta_title">Дельта в списке значений</string>
-    <string name="dashboard_rows_show_delta_desc">Показывать изменение рядом с каждым значением</string>
+    <string name="dashboard_rows_show_delta_desc">Показывать изменение рядом с каждым значением на панели и в истории</string>
     <string name="glucose_range_colors_title">Цвет значений по диапазону</string>
     <string name="glucose_range_colors_desc">Использовать цвета диапазонов на главной и в уведомлении</string>
     <string name="very_range_title">Очень низкий / очень высокий</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2321,7 +2321,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="notification_large_arrow_desc">Falaarta ku dheeree ogeysiisyada, widgets-ka iyo AOD</string>
     <string name="notification_show_delta_minutes_desc">Muuji isbeddelka %1$d daqiiqo agta falaarta</string>
     <string name="dashboard_rows_show_delta_title">Delta liiska akhrisyada</string>
-    <string name="dashboard_rows_show_delta_desc">Muuji isbeddelka agta akhris kasta</string>
+    <string name="dashboard_rows_show_delta_desc">Muuji isbeddelka agta akhris kasta, shaashadda hore iyo taariikhda</string>
     <string name="glucose_palette_sheet_desc">Dooro palette ama habee xad kasta oo gulukoos ah</string>
     <string name="glucose_palette_saturation">Dheregsanaanta</string>
     <string name="glucose_palette_brightness">Iftiinka</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2109,7 +2109,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_cob_desc">Visa journalens COB i statusraden</string>
     <string name="notification_show_delta_minutes_desc">Visa förändringen över %1$d min bredvid pilen</string>
     <string name="dashboard_rows_show_delta_title">Delta i avläsningslistan</string>
-    <string name="dashboard_rows_show_delta_desc">Visa förändringen bredvid varje avläsning</string>
+    <string name="dashboard_rows_show_delta_desc">Visa förändringen bredvid varje avläsning, på instrumentpanelen och i historiken</string>
     <string name="glucose_range_colors_title">Färga värden efter intervall</string>
     <string name="glucose_range_colors_desc">Använd intervallfärger på översikten och i aviseringen</string>
     <string name="very_range_title">Mycket låg / mycket hög</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2137,7 +2137,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="notification_show_cob_desc">Günlük COB değerini durum satırında göster</string>
     <string name="notification_show_delta_minutes_desc">%1$d dakikalık değişimi okun yanında göster</string>
     <string name="dashboard_rows_show_delta_title">Okuma listesi deltası</string>
-    <string name="dashboard_rows_show_delta_desc">Değişimi her okumanın yanında göster</string>
+    <string name="dashboard_rows_show_delta_desc">Değişimi her okumanın yanında, panoda ve geçmişte göster</string>
     <string name="glucose_range_colors_title">Değerleri aralığa göre renklendir</string>
     <string name="glucose_range_colors_desc">Pano ve bildirim değerlerinde aralık renklerini kullan</string>
     <string name="very_range_title">Çok düşük / çok yüksek</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2181,7 +2181,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_cob_desc">Показувати COB Журналу в рядку стану</string>
     <string name="notification_show_delta_minutes_desc">Показувати зміну за %1$d хв біля стрілки</string>
     <string name="dashboard_rows_show_delta_title">Дельта у списку значень</string>
-    <string name="dashboard_rows_show_delta_desc">Показувати зміну біля кожного значення</string>
+    <string name="dashboard_rows_show_delta_desc">Показувати зміну біля кожного значення на панелі та в історії</string>
     <string name="glucose_range_colors_title">Колір значень за діапазоном</string>
     <string name="glucose_range_colors_desc">Використовувати кольори діапазонів на головній і в сповіщенні</string>
     <string name="very_range_title">Дуже низький / дуже високий</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2125,7 +2125,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_cob_desc">在状态行显示日志 COB</string>
     <string name="notification_show_delta_minutes_desc">在箭头旁显示 %1$d 分钟变化</string>
     <string name="dashboard_rows_show_delta_title">读数列表 Delta</string>
-    <string name="dashboard_rows_show_delta_desc">在每条读数旁显示变化</string>
+    <string name="dashboard_rows_show_delta_desc">在仪表盘和历史记录中，在每条读数旁显示变化</string>
     <string name="glucose_range_colors_title">按范围为数值着色</string>
     <string name="glucose_range_colors_desc">在仪表板和通知中使用范围颜色</string>
     <string name="very_range_title">极低 / 极高</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2112,7 +2112,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="dashboard_show_delta_title">Dashboard delta</string>
     <string name="dashboard_show_delta_desc">Show measured change below the trend arrow</string>
     <string name="dashboard_rows_show_delta_title">Reading-list delta</string>
-    <string name="dashboard_rows_show_delta_desc">Show measured change beside each reading</string>
+    <string name="dashboard_rows_show_delta_desc">Show measured change beside each reading, on the dashboard and in the history</string>
     <string name="delta_interval_title">Delta (Δ) interval</string>
     <string name="delta_interval_desc">Time window for the Δ readout; the falling/rising alarms follow it unless given their own window</string>
     <string name="delta_interval_1min">1 min</string>

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
@@ -66,6 +66,9 @@ class HistoryRepository(context: Context = Applic.app) {
             "imported",
             "unknown"
         )
+
+        /** A row no sensor owns: imported, or stored before the serial was known. */
+        fun isImportedHistorySerial(serial: String): Boolean = serial in IMPORTED_HISTORY_SENSOR_SERIALS
         private val TIME_FORMATTER = object : ThreadLocal<SimpleDateFormat>() {
             override fun initialValue(): SimpleDateFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
         }

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
@@ -301,3 +301,86 @@ internal fun readingDeltaTexts(
         tk.glucodata.GlucoseDelta.format(delta, isMmol).takeIf { it.isNotEmpty() }
     }
 }
+
+/**
+ * The same "Δ" column for the history screen's reading rows, keyed by the reading
+ * itself: the history renders its rows per day section, so a positional list would
+ * have to be re-indexed at every section boundary; a map lets each row look its own
+ * text up.
+ *
+ * The history also reaches across sensors, and a difference between two sensors'
+ * readings is not a measured change. So the history is bucketed once per sensor —
+ * by [sameSensor], which is [tk.glucodata.SensorIdentity.matches] in the app, so a
+ * sensor stored under two names stays one — and every row walks back through its
+ * own sensor's bucket only. Rows the app cannot attribute ([isShared]: imported and
+ * unknown serials) belong to every bucket, which is what the dashboard's per-sensor
+ * history holds as well. Within one bucket the text is exactly [readingDeltaTexts]'s,
+ * gaps included: a row with no old-enough partner is absent.
+ *
+ * Build one index per [history] (oldest-first, unsmoothed) and ask it per visible
+ * window: [textsFor] does a binary search per bucket, not a pass over the data.
+ */
+internal class RowDeltaIndex(
+    history: List<GlucosePoint>,
+    private val sameSensor: (String, String) -> Boolean,
+    private val isShared: (String) -> Boolean = { false }
+) {
+    private val logicalSerials = ArrayList<String>()
+    private val keyBySerial = HashMap<String, String>()
+    private val historyByKey: Map<String?, List<GlucosePoint>>
+
+    init {
+        val shared = ArrayList<GlucosePoint>()
+        val own = LinkedHashMap<String?, ArrayList<GlucosePoint>>()
+        history.forEach { point ->
+            val key = keyOf(point.sensorSerial)
+            if (key === SHARED) shared.add(point) else own.getOrPut(key) { ArrayList() }.add(point)
+        }
+        historyByKey = if (shared.isEmpty()) {
+            own
+        } else {
+            own.mapValues { (_, points) -> (points + shared).sortedBy { it.timestamp } } + (SHARED to shared)
+        }
+    }
+
+    /** Blank and missing serials are one bucket, as in [GlucosePointSegments]. */
+    private fun keyOf(serial: String?): String? {
+        val raw = serial?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        return keyBySerial.getOrPut(raw) {
+            if (isShared(raw)) {
+                SHARED
+            } else {
+                logicalSerials.firstOrNull { sameSensor(it, raw) } ?: raw.also(logicalSerials::add)
+            }
+        }
+    }
+
+    /** [rows] newest-first, the order the history draws them. */
+    fun textsFor(rows: List<GlucosePoint>, isMmol: Boolean, deltaIntervalMinutes: Int): Map<GlucosePoint, String> {
+        if (rows.isEmpty() || historyByKey.isEmpty()) return emptyMap()
+        val texts = HashMap<GlucosePoint, String>()
+        rows.groupBy { keyOf(it.sensorSerial) }.forEach { (key, sensorRows) ->
+            val bucket = historyByKey[key] ?: return@forEach
+            // Nothing newer than the newest row takes part in its walk-back: cut the
+            // bucket there, so a window months back does not start at today.
+            val newest = sensorRows.first().timestamp
+            var cut = bucket.binarySearchBy(newest) { it.timestamp }.let { if (it >= 0) it + 1 else -it - 1 }
+            while (cut < bucket.size && bucket[cut].timestamp == newest) cut++
+            val sensorTexts = readingDeltaTexts(
+                sensorRows.map { it.timestamp },
+                bucket.subList(0, cut),
+                isMmol,
+                deltaIntervalMinutes
+            )
+            sensorRows.forEachIndexed { index, row ->
+                sensorTexts.getOrNull(index)?.let { texts[row] = it }
+            }
+        }
+        return texts
+    }
+
+    private companion object {
+        /** The bucket of the rows no sensor owns; a string no serial can be. */
+        const val SHARED = "\u0000shared"
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/HistoryBrowseScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/HistoryBrowseScreen.kt
@@ -65,7 +65,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import tk.glucodata.R
+import tk.glucodata.SensorIdentity
 import tk.glucodata.UiRefreshBus
+import tk.glucodata.data.HistoryRepository
 import tk.glucodata.data.journal.JournalEntry
 import tk.glucodata.data.journal.JournalEntryType
 import tk.glucodata.data.journal.JournalFood
@@ -379,7 +381,9 @@ fun HistoryBrowseScreen(
     onJournalEntryClick: ((JournalEntry) -> Unit)? = null,
     onAddJournalEntry: ((Long, JournalEntryType?, Float?) -> Unit)? = null,
     showTransferActions: Boolean = true,
-    quickAddAlwaysNow: Boolean = false
+    quickAddAlwaysNow: Boolean = false,
+    showRowDelta: Boolean = false,
+    deltaIntervalMinutes: Int = tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -466,6 +470,25 @@ fun HistoryBrowseScreen(
         )
     }
     val visibleSections = remember(visibleTimelineRows) { buildHistorySections(visibleTimelineRows) }
+    // The reading rows' "Δ", the dashboard's setting and function: null while the
+    // setting is off, so the row's slot stays hidden exactly as it does today. The
+    // index is built once per history; the visible window only asks it.
+    val rowDeltaIndex = remember(showRowDelta, sortedHistory) {
+        if (showRowDelta) {
+            RowDeltaIndex(
+                sortedHistory,
+                sameSensor = SensorIdentity::matches,
+                isShared = { HistoryRepository.isImportedHistorySerial(it) }
+            )
+        } else null
+    }
+    val rowDeltaTexts = remember(rowDeltaIndex, visibleTimelineRows, unit, deltaIntervalMinutes) {
+        rowDeltaIndex?.textsFor(
+            visibleTimelineRows.mapNotNull(TimelineRowItem::point),
+            tk.glucodata.ui.util.GlucoseFormatter.isMmol(unit),
+            deltaIntervalMinutes
+        ).orEmpty()
+    }
     val journalMarkers = remember(filteredJournalEntries, journalPresetsById, journalFoodsById, unit, activeHistory) {
         buildJournalChartMarkers(filteredJournalEntries, journalPresetsById, unit, activeHistory, journalFoodsById)
     }
@@ -759,6 +782,7 @@ fun HistoryBrowseScreen(
                                 index = index,
                                 totalCount = section.items.size,
                                 history = section.items.mapNotNull(TimelineRowItem::point),
+                                deltaText = rowDeltaTexts[readingPoint],
                                 sensorId = sensorId,
                                 calibrations = calibrations,
                                 highlightLeadRow = false,

--- a/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
@@ -159,6 +159,8 @@ private fun HistoryRoute(
     val journalFoods by dashboardViewModel.journalFoods.collectAsStateWithLifecycle()
     val journalQuickAddAlwaysNow by dashboardViewModel.journalQuickAddAlwaysNow.collectAsStateWithLifecycle()
     val appChartRangeColorsEnabled by dashboardViewModel.glucoseAppChartRangeColorsEnabled.collectAsStateWithLifecycle()
+    val rowsShowDelta by dashboardViewModel.dashboardRowsShowDelta.collectAsStateWithLifecycle()
+    val deltaIntervalMinutes by dashboardViewModel.deltaIntervalMinutes.collectAsStateWithLifecycle()
     val predictionCarbRatioGramsPerUnit by dashboardViewModel.predictionCarbRatioGramsPerUnit.collectAsStateWithLifecycle()
     val predictionInsulinSensitivityMgDlPerUnit by dashboardViewModel.predictionInsulinSensitivityMgDlPerUnit.collectAsStateWithLifecycle()
     val predictionModelProfile by dashboardViewModel.predictionModelProfile.collectAsStateWithLifecycle()
@@ -195,6 +197,8 @@ private fun HistoryRoute(
         journalInsulinPresets = journalInsulinPresets,
         journalFoods = journalFoods,
         quickAddAlwaysNow = journalQuickAddAlwaysNow,
+        showRowDelta = rowsShowDelta,
+        deltaIntervalMinutes = deltaIntervalMinutes,
         onBack = onBack,
         onPointClick = { point ->
             onTriggerCalibration(

--- a/Common/src/test/java/tk/glucodata/ui/HistoryRowDeltaTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/HistoryRowDeltaTests.kt
@@ -1,0 +1,204 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The history screen's reading rows carry the dashboard's "Δ": [RowDeltaIndex] is
+ * [readingDeltaTexts] keyed by reading, so for one sensor the two screens show the
+ * same text for the same reading, and the gap rule that blanks a row after a hole in
+ * the data holds there too. The history additionally spans sensors, and a row never
+ * pairs with another sensor's point.
+ */
+class HistoryRowDeltaTests {
+
+    private val nowMillis = 1_700_000_000_000L
+    private val minute = 60_000L
+
+    /** Oldest-first, like the history screen's sorted history. */
+    private fun oneMinuteCadence(
+        count: Int,
+        sensor: String? = null,
+        startMillis: Long = nowMillis,
+        valueAt: (minutesAgo: Int) -> Float
+    ): List<GlucosePoint> =
+        (count - 1 downTo 0).map { minutesAgo ->
+            GlucosePoint(
+                value = valueAt(minutesAgo),
+                time = "",
+                timestamp = startMillis - minutesAgo * minute,
+                sensorSerial = sensor
+            )
+        }
+
+    /** Newest-first, the order the history draws its rows in. */
+    private fun rowsOf(history: List<GlucosePoint>): List<GlucosePoint> = history.asReversed()
+
+    /** Serials are names, nothing more, unless a test says otherwise. */
+    private fun index(
+        history: List<GlucosePoint>,
+        sameSensor: (String, String) -> Boolean = { a, b -> a == b },
+        isShared: (String) -> Boolean = { false }
+    ) = RowDeltaIndex(history, sameSensor, isShared)
+
+    private fun dashboardTexts(rows: List<GlucosePoint>, history: List<GlucosePoint>): List<String?> =
+        readingDeltaTexts(rows.map { it.timestamp }, history, false, 5)
+
+    @Test
+    fun everyRowShowsWhatTheDashboardShowsForTheSameReading() {
+        val history = oneMinuteCadence(count = 30) { minutesAgo -> 100f + minutesAgo * 2f }
+        val rows = rowsOf(history)
+
+        val dashboard = dashboardTexts(rows, history)
+        val texts = index(history).textsFor(rows, false, 5)
+
+        rows.forEachIndexed { i, row -> assertEquals("row $i", dashboard[i], texts[row]) }
+        assertEquals("−10", texts[rows.first()])
+        assertEquals(25, texts.size) // the five oldest rows have no partner 4.5 min back
+    }
+
+    @Test
+    fun aWindowInTheMiddleOfTheHistoryMatchesTheDashboardToo() {
+        // The history shows a day weeks back: only the rows of that window are asked
+        // for, and they still pair with the points just before the window.
+        val history = oneMinuteCadence(count = 200) { minutesAgo -> 100f + (minutesAgo % 17) }
+        val window = history.subList(60, 90)
+        val rows = rowsOf(window)
+
+        val dashboard = dashboardTexts(rows, history)
+        val texts = index(history).textsFor(rows, false, 5)
+
+        rows.forEachIndexed { i, row -> assertEquals("row $i", dashboard[i], texts[row]) }
+        assertEquals(30, texts.size)
+    }
+
+    @Test
+    fun aRowWithoutAnOldEnoughPartnerIsAbsentNotEmpty() {
+        val history = oneMinuteCadence(count = 3) { 100f }
+        val rows = rowsOf(history)
+
+        val texts = index(history).textsFor(rows, false, 5)
+
+        assertTrue(texts.isEmpty())
+    }
+
+    @Test
+    fun aGapWiderThanThePairingRuleBlanksTheRowAfterIt() {
+        // A 25-minute hole, as the history shows after a dropped reader or a sensor
+        // that stopped. The rows after it have no partner within the 20-minute cap
+        // and show nothing rather than a number spanning the hole; the rows before
+        // it, eight minutes of them, pair among themselves as they always did.
+        val afterGap = (4 downTo 0).map { minutesAgo ->
+            GlucosePoint(value = 120f + minutesAgo, time = "", timestamp = nowMillis - minutesAgo * minute)
+        }
+        val beforeGap = (7 downTo 0).map { i ->
+            GlucosePoint(value = 100f + i, time = "", timestamp = nowMillis - 25 * minute - i * minute)
+        }
+        val history = beforeGap + afterGap
+        val rows = rowsOf(history)
+
+        val texts = index(history).textsFor(rows, false, 5)
+
+        afterGap.forEach { assertNull("after the gap: $it", texts[it]) }
+        assertEquals("−5", texts[beforeGap.last()])
+        assertEquals(3, texts.size) // the three newest rows before the gap reach 5 min back
+        assertFalse(texts.values.any { it.contains("NaN") })
+        val dashboard = dashboardTexts(rows, history)
+        rows.forEachIndexed { i, row -> assertEquals(dashboard[i], texts[row]) }
+    }
+
+    @Test
+    fun aRowNeverPairsWithAnotherSensorsReading() {
+        // Two sensors read side by side for ten minutes (the overlap of a swap):
+        // interleaved on the timeline, one minute apart. Each row's partner has to be
+        // its own sensor's point five minutes earlier, not the other sensor's.
+        val old = oneMinuteCadence(count = 10, sensor = "OLD") { 100f }
+        val new = oneMinuteCadence(count = 10, sensor = "NEW", startMillis = nowMillis - 30_000L) { 200f }
+        val history = (old + new).sortedBy { it.timestamp }
+        val rows = history.asReversed()
+
+        val texts = index(history).textsFor(rows, false, 5)
+
+        val oldOnly = dashboardTexts(old.asReversed(), old)
+        val newOnly = dashboardTexts(new.asReversed(), new)
+        old.asReversed().forEachIndexed { i, row -> assertEquals(oldOnly[i], texts[row]) }
+        new.asReversed().forEachIndexed { i, row -> assertEquals(newOnly[i], texts[row]) }
+        // Flat values on both sensors: a cross-sensor pair would have shown ±100.
+        assertTrue(texts.values.all { it == "0" })
+        assertNotNull(texts[old.last()])
+        assertNotNull(texts[new.last()])
+    }
+
+    @Test
+    fun theFirstRowsOfAReplacementSensorHaveNoDelta() {
+        // The new sensor starts six minutes after the old one stopped: close enough
+        // that, pooled, its first row would pair with the old sensor's last point.
+        val old = oneMinuteCadence(count = 10, sensor = "OLD", startMillis = nowMillis - 6 * minute) { 100f }
+        val new = oneMinuteCadence(count = 3, sensor = "NEW") { 150f }
+        val history = old + new
+        val rows = rowsOf(history)
+
+        val texts = index(history).textsFor(rows, false, 5)
+
+        new.forEach { assertNull("replacement sensor: $it", texts[it]) }
+        assertEquals("0", texts[old.last()])
+        assertNotNull("pooled, this row would read +50", dashboardTexts(rows, history).first())
+    }
+
+    @Test
+    fun aSensorStoredUnderTwoNamesIsOneSensor() {
+        // Older rows under the native name, newer ones under the app id — the identity
+        // rule says they match, so the walk-back crosses the rename.
+        val history = oneMinuteCadence(count = 12) { 100f }.mapIndexed { i, p ->
+            p.copy(sensorSerial = if (i < 6) "native-1" else "app-1")
+        }
+        val rows = rowsOf(history)
+        val sameSensor = { a: String, b: String -> a.removePrefix("native-").removePrefix("app-") == b.removePrefix("native-").removePrefix("app-") }
+
+        val texts = index(history, sameSensor).textsFor(rows, false, 5)
+
+        rows.forEachIndexed { i, row -> assertEquals(dashboardTexts(rows, history)[i], texts[row]) }
+        assertEquals(7, texts.size)
+        assertTrue("split by name, the rows right after the rename would be blank",
+            index(history).textsFor(rows, false, 5).size < 7)
+    }
+
+    @Test
+    fun importedRowsBelongToEverySensor() {
+        // A CSV import filled a hole in the live sensor's data: the live row after the
+        // hole pairs with the imported point, as it does on the dashboard.
+        val live = oneMinuteCadence(count = 3, sensor = "LIVE") { 120f }
+        val imported = listOf(GlucosePoint(value = 100f, time = "", timestamp = nowMillis - 6 * minute, sensorSerial = "imported"))
+        val history = imported + live
+        val rows = rowsOf(history)
+
+        val texts = index(history, isShared = { it == "imported" }).textsFor(rows, false, 5)
+
+        assertEquals("+16.7", texts[live.last()]) // 20 over six minutes, per five
+        assertEquals(dashboardTexts(rows, history)[0], texts[live.last()])
+        assertNull("not shared, the import is another sensor", index(history).textsFor(rows, false, 5)[live.last()])
+    }
+
+    @Test
+    fun blankAndMissingSerialsAreOneSensor() {
+        val history = oneMinuteCadence(count = 12) { 100f }.mapIndexed { i, p ->
+            if (i % 2 == 0) p.copy(sensorSerial = " ") else p
+        }
+        val rows = rowsOf(history)
+
+        val texts = index(history).textsFor(rows, false, 5)
+
+        rows.forEachIndexed { i, row -> assertEquals(dashboardTexts(rows, history)[i], texts[row]) }
+        assertEquals(7, texts.size)
+    }
+
+    @Test
+    fun emptyInputsProduceNoTexts() {
+        assertTrue(index(oneMinuteCadence(5) { 100f }).textsFor(emptyList(), false, 5).isEmpty())
+        assertTrue(index(emptyList()).textsFor(rowsOf(oneMinuteCadence(5) { 100f }), false, 5).isEmpty())
+    }
+}


### PR DESCRIPTION
The reading rows on the dashboard show a delta when "Reading-list delta" is on. Open the history and the same kind of list has none. `HistoryBrowseScreen` never read the setting: the row delta was built for the dashboard, where the request came from, and the history was never pulled along.

`HistoryRoute` now collects the same two flows (`dashboardRowsShowDelta`, `deltaIntervalMinutes`) and the screen calls the same `readingDeltaTexts` that the dashboard rows and the hero readout use, so both screens show the same number for the same reading instead of two computations that agree until they don't. The history draws its rows per day section, so the texts are keyed by the reading instead of by position, and only the reading branch passes one. Journal rows are unaffected.

The history has two things the dashboard list does not. It reaches back over real gaps: the existing minimum-gap rule and the 20-minute cap apply unchanged, so across a hole wider than the delta interval no delta is shown, instead of a figure that quietly spans two hours. And it spans sensors. A difference between two sensors' readings is not a measured change, so the history is bucketed per sensor (`SensorIdentity.matches`, so a sensor stored under two names stays one; imported and unknown rows belong to every bucket, as they do in the dashboard's per-sensor history) and each row walks back through its own bucket only. The index is built once per history, and a pan of the chart only binary-searches it.

The setting keeps its name and key, so there is no prefs migration for a rename. Its description now says it covers the dashboard and the history, in all maintained locales.

### Tests

Ten in `HistoryRowDeltaTests`: every row identical to the dashboard's text for the same reading, also for a window weeks back; a 25-minute hole blanks the rows after it and leaves the ones before it paired; interleaved sensors never pair; a replacement sensor starting six minutes after the last one has no delta where the pooled list would have shown one; a renamed sensor stays one; imported rows pair with the live sensor; blank and missing serials are one bucket; empty inputs. `DashboardReadingDeltaTests` and `GlucoseDeltaTests` are unchanged and green.
