### PR TITLE
Insulin pens: a pen tap with the app in the background imports on its own

### DIFF
--- a/Common/src/main/java/tk/glucodata/MainActivity.java
+++ b/Common/src/main/java/tk/glucodata/MainActivity.java
@@ -553,6 +553,16 @@ public class MainActivity extends AppCompatActivity implements NfcAdapter.Reader
         if (intent == null)
             return;
         final Bundle extras = intent.getExtras();
+        if ((intent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0) {
+            // A screen asked for from outside Compose: a notification carrying a route.
+            // The Compose host navigates once it is composed, so this also works from a
+            // cold start; a relaunch from Recents must not navigate again.
+            final String route = intent.getStringExtra(tk.glucodata.ui.PendingNavigation.EXTRA_ROUTE);
+            if (route != null && !route.isEmpty()) {
+                tk.glucodata.ui.PendingNavigation.request(route);
+                return;
+            }
+        }
         if (extras != null) {
             if (extras.getBoolean(Notify.fromnotification, false)) {
                 {
@@ -759,6 +769,12 @@ public class MainActivity extends AppCompatActivity implements NfcAdapter.Reader
     }
 
     boolean active = false;
+
+    /** Started and not stopped: the reader mode is armed and a tag belongs to it. */
+    public static boolean isInForeground() {
+        final MainActivity act = thisone;
+        return act != null && act.active;
+    }
     /*
      * static final class ShowMessage {
      * public String mess;
@@ -984,7 +1000,14 @@ public class MainActivity extends AppCompatActivity implements NfcAdapter.Reader
                             }
                             ;
                         }
-                            tk.glucodata.NovoPen.Scan.onTag(this, tag);
+                            // Reader mode delivers off the main thread; a TECH_DISCOVERED
+                            // intent (the background receiver handing a pen on) arrives on
+                            // it, and a pen read is seconds of I/O — same split as below.
+                            if (Thread.currentThread().equals(Looper.getMainLooper().getThread())) {
+                                new Thread(() -> tk.glucodata.NovoPen.Scan.onTag(this, tag)).start();
+                            } else {
+                                tk.glucodata.NovoPen.Scan.onTag(this, tag);
+                            }
                             // A full pen read takes seconds. Taps that arrived while it
                             // was running are queued on this monitor and would each start
                             // another read of the same pen, so re-arm the guard from now.

--- a/Common/src/main/java/tk/glucodata/ui/PendingNavigation.kt
+++ b/Common/src/main/java/tk/glucodata/ui/PendingNavigation.kt
@@ -1,0 +1,26 @@
+package tk.glucodata.ui
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * A navigation asked for from outside Compose (a notification tap, a quick-settings
+ * long press): MainActivity records the route here and the NavHost navigates when it
+ * is composed, so the request survives a cold start.
+ */
+object PendingNavigation {
+    const val EXTRA_ROUTE = "tk.glucodata.OPEN_ROUTE"
+
+    private val _route = MutableStateFlow<String?>(null)
+    val route: StateFlow<String?> = _route.asStateFlow()
+
+    @JvmStatic
+    fun request(route: String) {
+        _route.value = route
+    }
+
+    fun consume() {
+        _route.value = null
+    }
+}

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1230,6 +1230,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="preview">Папярэдні прагляд</string>
     <string name="previous_calibrations">Папярэднія каліброўкі</string>
     <string name="show_less">Паказаць менш</string>
+    <string name="show_more">Паказаць больш</string>
     <string name="show_all_count">Паказаць усе %1$d</string>
     <string name="anytime_calibration_target_reading">Паказанне #%1$d</string>
     <string name="anytime_calibration_applied_reading">Ужыта #%1$d</string>
@@ -2535,7 +2536,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_desc">Ручка захоўвае дозы за некалькі месяцаў, і поўнае счытванне займае некалькі секунд без адрыву. Так можна ўзяць даныя старэйшыя за апошні імпарт.</string>
     <string name="insulin_pen_read_cut_short">Ручку прыбралі занадта рана. Трымайце яе каля тэлефона, пакуль ён не завібруе.</string>
     <string name="insulin_pen_background_title">Імпарт у фоне</string>
-    <string name="insulin_pen_background_desc">Калі праграма не адкрыта, новыя дозы ручкі, прыкладзенай да тэлефона, дадаюцца ў журнал без пытанняў. Прапускі паветра прапускаюцца. Экран павінен быць уключаны, а тэлефон разблакіраваны — Android не чытае NFC пры выключаным экране. Любая бескантактная картка, прыкладзеная да тэлефона, на імгненне абуджае счытвальнік, а іншыя праграмы для картак могуць спытаць, якую праграму выкарыстоўваць.</string>
+    <string name="insulin_pen_background_desc">Калі праграма не адкрыта, новыя дозы ручкі, прыкладзенай да тэлефона, дадаюцца ў журнал без пытанняў.</string>
+    <string name="insulin_pen_background_desc_more">Прапускі паветра прапускаюцца. Экран павінен быць уключаны, а тэлефон разблакіраваны — Android не чытае NFC пры выключаным экране. Любая бескантактная картка, прыкладзеная да тэлефона, на імгненне абуджае счытвальнік, а іншыя праграмы для картак могуць спытаць, якую праграму выкарыстоўваць.</string>
     <string name="insulin_pen_import_channel">Імпарт з ручкі</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d доза дададзена ў журнал</item>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2534,6 +2534,21 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_armed">Гатова — паднясіце ручку да тэлефона</string>
     <string name="insulin_pen_full_read_desc">Ручка захоўвае дозы за некалькі месяцаў, і поўнае счытванне займае некалькі секунд без адрыву. Так можна ўзяць даныя старэйшыя за апошні імпарт.</string>
     <string name="insulin_pen_read_cut_short">Ручку прыбралі занадта рана. Трымайце яе каля тэлефона, пакуль ён не завібруе.</string>
+    <string name="insulin_pen_background_title">Імпарт у фоне</string>
+    <string name="insulin_pen_background_desc">Калі праграма не адкрыта, новыя дозы ручкі, прыкладзенай да тэлефона, дадаюцца ў журнал без пытанняў. Прапускі паветра прапускаюцца. Экран павінен быць уключаны, а тэлефон разблакіраваны — Android не чытае NFC пры выключаным экране. Любая бескантактная картка, прыкладзеная да тэлефона, на імгненне абуджае счытвальнік, а іншыя праграмы для картак могуць спытаць, якую праграму выкарыстоўваць.</string>
+    <string name="insulin_pen_import_channel">Імпарт з ручкі</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d доза дададзена ў журнал</item>
+        <item quantity="few">%d дозы дададзены ў журнал</item>
+        <item quantity="many">%d доз дададзена ў журнал</item>
+        <item quantity="other">%d дозы дададзена ў журнал</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">Лічана %d доза — адкрыйце праграму, каб выбраць інсулін</item>
+        <item quantity="few">Лічаны %d дозы — адкрыйце праграму, каб выбраць інсулін</item>
+        <item quantity="many">Лічана %d доз — адкрыйце праграму, каб выбраць інсулін</item>
+        <item quantity="other">Лічана %d дозы — адкрыйце праграму, каб выбраць інсулін</item>
+    </plurals>
     <string name="status_watch_reading">Гадзіннік чытае гэты сэнсар</string>
     <string name="return_sensor_to_phone">Вярнуць датчык на тэлефон</string>
     <string name="wear_prediction_title">Прагноз</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1303,6 +1303,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="preview">Vorschau</string>
     <string name="previous_calibrations">Frühere Kalibrierungen</string>
     <string name="show_less">Weniger anzeigen</string>
+    <string name="show_more">Mehr anzeigen</string>
     <string name="show_all_count">Alle %1$d anzeigen</string>
     <string name="anytime_calibration_target_reading">Messung #%1$d</string>
     <string name="anytime_calibration_applied_reading">Angewendet #%1$d</string>
@@ -2507,7 +2508,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="insulin_pen_full_read_desc">Ein Pen speichert Monate an Dosen und braucht mehrere Sekunden ruhigen Kontakt. Damit gehen Sie weiter zurück als bis zum letzten Import.</string>
     <string name="insulin_pen_read_cut_short">Der Pen war zu kurz am Telefon. Halten Sie ihn dran, bis es vibriert.</string>
     <string name="insulin_pen_background_title">Im Hintergrund importieren</string>
-    <string name="insulin_pen_background_desc">Ist die App nicht geöffnet, werden die neuen Dosen eines an das Telefon gehaltenen Pens ohne Rückfrage ins Tagebuch übernommen. Entlüftungsstöße werden übersprungen. Der Bildschirm muss an und das Telefon entsperrt sein — bei ausgeschaltetem Bildschirm liest Android kein NFC. Jede kontaktlose Karte am Telefon weckt den Leser kurz, und andere Karten-Apps fragen womöglich, welche App verwendet werden soll.</string>
+    <string name="insulin_pen_background_desc">Ist die App nicht geöffnet, werden die neuen Dosen eines an das Telefon gehaltenen Pens ohne Rückfrage ins Tagebuch übernommen.</string>
+    <string name="insulin_pen_background_desc_more">Entlüftungsstöße werden übersprungen. Der Bildschirm muss an und das Telefon entsperrt sein — bei ausgeschaltetem Bildschirm liest Android kein NFC. Jede kontaktlose Karte am Telefon weckt den Leser kurz, und andere Karten-Apps fragen womöglich, welche App verwendet werden soll.</string>
     <string name="insulin_pen_import_channel">Pen-Importe</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d Dosis ins Tagebuch übernommen</item>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2506,6 +2506,17 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="insulin_pen_full_read_armed">Bereit — Pen an das Telefon halten</string>
     <string name="insulin_pen_full_read_desc">Ein Pen speichert Monate an Dosen und braucht mehrere Sekunden ruhigen Kontakt. Damit gehen Sie weiter zurück als bis zum letzten Import.</string>
     <string name="insulin_pen_read_cut_short">Der Pen war zu kurz am Telefon. Halten Sie ihn dran, bis es vibriert.</string>
+    <string name="insulin_pen_background_title">Im Hintergrund importieren</string>
+    <string name="insulin_pen_background_desc">Ist die App nicht geöffnet, werden die neuen Dosen eines an das Telefon gehaltenen Pens ohne Rückfrage ins Tagebuch übernommen. Entlüftungsstöße werden übersprungen. Der Bildschirm muss an und das Telefon entsperrt sein — bei ausgeschaltetem Bildschirm liest Android kein NFC. Jede kontaktlose Karte am Telefon weckt den Leser kurz, und andere Karten-Apps fragen womöglich, welche App verwendet werden soll.</string>
+    <string name="insulin_pen_import_channel">Pen-Importe</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d Dosis ins Tagebuch übernommen</item>
+        <item quantity="other">%d Dosen ins Tagebuch übernommen</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d Dosis gelesen — App öffnen, um das Insulin zu wählen</item>
+        <item quantity="other">%d Dosen gelesen — App öffnen, um das Insulin zu wählen</item>
+    </plurals>
     <string name="status_watch_reading">Die Uhr liest diesen Sensor</string>
     <string name="return_sensor_to_phone">Sensor an Smartphone zurückgeben</string>
     <string name="wear_prediction_title">Prognose</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2473,6 +2473,17 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_armed">Prêt — approchez le stylo du téléphone</string>
     <string name="insulin_pen_full_read_desc">Un stylo conserve des mois de doses et demande plusieurs secondes de contact stable. Ceci permet de remonter au-delà du dernier import.</string>
     <string name="insulin_pen_read_cut_short">Le stylo a été retiré trop tôt. Maintenez-le contre le téléphone jusqu\'à ce qu\'il vibre.</string>
+    <string name="insulin_pen_background_title">Importer en arrière-plan</string>
+    <string name="insulin_pen_background_desc">Quand l’application n’est pas ouverte, un stylo approché du téléphone voit ses nouvelles doses ajoutées au journal sans confirmation. Les purges sont ignorées. L’écran doit être allumé et le téléphone déverrouillé — Android ne lit pas le NFC écran éteint. Toute carte sans contact approchée du téléphone réveille un instant le lecteur, et d’autres applications de cartes peuvent demander laquelle utiliser.</string>
+    <string name="insulin_pen_import_channel">Imports de stylo</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d dose ajoutée au journal</item>
+        <item quantity="other">%d doses ajoutées au journal</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d dose lue — ouvrez l’application pour choisir l’insuline</item>
+        <item quantity="other">%d doses lues — ouvrez l’application pour choisir l’insuline</item>
+    </plurals>
     <string name="status_watch_reading">La montre lit ce capteur</string>
     <string name="return_sensor_to_phone">Reprendre le capteur sur le téléphone</string>
     <string name="wear_prediction_title">Prévision</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1237,6 +1237,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="preview">Aperçu</string>
     <string name="previous_calibrations">Étalonnages précédents</string>
     <string name="show_less">Afficher moins</string>
+    <string name="show_more">Afficher plus</string>
     <string name="show_all_count">Tout afficher %1$d</string>
     <string name="anytime_calibration_target_reading">Lecture #%1$d</string>
     <string name="anytime_calibration_applied_reading">Appliquée #%1$d</string>
@@ -2474,7 +2475,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_desc">Un stylo conserve des mois de doses et demande plusieurs secondes de contact stable. Ceci permet de remonter au-delà du dernier import.</string>
     <string name="insulin_pen_read_cut_short">Le stylo a été retiré trop tôt. Maintenez-le contre le téléphone jusqu\'à ce qu\'il vibre.</string>
     <string name="insulin_pen_background_title">Importer en arrière-plan</string>
-    <string name="insulin_pen_background_desc">Quand l’application n’est pas ouverte, un stylo approché du téléphone voit ses nouvelles doses ajoutées au journal sans confirmation. Les purges sont ignorées. L’écran doit être allumé et le téléphone déverrouillé — Android ne lit pas le NFC écran éteint. Toute carte sans contact approchée du téléphone réveille un instant le lecteur, et d’autres applications de cartes peuvent demander laquelle utiliser.</string>
+    <string name="insulin_pen_background_desc">Quand l’application n’est pas ouverte, un stylo approché du téléphone voit ses nouvelles doses ajoutées au journal sans confirmation.</string>
+    <string name="insulin_pen_background_desc_more">Les purges sont ignorées. L’écran doit être allumé et le téléphone déverrouillé — Android ne lit pas le NFC écran éteint. Toute carte sans contact approchée du téléphone réveille un instant le lecteur, et d’autres applications de cartes peuvent demander laquelle utiliser.</string>
     <string name="insulin_pen_import_channel">Imports de stylo</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d dose ajoutée au journal</item>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1221,6 +1221,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="preview">Anteprima</string>
     <string name="previous_calibrations">Calibrazioni precedenti</string>
     <string name="show_less">Mostra meno</string>
+    <string name="show_more">Mostra altro</string>
     <string name="show_all_count">Mostra tutti %1$d</string>
     <string name="anytime_calibration_target_reading">Lettura #%1$d</string>
     <string name="anytime_calibration_applied_reading">Applicata #%1$d</string>
@@ -2458,7 +2459,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_desc">Una penna conserva mesi di dosi e richiede alcuni secondi di contatto stabile. Serve per andare più indietro dell\'ultima importazione.</string>
     <string name="insulin_pen_read_cut_short">La penna si è allontanata troppo presto. Tienila sul telefono finché non vibra.</string>
     <string name="insulin_pen_background_title">Importa in background</string>
-    <string name="insulin_pen_background_desc">Quando l’app non è aperta, le nuove dosi di una penna avvicinata al telefono vengono aggiunte al diario senza chiedere. Gli spurghi vengono saltati. Lo schermo deve essere acceso e il telefono sbloccato — Android non legge l’NFC a schermo spento. Qualsiasi carta contactless avvicinata al telefono risveglia per un attimo il lettore, e altre app per carte potrebbero chiedere quale app usare.</string>
+    <string name="insulin_pen_background_desc">Quando l’app non è aperta, le nuove dosi di una penna avvicinata al telefono vengono aggiunte al diario senza chiedere.</string>
+    <string name="insulin_pen_background_desc_more">Gli spurghi vengono saltati. Lo schermo deve essere acceso e il telefono sbloccato — Android non legge l’NFC a schermo spento. Qualsiasi carta contactless avvicinata al telefono risveglia per un attimo il lettore, e altre app per carte potrebbero chiedere quale app usare.</string>
     <string name="insulin_pen_import_channel">Importazioni penna</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d dose aggiunta al diario</item>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2457,6 +2457,17 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_armed">Pronto — avvicina la penna al telefono</string>
     <string name="insulin_pen_full_read_desc">Una penna conserva mesi di dosi e richiede alcuni secondi di contatto stabile. Serve per andare più indietro dell\'ultima importazione.</string>
     <string name="insulin_pen_read_cut_short">La penna si è allontanata troppo presto. Tienila sul telefono finché non vibra.</string>
+    <string name="insulin_pen_background_title">Importa in background</string>
+    <string name="insulin_pen_background_desc">Quando l’app non è aperta, le nuove dosi di una penna avvicinata al telefono vengono aggiunte al diario senza chiedere. Gli spurghi vengono saltati. Lo schermo deve essere acceso e il telefono sbloccato — Android non legge l’NFC a schermo spento. Qualsiasi carta contactless avvicinata al telefono risveglia per un attimo il lettore, e altre app per carte potrebbero chiedere quale app usare.</string>
+    <string name="insulin_pen_import_channel">Importazioni penna</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d dose aggiunta al diario</item>
+        <item quantity="other">%d dosi aggiunte al diario</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d dose letta — apri l’app per scegliere l’insulina</item>
+        <item quantity="other">%d dosi lette — apri l’app per scegliere l’insulina</item>
+    </plurals>
     <string name="status_watch_reading">L\'orologio sta leggendo questo sensore</string>
     <string name="return_sensor_to_phone">Riporta il sensore al telefono</string>
     <string name="wear_prediction_title">Previsione</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1253,6 +1253,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="preview">Preview</string>
     <string name="previous_calibrations">Өмнөх тохируулгууд</string>
     <string name="show_less">Бага харуулах</string>
+    <string name="show_more">Дэлгэрэнгүй харуулах</string>
     <string name="show_all_count">Бүгдийг харуулах %1$d</string>
     <string name="anytime_calibration_target_reading">Уншилт #%1$d</string>
     <string name="anytime_calibration_applied_reading">Хэрэглэсэн #%1$d</string>
@@ -2583,7 +2584,8 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="insulin_pen_full_read_desc">Үзэг хэдэн сарын тунг хадгалдаг бөгөөд бүрэн уншихад хэдэн секунд тогтвортой хүрэлцээ шаардана. Сүүлийн оруулснаас цааш ухахад ашиглана.</string>
     <string name="insulin_pen_read_cut_short">Үзгийг хэт эрт авчихлаа. Утас чичрэх хүртэл барина уу.</string>
     <string name="insulin_pen_background_title">Арын горимд импортлох</string>
-    <string name="insulin_pen_background_desc">Апп нээлттэй биш үед утсанд ойртуулсан үзэгний шинэ тунгууд асуулгүйгээр өдрийн тэмдэглэлд нэмэгдэнэ. Агааржуулалтын тунг алгасна. Дэлгэц асаалттай, утас түгжээгүй байх ёстой — дэлгэц унтраалттай үед Android NFC уншдаггүй. Утсанд ойртуулсан аливаа контактгүй карт уншигчийг хормын төдий сэрээх бөгөөд бусад картын аппууд аль аппыг ашиглахыг асууж магадгүй.</string>
+    <string name="insulin_pen_background_desc">Апп нээлттэй биш үед утсанд ойртуулсан үзэгний шинэ тунгууд асуулгүйгээр өдрийн тэмдэглэлд нэмэгдэнэ.</string>
+    <string name="insulin_pen_background_desc_more">Агааржуулалтын тунг алгасна. Дэлгэц асаалттай, утас түгжээгүй байх ёстой — дэлгэц унтраалттай үед Android NFC уншдаггүй. Утсанд ойртуулсан аливаа контактгүй карт уншигчийг хормын төдий сэрээх бөгөөд бусад картын аппууд аль аппыг ашиглахыг асууж магадгүй.</string>
     <string name="insulin_pen_import_channel">Үзэгний импорт</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d тун тэмдэглэлд нэмэгдлээ</item>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2582,6 +2582,17 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="insulin_pen_full_read_armed">Бэлэн — үзгээ утсандаа ойртуулна уу</string>
     <string name="insulin_pen_full_read_desc">Үзэг хэдэн сарын тунг хадгалдаг бөгөөд бүрэн уншихад хэдэн секунд тогтвортой хүрэлцээ шаардана. Сүүлийн оруулснаас цааш ухахад ашиглана.</string>
     <string name="insulin_pen_read_cut_short">Үзгийг хэт эрт авчихлаа. Утас чичрэх хүртэл барина уу.</string>
+    <string name="insulin_pen_background_title">Арын горимд импортлох</string>
+    <string name="insulin_pen_background_desc">Апп нээлттэй биш үед утсанд ойртуулсан үзэгний шинэ тунгууд асуулгүйгээр өдрийн тэмдэглэлд нэмэгдэнэ. Агааржуулалтын тунг алгасна. Дэлгэц асаалттай, утас түгжээгүй байх ёстой — дэлгэц унтраалттай үед Android NFC уншдаггүй. Утсанд ойртуулсан аливаа контактгүй карт уншигчийг хормын төдий сэрээх бөгөөд бусад картын аппууд аль аппыг ашиглахыг асууж магадгүй.</string>
+    <string name="insulin_pen_import_channel">Үзэгний импорт</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d тун тэмдэглэлд нэмэгдлээ</item>
+        <item quantity="other">%d тун тэмдэглэлд нэмэгдлээ</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d тун уншлаа — инсулинаа сонгохын тулд аппаа нээнэ үү</item>
+        <item quantity="other">%d тун уншлаа — инсулинаа сонгохын тулд аппаа нээнэ үү</item>
+    </plurals>
     <string name="status_watch_reading">Цаг энэ мэдрэгчийг уншиж байна</string>
     <string name="return_sensor_to_phone">Мэдрэгчийг утсанд буцаах</string>
     <string name="wear_prediction_title">Таамаглал</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1274,6 +1274,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="preview">Voorbeeld</string>
     <string name="previous_calibrations">Eerdere kalibraties</string>
     <string name="show_less">Minder tonen</string>
+    <string name="show_more">Meer tonen</string>
     <string name="show_all_count">Alle %1$d tonen</string>
     <string name="anytime_calibration_target_reading">Meting #%1$d</string>
     <string name="anytime_calibration_applied_reading">Toegepast #%1$d</string>
@@ -2511,7 +2512,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="insulin_pen_full_read_desc">Een pen bewaart maanden aan doses en heeft enkele seconden stabiel contact nodig. Hiermee ga je verder terug dan de laatste import.</string>
     <string name="insulin_pen_read_cut_short">De pen ging te snel weg. Houd hem tegen de telefoon tot deze trilt.</string>
     <string name="insulin_pen_background_title">Op de achtergrond importeren</string>
-    <string name="insulin_pen_background_desc">Als de app niet open is, worden de nieuwe doses van een pen die tegen de telefoon wordt gehouden zonder vragen aan het logboek toegevoegd. Ontluchtingen worden overgeslagen. Het scherm moet aan staan en de telefoon ontgrendeld zijn — Android leest geen NFC met het scherm uit. Elke contactloze kaart tegen de telefoon wekt de lezer even, en andere kaart-apps kunnen vragen welke app te gebruiken.</string>
+    <string name="insulin_pen_background_desc">Als de app niet open is, worden de nieuwe doses van een pen die tegen de telefoon wordt gehouden zonder vragen aan het logboek toegevoegd.</string>
+    <string name="insulin_pen_background_desc_more">Ontluchtingen worden overgeslagen. Het scherm moet aan staan en de telefoon ontgrendeld zijn — Android leest geen NFC met het scherm uit. Elke contactloze kaart tegen de telefoon wekt de lezer even, en andere kaart-apps kunnen vragen welke app te gebruiken.</string>
     <string name="insulin_pen_import_channel">Pen-imports</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d dosis aan het dagboek toegevoegd</item>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2510,6 +2510,17 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="insulin_pen_full_read_armed">Klaar — houd de pen tegen de telefoon</string>
     <string name="insulin_pen_full_read_desc">Een pen bewaart maanden aan doses en heeft enkele seconden stabiel contact nodig. Hiermee ga je verder terug dan de laatste import.</string>
     <string name="insulin_pen_read_cut_short">De pen ging te snel weg. Houd hem tegen de telefoon tot deze trilt.</string>
+    <string name="insulin_pen_background_title">Op de achtergrond importeren</string>
+    <string name="insulin_pen_background_desc">Als de app niet open is, worden de nieuwe doses van een pen die tegen de telefoon wordt gehouden zonder vragen aan het logboek toegevoegd. Ontluchtingen worden overgeslagen. Het scherm moet aan staan en de telefoon ontgrendeld zijn — Android leest geen NFC met het scherm uit. Elke contactloze kaart tegen de telefoon wekt de lezer even, en andere kaart-apps kunnen vragen welke app te gebruiken.</string>
+    <string name="insulin_pen_import_channel">Pen-imports</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d dosis aan het dagboek toegevoegd</item>
+        <item quantity="other">%d doses aan het dagboek toegevoegd</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d dosis gelezen — open de app om de insuline te kiezen</item>
+        <item quantity="other">%d doses gelezen — open de app om de insuline te kiezen</item>
+    </plurals>
     <string name="status_watch_reading">De horloge leest deze sensor</string>
     <string name="return_sensor_to_phone">Sensor terug naar telefoon</string>
     <string name="wear_prediction_title">Voorspelling</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1266,6 +1266,7 @@
     <string name="preview">Podgląd</string>
     <string name="previous_calibrations">Poprzednie kalibracje</string>
     <string name="show_less">Pokaż mniej</string>
+    <string name="show_more">Pokaż więcej</string>
     <string name="show_all_count">Pokaż wszystkie %1$d</string>
     <string name="anytime_calibration_target_reading">Odczyt #%1$d</string>
     <string name="anytime_calibration_applied_reading">Zastosowano #%1$d</string>
@@ -2502,7 +2503,8 @@
     <string name="insulin_pen_full_read_desc">Wstrzykiwacz przechowuje dawki z wielu miesięcy i wymaga kilku sekund stabilnego kontaktu. Pozwala sięgnąć dalej niż ostatni import.</string>
     <string name="insulin_pen_read_cut_short">Wstrzykiwacz został odsunięty za wcześnie. Trzymaj go przy telefonie, aż zawibruje.</string>
     <string name="insulin_pen_background_title">Importuj w tle</string>
-    <string name="insulin_pen_background_desc">Gdy aplikacja nie jest otwarta, nowe dawki pena przyłożonego do telefonu są dodawane do dziennika bez pytania. Odpowietrzenia są pomijane. Ekran musi być włączony, a telefon odblokowany — Android nie czyta NFC przy wyłączonym ekranie. Każda karta zbliżeniowa przyłożona do telefonu na chwilę budzi czytnik, a inne aplikacje kart mogą zapytać, której aplikacji użyć.</string>
+    <string name="insulin_pen_background_desc">Gdy aplikacja nie jest otwarta, nowe dawki pena przyłożonego do telefonu są dodawane do dziennika bez pytania.</string>
+    <string name="insulin_pen_background_desc_more">Odpowietrzenia są pomijane. Ekran musi być włączony, a telefon odblokowany — Android nie czyta NFC przy wyłączonym ekranie. Każda karta zbliżeniowa przyłożona do telefonu na chwilę budzi czytnik, a inne aplikacje kart mogą zapytać, której aplikacji użyć.</string>
     <string name="insulin_pen_import_channel">Importy z pena</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d dawka dodana do dziennika</item>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2501,6 +2501,21 @@
     <string name="insulin_pen_full_read_armed">Gotowe — przyłóż wstrzykiwacz do telefonu</string>
     <string name="insulin_pen_full_read_desc">Wstrzykiwacz przechowuje dawki z wielu miesięcy i wymaga kilku sekund stabilnego kontaktu. Pozwala sięgnąć dalej niż ostatni import.</string>
     <string name="insulin_pen_read_cut_short">Wstrzykiwacz został odsunięty za wcześnie. Trzymaj go przy telefonie, aż zawibruje.</string>
+    <string name="insulin_pen_background_title">Importuj w tle</string>
+    <string name="insulin_pen_background_desc">Gdy aplikacja nie jest otwarta, nowe dawki pena przyłożonego do telefonu są dodawane do dziennika bez pytania. Odpowietrzenia są pomijane. Ekran musi być włączony, a telefon odblokowany — Android nie czyta NFC przy wyłączonym ekranie. Każda karta zbliżeniowa przyłożona do telefonu na chwilę budzi czytnik, a inne aplikacje kart mogą zapytać, której aplikacji użyć.</string>
+    <string name="insulin_pen_import_channel">Importy z pena</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d dawka dodana do dziennika</item>
+        <item quantity="few">%d dawki dodane do dziennika</item>
+        <item quantity="many">%d dawek dodanych do dziennika</item>
+        <item quantity="other">%d dawki dodane do dziennika</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">Odczytano %d dawkę — otwórz aplikację, aby wybrać insulinę</item>
+        <item quantity="few">Odczytano %d dawki — otwórz aplikację, aby wybrać insulinę</item>
+        <item quantity="many">Odczytano %d dawek — otwórz aplikację, aby wybrać insulinę</item>
+        <item quantity="other">Odczytano %d dawki — otwórz aplikację, aby wybrać insulinę</item>
+    </plurals>
     <string name="status_watch_reading">Zegarek odczytuje ten czujnik</string>
     <string name="return_sensor_to_phone">Przenieś sensor z powrotem na telefon</string>
     <string name="wear_prediction_title">Prognoza</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1232,6 +1232,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="preview">Visualização</string>
     <string name="previous_calibrations">Calibrações anteriores</string>
     <string name="show_less">Mostrar menos</string>
+    <string name="show_more">Mostrar mais</string>
     <string name="show_all_count">Mostrar todos %1$d</string>
     <string name="anytime_calibration_target_reading">Leitura #%1$d</string>
     <string name="anytime_calibration_applied_reading">Aplicada #%1$d</string>
@@ -2469,7 +2470,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_desc">Uma caneta guarda meses de doses e precisa de alguns segundos de contacto estável. Serve para recuar mais do que a última importação.</string>
     <string name="insulin_pen_read_cut_short">A caneta afastou-se cedo demais. Mantenha-a no telemóvel até vibrar.</string>
     <string name="insulin_pen_background_title">Importar em segundo plano</string>
-    <string name="insulin_pen_background_desc">Com a aplicação fechada, as novas doses de uma caneta encostada ao telefone são adicionadas ao diário sem perguntar. As purgas são ignoradas. O ecrã tem de estar ligado e o telefone desbloqueado — o Android não lê NFC com o ecrã desligado. Qualquer cartão sem contacto encostado ao telefone acorda o leitor por um instante, e outras aplicações de cartões podem perguntar qual usar.</string>
+    <string name="insulin_pen_background_desc">Com a aplicação fechada, as novas doses de uma caneta encostada ao telefone são adicionadas ao diário sem perguntar.</string>
+    <string name="insulin_pen_background_desc_more">As purgas são ignoradas. O ecrã tem de estar ligado e o telefone desbloqueado — o Android não lê NFC com o ecrã desligado. Qualquer cartão sem contacto encostado ao telefone acorda o leitor por um instante, e outras aplicações de cartões podem perguntar qual usar.</string>
     <string name="insulin_pen_import_channel">Importações da caneta</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d dose adicionada ao diário</item>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2468,6 +2468,17 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_armed">Pronto — encoste a caneta ao telemóvel</string>
     <string name="insulin_pen_full_read_desc">Uma caneta guarda meses de doses e precisa de alguns segundos de contacto estável. Serve para recuar mais do que a última importação.</string>
     <string name="insulin_pen_read_cut_short">A caneta afastou-se cedo demais. Mantenha-a no telemóvel até vibrar.</string>
+    <string name="insulin_pen_background_title">Importar em segundo plano</string>
+    <string name="insulin_pen_background_desc">Com a aplicação fechada, as novas doses de uma caneta encostada ao telefone são adicionadas ao diário sem perguntar. As purgas são ignoradas. O ecrã tem de estar ligado e o telefone desbloqueado — o Android não lê NFC com o ecrã desligado. Qualquer cartão sem contacto encostado ao telefone acorda o leitor por um instante, e outras aplicações de cartões podem perguntar qual usar.</string>
+    <string name="insulin_pen_import_channel">Importações da caneta</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d dose adicionada ao diário</item>
+        <item quantity="other">%d doses adicionadas ao diário</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d dose lida — abra a app para escolher a insulina</item>
+        <item quantity="other">%d doses lidas — abra a app para escolher a insulina</item>
+    </plurals>
     <string name="status_watch_reading">O relógio está a ler este sensor</string>
     <string name="return_sensor_to_phone">Devolver o sensor ao telemóvel</string>
     <string name="wear_prediction_title">Previsão</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1268,6 +1268,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="preview">Предварительный просмотр</string>
     <string name="previous_calibrations">Предыдущие калибровки</string>
     <string name="show_less">Скрыть</string>
+    <string name="show_more">Показать больше</string>
     <string name="show_all_count">Показать все %1$d</string>
     <string name="anytime_calibration_target_reading">Измерение #%1$d</string>
     <string name="anytime_calibration_applied_reading">Применено #%1$d</string>
@@ -2511,7 +2512,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_desc">Ручка хранит дозы за несколько месяцев, и на полное считывание нужно несколько секунд без отрыва. Так можно взять данные старше последнего импорта.</string>
     <string name="insulin_pen_read_cut_short">Ручку убрали слишком рано. Держите её у телефона, пока он не завибрирует.</string>
     <string name="insulin_pen_background_title">Импорт в фоне</string>
-    <string name="insulin_pen_background_desc">Когда приложение не открыто, новые дозы ручки, приложенной к телефону, добавляются в журнал без вопросов. Продувки пропускаются. Экран должен быть включён, а телефон разблокирован — Android не читает NFC при выключенном экране. Любая бесконтактная карта, приложенная к телефону, на мгновение будит считыватель, а другие приложения для карт могут спросить, какое приложение использовать.</string>
+    <string name="insulin_pen_background_desc">Когда приложение не открыто, новые дозы ручки, приложенной к телефону, добавляются в журнал без вопросов.</string>
+    <string name="insulin_pen_background_desc_more">Продувки пропускаются. Экран должен быть включён, а телефон разблокирован — Android не читает NFC при выключенном экране. Любая бесконтактная карта, приложенная к телефону, на мгновение будит считыватель, а другие приложения для карт могут спросить, какое приложение использовать.</string>
     <string name="insulin_pen_import_channel">Импорт с ручки</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d доза добавлена в журнал</item>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2510,6 +2510,21 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_armed">Готово — поднесите ручку к телефону</string>
     <string name="insulin_pen_full_read_desc">Ручка хранит дозы за несколько месяцев, и на полное считывание нужно несколько секунд без отрыва. Так можно взять данные старше последнего импорта.</string>
     <string name="insulin_pen_read_cut_short">Ручку убрали слишком рано. Держите её у телефона, пока он не завибрирует.</string>
+    <string name="insulin_pen_background_title">Импорт в фоне</string>
+    <string name="insulin_pen_background_desc">Когда приложение не открыто, новые дозы ручки, приложенной к телефону, добавляются в журнал без вопросов. Продувки пропускаются. Экран должен быть включён, а телефон разблокирован — Android не читает NFC при выключенном экране. Любая бесконтактная карта, приложенная к телефону, на мгновение будит считыватель, а другие приложения для карт могут спросить, какое приложение использовать.</string>
+    <string name="insulin_pen_import_channel">Импорт с ручки</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d доза добавлена в журнал</item>
+        <item quantity="few">%d дозы добавлены в журнал</item>
+        <item quantity="many">%d доз добавлено в журнал</item>
+        <item quantity="other">%d дозы добавлено в журнал</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">Считана %d доза — откройте приложение, чтобы выбрать инсулин</item>
+        <item quantity="few">Считаны %d дозы — откройте приложение, чтобы выбрать инсулин</item>
+        <item quantity="many">Считано %d доз — откройте приложение, чтобы выбрать инсулин</item>
+        <item quantity="other">Считано %d дозы — откройте приложение, чтобы выбрать инсулин</item>
+    </plurals>
     <string name="status_watch_reading">Часы читают этот датчик</string>
     <string name="return_sensor_to_phone">Вернуть датчик на телефон</string>
     <string name="wear_prediction_title">Прогноз</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2667,6 +2667,17 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="insulin_pen_full_read_armed">Diyaar — qalinka taabsii taleefanka</string>
     <string name="insulin_pen_full_read_desc">Qalinku wuxuu hayaa qiyaaso bilo ah, akhrintooda dhammaystiran waxay u baahan tahay dhowr ilbiriqsi oo taabasho degan ah. Isticmaal si aad uga gudubto wixii ugu dambeeyay ee la soo geliyay.</string>
     <string name="insulin_pen_read_cut_short">Qalinka ayaa goor hore laga fogeeyay. Ku hay taleefanka ilaa uu gariiro.</string>
+    <string name="insulin_pen_background_title">Gudaha ka soo dejiso</string>
+    <string name="insulin_pen_background_desc">Marka appku furnayn, qalinka la dhigo taleefanka qiyaasihiisa cusub ayaa lagu daraa joornaalka iyada oo aan la weydiin. Hawo-bixinta waa la boodaa. Shaashaddu waa inay shidan tahay, taleefankuna furan yahay — Android ma akhriyo NFC marka shaashaddu damsan tahay. Kaar kasta oo aan taabasho lahayn oo la dhigo taleefanka wuxuu in yar toosiyaa akhristaha, appyada kale ee kaararkuna waxay weydiin karaan appka la isticmaalayo.</string>
+    <string name="insulin_pen_import_channel">Soo dejinta qalinka</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d qiyaas ayaa lagu daray xusuus-qorka</item>
+        <item quantity="other">%d qiyaasood ayaa lagu daray xusuus-qorka</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d qiyaas ayaa la akhriyay — fur app-ka si aad u doorato insulinta</item>
+        <item quantity="other">%d qiyaasood ayaa la akhriyay — fur app-ka si aad u doorato insulinta</item>
+    </plurals>
     <string name="status_watch_reading">Saacaddu waxay akhrinaysaa dareemahan</string>
     <string name="return_sensor_to_phone">Dareemaha ku celi telefoonka</string>
     <string name="wear_prediction_title">Saadaal</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1530,6 +1530,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="preview">Horudhac</string>
     <string name="previous_calibrations">Qalabkii hore</string>
     <string name="show_less">Muuji wax yar</string>
+    <string name="show_more">Muuji wax badan</string>
     <string name="show_all_count">Tus dhammaan %1$d</string>
     <string name="anytime_calibration_target_reading">Akhriska #%1$d</string>
     <string name="anytime_calibration_applied_reading">Codsaday #%1$d</string>
@@ -2668,7 +2669,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="insulin_pen_full_read_desc">Qalinku wuxuu hayaa qiyaaso bilo ah, akhrintooda dhammaystiran waxay u baahan tahay dhowr ilbiriqsi oo taabasho degan ah. Isticmaal si aad uga gudubto wixii ugu dambeeyay ee la soo geliyay.</string>
     <string name="insulin_pen_read_cut_short">Qalinka ayaa goor hore laga fogeeyay. Ku hay taleefanka ilaa uu gariiro.</string>
     <string name="insulin_pen_background_title">Gudaha ka soo dejiso</string>
-    <string name="insulin_pen_background_desc">Marka appku furnayn, qalinka la dhigo taleefanka qiyaasihiisa cusub ayaa lagu daraa joornaalka iyada oo aan la weydiin. Hawo-bixinta waa la boodaa. Shaashaddu waa inay shidan tahay, taleefankuna furan yahay — Android ma akhriyo NFC marka shaashaddu damsan tahay. Kaar kasta oo aan taabasho lahayn oo la dhigo taleefanka wuxuu in yar toosiyaa akhristaha, appyada kale ee kaararkuna waxay weydiin karaan appka la isticmaalayo.</string>
+    <string name="insulin_pen_background_desc">Marka appku furnayn, qalinka la dhigo taleefanka qiyaasihiisa cusub ayaa lagu daraa joornaalka iyada oo aan la weydiin.</string>
+    <string name="insulin_pen_background_desc_more">Hawo-bixinta waa la boodaa. Shaashaddu waa inay shidan tahay, taleefankuna furan yahay — Android ma akhriyo NFC marka shaashaddu damsan tahay. Kaar kasta oo aan taabasho lahayn oo la dhigo taleefanka wuxuu in yar toosiyaa akhristaha, appyada kale ee kaararkuna waxay weydiin karaan appka la isticmaalayo.</string>
     <string name="insulin_pen_import_channel">Soo dejinta qalinka</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d qiyaas ayaa lagu daray xusuus-qorka</item>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1231,6 +1231,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="preview">Förhandsgranska</string>
     <string name="previous_calibrations">Tidigare kalibreringar</string>
     <string name="show_less">Visa mindre</string>
+    <string name="show_more">Visa mer</string>
     <string name="show_all_count">Visa alla %1$d</string>
     <string name="anytime_calibration_target_reading">Avläsning #%1$d</string>
     <string name="anytime_calibration_applied_reading">Tillämpad #%1$d</string>
@@ -2468,7 +2469,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_desc">En penna sparar månader av doser och behöver flera sekunders stadig kontakt. Använd detta för att gå längre bakåt än senaste importen.</string>
     <string name="insulin_pen_read_cut_short">Pennan togs bort för tidigt. Håll den mot telefonen tills den vibrerar.</string>
     <string name="insulin_pen_background_title">Importera i bakgrunden</string>
-    <string name="insulin_pen_background_desc">När appen inte är öppen läggs nya doser från en penna som hålls mot telefonen till i dagboken utan att fråga. Luftningar hoppas över. Skärmen måste vara på och telefonen upplåst — Android läser inte NFC med släckt skärm. Alla kontaktlösa kort som hålls mot telefonen väcker läsaren ett ögonblick, och andra kortappar kan fråga vilken app som ska användas.</string>
+    <string name="insulin_pen_background_desc">När appen inte är öppen läggs nya doser från en penna som hålls mot telefonen till i dagboken utan att fråga.</string>
+    <string name="insulin_pen_background_desc_more">Luftningar hoppas över. Skärmen måste vara på och telefonen upplåst — Android läser inte NFC med släckt skärm. Alla kontaktlösa kort som hålls mot telefonen väcker läsaren ett ögonblick, och andra kortappar kan fråga vilken app som ska användas.</string>
     <string name="insulin_pen_import_channel">Pennimporter</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d dos tillagd i dagboken</item>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2467,6 +2467,17 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_armed">Redo — håll pennan mot telefonen</string>
     <string name="insulin_pen_full_read_desc">En penna sparar månader av doser och behöver flera sekunders stadig kontakt. Använd detta för att gå längre bakåt än senaste importen.</string>
     <string name="insulin_pen_read_cut_short">Pennan togs bort för tidigt. Håll den mot telefonen tills den vibrerar.</string>
+    <string name="insulin_pen_background_title">Importera i bakgrunden</string>
+    <string name="insulin_pen_background_desc">När appen inte är öppen läggs nya doser från en penna som hålls mot telefonen till i dagboken utan att fråga. Luftningar hoppas över. Skärmen måste vara på och telefonen upplåst — Android läser inte NFC med släckt skärm. Alla kontaktlösa kort som hålls mot telefonen väcker läsaren ett ögonblick, och andra kortappar kan fråga vilken app som ska användas.</string>
+    <string name="insulin_pen_import_channel">Pennimporter</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d dos tillagd i dagboken</item>
+        <item quantity="other">%d doser tillagda i dagboken</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d dos läst — öppna appen för att välja insulin</item>
+        <item quantity="other">%d doser lästa — öppna appen för att välja insulin</item>
+    </plurals>
     <string name="status_watch_reading">Klockan läser av den här sensorn</string>
     <string name="return_sensor_to_phone">Flytta tillbaka sensorn till telefonen</string>
     <string name="wear_prediction_title">Prognos</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1259,6 +1259,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="preview">Önizleme</string>
     <string name="previous_calibrations">Önceki kalibrasyonlar</string>
     <string name="show_less">Daha az göster</string>
+    <string name="show_more">Daha fazla göster</string>
     <string name="show_all_count">Tüm %1$d öğeyi göster</string>
     <string name="anytime_calibration_target_reading">Okuma #%1$d</string>
     <string name="anytime_calibration_applied_reading">Uygulandı #%1$d</string>
@@ -2496,7 +2497,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="insulin_pen_full_read_desc">Bir kalem aylarca dozu saklar ve tamamının okunması birkaç saniye sabit temas ister. Son aktarımdan daha geriye gitmek için kullanın.</string>
     <string name="insulin_pen_read_cut_short">Kalem çok erken uzaklaştı. Telefon titreyene kadar kalemi tutun.</string>
     <string name="insulin_pen_background_title">Arka planda içe aktar</string>
-    <string name="insulin_pen_background_desc">Uygulama açık değilken telefona tutulan kalemin yeni dozları sorulmadan günlüğe eklenir. Hava atışları atlanır. Ekran açık ve telefon kilidi çözülmüş olmalıdır — Android ekran kapalıyken NFC okumaz. Telefona tutulan herhangi bir temassız kart okuyucuyu bir an uyandırır ve diğer kart uygulamaları hangi uygulamanın kullanılacağını sorabilir.</string>
+    <string name="insulin_pen_background_desc">Uygulama açık değilken telefona tutulan kalemin yeni dozları sorulmadan günlüğe eklenir.</string>
+    <string name="insulin_pen_background_desc_more">Hava atışları atlanır. Ekran açık ve telefon kilidi çözülmüş olmalıdır — Android ekran kapalıyken NFC okumaz. Telefona tutulan herhangi bir temassız kart okuyucuyu bir an uyandırır ve diğer kart uygulamaları hangi uygulamanın kullanılacağını sorabilir.</string>
     <string name="insulin_pen_import_channel">Kalem içe aktarımları</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d doz günlüğe eklendi</item>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2495,6 +2495,17 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="insulin_pen_full_read_armed">Hazır — kalemi telefona tutun</string>
     <string name="insulin_pen_full_read_desc">Bir kalem aylarca dozu saklar ve tamamının okunması birkaç saniye sabit temas ister. Son aktarımdan daha geriye gitmek için kullanın.</string>
     <string name="insulin_pen_read_cut_short">Kalem çok erken uzaklaştı. Telefon titreyene kadar kalemi tutun.</string>
+    <string name="insulin_pen_background_title">Arka planda içe aktar</string>
+    <string name="insulin_pen_background_desc">Uygulama açık değilken telefona tutulan kalemin yeni dozları sorulmadan günlüğe eklenir. Hava atışları atlanır. Ekran açık ve telefon kilidi çözülmüş olmalıdır — Android ekran kapalıyken NFC okumaz. Telefona tutulan herhangi bir temassız kart okuyucuyu bir an uyandırır ve diğer kart uygulamaları hangi uygulamanın kullanılacağını sorabilir.</string>
+    <string name="insulin_pen_import_channel">Kalem içe aktarımları</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d doz günlüğe eklendi</item>
+        <item quantity="other">%d doz günlüğe eklendi</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d doz okundu — insülini seçmek için uygulamayı açın</item>
+        <item quantity="other">%d doz okundu — insülini seçmek için uygulamayı açın</item>
+    </plurals>
     <string name="status_watch_reading">Sensörü saat okuyor</string>
     <string name="return_sensor_to_phone">Sensörü telefona geri al</string>
     <string name="wear_prediction_title">Tahmin</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1245,6 +1245,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="preview">Попередній перегляд</string>
     <string name="previous_calibrations">Попередні калібрування</string>
     <string name="show_less">Показати менше</string>
+    <string name="show_more">Показати більше</string>
     <string name="show_all_count">Показати всі %1$d</string>
     <string name="anytime_calibration_target_reading">Показ #%1$d</string>
     <string name="anytime_calibration_applied_reading">Застосовано #%1$d</string>
@@ -2540,7 +2541,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_desc">Ручка зберігає дози за кілька місяців, і повне зчитування триває кілька секунд без відриву. Так можна взяти дані, старіші за останній імпорт.</string>
     <string name="insulin_pen_read_cut_short">Ручку прибрали надто рано. Тримайте її біля телефона, доки він не завібрує.</string>
     <string name="insulin_pen_background_title">Імпорт у фоні</string>
-    <string name="insulin_pen_background_desc">Коли застосунок не відкрито, нові дози ручки, прикладеної до телефона, додаються до журналу без запитань. Продувки пропускаються. Екран має бути ввімкнений, а телефон розблокований — Android не читає NFC з вимкненим екраном. Будь-яка безконтактна картка, прикладена до телефона, на мить будить зчитувач, а інші застосунки для карток можуть запитати, який застосунок використати.</string>
+    <string name="insulin_pen_background_desc">Коли застосунок не відкрито, нові дози ручки, прикладеної до телефона, додаються до журналу без запитань.</string>
+    <string name="insulin_pen_background_desc_more">Продувки пропускаються. Екран має бути ввімкнений, а телефон розблокований — Android не читає NFC з вимкненим екраном. Будь-яка безконтактна картка, прикладена до телефона, на мить будить зчитувач, а інші застосунки для карток можуть запитати, який застосунок використати.</string>
     <string name="insulin_pen_import_channel">Імпорт з ручки</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d дозу додано до журналу</item>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2539,6 +2539,21 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_armed">Готово — піднесіть ручку до телефона</string>
     <string name="insulin_pen_full_read_desc">Ручка зберігає дози за кілька місяців, і повне зчитування триває кілька секунд без відриву. Так можна взяти дані, старіші за останній імпорт.</string>
     <string name="insulin_pen_read_cut_short">Ручку прибрали надто рано. Тримайте її біля телефона, доки він не завібрує.</string>
+    <string name="insulin_pen_background_title">Імпорт у фоні</string>
+    <string name="insulin_pen_background_desc">Коли застосунок не відкрито, нові дози ручки, прикладеної до телефона, додаються до журналу без запитань. Продувки пропускаються. Екран має бути ввімкнений, а телефон розблокований — Android не читає NFC з вимкненим екраном. Будь-яка безконтактна картка, прикладена до телефона, на мить будить зчитувач, а інші застосунки для карток можуть запитати, який застосунок використати.</string>
+    <string name="insulin_pen_import_channel">Імпорт з ручки</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d дозу додано до журналу</item>
+        <item quantity="few">%d дози додано до журналу</item>
+        <item quantity="many">%d доз додано до журналу</item>
+        <item quantity="other">%d дози додано до журналу</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">Зчитано %d дозу — відкрийте застосунок, щоб вибрати інсулін</item>
+        <item quantity="few">Зчитано %d дози — відкрийте застосунок, щоб вибрати інсулін</item>
+        <item quantity="many">Зчитано %d доз — відкрийте застосунок, щоб вибрати інсулін</item>
+        <item quantity="other">Зчитано %d дози — відкрийте застосунок, щоб вибрати інсулін</item>
+    </plurals>
     <string name="status_watch_reading">Годинник зчитує цей сенсор</string>
     <string name="return_sensor_to_phone">Повернути датчик на телефон</string>
     <string name="wear_prediction_title">Прогноз</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1247,6 +1247,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="preview">预览</string>
     <string name="previous_calibrations">之前的校准</string>
     <string name="show_less">显示较少</string>
+    <string name="show_more">显示更多</string>
     <string name="show_all_count">显示全部 %1$d</string>
     <string name="anytime_calibration_target_reading">读数 #%1$d</string>
     <string name="anytime_calibration_applied_reading">已应用 #%1$d</string>
@@ -2484,7 +2485,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_desc">胰岛素笔会保存数月的剂量，完整读取需要数秒的稳定贴合。用这个可以取回上次导入之前的记录。</string>
     <string name="insulin_pen_read_cut_short">笔移开得太早了。请贴住手机直到它振动。</string>
     <string name="insulin_pen_background_title">在后台导入</string>
-    <string name="insulin_pen_background_desc">应用未打开时，贴近手机的胰岛素笔会将新剂量直接添加到日志，不再询问。排气剂量会被跳过。屏幕必须亮起且手机已解锁——熄屏时 Android 不读取 NFC。任何贴近手机的非接触卡都会短暂唤醒读取器，其他卡片应用可能会询问使用哪个应用。</string>
+    <string name="insulin_pen_background_desc">应用未打开时，贴近手机的胰岛素笔会将新剂量直接添加到日志，不再询问。</string>
+    <string name="insulin_pen_background_desc_more">排气剂量会被跳过。屏幕必须亮起且手机已解锁——熄屏时 Android 不读取 NFC。任何贴近手机的非接触卡都会短暂唤醒读取器，其他卡片应用可能会询问使用哪个应用。</string>
     <string name="insulin_pen_import_channel">胰岛素笔导入</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">已将 %d 个剂量添加到日志</item>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2483,6 +2483,17 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_armed">已就绪 — 把笔贴近手机</string>
     <string name="insulin_pen_full_read_desc">胰岛素笔会保存数月的剂量，完整读取需要数秒的稳定贴合。用这个可以取回上次导入之前的记录。</string>
     <string name="insulin_pen_read_cut_short">笔移开得太早了。请贴住手机直到它振动。</string>
+    <string name="insulin_pen_background_title">在后台导入</string>
+    <string name="insulin_pen_background_desc">应用未打开时，贴近手机的胰岛素笔会将新剂量直接添加到日志，不再询问。排气剂量会被跳过。屏幕必须亮起且手机已解锁——熄屏时 Android 不读取 NFC。任何贴近手机的非接触卡都会短暂唤醒读取器，其他卡片应用可能会询问使用哪个应用。</string>
+    <string name="insulin_pen_import_channel">胰岛素笔导入</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">已将 %d 个剂量添加到日志</item>
+        <item quantity="other">已将 %d 个剂量添加到日志</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">已读取 %d 个剂量——打开应用选择胰岛素</item>
+        <item quantity="other">已读取 %d 个剂量——打开应用选择胰岛素</item>
+    </plurals>
     <string name="status_watch_reading">手表正在读取此传感器</string>
     <string name="return_sensor_to_phone">将传感器切回手机</string>
     <string name="wear_prediction_title">预测</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2692,6 +2692,17 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_armed">Ready — hold the pen to the phone</string>
     <string name="insulin_pen_full_read_desc">A pen keeps months of doses and takes several seconds of steady contact to read out. Use this to go back further than the last import.</string>
     <string name="insulin_pen_read_cut_short">The pen moved away too soon. Hold it against the phone until it vibrates.</string>
+    <string name="insulin_pen_background_title">Import in the background</string>
+    <string name="insulin_pen_background_desc">When the app is not open, a pen held to the phone has its new doses added to the journal without asking. Air shots are skipped. The screen has to be on and the phone unlocked — Android does not read NFC with the screen off. Any contactless card held to the phone wakes the reader for a moment, and other card apps may ask which app to use.</string>
+    <string name="insulin_pen_import_channel">Pen imports</string>
+    <plurals name="insulin_pen_imported_count">
+        <item quantity="one">%d dose added to the journal</item>
+        <item quantity="other">%d doses added to the journal</item>
+    </plurals>
+    <plurals name="insulin_pen_review_count">
+        <item quantity="one">%d dose read — open the app to choose the insulin</item>
+        <item quantity="other">%d doses read — open the app to choose the insulin</item>
+    </plurals>
     <string name="status_watch_reading">Watch is reading this sensor</string>
     <string name="return_sensor_to_phone">Return sensor to phone</string>
     <string name="wear_prediction_title">Prediction</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1593,6 +1593,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="preview">Preview</string>
     <string name="previous_calibrations">Previous calibrations</string>
     <string name="show_less">Show less</string>
+    <string name="show_more">Show more</string>
     <string name="show_all_count">Show all %1$d</string>
     <string name="anytime_calibration_target_reading">Reading #%1$d</string>
     <string name="anytime_calibration_applied_reading">Applied #%1$d</string>
@@ -2693,7 +2694,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_full_read_desc">A pen keeps months of doses and takes several seconds of steady contact to read out. Use this to go back further than the last import.</string>
     <string name="insulin_pen_read_cut_short">The pen moved away too soon. Hold it against the phone until it vibrates.</string>
     <string name="insulin_pen_background_title">Import in the background</string>
-    <string name="insulin_pen_background_desc">When the app is not open, a pen held to the phone has its new doses added to the journal without asking. Air shots are skipped. The screen has to be on and the phone unlocked — Android does not read NFC with the screen off. Any contactless card held to the phone wakes the reader for a moment, and other card apps may ask which app to use.</string>
+    <string name="insulin_pen_background_desc">When the app is not open, a pen held to the phone has its new doses added to the journal without asking.</string>
+    <string name="insulin_pen_background_desc_more">Air shots are skipped. The screen has to be on and the phone unlocked — Android does not read NFC with the screen off. Any contactless card held to the phone wakes the reader for a moment, and other card apps may ask which app to use.</string>
     <string name="insulin_pen_import_channel">Pen imports</string>
     <plurals name="insulin_pen_imported_count">
         <item quantity="one">%d dose added to the journal</item>

--- a/Common/src/main/res/xml/nfc_pen_tech_filter.xml
+++ b/Common/src/main/res/xml/nfc_pen_tech_filter.xml
@@ -1,0 +1,7 @@
+<!-- The insulin-pen receiver's filter: pens speak ISO-DEP. Kept apart from
+     nfc_tech_filter.xml (NfcV, the sensors) so sensor routing is untouched. -->
+<resources>
+    <tech-list>
+        <tech>android.nfc.tech.IsoDep</tech>
+    </tech-list>
+</resources>

--- a/Common/src/mobile/AndroidManifest.xml
+++ b/Common/src/mobile/AndroidManifest.xml
@@ -126,6 +126,27 @@
 
         </activity>
         
+        <!-- Takes an insulin-pen tap while the app is not in front and imports the
+             doses without bringing the UI up. Disabled until the "import in the
+             background" setting enables it; see InsulinPenManager. -->
+        <activity
+            android:name=".ui.PenTagReceiverActivity"
+            android:enabled="false"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTop"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:theme="@style/Theme.PenTagReceiver">
+            <intent-filter>
+                <action android:name="android.nfc.action.TECH_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.action.TECH_DISCOVERED"
+                android:resource="@xml/nfc_pen_tech_filter" />
+        </activity>
+
         <activity
             android:name=".ui.ComposeUIActivity"
             android:label="Search"

--- a/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
@@ -1,6 +1,8 @@
 package tk.glucodata
 
+import android.content.ComponentName
 import android.content.Context
+import android.content.pm.PackageManager
 import androidx.annotation.Keep
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,6 +16,8 @@ import org.json.JSONArray
 import org.json.JSONObject
 import tk.glucodata.NovoPen.PenDose
 import tk.glucodata.NovoPen.PenDoseParser
+import tk.glucodata.NovoPen.PenImportNotifier
+import tk.glucodata.NovoPen.PenUnattendedImportPolicy
 import tk.glucodata.NovoPen.opennov.OpContext
 import tk.glucodata.data.journal.JournalEntryInput
 import tk.glucodata.data.journal.JournalEntrySource
@@ -45,6 +49,7 @@ object InsulinPenManager {
     private const val LOG_ID = "InsulinPen"
     private const val PREFS_NAME = "tk.glucodata_preferences"
     private const val ENABLED_KEY = "insulin_pen_enabled"
+    private const val BACKGROUND_IMPORT_KEY = "insulin_pen_background_import"
     private const val PENS_KEY = "insulin_pen_registry"
 
     /** A newly paired pen only offers this much of its stored log pre-selected. */
@@ -75,6 +80,48 @@ object InsulinPenManager {
     fun setEnabled(enabled: Boolean) {
         _enabled.value = enabled
         prefs.edit().putBoolean(ENABLED_KEY, enabled).apply()
+        syncBackgroundReceiver(Applic.app)
+    }
+
+    private val _backgroundImportEnabled = MutableStateFlow(prefs.getBoolean(BACKGROUND_IMPORT_KEY, false))
+    val backgroundImportEnabled: StateFlow<Boolean> = _backgroundImportEnabled.asStateFlow()
+
+    /**
+     * Off until asked for: with the app in the background a pen tap imports without a
+     * review sheet, so it is the reader's choice to take that. See
+     * [tk.glucodata.ui.PenTagReceiverActivity].
+     */
+    @JvmStatic
+    fun isBackgroundImportEnabled(): Boolean = _backgroundImportEnabled.value
+
+    fun setBackgroundImportEnabled(context: Context, enabled: Boolean) {
+        _backgroundImportEnabled.value = enabled
+        prefs.edit().putBoolean(BACKGROUND_IMPORT_KEY, enabled).apply()
+        syncBackgroundReceiver(context)
+    }
+
+    /**
+     * The receiver activity is a manifest component, so the system only hands it a tag
+     * while it is enabled: enabled exactly when pens are read and the background import
+     * is on. Called on each change and once per start, so an upgrade or a restored
+     * backup ends up matching the settings.
+     */
+    fun syncBackgroundReceiver(context: Context) {
+        val wanted = isEnabled() && isBackgroundImportEnabled()
+        runCatching {
+            val pm = context.packageManager
+            val receiver = ComponentName(context, tk.glucodata.ui.PenTagReceiverActivity::class.java)
+            val state = if (wanted) {
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            } else {
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+            }
+            if (pm.getComponentEnabledSetting(receiver) != state) {
+                pm.setComponentEnabledSetting(receiver, state, PackageManager.DONT_KILL_APP)
+            }
+        }.onFailure { error ->
+            Log.e(LOG_ID, "Pen receiver component: ${Log.stackline(error)}")
+        }
     }
 
     fun pen(serial: String): InsulinPen? = _pens.value.firstOrNull { it.serial == serial }
@@ -123,27 +170,68 @@ object InsulinPenManager {
         update(serial) { it.copy(lastScanAt = System.currentTimeMillis(), fullReadArmed = false) }
         scope.launch {
             val now = nowSeconds()
-            val doses = PenDoseParser.merge(
-                chunks.map { PenDoseParser.parse(it.referencetime, it.rawdoses, now) }
-            )
-            val cutoff = now - REVIEW_WINDOW_SECONDS
-            val repository = JournalRepository()
-            val fresh = doses
-                .filter { it.timestampSeconds > cutoff }
-                .filterNot { repository.hasEntryWithSourceRecordId(sourceRecordId(serial, it)) }
+            val fresh = freshDoses(serial, chunks, now)
             if (fresh.isEmpty()) {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_no_new_doses))
                 return@launch
             }
             val preselectFrom = if (known == null) now - FIRST_SCAN_PRESELECT_SECONDS else 0L
-            InsulinPenScanBus.offer(
-                PenScanResult(
-                    serial = serial,
-                    doses = fresh.sortedByDescending(PenDose::timestampSeconds),
-                    preselectFromSeconds = preselectFrom,
-                )
-            )
+            InsulinPenScanBus.offer(PenScanResult(serial, fresh, preselectFrom))
         }
+    }
+
+    /**
+     * The same read, taken with the app in the background: nobody will see a sheet, so
+     * what a foreground scan would have offered is written — the pen's insulin, air shots
+     * left out — and a notification says what happened. A pen without an insulin chosen
+     * has nothing to name its doses with, so its doses wait for the sheet instead and the
+     * notification says so. The decision itself is [PenUnattendedImportPolicy].
+     */
+    @JvmStatic
+    fun onScannedUnattended(serial: String, chunks: List<OpContext.Doses>) {
+        val known = pen(serial)
+        update(serial) { it.copy(lastScanAt = System.currentTimeMillis(), fullReadArmed = false) }
+        scope.launch {
+            val context = Applic.app
+            val now = nowSeconds()
+            val fresh = freshDoses(serial, chunks, now)
+            val presetName = known?.insulinName?.takeIf { it.isNotBlank() }
+            when (val plan = PenUnattendedImportPolicy.plan(fresh, hasPreset = presetName != null)) {
+                PenUnattendedImportPolicy.Plan.NothingNew ->
+                    PenImportNotifier.nothingNew(context, serial)
+
+                is PenUnattendedImportPolicy.Plan.Import -> {
+                    // importDoses moves the cursor over the doses it is handed, nothing
+                    // beyond — so the air shots left out here never mark a later real
+                    // dose as done. That is the rule the review sheet already relies on.
+                    val saved = importDoses(serial, plan.doses, known?.insulinPresetId ?: 0L, presetName!!)
+                    PenImportNotifier.imported(context, serial, saved)
+                }
+
+                is PenUnattendedImportPolicy.Plan.Review -> {
+                    val preselectFrom = if (known == null) now - FIRST_SCAN_PRESELECT_SECONDS else 0L
+                    InsulinPenScanBus.offer(PenScanResult(serial, plan.doses, preselectFrom))
+                    PenImportNotifier.awaitingReview(context, serial, plan.doses.size)
+                }
+            }
+        }
+    }
+
+    /**
+     * What a scan has to offer, newest first: the chunks parsed and merged, cut to the
+     * review window, minus what the journal already holds. One function for both the
+     * review sheet and the unattended import, so the two cannot come to differ.
+     */
+    private suspend fun freshDoses(serial: String, chunks: List<OpContext.Doses>, now: Long): List<PenDose> {
+        val doses = PenDoseParser.merge(
+            chunks.map { PenDoseParser.parse(it.referencetime, it.rawdoses, now) }
+        )
+        val cutoff = now - REVIEW_WINDOW_SECONDS
+        val repository = JournalRepository()
+        return doses
+            .filter { it.timestampSeconds > cutoff }
+            .filterNot { repository.hasEntryWithSourceRecordId(sourceRecordId(serial, it)) }
+            .sortedByDescending(PenDose::timestampSeconds)
     }
 
     /**

--- a/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
@@ -16,6 +16,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import tk.glucodata.NovoPen.PenDose
 import tk.glucodata.NovoPen.PenDoseParser
+import tk.glucodata.NovoPen.PenImportNotificationPolicy
 import tk.glucodata.NovoPen.PenImportNotifier
 import tk.glucodata.NovoPen.PenUnattendedImportPolicy
 import tk.glucodata.NovoPen.opennov.OpContext
@@ -50,6 +51,7 @@ object InsulinPenManager {
     private const val PREFS_NAME = "tk.glucodata_preferences"
     private const val ENABLED_KEY = "insulin_pen_enabled"
     private const val BACKGROUND_IMPORT_KEY = "insulin_pen_background_import"
+    private const val IMPORT_NOTIFICATION_DURATION_KEY = "insulin_pen_import_notification_duration_minutes"
     private const val PENS_KEY = "insulin_pen_registry"
 
     /** A newly paired pen only offers this much of its stored log pre-selected. */
@@ -98,6 +100,26 @@ object InsulinPenManager {
         _backgroundImportEnabled.value = enabled
         prefs.edit().putBoolean(BACKGROUND_IMPORT_KEY, enabled).apply()
         syncBackgroundReceiver(context)
+    }
+
+    private val _importNotificationDurationMinutes = MutableStateFlow(
+        PenImportNotificationPolicy.normalizeDurationMinutes(
+            prefs.getInt(
+                IMPORT_NOTIFICATION_DURATION_KEY,
+                PenImportNotificationPolicy.DEFAULT_DURATION_MINUTES,
+            ),
+        ),
+    )
+    val importNotificationDurationMinutes: StateFlow<Int> =
+        _importNotificationDurationMinutes.asStateFlow()
+
+    fun importNotificationDurationMinutes(): Int = _importNotificationDurationMinutes.value
+
+    fun setImportNotificationDurationMinutes(minutes: Int) {
+        val normalized = PenImportNotificationPolicy.normalizeDurationMinutes(minutes)
+        _importNotificationDurationMinutes.value = normalized
+        prefs.edit().putInt(IMPORT_NOTIFICATION_DURATION_KEY, normalized).apply()
+        if (normalized == 0) PenImportNotifier.cancel(Applic.app)
     }
 
     /**

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportNotificationPolicy.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportNotificationPolicy.kt
@@ -1,0 +1,29 @@
+package tk.glucodata.NovoPen
+
+import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
+
+/**
+ * The lifetime of the result notification shown after an unattended pen read.
+ * Zero deliberately means no notification; the caller still shows the result toast.
+ */
+object PenImportNotificationPolicy {
+    const val DEFAULT_DURATION_MINUTES = 1
+
+    val durationOptionsMinutes = listOf(0, 1, 5, 15, 30, 60, 180, 720)
+
+    fun normalizeDurationMinutes(minutes: Int): Int =
+        durationOptionsMinutes.minByOrNull { kotlin.math.abs(it.toLong() - minutes.toLong()) }
+            ?: DEFAULT_DURATION_MINUTES
+
+    fun sliderIndexForDuration(minutes: Int): Float =
+        durationOptionsMinutes.indexOf(normalizeDurationMinutes(minutes)).toFloat()
+
+    fun durationMinutesForSliderIndex(index: Float): Int =
+        durationOptionsMinutes[index.roundToInt().coerceIn(durationOptionsMinutes.indices)]
+
+    fun timeoutMillis(minutes: Int): Long? =
+        normalizeDurationMinutes(minutes)
+            .takeIf { it > 0 }
+            ?.let { TimeUnit.MINUTES.toMillis(it.toLong()) }
+}

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportNotifier.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportNotifier.kt
@@ -13,6 +13,7 @@ import androidx.core.content.ContextCompat
 import tk.glucodata.MainActivity
 import tk.glucodata.R
 import tk.glucodata.ui.PendingNavigation
+import java.util.concurrent.TimeUnit
 
 /**
  * The result of a pen read taken with the app in the background. There is no sheet to
@@ -20,7 +21,14 @@ import tk.glucodata.ui.PendingNavigation
  * app itself when the read is waiting for a review.
  */
 internal object PenImportNotifier {
-    private const val CHANNEL_ID = "PEN_IMPORT"
+    /**
+     * High importance, so the result shows as a heads-up for a moment: the app is not
+     * on screen, and a notification that only lands in the shade is invisible to the
+     * person holding the pen. The first channel was default importance; a channel's
+     * importance cannot be raised once it exists, so it is replaced.
+     */
+    private const val CHANNEL_ID = "PEN_IMPORT_RESULT"
+    private const val LEGACY_CHANNEL_ID = "PEN_IMPORT"
     private const val NOTIFICATION_ID = 0x5045
 
     private const val PREFS_NAME = "tk.glucodata_preferences"
@@ -44,14 +52,15 @@ internal object PenImportNotifier {
     }
 
     private fun show(context: Context, serial: String, text: String, openJournal: Boolean) {
+        // Said on screen as the foreground scan says it: the receiver activity is still
+        // up while the result is known, so the toast shows over whatever is there.
+        tk.glucodata.Applic.Toaster(text)
         val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager ?: return
         createChannel(context, manager)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
             PackageManager.PERMISSION_GRANTED
         ) {
-            // Notifications refused: say it the way the foreground scan does, at least.
-            tk.glucodata.Applic.Toaster(text)
             return
         }
         val contentIntent = PendingIntent.getActivity(
@@ -71,10 +80,10 @@ internal object PenImportNotifier {
             .setContentText(text)
             .setStyle(NotificationCompat.BigTextStyle().bigText(text))
             .setContentIntent(contentIntent)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_STATUS)
             .setAutoCancel(true)
-            .setOnlyAlertOnce(true)
+            .setTimeoutAfter(TimeUnit.HOURS.toMillis(12))
             .build()
         manager.notify(NOTIFICATION_ID, notification)
     }
@@ -88,16 +97,16 @@ internal object PenImportNotifier {
     }
 
     private fun createChannel(context: Context, manager: NotificationManager) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
-            manager.getNotificationChannel(CHANNEL_ID) != null
-        ) {
-            return
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        if (manager.getNotificationChannel(LEGACY_CHANNEL_ID) != null) {
+            manager.deleteNotificationChannel(LEGACY_CHANNEL_ID)
         }
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
         manager.createNotificationChannel(
             NotificationChannel(
                 CHANNEL_ID,
                 context.getString(R.string.insulin_pen_import_channel),
-                NotificationManager.IMPORTANCE_DEFAULT,
+                NotificationManager.IMPORTANCE_HIGH,
             ).apply {
                 setSound(null, null)
                 setShowBadge(false)

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportNotifier.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportNotifier.kt
@@ -1,0 +1,107 @@
+package tk.glucodata.NovoPen
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import tk.glucodata.MainActivity
+import tk.glucodata.R
+import tk.glucodata.ui.PendingNavigation
+
+/**
+ * The result of a pen read taken with the app in the background. There is no sheet to
+ * show, so a notification says what happened; tapping it opens the journal, or the
+ * app itself when the read is waiting for a review.
+ */
+internal object PenImportNotifier {
+    private const val CHANNEL_ID = "PEN_IMPORT"
+    private const val NOTIFICATION_ID = 0x5045
+
+    private const val PREFS_NAME = "tk.glucodata_preferences"
+
+    fun imported(context: Context, serial: String, count: Int) {
+        val text = if (count > 0) {
+            context.resources.getQuantityString(R.plurals.insulin_pen_imported_count, count, count)
+        } else {
+            context.getString(R.string.insulin_pen_no_new_doses)
+        }
+        show(context, serial, text, openJournal = true)
+    }
+
+    fun nothingNew(context: Context, serial: String) {
+        show(context, serial, context.getString(R.string.insulin_pen_no_new_doses), openJournal = true)
+    }
+
+    fun awaitingReview(context: Context, serial: String, count: Int) {
+        val text = context.resources.getQuantityString(R.plurals.insulin_pen_review_count, count, count)
+        show(context, serial, text, openJournal = false)
+    }
+
+    private fun show(context: Context, serial: String, text: String, openJournal: Boolean) {
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager ?: return
+        createChannel(context, manager)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            // Notifications refused: say it the way the foreground scan does, at least.
+            tk.glucodata.Applic.Toaster(text)
+            return
+        }
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            NOTIFICATION_ID,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                    Intent.FLAG_ACTIVITY_SINGLE_TOP
+                if (openJournal) putExtra(PendingNavigation.EXTRA_ROUTE, journalRoute(context))
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.novalue)
+            .setContentTitle(context.getString(R.string.insulin_pen_name, serial))
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setContentIntent(contentIntent)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(true)
+            .build()
+        manager.notify(NOTIFICATION_ID, notification)
+    }
+
+    /** The same choice the journal settings make: the tab when it is shown, else the settings page. */
+    private fun journalRoute(context: Context): String {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val tab = prefs.getBoolean("dashboard_journal_enabled", true) &&
+            prefs.getBoolean("dashboard_journal_navigation_tab_enabled", false)
+        return if (tab) "journal" else "settings/journal/history"
+    }
+
+    private fun createChannel(context: Context, manager: NotificationManager) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
+            manager.getNotificationChannel(CHANNEL_ID) != null
+        ) {
+            return
+        }
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.insulin_pen_import_channel),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                setSound(null, null)
+                setShowBadge(false)
+            },
+        )
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportNotifier.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportNotifier.kt
@@ -10,10 +10,10 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import tk.glucodata.InsulinPenManager
 import tk.glucodata.MainActivity
 import tk.glucodata.R
 import tk.glucodata.ui.PendingNavigation
-import java.util.concurrent.TimeUnit
 
 /**
  * The result of a pen read taken with the app in the background. There is no sheet to
@@ -51,10 +51,18 @@ internal object PenImportNotifier {
         show(context, serial, text, openJournal = false)
     }
 
+    fun cancel(context: Context) {
+        (context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager)
+            ?.cancel(NOTIFICATION_ID)
+    }
+
     private fun show(context: Context, serial: String, text: String, openJournal: Boolean) {
         // Said on screen as the foreground scan says it: the receiver activity is still
         // up while the result is known, so the toast shows over whatever is there.
         tk.glucodata.Applic.Toaster(text)
+        val timeoutMillis = PenImportNotificationPolicy.timeoutMillis(
+            InsulinPenManager.importNotificationDurationMinutes(),
+        ) ?: return
         val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager ?: return
         createChannel(context, manager)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
@@ -83,7 +91,7 @@ internal object PenImportNotifier {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_STATUS)
             .setAutoCancel(true)
-            .setTimeoutAfter(TimeUnit.HOURS.toMillis(12))
+            .setTimeoutAfter(timeoutMillis)
             .build()
         manager.notify(NOTIFICATION_ID, notification)
     }

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenUnattendedImportPolicy.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenUnattendedImportPolicy.kt
@@ -1,0 +1,47 @@
+package tk.glucodata.NovoPen
+
+/**
+ * What a pen read does when nobody is looking at a review sheet: the receiver
+ * activity imports with the app in the background, and there is no chance to untick
+ * a dose. So the mode is "everything new", with two consequences that live here, as
+ * plain logic, so they can be tested without a pen or a phone.
+ */
+object PenUnattendedImportPolicy {
+    private const val ISO_DEP = "android.nfc.tech.IsoDep"
+
+    sealed class Plan {
+        /** Nothing to write and nothing to ask about. */
+        data object NothingNew : Plan()
+
+        /** Write these, in the pen's insulin; air shots are already out. */
+        data class Import(val doses: List<PenDose>) : Plan()
+
+        /**
+         * The pen has no insulin chosen yet, so the import has nothing to name the
+         * doses with: hand the whole fresh list to the review sheet as a foreground
+         * scan would, air shots included, since the sheet shows those pre-unticked.
+         */
+        data class Review(val doses: List<PenDose>) : Plan()
+    }
+
+    /**
+     * [fresh] is what a foreground scan would have offered: inside the review window
+     * and not in the journal. Air shots are dropped rather than pre-unticked: nobody
+     * is there to untick, and a priming dose in the journal inflates IOB.
+     */
+    fun plan(fresh: List<PenDose>, hasPreset: Boolean): Plan {
+        if (fresh.isEmpty()) return Plan.NothingNew
+        if (!hasPreset) return Plan.Review(fresh)
+        val therapy = fresh.filterNot(PenDose::priming)
+        return if (therapy.isEmpty()) Plan.NothingNew else Plan.Import(therapy)
+    }
+
+    /**
+     * The pen/sensor split, the rule MainActivity uses for a foreground tap: pens are
+     * ISO-DEP, the sensors are NfcV. MainActivity looks at the first listed technology;
+     * this accepts ISO-DEP anywhere in the list, so it takes everything that rule takes
+     * whatever order the system reports. Anything else is not ours to import.
+     */
+    fun isPenTag(techList: Array<String>?): Boolean =
+        techList?.any { it == ISO_DEP } == true
+}

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/Scan.java
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/Scan.java
@@ -27,6 +27,7 @@ import static tk.glucodata.ScanNfcV.failure;
 import static tk.glucodata.ScanNfcV.getvibrator;
 import static tk.glucodata.ScanNfcV.startvibration;
 
+import android.content.Context;
 import android.nfc.Tag;
 
 import tk.glucodata.NovoPen.opennov.OpContext;
@@ -46,6 +47,15 @@ public class Scan {
     static final private String LOG_ID = "Scan";
 
     static public void onTag(MainActivity act, Tag tag) {
+        onTag(act, tag, false);
+    }
+
+    /**
+     * The one read path. {@code unattended} is the background receiver's case: the app
+     * is not in front, so the result goes to the journal and a notification rather than
+     * to the review sheet.
+     */
+    static public void onTag(Context act, Tag tag, boolean unattended) {
         // Every ISO-DEP tag the phone sees while Juggluco is in front lands here. Without
         // pen support switched on, that tag is somebody's bank card and none of our business.
         if (!InsulinPenManager.isEnabled()) {
@@ -78,7 +88,11 @@ public class Scan {
         } else if (op.doses == null) {
             Log.e(LOG_ID, "op.doses==null");
         } else {
-            InsulinPenManager.onScanned(op.specification.getSerial(), op.doses);
+            if (unattended) {
+                InsulinPenManager.onScannedUnattended(op.specification.getSerial(), op.doses);
+            } else {
+                InsulinPenManager.onScanned(op.specification.getSerial(), op.doses);
+            }
             return;
         }
 

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
@@ -61,6 +61,7 @@ import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.MasterSwitchCard
 import tk.glucodata.ui.components.SectionLabel
 import tk.glucodata.ui.components.SettingsItem
+import tk.glucodata.ui.components.SettingsSwitchItem
 import java.text.DateFormat
 import java.util.Calendar
 import java.util.Date
@@ -69,6 +70,7 @@ import java.util.Date
 fun InsulinPenSettingsScreen(navController: NavController) {
     val context = LocalContext.current
     val enabled by InsulinPenManager.enabled.collectAsStateWithLifecycle()
+    val backgroundImportEnabled by InsulinPenManager.backgroundImportEnabled.collectAsStateWithLifecycle()
     val pens by InsulinPenManager.pens.collectAsStateWithLifecycle()
     val presets by rememberInsulinPresets()
     val journalEnabled = remember(context) {
@@ -109,6 +111,19 @@ fun InsulinPenSettingsScreen(navController: NavController) {
                     onCheckedChange = InsulinPenManager::setEnabled,
                     icon = Icons.Default.Vaccines,
                 )
+            }
+
+            if (enabled) {
+                item("pen_background") {
+                    Spacer(Modifier.size(16.dp))
+                    SettingsSwitchItem(
+                        title = stringResource(R.string.insulin_pen_background_title),
+                        subtitle = stringResource(R.string.insulin_pen_background_desc),
+                        checked = backgroundImportEnabled,
+                        onCheckedChange = { InsulinPenManager.setBackgroundImportEnabled(context, it) },
+                        icon = Icons.Default.Contactless,
+                    )
+                }
             }
 
             // Doses become journal entries, so with the journal switched off a scan would

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -43,6 +44,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import tk.glucodata.ui.components.cardShape
 import androidx.compose.runtime.mutableStateOf
@@ -58,6 +60,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import tk.glucodata.InsulinPen
 import tk.glucodata.InsulinPenManager
+import tk.glucodata.NovoPen.PenImportNotificationPolicy
 import tk.glucodata.R
 import tk.glucodata.data.journal.JournalInsulinPreset
 import tk.glucodata.data.journal.JournalRepository
@@ -69,12 +72,15 @@ import tk.glucodata.ui.components.SettingsSwitchItem
 import java.text.DateFormat
 import java.util.Calendar
 import java.util.Date
+import kotlin.math.roundToInt
 
 @Composable
 fun InsulinPenSettingsScreen(navController: NavController) {
     val context = LocalContext.current
     val enabled by InsulinPenManager.enabled.collectAsStateWithLifecycle()
     val backgroundImportEnabled by InsulinPenManager.backgroundImportEnabled.collectAsStateWithLifecycle()
+    val importNotificationDurationMinutes by
+        InsulinPenManager.importNotificationDurationMinutes.collectAsStateWithLifecycle()
     val pens by InsulinPenManager.pens.collectAsStateWithLifecycle()
     val presets by rememberInsulinPresets()
     val journalEnabled = remember(context) {
@@ -128,6 +134,53 @@ fun InsulinPenSettingsScreen(navController: NavController) {
                         icon = Icons.Default.Nfc,
                         position = CardPosition.TOP,
                     )
+                    var notificationDurationIndex by remember(importNotificationDurationMinutes) {
+                        mutableFloatStateOf(
+                            PenImportNotificationPolicy.sliderIndexForDuration(
+                                importNotificationDurationMinutes,
+                            ),
+                        )
+                    }
+                    val pendingDurationMinutes =
+                        PenImportNotificationPolicy.durationMinutesForSliderIndex(notificationDurationIndex)
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = cardShape(CardPosition.MIDDLE),
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    ) {
+                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    stringResource(R.string.alert_delivery_notification),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                Text(
+                                    penImportNotificationDurationLabel(pendingDurationMinutes),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                            Slider(
+                                value = notificationDurationIndex,
+                                onValueChange = { value ->
+                                    notificationDurationIndex = value.roundToInt().toFloat()
+                                },
+                                onValueChangeFinished = {
+                                    InsulinPenManager.setImportNotificationDurationMinutes(
+                                        PenImportNotificationPolicy.durationMinutesForSliderIndex(
+                                            notificationDurationIndex,
+                                        ),
+                                    )
+                                },
+                                valueRange = 0f..PenImportNotificationPolicy.durationOptionsMinutes.lastIndex.toFloat(),
+                                steps = PenImportNotificationPolicy.durationOptionsMinutes.size - 2,
+                            )
+                        }
+                    }
                     // What the mode cannot do is worth a paragraph, not a row: folded away
                     // behind "show more" so the switch stays the size of a switch.
                     var showBackgroundDetails by rememberSaveable { mutableStateOf(false) }
@@ -244,6 +297,14 @@ fun InsulinPenSettingsScreen(navController: NavController) {
             },
         )
     }
+}
+
+@Composable
+private fun penImportNotificationDurationLabel(minutes: Int): String = when {
+    minutes <= 0 -> stringResource(R.string.off)
+    minutes < 60 -> stringResource(R.string.stats_duration_minutes, minutes)
+    minutes % 60 == 0 -> stringResource(R.string.stats_duration_hours, minutes / 60)
+    else -> stringResource(R.string.stats_duration_hours_minutes, minutes / 60, minutes % 60)
 }
 
 @Composable

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
@@ -41,6 +41,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.runtime.saveable.rememberSaveable
+import tk.glucodata.ui.components.cardShape
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -122,7 +125,37 @@ fun InsulinPenSettingsScreen(navController: NavController) {
                         checked = backgroundImportEnabled,
                         onCheckedChange = { InsulinPenManager.setBackgroundImportEnabled(context, it) },
                         icon = Icons.Default.Contactless,
+                        position = CardPosition.TOP,
                     )
+                    // What the mode cannot do is worth a paragraph, not a row: folded away
+                    // behind "show more" so the switch stays the size of a switch.
+                    var showBackgroundDetails by rememberSaveable { mutableStateOf(false) }
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = cardShape(CardPosition.BOTTOM),
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    ) {
+                        Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp)) {
+                            AnimatedVisibility(visible = showBackgroundDetails) {
+                                Text(
+                                    stringResource(R.string.insulin_pen_background_desc_more),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(top = 4.dp, bottom = 4.dp),
+                                )
+                            }
+                            TextButton(
+                                onClick = { showBackgroundDetails = !showBackgroundDetails },
+                                contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
+                            ) {
+                                Text(
+                                    stringResource(
+                                        if (showBackgroundDetails) R.string.show_less else R.string.show_more
+                                    )
+                                )
+                            }
+                        }
+                    }
                 }
             }
 

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Contactless
+import androidx.compose.material.icons.filled.Nfc
 import androidx.compose.material.icons.filled.Vaccines
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilterChip
@@ -124,7 +125,7 @@ fun InsulinPenSettingsScreen(navController: NavController) {
                         subtitle = stringResource(R.string.insulin_pen_background_desc),
                         checked = backgroundImportEnabled,
                         onCheckedChange = { InsulinPenManager.setBackgroundImportEnabled(context, it) },
-                        icon = Icons.Default.Contactless,
+                        icon = Icons.Default.Nfc,
                         position = CardPosition.TOP,
                     )
                     // What the mode cannot do is worth a paragraph, not a row: folded away

--- a/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
@@ -690,10 +690,18 @@ fun MainApp(themeMode: ThemeMode, onThemeChanged: (ThemeMode) -> Unit) {
 
     // A screen asked for from outside Compose — a notification's tap — is parked in
     // PendingNavigation by MainActivity and taken here, so it works from a cold start.
+    // It is placed directly above the dashboard, as a tab tap would place it, so the
+    // bar keeps working: whatever was open is popped (state saved), Back returns to
+    // the dashboard, and the dashboard tab is one tap away.
     LaunchedEffect(navController) {
         PendingNavigation.route.collect { route ->
             if (route != null) {
-                runCatching { navController.navigate(route) { launchSingleTop = true } }
+                runCatching {
+                    navController.navigate(route) {
+                        popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                        launchSingleTop = true
+                    }
+                }
                 PendingNavigation.consume()
             }
         }

--- a/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
@@ -70,6 +70,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import tk.glucodata.InsulinPenManager
 import tk.glucodata.R
 import tk.glucodata.SensorIdentity
 import tk.glucodata.data.journal.JournalEntry
@@ -685,6 +686,23 @@ fun MainApp(themeMode: ThemeMode, onThemeChanged: (ThemeMode) -> Unit) {
 
     LaunchedEffect(currentRoute) {
         dashboardViewModel.setCollectionMode(collectionModeForRoute(currentRoute))
+    }
+
+    // A screen asked for from outside Compose — a notification's tap — is parked in
+    // PendingNavigation by MainActivity and taken here, so it works from a cold start.
+    LaunchedEffect(navController) {
+        PendingNavigation.route.collect { route ->
+            if (route != null) {
+                runCatching { navController.navigate(route) { launchSingleTop = true } }
+                PendingNavigation.consume()
+            }
+        }
+    }
+
+    // The pen receiver is a manifest component switched by a setting; line it up with
+    // the settings once per start, for an upgrade or a restored backup.
+    LaunchedEffect(Unit) {
+        InsulinPenManager.syncBackgroundReceiver(context)
     }
 
     BackHandler(enabled = currentRoute == "dashboard") {

--- a/Common/src/mobile/java/tk/glucodata/ui/PenTagReceiverActivity.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/PenTagReceiverActivity.kt
@@ -1,0 +1,94 @@
+package tk.glucodata.ui
+
+import android.app.Activity
+import android.content.Intent
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import tk.glucodata.InsulinPenManager
+import tk.glucodata.Log
+import tk.glucodata.MainActivity
+import tk.glucodata.NovoPen.PenUnattendedImportPolicy
+import tk.glucodata.NovoPen.Scan
+
+/**
+ * Receives an insulin-pen tap while the app is not in front. The system starts this
+ * for an ISO-DEP tag (see nfc_pen_tech_filter.xml); it draws nothing, reads the pen on
+ * a background thread, and finishes. The import itself, and what is said about it,
+ * lives in [InsulinPenManager] and [Scan] — this is only the doorway.
+ *
+ * Only reachable while the "import in the background" setting has enabled the
+ * component. A sensor, or a tap with the app already in front, goes to MainActivity
+ * exactly as it would have without this activity.
+ */
+class PenTagReceiverActivity : Activity() {
+    private val handler = Handler(Looper.getMainLooper())
+    private var reading = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        handle(intent)
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        handle(intent)
+    }
+
+    private fun handle(intent: Intent?) {
+        if (reading) return
+        val tag: Tag? = intent?.getParcelableExtra(NfcAdapter.EXTRA_TAG)
+        if (intent == null || tag == null || NfcAdapter.ACTION_TECH_DISCOVERED != intent.action) {
+            finish()
+            return
+        }
+        if (!PenUnattendedImportPolicy.isPenTag(tag.techList) || MainActivity.isInForeground()) {
+            // Not a pen, or the app is up and its reader mode is the right home for the
+            // tag: hand it on as the system would have, and get out of the way.
+            forwardToMainActivity(intent)
+            finish()
+            return
+        }
+        if (!InsulinPenManager.isEnabled() || !InsulinPenManager.isBackgroundImportEnabled()) {
+            finish()
+            return
+        }
+        reading = true
+        handler.postDelayed({ if (!isFinishing) finish() }, READ_TIMEOUT_MS)
+        val appContext = applicationContext
+        Thread({
+            try {
+                Scan.onTag(appContext, tag, true)
+            } catch (error: Throwable) {
+                Log.e(LOG_ID, "background pen read failed: ${Log.stackline(error)}")
+            } finally {
+                handler.post { if (!isFinishing) finish() }
+            }
+        }, "PenTagReceiver").start()
+    }
+
+    private fun forwardToMainActivity(intent: Intent) {
+        runCatching {
+            startActivity(
+                Intent(intent).apply {
+                    setClass(this@PenTagReceiverActivity, MainActivity::class.java)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+            )
+        }.onFailure { error -> Log.e(LOG_ID, "forward to MainActivity failed: ${Log.stackline(error)}") }
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacksAndMessages(null)
+        super.onDestroy()
+    }
+
+    private companion object {
+        const val LOG_ID = "PenTagReceiver"
+
+        /** A full pen read takes a few seconds of contact; longer than this and it has failed. */
+        const val READ_TIMEOUT_MS = 15_000L
+    }
+}

--- a/Common/src/mobile/res/values/styles.xml
+++ b/Common/src/mobile/res/values/styles.xml
@@ -31,6 +31,17 @@
     <item name="android:paddingRight">20dp</item>
 </style>
 
+<!-- The pen receiver draws nothing: it reads the tag it was started for and finishes.
+     Translucent rather than NoDisplay, because it has to stay alive for the few
+     seconds the read takes. -->
+<style name="Theme.PenTagReceiver" parent="android:Theme.Translucent.NoTitleBar">
+    <item name="android:windowBackground">@android:color/transparent</item>
+    <item name="android:windowIsTranslucent">true</item>
+    <item name="android:windowAnimationStyle">@null</item>
+    <item name="android:windowNoTitle">true</item>
+    <item name="android:backgroundDimEnabled">false</item>
+</style>
+
 
 
 </resources>

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenImportNotificationPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenImportNotificationPolicyTests.kt
@@ -1,0 +1,53 @@
+package tk.glucodata.NovoPen
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class PenImportNotificationPolicyTests {
+
+    @Test
+    fun theResultNotificationDefaultsToOneMinute() {
+        assertEquals(1, PenImportNotificationPolicy.DEFAULT_DURATION_MINUTES)
+        assertEquals(
+            TimeUnit.MINUTES.toMillis(1),
+            PenImportNotificationPolicy.timeoutMillis(
+                PenImportNotificationPolicy.DEFAULT_DURATION_MINUTES,
+            ),
+        )
+    }
+
+    @Test
+    fun zeroTurnsTheNotificationOff() {
+        assertNull(PenImportNotificationPolicy.timeoutMillis(0))
+    }
+
+    @Test
+    fun sliderOffersShortResultsWithoutLosingTheOldMaximum() {
+        assertEquals(
+            listOf(0, 1, 5, 15, 30, 60, 180, 720),
+            PenImportNotificationPolicy.durationOptionsMinutes,
+        )
+    }
+
+    @Test
+    fun storedValuesAreClampedToTheNearestSupportedDuration() {
+        assertEquals(0, PenImportNotificationPolicy.normalizeDurationMinutes(-3))
+        assertEquals(5, PenImportNotificationPolicy.normalizeDurationMinutes(4))
+        assertEquals(30, PenImportNotificationPolicy.normalizeDurationMinutes(40))
+        assertEquals(720, PenImportNotificationPolicy.normalizeDurationMinutes(10_000))
+        assertEquals(0, PenImportNotificationPolicy.normalizeDurationMinutes(Int.MIN_VALUE))
+        assertEquals(720, PenImportNotificationPolicy.normalizeDurationMinutes(Int.MAX_VALUE))
+    }
+
+    @Test
+    fun sliderIndicesRoundAndStayInRange() {
+        assertEquals(1f, PenImportNotificationPolicy.sliderIndexForDuration(1))
+        assertEquals(7f, PenImportNotificationPolicy.sliderIndexForDuration(10_000))
+        assertEquals(0, PenImportNotificationPolicy.durationMinutesForSliderIndex(-1f))
+        assertEquals(15, PenImportNotificationPolicy.durationMinutesForSliderIndex(3.4f))
+        assertEquals(30, PenImportNotificationPolicy.durationMinutesForSliderIndex(3.6f))
+        assertEquals(720, PenImportNotificationPolicy.durationMinutesForSliderIndex(99f))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenUnattendedImportPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenUnattendedImportPolicyTests.kt
@@ -1,0 +1,66 @@
+package tk.glucodata.NovoPen
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.NovoPen.PenUnattendedImportPolicy.Plan
+
+/**
+ * A pen read with the app in the background has no sheet to untick a dose on, so the
+ * mode is "everything new": air shots are dropped rather than pre-unticked, a pen with
+ * no insulin chosen waits for the sheet, and only an ISO-DEP tag is a pen at all.
+ */
+class PenUnattendedImportPolicyTests {
+
+    private fun dose(seconds: Long, units: Float, priming: Boolean = false) =
+        PenDose(timestampSeconds = seconds, units = units, flags = 0, priming = priming)
+
+    @Test
+    fun airShotsAreLeftOutOfAnUnattendedImport() {
+        val fresh = listOf(dose(300, 6f), dose(240, 2f, priming = true), dose(100, 4f))
+
+        val plan = PenUnattendedImportPolicy.plan(fresh, hasPreset = true)
+
+        assertEquals(Plan.Import(listOf(dose(300, 6f), dose(100, 4f))), plan)
+    }
+
+    @Test
+    fun onlyAirShotsMeansNothingNew() {
+        val fresh = listOf(dose(300, 2f, priming = true), dose(240, 1f, priming = true))
+
+        assertEquals(Plan.NothingNew, PenUnattendedImportPolicy.plan(fresh, hasPreset = true))
+    }
+
+    @Test
+    fun aPenWithoutAnInsulinWaitsForTheSheetWithEverything() {
+        // The sheet shows air shots pre-unticked, so it gets the whole fresh list.
+        val fresh = listOf(dose(300, 6f), dose(240, 2f, priming = true))
+
+        assertEquals(Plan.Review(fresh), PenUnattendedImportPolicy.plan(fresh, hasPreset = false))
+    }
+
+    @Test
+    fun nothingFreshIsNothingNewWithOrWithoutAnInsulin() {
+        assertEquals(Plan.NothingNew, PenUnattendedImportPolicy.plan(emptyList(), hasPreset = true))
+        assertEquals(Plan.NothingNew, PenUnattendedImportPolicy.plan(emptyList(), hasPreset = false))
+    }
+
+    @Test
+    fun anImportKeepsTheOrderItWasGiven() {
+        val fresh = listOf(dose(300, 6f), dose(200, 5f), dose(100, 4f))
+
+        val plan = PenUnattendedImportPolicy.plan(fresh, hasPreset = true) as Plan.Import
+
+        assertEquals(listOf(300L, 200L, 100L), plan.doses.map(PenDose::timestampSeconds))
+    }
+
+    @Test
+    fun onlyAnIsoDepTagIsAPen() {
+        assertTrue(PenUnattendedImportPolicy.isPenTag(arrayOf("android.nfc.tech.IsoDep", "android.nfc.tech.NfcA")))
+        assertTrue(PenUnattendedImportPolicy.isPenTag(arrayOf("android.nfc.tech.NfcA", "android.nfc.tech.IsoDep")))
+        assertFalse("a Libre sensor", PenUnattendedImportPolicy.isPenTag(arrayOf("android.nfc.tech.NfcV", "android.nfc.tech.NdefFormatable")))
+        assertFalse(PenUnattendedImportPolicy.isPenTag(emptyArray()))
+        assertFalse(PenUnattendedImportPolicy.isPenTag(null))
+    }
+}


### PR DESCRIPTION
Reading a pen currently means opening the app first. The reader mode that takes the tag lives in `MainActivity` and is torn down in `onPause`, and the manifest's `TECH_DISCOVERED` filter lists `NfcV` only, which is the sensors. A NovoPen is ISO-DEP, so with the app in the background a pen tap reaches nothing at all. For a gesture that takes two seconds, opening the app and working through the review sheet is most of the work.

A second, pen-only tech filter (`IsoDep`) on a new receiver activity lets the system start the app for a pen while it is not running. `PenTagReceiverActivity` is translucent, kept out of recents and history, has no task affinity of its own and draws nothing. It takes the tag, reads the pen on a background thread through the existing `Scan` path, and finishes. A tag that is not a pen, or a tap while the app is in front, is handed on to `MainActivity` as the system would have done. The sensor filter (`nfc_tech_filter.xml`) and the foreground reader mode are untouched.

The component is disabled in the manifest and switched by a new setting, off by default, under the pen master switch. With the setting off the system does not offer the app for pen tags at all, which is today's behaviour. The description says plainly what the mode cannot do: NFC polling is off while the screen is off, so this needs the screen on and the phone unlocked (a platform limit, not a missing feature), and any contactless card held to the phone wakes the reader for a moment.

Without a sheet there is no chance to untick anything, so the mode means "import everything new": what a foreground scan would have offered (the same `freshDoses`, now shared by both paths so they cannot drift) minus air shots. Those are excluded outright instead of pre-unticked, because nobody is there to untick and a priming dose in the journal inflates IOB. Doses are written under the pen's insulin through the existing `importDoses`, which moves the cursor only over the doses it is handed, so a skipped air shot never marks a later real dose as done. A pen that has no insulin chosen yet has nothing to name its doses with; those wait for the review sheet and the notification says so.

A notification reports the result ("3 doses added to the journal", "No new doses", or "2 doses read, open the app to choose the insulin") and opens the journal. That needed one piece of plumbing that did not exist: a route carried in the intent, parked by `MainActivity` in `PendingNavigation` and taken by the Compose host once it is composed, so it works from a cold start. A relaunch from recents does not navigate again.

The result notification expires after one minute by default. Its lifetime is adjustable under the background-import switch: Off, 1, 5, 15 or 30 minutes, or 1, 3 or 12 hours. Off leaves the toast in place, skips future result notifications and removes one that is already showing.

One adjacent fix: the pen branch of `startnfc` now runs the read off the main thread when the tag arrived as an intent rather than through reader mode. The receiver's forward is the first path to get there on the main thread, and a pen read is seconds of I/O.

### Tests

`PenUnattendedImportPolicyTests`, six: air shots dropped from an unattended import, only air shots is nothing new, no insulin means review with the whole list, order kept, the pen/sensor split on the tech list. `PenImportNotificationPolicyTests`, five: the one-minute default, Off, the supported durations, stored-value normalization and slider bounds. `PenDoseParserTests` is unchanged and green. The NFC path is only exercised by a real pen, and it has been: with the app closed and the setting on, a tap imports and notifies without the app coming up; a Libre tap still scans as before; with the setting off nothing happens.

The switch that turns the mode on now carries the square NFC badge instead of the payment contactless arcs, the same mark a pen-sourced journal row already uses. The how-to card above it keeps the arcs here only because #220 changes that line; whichever of the two lands first, the other rebases onto it.
