### PR TITLE
iCan: repair live gaps behind the history tail

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
@@ -196,6 +196,7 @@ class ICanHealthBleManager(
     @Volatile private var lastHandledLiveSequence = -1
     @Volatile private var lastHandledLiveTimestampMs = 0L
     @Volatile private var lastLiveGapBackfillAtMs = 0L
+    @Volatile private var pendingLiveHistoryGap: ICanHealthSequenceGap? = null
     @Volatile private var historyTzRepairLoadedSensorId: String? = null
     @Volatile private var historyTzRepairPending = false
     @Volatile private var persistedHistoryTailTimestampMs = 0L
@@ -971,16 +972,15 @@ class ICanHealthBleManager(
 
     private fun shouldSkipHistoryOverlap(sequenceNumber: Int, sampleTimeMs: Long): Boolean {
         loadPersistedCoveredEdge()
-        if (!canUseHistoryPastEndedStatusCap()) {
-            val coveredSequence = maxOf(lastHandledLiveSequence, persistedCoveredSequence)
-            if (coveredSequence >= 0 && sequenceNumber >= 0 && sequenceNumber <= coveredSequence) {
-                return true
-            }
-        }
         val coveredTimestampMs = maxOf(persistedHistoryTailTimestampMs, persistedCoveredTimestampMs)
-        return coveredTimestampMs > 0L &&
-            sampleTimeMs > 0L &&
-            sampleTimeMs <= coveredTimestampMs
+        return ICanHealthHistoryPolicy.shouldSkipHistoryOverlap(
+            sequenceNumber = sequenceNumber,
+            sampleTimeMs = sampleTimeMs,
+            coveredSequence = maxOf(lastHandledLiveSequence, persistedCoveredSequence),
+            coveredTimestampMs = coveredTimestampMs,
+            pendingLiveGap = pendingLiveHistoryGap,
+            ignoreCoveredSequence = canUseHistoryPastEndedStatusCap(),
+        )
     }
 
     private fun legacyAuthBypassPrefKeys(sensorId: String = SerialNumber): LinkedHashSet<String> {
@@ -2280,20 +2280,27 @@ class ICanHealthBleManager(
         val anchorTimeMs = resolveSequenceAnchorTimeMs(nowMs)
         val persistedTailSequence = estimatePersistedTailSequence(anchorTimeMs)
         val latestKnownSequence = maxOf(lastHandledLiveSequence, persistedTailSequence ?: -1)
-        if (latestKnownSequence >= readingInterval) {
-            val nextMissingSequence = latestKnownSequence + readingInterval
-            if (currentSequenceNumber >= nextMissingSequence) {
-                return nextMissingSequence
-            }
+        val startSequence = ICanHealthHistoryPolicy.automaticGlucoseHistoryStartSequence(
+            readingIntervalMinutes = readingInterval,
+            currentSequence = currentSequenceNumber,
+            latestKnownSequence = latestKnownSequence,
+            pendingLiveGap = pendingLiveHistoryGap,
+        )
+        if (startSequence == null) {
             Log.i(
                 TAG,
                 "Skipping glucose-history read; persisted/local tail already covers current end index (tailSeq=$latestKnownSequence current=$currentSequenceNumber)"
             )
             return null
         }
-        // Cold start / no in-memory tail: mirror the vendor fallback and ask
-        // from the first valid glucose-history slot.
-        return readingInterval
+        pendingLiveHistoryGap?.takeIf { it.startSequence == startSequence }?.let { gap ->
+            Log.i(
+                TAG,
+                "Requesting iCan history to repair live gap ${gap.startSequence}..<${gap.endSequenceExclusive} " +
+                    "(${gap.readingCount} reading(s))"
+            )
+        }
+        return startSequence
     }
 
     private fun resolveCappedEndedHistoryStartSequence(nowMs: Long, readingInterval: Int): Int? {
@@ -2436,8 +2443,9 @@ class ICanHealthBleManager(
         sawUnsupportedSnHistoryBatch = false
         if (importedGlucoseHistory > 0) {
             val cappedHistoryPolling = canUseHistoryPastEndedStatusCap()
+            val liveGapStillPending = pendingLiveHistoryGap != null
             suppressAutomaticHistoryBackfill = false
-            shouldRequestAuthenticatedHistoryBackfill = cappedHistoryPolling
+            shouldRequestAuthenticatedHistoryBackfill = cappedHistoryPolling || liveGapStillPending
             receivedGlucoseThisConnection = true
             lastGlucoseReceiptRealtimeMs = System.currentTimeMillis()
             phase = Phase.STREAMING
@@ -2447,7 +2455,11 @@ class ICanHealthBleManager(
             Log.i(
                 TAG,
                 "Authenticated glucose-history cycle completed with $importedGlucoseHistory imported records" +
-                    if (cappedHistoryPolling) "; capped history polling remains enabled" else ""
+                    when {
+                        liveGapStillPending -> "; live-gap repair remains pending"
+                        cappedHistoryPolling -> "; capped history polling remains enabled"
+                        else -> ""
+                    }
             )
         } else if (unsupportedBatch) {
             suppressAutomaticHistoryBackfill = true
@@ -2658,14 +2670,12 @@ class ICanHealthBleManager(
         if (suppressAutomaticHistoryBackfill || historyBackfillRequested) {
             return
         }
-        val missedReadings = ICanHealthConstants.missedReadingsBetween(
+        val detectedGap = ICanHealthHistoryPolicy.liveGapBetween(
             previousSequence = previousSequence,
             currentSequence = currentSequence,
             readingIntervalMinutes = readingIntervalMinutes(),
-        )
-        if (missedReadings < 1) {
-            return
-        }
+        ) ?: return
+        val missedReadings = detectedGap.readingCount
         val sinceLastMs = nowMs - lastLiveGapBackfillAtMs
         if (lastLiveGapBackfillAtMs > 0L && sinceLastMs < LIVE_GAP_BACKFILL_MIN_INTERVAL_MS) {
             logd(TAG) {
@@ -2675,6 +2685,7 @@ class ICanHealthBleManager(
             return
         }
         lastLiveGapBackfillAtMs = nowMs
+        pendingLiveHistoryGap = pendingLiveHistoryGap?.mergedWith(detectedGap) ?: detectedGap
         historyBackfillAttemptedThisConnection = false
         shouldRequestAuthenticatedHistoryBackfill = true
         Log.i(
@@ -2828,6 +2839,15 @@ class ICanHealthBleManager(
             val lastRecord = ordered.last()
             rememberCoveredEdge(lastRecord.sequenceNumber, lastRecord.timestampMs)
             mirrorHistoryBatchIntoNative(ordered, repairing)
+            val liveGap = pendingLiveHistoryGap
+            if (liveGap != null && liveGap.isFullyCoveredBy(ordered.mapTo(HashSet<Int>()) { it.sequenceNumber })) {
+                pendingLiveHistoryGap = null
+                Log.i(
+                    TAG,
+                    "Filled iCan live gap ${liveGap.startSequence}..<${liveGap.endSequenceExclusive} " +
+                        "(${liveGap.readingCount} reading(s))"
+                )
+            }
             if (repairing) {
                 markHistoryTimezoneRepairApplied()
             }

--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthHistoryPolicy.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthHistoryPolicy.kt
@@ -1,0 +1,100 @@
+package tk.glucodata.drivers.icanhealth
+
+/**
+ * A hole between two accepted live sequence numbers.
+ *
+ * [endSequenceExclusive] is the newer live sequence, which is already stored and must remain an
+ * overlap. Only cadence-aligned records inside the window are eligible for gap repair.
+ */
+internal data class ICanHealthSequenceGap(
+    val startSequence: Int,
+    val endSequenceExclusive: Int,
+    val intervalMinutes: Int,
+) {
+    val readingCount: Int
+        get() = (endSequenceExclusive - startSequence) / intervalMinutes
+
+    fun contains(sequenceNumber: Int): Boolean =
+        sequenceNumber >= startSequence &&
+            sequenceNumber < endSequenceExclusive &&
+            (sequenceNumber - startSequence) % intervalMinutes == 0
+
+    fun isFullyCoveredBy(sequenceNumbers: Set<Int>): Boolean {
+        var sequence = startSequence
+        while (sequence < endSequenceExclusive) {
+            if (sequence !in sequenceNumbers) return false
+            sequence += intervalMinutes
+        }
+        return true
+    }
+
+    fun mergedWith(other: ICanHealthSequenceGap): ICanHealthSequenceGap {
+        if (intervalMinutes != other.intervalMinutes) return other
+        return ICanHealthSequenceGap(
+            startSequence = minOf(startSequence, other.startSequence),
+            endSequenceExclusive = maxOf(endSequenceExclusive, other.endSequenceExclusive),
+            intervalMinutes = intervalMinutes,
+        )
+    }
+}
+
+/** Pure history decisions shared by the BLE manager and JVM regression tests. */
+internal object ICanHealthHistoryPolicy {
+    fun liveGapBetween(
+        previousSequence: Int,
+        currentSequence: Int,
+        readingIntervalMinutes: Int,
+    ): ICanHealthSequenceGap? {
+        val missedReadings = ICanHealthConstants.missedReadingsBetween(
+            previousSequence = previousSequence,
+            currentSequence = currentSequence,
+            readingIntervalMinutes = readingIntervalMinutes,
+        )
+        if (missedReadings < 1) return null
+        return ICanHealthSequenceGap(
+            startSequence = previousSequence + readingIntervalMinutes,
+            endSequenceExclusive = currentSequence,
+            intervalMinutes = readingIntervalMinutes,
+        )
+    }
+
+    fun automaticGlucoseHistoryStartSequence(
+        readingIntervalMinutes: Int,
+        currentSequence: Int,
+        latestKnownSequence: Int,
+        pendingLiveGap: ICanHealthSequenceGap?,
+    ): Int? {
+        if (pendingLiveGap != null &&
+            pendingLiveGap.startSequence >= readingIntervalMinutes &&
+            pendingLiveGap.startSequence < currentSequence
+        ) {
+            return pendingLiveGap.startSequence
+        }
+        if (latestKnownSequence >= readingIntervalMinutes) {
+            val nextMissingSequence = latestKnownSequence + readingIntervalMinutes
+            return nextMissingSequence.takeIf { currentSequence >= it }
+        }
+        return readingIntervalMinutes
+    }
+
+    fun shouldSkipHistoryOverlap(
+        sequenceNumber: Int,
+        sampleTimeMs: Long,
+        coveredSequence: Int,
+        coveredTimestampMs: Long,
+        pendingLiveGap: ICanHealthSequenceGap?,
+        ignoreCoveredSequence: Boolean,
+    ): Boolean {
+        // A scalar tail cannot describe an interior hole. Prefer the explicitly observed hole
+        // before applying either edge-based overlap check.
+        if (pendingLiveGap?.contains(sequenceNumber) == true) return false
+        if (!ignoreCoveredSequence &&
+            coveredSequence >= 0 &&
+            sequenceNumber >= 0 &&
+            sequenceNumber <= coveredSequence
+        ) {
+            return true
+        }
+        return coveredTimestampMs > 0L && sampleTimeMs > 0L && sampleTimeMs <= coveredTimestampMs
+    }
+}

--- a/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthHistoryPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthHistoryPolicyTests.kt
@@ -1,0 +1,94 @@
+package tk.glucodata.drivers.icanhealth
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ICanHealthHistoryPolicyTests {
+
+    @Test
+    fun liveGap_tracksThreeMissingI3ReadingsWithoutIncludingTheNewLiveEdge() {
+        val gap = ICanHealthHistoryPolicy.liveGapBetween(300, 312, 3)!!
+
+        assertEquals(303, gap.startSequence)
+        assertEquals(312, gap.endSequenceExclusive)
+        assertTrue(gap.contains(303))
+        assertTrue(gap.contains(306))
+        assertTrue(gap.contains(309))
+        assertFalse(gap.contains(304))
+        assertFalse(gap.contains(312))
+    }
+
+    @Test
+    fun automaticStart_prefersInteriorGapAfterLiveTailHasAlreadyAdvanced() {
+        val gap = ICanHealthHistoryPolicy.liveGapBetween(300, 312, 3)
+
+        assertEquals(
+            303,
+            ICanHealthHistoryPolicy.automaticGlucoseHistoryStartSequence(
+                readingIntervalMinutes = 3,
+                currentSequence = 312,
+                latestKnownSequence = 312,
+                pendingLiveGap = gap,
+            )
+        )
+    }
+
+    @Test
+    fun automaticStart_withoutGapStillSkipsAnAlreadyCoveredTail() {
+        assertNull(
+            ICanHealthHistoryPolicy.automaticGlucoseHistoryStartSequence(
+                readingIntervalMinutes = 3,
+                currentSequence = 312,
+                latestKnownSequence = 312,
+                pendingLiveGap = null,
+            )
+        )
+    }
+
+    @Test
+    fun overlap_allowsOnlyCadenceAlignedRecordsInsidePendingGap() {
+        val gap = ICanHealthHistoryPolicy.liveGapBetween(300, 312, 3)
+        val skip: (Int) -> Boolean = { sequence ->
+            ICanHealthHistoryPolicy.shouldSkipHistoryOverlap(
+                sequenceNumber = sequence,
+                sampleTimeMs = 900_000L,
+                coveredSequence = 312,
+                coveredTimestampMs = 1_000_000L,
+                pendingLiveGap = gap,
+                ignoreCoveredSequence = false,
+            )
+        }
+
+        assertFalse(skip(303))
+        assertFalse(skip(306))
+        assertFalse(skip(309))
+        assertTrue(skip(300))
+        assertTrue(skip(304))
+        assertTrue(skip(312))
+    }
+
+    @Test
+    fun gap_isCompleteOnlyWhenEveryExpectedReadingWasStored() {
+        val gap = ICanHealthHistoryPolicy.liveGapBetween(300, 312, 3)!!
+
+        assertFalse(gap.isFullyCoveredBy(setOf(303, 309)))
+        assertTrue(gap.isFullyCoveredBy(setOf(303, 306, 309)))
+    }
+
+    @Test
+    fun pendingRepairWindow_mergesASecondGapSoNeitherHoleIsForgotten() {
+        val first = ICanHealthHistoryPolicy.liveGapBetween(300, 312, 3)!!
+        val second = ICanHealthHistoryPolicy.liveGapBetween(318, 327, 3)!!
+
+        val merged = first.mergedWith(second)
+
+        assertEquals(303, merged.startSequence)
+        assertEquals(327, merged.endSequenceExclusive)
+        assertTrue(merged.contains(306))
+        assertTrue(merged.contains(321))
+        assertTrue(merged.contains(324))
+    }
+}


### PR DESCRIPTION
## Summary

- keep an explicit cadence-aligned sequence window when a live iCan reading reveals an interior gap
- prefer that window's first missing sequence over the already-advanced scalar tail when building the RACP request
- allow only records inside the pending gap to bypass the ordinary edge/timestamp overlap filter
- clear the gap only after every expected sequence was successfully stored; merge later pending gaps instead of forgetting the first one

## Problem

On a three-minute iCan sensor, receiving sequence 300 and then 312 correctly reports three missed readings (303, 306, and 309). The current manager stores 312 as the covered edge before resolving automatic history. The resolver therefore sees `tail=312, current=312` and skips RACP. Even if history is returned, the overlap filter rejects every sequence at or below 312.

This leaves an interior chart hole although the transmitter can still retain those records.

## Tests

- `:Common:testMobileDebugUnitTest --tests tk.glucodata.drivers.icanhealth.*`
- `:Common:assembleMobileDebug`

Both pass locally. The PR is draft because the manager-level behavior has not yet been verified against a physical iCan RACP transfer.