### PR TITLE
Fix CGM readiness banner's ugly inset outline on dashboard

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/CgmReadiness.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/CgmReadiness.kt
@@ -448,16 +448,25 @@ private fun CgmReadinessSummaryCard(
         }
     }
     val visibleItems = items.take(maxVisibleItems)
+    val supportingColor = if (elevated) {
+        MaterialTheme.colorScheme.onErrorContainer
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(20.dp),
         color = if (elevated) {
-            MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.64f)
+            MaterialTheme.colorScheme.errorContainer
         } else {
             MaterialTheme.colorScheme.surfaceContainerHigh
         },
-        border = BorderStroke(1.dp, primaryColor.copy(alpha = 0.24f)),
+        border = if (elevated) {
+            null
+        } else {
+            BorderStroke(1.dp, primaryColor.copy(alpha = 0.24f))
+        },
         shadowElevation = if (elevated) 1.dp else 0.dp
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -481,14 +490,14 @@ private fun CgmReadinessSummaryCard(
                     Text(
                         text = summaryText ?: stringResource(R.string.cgm_readiness_summary_body, attentionCount),
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = supportingColor
                     )
                 }
                 IconButton(onClick = onDismiss, modifier = Modifier.size(36.dp)) {
                     Icon(
                         Icons.Filled.Close,
                         contentDescription = stringResource(R.string.cgm_readiness_dismiss_action),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        tint = supportingColor
                     )
                 }
             }


### PR DESCRIPTION
## Problem

On some devices the dashboard CGM readiness banner ("CGM setup needs attention") renders an ugly hairline ring inset from the card edge, and the chart visibly bleeds through the card.

Root cause — the elevated `CgmReadinessSummaryCard` stacked three things that fight each other:

- **Translucent fill**: `errorContainer.copy(alpha = 0.64f)` lets the dashboard content behind the card bleed through, so contrast varies with what's underneath and with theme/density.
- **Inset stroke**: Compose paints `BorderStroke` *inside* the surface bounds. A 1dp stroke at 24% alpha over a translucent fill antialiases into a muddy "inside outline" on rounded corners; its weight shifts with screen density (1dp = 2–3px at common densities).
- **Mismatched supporting text**: summary text and dismiss icon used `onSurfaceVariant` regardless of container, instead of a color derived from the container token.

## Fix

Scoped to the elevated variant only (dashboard + setup-wizard banners); the non-elevated sensors-screen banner keeps its outlined style:

- Solid `errorContainer` fill — no bleed-through, crisp edges everywhere.
- Border stroke removed — separation now comes from fill contrast + 1dp shadow, per M3 emphasis-by-tone.
- Supporting text/dismiss icon use `onErrorContainer` when elevated.

## Verification

- `:Common:compileMobileDebugKotlin` passes.
- Not visually verified on-device yet — needs a look on a device showing the critical state (e.g. notification permission denied).