### PR TITLE
Insulin pens: a dose written down before injecting is not imported again

### DIFF
--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2533,6 +2533,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_new_doses">новых доз: %1$d</string>
     <string name="insulin_pen_no_new_doses">Ручка счытана. Новых доз няма.</string>
     <string name="insulin_pen_duplicates_removed">Выдалена дубляваных доз ад ранейшых счытванняў: %1$d</string>
+    <string name="insulin_pen_duplicates_found">Дубляваных доз ад ранейшых счытванняў: %1$d. Выдаліце іх у наладах ручкі.</string>
+    <string name="insulin_pen_cleanup">Выдаліць дубляваныя дозы</string>
+    <string name="insulin_pen_cleanup_count">Выдаліць дубляваныя дозы: %1$d</string>
+    <string name="insulin_pen_cleanup_desc">Ранейшыя версіі запісвалі дозу зноў пры кожным счытванні. Уласны журнал ручкі кажа, што гэта былі адзінкавыя ін’екцыі.</string>
+    <string name="insulin_pen_cleanup_none">Няма чаго выдаляць. Счытайце ручку, калі яе не чыталі пасля абнаўлення.</string>
+    <string name="insulin_pen_cleanup_confirm">Выдаліць дубляваныя дозы (%1$d)?</string>
     <string name="insulin_pen_doses_label">Дозы</string>
     <string name="insulin_pen_select_all">Выбраць усе</string>
     <string name="insulin_pen_select_none">Зняць выбар</string>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2532,6 +2532,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_forget_desc">Дозы, якія ўжо ёсць у дзённіку, застануцца.</string>
     <string name="insulin_pen_new_doses">новых доз: %1$d</string>
     <string name="insulin_pen_no_new_doses">Ручка счытана. Новых доз няма.</string>
+    <string name="insulin_pen_duplicates_removed">Выдалена дубляваных доз ад ранейшых счытванняў: %1$d</string>
     <string name="insulin_pen_doses_label">Дозы</string>
     <string name="insulin_pen_select_all">Выбраць усе</string>
     <string name="insulin_pen_select_none">Зняць выбар</string>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2544,7 +2544,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_select_all">Выбраць усе</string>
     <string name="insulin_pen_select_none">Зняць выбар</string>
     <string name="insulin_pen_units">%1$s ад.</string>
-    <string name="insulin_pen_priming">Пракачка</string>
+    <string name="insulin_pen_replaces">замяняе %1$s</string>
+    <string name="insulin_pen_priming_skipped">%1$d прапуск паветра прапушчаны</string>
     <string name="insulin_pen_add_doses">Дадаць доз: %1$d</string>
     <string name="insulin_pen_doses_added">Дададзена доз у дзённік: %1$d</string>
     <string name="insulin_pens_journal_off">Дзённік выключаны, таму імпартаваныя дозы нідзе не з\'явяцца.</string>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2534,6 +2534,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_no_new_doses">Ручка счытана. Новых доз няма.</string>
     <string name="insulin_pen_duplicates_removed">Выдалена дубляваных доз ад ранейшых счытванняў: %1$d</string>
     <string name="insulin_pen_duplicates_found">Дубляваных доз ад ранейшых счытванняў: %1$d. Выдаліце іх у наладах ручкі.</string>
+    <string name="insulin_pen_merged_manual">%1$d доза(ы) супалі з тым, што вы ўжо ўвялі ўручную.</string>
     <string name="insulin_pen_cleanup">Выдаліць дубляваныя дозы</string>
     <string name="insulin_pen_cleanup_count">Выдаліць дубляваныя дозы: %1$d</string>
     <string name="insulin_pen_cleanup_desc">Ранейшыя версіі запісвалі дозу зноў пры кожным счытванні. Уласны журнал ручкі кажа, што гэта былі адзінкавыя ін’екцыі.</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2506,6 +2506,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="insulin_pen_no_new_doses">Pen gelesen. Keine neuen Dosen.</string>
     <string name="insulin_pen_duplicates_removed">%1$d doppelte Dosen aus früheren Scans entfernt</string>
     <string name="insulin_pen_duplicates_found">%1$d doppelte Dosen aus früheren Scans. Entfernen lassen sie sich in den Pen-Einstellungen.</string>
+    <string name="insulin_pen_merged_manual">%1$d Dosis/Dosen entsprachen dem, was Sie bereits von Hand eingetragen hatten.</string>
     <string name="insulin_pen_cleanup">Doppelte Dosen entfernen</string>
     <string name="insulin_pen_cleanup_count">%1$d doppelte Dosen entfernen</string>
     <string name="insulin_pen_cleanup_desc">Frühere Versionen haben eine Dosis bei jedem Scan erneut geschrieben. Das Protokoll des Pens sagt, dass es einzelne Injektionen waren.</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2516,7 +2516,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="insulin_pen_select_all">Alle auswählen</string>
     <string name="insulin_pen_select_none">Leeren</string>
     <string name="insulin_pen_units">%1$s E</string>
-    <string name="insulin_pen_priming">Entlüftung</string>
+    <string name="insulin_pen_replaces">ersetzt %1$s</string>
+    <string name="insulin_pen_priming_skipped">%1$d Entlüftung übersprungen</string>
     <string name="insulin_pen_add_doses">%1$d Dosen hinzufügen</string>
     <string name="insulin_pen_doses_added">%1$d Dosen ins Tagebuch übernommen</string>
     <string name="insulin_pens_journal_off">Das Tagebuch ist ausgeschaltet, übernommene Dosen würden nirgends erscheinen.</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2505,6 +2505,12 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="insulin_pen_new_doses">%1$d neue Dosen</string>
     <string name="insulin_pen_no_new_doses">Pen gelesen. Keine neuen Dosen.</string>
     <string name="insulin_pen_duplicates_removed">%1$d doppelte Dosen aus früheren Scans entfernt</string>
+    <string name="insulin_pen_duplicates_found">%1$d doppelte Dosen aus früheren Scans. Entfernen lassen sie sich in den Pen-Einstellungen.</string>
+    <string name="insulin_pen_cleanup">Doppelte Dosen entfernen</string>
+    <string name="insulin_pen_cleanup_count">%1$d doppelte Dosen entfernen</string>
+    <string name="insulin_pen_cleanup_desc">Frühere Versionen haben eine Dosis bei jedem Scan erneut geschrieben. Das Protokoll des Pens sagt, dass es einzelne Injektionen waren.</string>
+    <string name="insulin_pen_cleanup_none">Nichts zu entfernen. Lies den Pen einmal aus, falls das seit dem Update nicht passiert ist.</string>
+    <string name="insulin_pen_cleanup_confirm">%1$d doppelte Dosen entfernen?</string>
     <string name="insulin_pen_doses_label">Dosen</string>
     <string name="insulin_pen_select_all">Alle auswählen</string>
     <string name="insulin_pen_select_none">Leeren</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2504,6 +2504,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="insulin_pen_forget_desc">Bereits im Tagebuch gespeicherte Dosen bleiben erhalten.</string>
     <string name="insulin_pen_new_doses">%1$d neue Dosen</string>
     <string name="insulin_pen_no_new_doses">Pen gelesen. Keine neuen Dosen.</string>
+    <string name="insulin_pen_duplicates_removed">%1$d doppelte Dosen aus früheren Scans entfernt</string>
     <string name="insulin_pen_doses_label">Dosen</string>
     <string name="insulin_pen_select_all">Alle auswählen</string>
     <string name="insulin_pen_select_none">Leeren</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2473,6 +2473,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_no_new_doses">Stylo lu. Aucune nouvelle dose.</string>
     <string name="insulin_pen_duplicates_removed">%1$d doses en double issues de scans précédents supprimées</string>
     <string name="insulin_pen_duplicates_found">%1$d doses en double issues de scans précédents. Supprimez-les dans les réglages du stylo.</string>
+    <string name="insulin_pen_merged_manual">%1$d dose(s) correspondaient à ce que vous aviez déjà saisi à la main.</string>
     <string name="insulin_pen_cleanup">Supprimer les doses en double</string>
     <string name="insulin_pen_cleanup_count">Supprimer %1$d doses en double</string>
     <string name="insulin_pen_cleanup_desc">Les versions précédentes réécrivaient une dose à chaque scan. Le journal du stylo indique qu’il s’agissait d’injections uniques.</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2471,6 +2471,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_forget_desc">Les doses déjà présentes dans le journal sont conservées.</string>
     <string name="insulin_pen_new_doses">%1$d nouvelles doses</string>
     <string name="insulin_pen_no_new_doses">Stylo lu. Aucune nouvelle dose.</string>
+    <string name="insulin_pen_duplicates_removed">%1$d doses en double issues de scans précédents supprimées</string>
     <string name="insulin_pen_doses_label">Doses</string>
     <string name="insulin_pen_select_all">Tout sélectionner</string>
     <string name="insulin_pen_select_none">Effacer</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2483,7 +2483,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_select_all">Tout sélectionner</string>
     <string name="insulin_pen_select_none">Effacer</string>
     <string name="insulin_pen_units">%1$s U</string>
-    <string name="insulin_pen_priming">Purge</string>
+    <string name="insulin_pen_replaces">remplace %1$s</string>
+    <string name="insulin_pen_priming_skipped">%1$d purge ignorée</string>
     <string name="insulin_pen_add_doses">Ajouter %1$d doses</string>
     <string name="insulin_pen_doses_added">%1$d doses ajoutées au journal</string>
     <string name="insulin_pens_journal_off">Le journal est désactivé : les doses importées ne seraient affichées nulle part.</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2472,6 +2472,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_new_doses">%1$d nouvelles doses</string>
     <string name="insulin_pen_no_new_doses">Stylo lu. Aucune nouvelle dose.</string>
     <string name="insulin_pen_duplicates_removed">%1$d doses en double issues de scans précédents supprimées</string>
+    <string name="insulin_pen_duplicates_found">%1$d doses en double issues de scans précédents. Supprimez-les dans les réglages du stylo.</string>
+    <string name="insulin_pen_cleanup">Supprimer les doses en double</string>
+    <string name="insulin_pen_cleanup_count">Supprimer %1$d doses en double</string>
+    <string name="insulin_pen_cleanup_desc">Les versions précédentes réécrivaient une dose à chaque scan. Le journal du stylo indique qu’il s’agissait d’injections uniques.</string>
+    <string name="insulin_pen_cleanup_none">Rien à supprimer. Lisez le stylo une fois s’il ne l’a pas été depuis la mise à jour.</string>
+    <string name="insulin_pen_cleanup_confirm">Supprimer %1$d doses en double ?</string>
     <string name="insulin_pen_doses_label">Doses</string>
     <string name="insulin_pen_select_all">Tout sélectionner</string>
     <string name="insulin_pen_select_none">Effacer</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2455,6 +2455,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_forget_desc">Le dosi già presenti nel diario restano.</string>
     <string name="insulin_pen_new_doses">%1$d nuove dosi</string>
     <string name="insulin_pen_no_new_doses">Penna letta. Nessuna nuova dose.</string>
+    <string name="insulin_pen_duplicates_removed">Rimosse %1$d dosi duplicate da scansioni precedenti</string>
     <string name="insulin_pen_doses_label">Dosi</string>
     <string name="insulin_pen_select_all">Seleziona tutto</string>
     <string name="insulin_pen_select_none">Deseleziona</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2456,6 +2456,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_new_doses">%1$d nuove dosi</string>
     <string name="insulin_pen_no_new_doses">Penna letta. Nessuna nuova dose.</string>
     <string name="insulin_pen_duplicates_removed">Rimosse %1$d dosi duplicate da scansioni precedenti</string>
+    <string name="insulin_pen_duplicates_found">%1$d dosi duplicate da scansioni precedenti. Rimuovile nelle impostazioni della penna.</string>
+    <string name="insulin_pen_cleanup">Rimuovi le dosi duplicate</string>
+    <string name="insulin_pen_cleanup_count">Rimuovi %1$d dosi duplicate</string>
+    <string name="insulin_pen_cleanup_desc">Le versioni precedenti riscrivevano una dose a ogni scansione. Il registro della penna dice che erano iniezioni singole.</string>
+    <string name="insulin_pen_cleanup_none">Niente da rimuovere. Leggi la penna una volta se non lo hai fatto dopo l’aggiornamento.</string>
+    <string name="insulin_pen_cleanup_confirm">Rimuovere %1$d dosi duplicate?</string>
     <string name="insulin_pen_doses_label">Dosi</string>
     <string name="insulin_pen_select_all">Seleziona tutto</string>
     <string name="insulin_pen_select_none">Deseleziona</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2457,6 +2457,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_no_new_doses">Penna letta. Nessuna nuova dose.</string>
     <string name="insulin_pen_duplicates_removed">Rimosse %1$d dosi duplicate da scansioni precedenti</string>
     <string name="insulin_pen_duplicates_found">%1$d dosi duplicate da scansioni precedenti. Rimuovile nelle impostazioni della penna.</string>
+    <string name="insulin_pen_merged_manual">%1$d dose corrispondono a quanto avevi già inserito a mano.</string>
     <string name="insulin_pen_cleanup">Rimuovi le dosi duplicate</string>
     <string name="insulin_pen_cleanup_count">Rimuovi %1$d dosi duplicate</string>
     <string name="insulin_pen_cleanup_desc">Le versioni precedenti riscrivevano una dose a ogni scansione. Il registro della penna dice che erano iniezioni singole.</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2467,7 +2467,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_select_all">Seleziona tutto</string>
     <string name="insulin_pen_select_none">Deseleziona</string>
     <string name="insulin_pen_units">%1$s U</string>
-    <string name="insulin_pen_priming">Spurgo</string>
+    <string name="insulin_pen_replaces">sostituisce le %1$s</string>
+    <string name="insulin_pen_priming_skipped">%1$d spurgo saltato</string>
     <string name="insulin_pen_add_doses">Aggiungi %1$d dosi</string>
     <string name="insulin_pen_doses_added">%1$d dosi aggiunte al diario</string>
     <string name="insulin_pens_journal_off">Il diario è disattivato, quindi le dosi importate non verrebbero mostrate.</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2592,7 +2592,8 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="insulin_pen_select_all">Бүгдийг сонгох</string>
     <string name="insulin_pen_select_none">Цэвэрлэх</string>
     <string name="insulin_pen_units">%1$s нэгж</string>
-    <string name="insulin_pen_priming">Агаар гаргалт</string>
+    <string name="insulin_pen_replaces">%1$s-г орлуулна</string>
+    <string name="insulin_pen_priming_skipped">%1$d агааржуулалт алгасав</string>
     <string name="insulin_pen_add_doses">%1$d тун нэмэх</string>
     <string name="insulin_pen_doses_added">Тэмдэглэлд %1$d тун нэмэгдлээ</string>
     <string name="insulin_pens_journal_off">Тэмдэглэл унтраалттай тул оруулсан тунгууд хаана ч харагдахгүй.</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2581,6 +2581,12 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="insulin_pen_new_doses">%1$d шинэ тун</string>
     <string name="insulin_pen_no_new_doses">Үзгийг уншлаа. Шинэ тун алга.</string>
     <string name="insulin_pen_duplicates_removed">Өмнөх уншилтаас үлдсэн давхардсан %1$d тунг устгалаа</string>
+    <string name="insulin_pen_duplicates_found">Өмнөх уншилтаас үлдсэн давхардсан %1$d тун байна. Үзгийн тохиргооноос устгана уу.</string>
+    <string name="insulin_pen_cleanup">Давхардсан тунг устгах</string>
+    <string name="insulin_pen_cleanup_count">Давхардсан %1$d тунг устгах</string>
+    <string name="insulin_pen_cleanup_desc">Өмнөх хувилбарууд уншилт бүрт тунг дахин бичдэг байсан. Үзгийн өөрийн бүртгэл эдгээр нь ганц тарилга байсныг харуулж байна.</string>
+    <string name="insulin_pen_cleanup_none">Устгах зүйл алга. Шинэчилсний дараа уншаагүй бол үзгийг нэг уншуулна уу.</string>
+    <string name="insulin_pen_cleanup_confirm">Давхардсан %1$d тунг устгах уу?</string>
     <string name="insulin_pen_doses_label">Тунгууд</string>
     <string name="insulin_pen_select_all">Бүгдийг сонгох</string>
     <string name="insulin_pen_select_none">Цэвэрлэх</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2582,6 +2582,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="insulin_pen_no_new_doses">Үзгийг уншлаа. Шинэ тун алга.</string>
     <string name="insulin_pen_duplicates_removed">Өмнөх уншилтаас үлдсэн давхардсан %1$d тунг устгалаа</string>
     <string name="insulin_pen_duplicates_found">Өмнөх уншилтаас үлдсэн давхардсан %1$d тун байна. Үзгийн тохиргооноос устгана уу.</string>
+    <string name="insulin_pen_merged_manual">%1$d тун таны гараар оруулсантай тохирлоо.</string>
     <string name="insulin_pen_cleanup">Давхардсан тунг устгах</string>
     <string name="insulin_pen_cleanup_count">Давхардсан %1$d тунг устгах</string>
     <string name="insulin_pen_cleanup_desc">Өмнөх хувилбарууд уншилт бүрт тунг дахин бичдэг байсан. Үзгийн өөрийн бүртгэл эдгээр нь ганц тарилга байсныг харуулж байна.</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2580,6 +2580,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="insulin_pen_forget_desc">Тэмдэглэлд аль хэдийн байгаа тунгууд хэвээр үлдэнэ.</string>
     <string name="insulin_pen_new_doses">%1$d шинэ тун</string>
     <string name="insulin_pen_no_new_doses">Үзгийг уншлаа. Шинэ тун алга.</string>
+    <string name="insulin_pen_duplicates_removed">Өмнөх уншилтаас үлдсэн давхардсан %1$d тунг устгалаа</string>
     <string name="insulin_pen_doses_label">Тунгууд</string>
     <string name="insulin_pen_select_all">Бүгдийг сонгох</string>
     <string name="insulin_pen_select_none">Цэвэрлэх</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2509,6 +2509,12 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="insulin_pen_new_doses">%1$d nieuwe doses</string>
     <string name="insulin_pen_no_new_doses">Pen gelezen. Geen nieuwe doses.</string>
     <string name="insulin_pen_duplicates_removed">%1$d dubbele doses uit eerdere scans verwijderd</string>
+    <string name="insulin_pen_duplicates_found">%1$d dubbele doses uit eerdere scans. Verwijder ze in de instellingen van de pen.</string>
+    <string name="insulin_pen_cleanup">Dubbele doses verwijderen</string>
+    <string name="insulin_pen_cleanup_count">%1$d dubbele doses verwijderen</string>
+    <string name="insulin_pen_cleanup_desc">Eerdere versies schreven een dosis bij elke scan opnieuw weg. Het logboek van de pen zegt dat dit losse injecties waren.</string>
+    <string name="insulin_pen_cleanup_none">Niets te verwijderen. Lees de pen een keer uit als dat sinds de update niet is gebeurd.</string>
+    <string name="insulin_pen_cleanup_confirm">%1$d dubbele doses verwijderen?</string>
     <string name="insulin_pen_doses_label">Doses</string>
     <string name="insulin_pen_select_all">Alles selecteren</string>
     <string name="insulin_pen_select_none">Wissen</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2510,6 +2510,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="insulin_pen_no_new_doses">Pen gelezen. Geen nieuwe doses.</string>
     <string name="insulin_pen_duplicates_removed">%1$d dubbele doses uit eerdere scans verwijderd</string>
     <string name="insulin_pen_duplicates_found">%1$d dubbele doses uit eerdere scans. Verwijder ze in de instellingen van de pen.</string>
+    <string name="insulin_pen_merged_manual">%1$d dosis(sen) kwamen overeen met wat u al met de hand had ingevoerd.</string>
     <string name="insulin_pen_cleanup">Dubbele doses verwijderen</string>
     <string name="insulin_pen_cleanup_count">%1$d dubbele doses verwijderen</string>
     <string name="insulin_pen_cleanup_desc">Eerdere versies schreven een dosis bij elke scan opnieuw weg. Het logboek van de pen zegt dat dit losse injecties waren.</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2520,7 +2520,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="insulin_pen_select_all">Alles selecteren</string>
     <string name="insulin_pen_select_none">Wissen</string>
     <string name="insulin_pen_units">%1$s E</string>
-    <string name="insulin_pen_priming">Ontluchting</string>
+    <string name="insulin_pen_replaces">vervangt %1$s</string>
+    <string name="insulin_pen_priming_skipped">%1$d ontluchting overgeslagen</string>
     <string name="insulin_pen_add_doses">%1$d doses toevoegen</string>
     <string name="insulin_pen_doses_added">%1$d doses toegevoegd aan het dagboek</string>
     <string name="insulin_pens_journal_off">Het dagboek staat uit, dus ingelezen doses worden nergens getoond.</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2508,6 +2508,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="insulin_pen_forget_desc">Doses die al in het dagboek staan, blijven staan.</string>
     <string name="insulin_pen_new_doses">%1$d nieuwe doses</string>
     <string name="insulin_pen_no_new_doses">Pen gelezen. Geen nieuwe doses.</string>
+    <string name="insulin_pen_duplicates_removed">%1$d dubbele doses uit eerdere scans verwijderd</string>
     <string name="insulin_pen_doses_label">Doses</string>
     <string name="insulin_pen_select_all">Alles selecteren</string>
     <string name="insulin_pen_select_none">Wissen</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2501,6 +2501,7 @@
     <string name="insulin_pen_no_new_doses">Odczytano wstrzykiwacz. Brak nowych dawek.</string>
     <string name="insulin_pen_duplicates_removed">Usunięto zduplikowane dawki z wcześniejszych odczytów: %1$d</string>
     <string name="insulin_pen_duplicates_found">Zduplikowane dawki z wcześniejszych odczytów: %1$d. Usuń je w ustawieniach wstrzykiwacza.</string>
+    <string name="insulin_pen_merged_manual">%1$d dawka(i) odpowiadały temu, co już wpisano ręcznie.</string>
     <string name="insulin_pen_cleanup">Usuń zduplikowane dawki</string>
     <string name="insulin_pen_cleanup_count">Usuń zduplikowane dawki: %1$d</string>
     <string name="insulin_pen_cleanup_desc">Wcześniejsze wersje zapisywały dawkę ponownie przy każdym odczycie. Dziennik wstrzykiwacza mówi, że były to pojedyncze wstrzyknięcia.</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2500,6 +2500,12 @@
     <string name="insulin_pen_new_doses">nowe dawki: %1$d</string>
     <string name="insulin_pen_no_new_doses">Odczytano wstrzykiwacz. Brak nowych dawek.</string>
     <string name="insulin_pen_duplicates_removed">Usunięto zduplikowane dawki z wcześniejszych odczytów: %1$d</string>
+    <string name="insulin_pen_duplicates_found">Zduplikowane dawki z wcześniejszych odczytów: %1$d. Usuń je w ustawieniach wstrzykiwacza.</string>
+    <string name="insulin_pen_cleanup">Usuń zduplikowane dawki</string>
+    <string name="insulin_pen_cleanup_count">Usuń zduplikowane dawki: %1$d</string>
+    <string name="insulin_pen_cleanup_desc">Wcześniejsze wersje zapisywały dawkę ponownie przy każdym odczycie. Dziennik wstrzykiwacza mówi, że były to pojedyncze wstrzyknięcia.</string>
+    <string name="insulin_pen_cleanup_none">Nie ma czego usuwać. Odczytaj wstrzykiwacz raz, jeśli nie był odczytany po aktualizacji.</string>
+    <string name="insulin_pen_cleanup_confirm">Usunąć zduplikowane dawki (%1$d)?</string>
     <string name="insulin_pen_doses_label">Dawki</string>
     <string name="insulin_pen_select_all">Zaznacz wszystko</string>
     <string name="insulin_pen_select_none">Wyczyść</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2511,7 +2511,8 @@
     <string name="insulin_pen_select_all">Zaznacz wszystko</string>
     <string name="insulin_pen_select_none">Wyczyść</string>
     <string name="insulin_pen_units">%1$s j.</string>
-    <string name="insulin_pen_priming">Odpowietrzenie</string>
+    <string name="insulin_pen_replaces">zastępuje %1$s</string>
+    <string name="insulin_pen_priming_skipped">Pominięto odpowietrzenia: %1$d</string>
     <string name="insulin_pen_add_doses">Dodaj dawki: %1$d</string>
     <string name="insulin_pen_doses_added">Dodano dawki do dziennika: %1$d</string>
     <string name="insulin_pens_journal_off">Dziennik jest wyłączony, więc zaimportowane dawki nigdzie się nie pojawią.</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2499,6 +2499,7 @@
     <string name="insulin_pen_forget_desc">Dawki już zapisane w dzienniku pozostają.</string>
     <string name="insulin_pen_new_doses">nowe dawki: %1$d</string>
     <string name="insulin_pen_no_new_doses">Odczytano wstrzykiwacz. Brak nowych dawek.</string>
+    <string name="insulin_pen_duplicates_removed">Usunięto zduplikowane dawki z wcześniejszych odczytów: %1$d</string>
     <string name="insulin_pen_doses_label">Dawki</string>
     <string name="insulin_pen_select_all">Zaznacz wszystko</string>
     <string name="insulin_pen_select_none">Wyczyść</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2468,6 +2468,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_no_new_doses">Caneta lida. Sem doses novas.</string>
     <string name="insulin_pen_duplicates_removed">%1$d doses duplicadas de leituras anteriores removidas</string>
     <string name="insulin_pen_duplicates_found">%1$d doses duplicadas de leituras anteriores. Remova-as nas definições da caneta.</string>
+    <string name="insulin_pen_merged_manual">%1$d dose(s) correspondiam ao que já tinha introduzido à mão.</string>
     <string name="insulin_pen_cleanup">Remover doses duplicadas</string>
     <string name="insulin_pen_cleanup_count">Remover %1$d doses duplicadas</string>
     <string name="insulin_pen_cleanup_desc">As versões anteriores gravavam uma dose de novo em cada leitura. O registo da caneta diz que foram injeções únicas.</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2467,6 +2467,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_new_doses">%1$d novas doses</string>
     <string name="insulin_pen_no_new_doses">Caneta lida. Sem doses novas.</string>
     <string name="insulin_pen_duplicates_removed">%1$d doses duplicadas de leituras anteriores removidas</string>
+    <string name="insulin_pen_duplicates_found">%1$d doses duplicadas de leituras anteriores. Remova-as nas definições da caneta.</string>
+    <string name="insulin_pen_cleanup">Remover doses duplicadas</string>
+    <string name="insulin_pen_cleanup_count">Remover %1$d doses duplicadas</string>
+    <string name="insulin_pen_cleanup_desc">As versões anteriores gravavam uma dose de novo em cada leitura. O registo da caneta diz que foram injeções únicas.</string>
+    <string name="insulin_pen_cleanup_none">Nada a remover. Leia a caneta uma vez se não o fez desde a atualização.</string>
+    <string name="insulin_pen_cleanup_confirm">Remover %1$d doses duplicadas?</string>
     <string name="insulin_pen_doses_label">Doses</string>
     <string name="insulin_pen_select_all">Selecionar tudo</string>
     <string name="insulin_pen_select_none">Limpar</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2466,6 +2466,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_forget_desc">As doses já registadas no diário permanecem.</string>
     <string name="insulin_pen_new_doses">%1$d novas doses</string>
     <string name="insulin_pen_no_new_doses">Caneta lida. Sem doses novas.</string>
+    <string name="insulin_pen_duplicates_removed">%1$d doses duplicadas de leituras anteriores removidas</string>
     <string name="insulin_pen_doses_label">Doses</string>
     <string name="insulin_pen_select_all">Selecionar tudo</string>
     <string name="insulin_pen_select_none">Limpar</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2478,7 +2478,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_select_all">Selecionar tudo</string>
     <string name="insulin_pen_select_none">Limpar</string>
     <string name="insulin_pen_units">%1$s U</string>
-    <string name="insulin_pen_priming">Purga</string>
+    <string name="insulin_pen_replaces">substitui %1$s</string>
+    <string name="insulin_pen_priming_skipped">%1$d purga ignorada</string>
     <string name="insulin_pen_add_doses">Adicionar %1$d doses</string>
     <string name="insulin_pen_doses_added">%1$d doses adicionadas ao diário</string>
     <string name="insulin_pens_journal_off">O diário está desligado, por isso as doses importadas não apareceriam em lado nenhum.</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2510,6 +2510,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_no_new_doses">Ручка считана. Новых доз нет.</string>
     <string name="insulin_pen_duplicates_removed">Удалено дублей доз от прежних считываний: %1$d</string>
     <string name="insulin_pen_duplicates_found">Дублей доз от прежних считываний: %1$d. Удалите их в настройках ручки.</string>
+    <string name="insulin_pen_merged_manual">%1$d доза(ы) совпали с тем, что вы уже ввели вручную.</string>
     <string name="insulin_pen_cleanup">Удалить дубли доз</string>
     <string name="insulin_pen_cleanup_count">Удалить дубли доз: %1$d</string>
     <string name="insulin_pen_cleanup_desc">Прежние версии записывали дозу заново при каждом считывании. Собственный журнал ручки говорит, что это были одиночные инъекции.</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2509,6 +2509,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_new_doses">новых доз: %1$d</string>
     <string name="insulin_pen_no_new_doses">Ручка считана. Новых доз нет.</string>
     <string name="insulin_pen_duplicates_removed">Удалено дублей доз от прежних считываний: %1$d</string>
+    <string name="insulin_pen_duplicates_found">Дублей доз от прежних считываний: %1$d. Удалите их в настройках ручки.</string>
+    <string name="insulin_pen_cleanup">Удалить дубли доз</string>
+    <string name="insulin_pen_cleanup_count">Удалить дубли доз: %1$d</string>
+    <string name="insulin_pen_cleanup_desc">Прежние версии записывали дозу заново при каждом считывании. Собственный журнал ручки говорит, что это были одиночные инъекции.</string>
+    <string name="insulin_pen_cleanup_none">Удалять нечего. Считайте ручку, если после обновления её не читали.</string>
+    <string name="insulin_pen_cleanup_confirm">Удалить дубли доз (%1$d)?</string>
     <string name="insulin_pen_doses_label">Дозы</string>
     <string name="insulin_pen_select_all">Выбрать все</string>
     <string name="insulin_pen_select_none">Снять выбор</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2508,6 +2508,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_forget_desc">Дозы, уже записанные в журнал, останутся.</string>
     <string name="insulin_pen_new_doses">новых доз: %1$d</string>
     <string name="insulin_pen_no_new_doses">Ручка считана. Новых доз нет.</string>
+    <string name="insulin_pen_duplicates_removed">Удалено дублей доз от прежних считываний: %1$d</string>
     <string name="insulin_pen_doses_label">Дозы</string>
     <string name="insulin_pen_select_all">Выбрать все</string>
     <string name="insulin_pen_select_none">Снять выбор</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2520,7 +2520,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_select_all">Выбрать все</string>
     <string name="insulin_pen_select_none">Снять выбор</string>
     <string name="insulin_pen_units">%1$s ед.</string>
-    <string name="insulin_pen_priming">Прокачка</string>
+    <string name="insulin_pen_replaces">заменяет %1$s</string>
+    <string name="insulin_pen_priming_skipped">Продувок пропущено: %1$d</string>
     <string name="insulin_pen_add_doses">Добавить доз: %1$d</string>
     <string name="insulin_pen_doses_added">Добавлено доз в журнал: %1$d</string>
     <string name="insulin_pens_journal_off">Журнал выключен, поэтому импортированные дозы нигде не появятся.</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2677,7 +2677,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="insulin_pen_select_all">Dhammaan dooro</string>
     <string name="insulin_pen_select_none">Nadiifi</string>
     <string name="insulin_pen_units">%1$s U</string>
-    <string name="insulin_pen_priming">Hawo-bixin</string>
+    <string name="insulin_pen_replaces">beddelaya %1$s</string>
+    <string name="insulin_pen_priming_skipped">%1$d hawo-bixin ayaa la booday</string>
     <string name="insulin_pen_add_doses">Ku dar %1$d qiyaas</string>
     <string name="insulin_pen_doses_added">%1$d qiyaas ayaa xusuus-qorka lagu daray</string>
     <string name="insulin_pens_journal_off">Xusuus-qorka waa la damiyay, sidaas darteed qiyaasaha la soo geliyo meelna kama muuqan doonaan.</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2665,6 +2665,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="insulin_pen_forget_desc">Qiyaasaha horey ugu jiray xusuus-qorka way sii jiraan.</string>
     <string name="insulin_pen_new_doses">%1$d qiyaas oo cusub</string>
     <string name="insulin_pen_no_new_doses">Qalinka waa la akhriyay. Qiyaas cusub ma jiro.</string>
+    <string name="insulin_pen_duplicates_removed">Waa la tirtiray %1$d qiyaasood oo laba jibbaaran oo ka hadhay akhrisyadii hore</string>
     <string name="insulin_pen_doses_label">Qiyaasaha</string>
     <string name="insulin_pen_select_all">Dhammaan dooro</string>
     <string name="insulin_pen_select_none">Nadiifi</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2666,6 +2666,12 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="insulin_pen_new_doses">%1$d qiyaas oo cusub</string>
     <string name="insulin_pen_no_new_doses">Qalinka waa la akhriyay. Qiyaas cusub ma jiro.</string>
     <string name="insulin_pen_duplicates_removed">Waa la tirtiray %1$d qiyaasood oo laba jibbaaran oo ka hadhay akhrisyadii hore</string>
+    <string name="insulin_pen_duplicates_found">%1$d qiyaasood oo laba jibbaaran oo ka hadhay akhrisyadii hore. Kaga saar goobaha qalinka.</string>
+    <string name="insulin_pen_cleanup">Ka saar qiyaasaha laba jibbaaran</string>
+    <string name="insulin_pen_cleanup_count">Ka saar %1$d qiyaasood oo laba jibbaaran</string>
+    <string name="insulin_pen_cleanup_desc">Noocyadii hore mar kasta oo la akhriyo ayay qiyaas dib u qoraan. Diiwaanka qalanka wuxuu sheegayaa in kuwani ay ahaayeen irbado kali ah.</string>
+    <string name="insulin_pen_cleanup_none">Waxba lagama saarayo. Hal mar akhri qalinka haddii aan la akhrin tan iyo cusboonaysiintii.</string>
+    <string name="insulin_pen_cleanup_confirm">Ma ka saaraa %1$d qiyaasood oo laba jibbaaran?</string>
     <string name="insulin_pen_doses_label">Qiyaasaha</string>
     <string name="insulin_pen_select_all">Dhammaan dooro</string>
     <string name="insulin_pen_select_none">Nadiifi</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2667,6 +2667,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="insulin_pen_no_new_doses">Qalinka waa la akhriyay. Qiyaas cusub ma jiro.</string>
     <string name="insulin_pen_duplicates_removed">Waa la tirtiray %1$d qiyaasood oo laba jibbaaran oo ka hadhay akhrisyadii hore</string>
     <string name="insulin_pen_duplicates_found">%1$d qiyaasood oo laba jibbaaran oo ka hadhay akhrisyadii hore. Kaga saar goobaha qalinka.</string>
+    <string name="insulin_pen_merged_manual">%1$d qiyaas ayaa la mid ah wixii aad horey gacanta u gelisay.</string>
     <string name="insulin_pen_cleanup">Ka saar qiyaasaha laba jibbaaran</string>
     <string name="insulin_pen_cleanup_count">Ka saar %1$d qiyaasood oo laba jibbaaran</string>
     <string name="insulin_pen_cleanup_desc">Noocyadii hore mar kasta oo la akhriyo ayay qiyaas dib u qoraan. Diiwaanka qalanka wuxuu sheegayaa in kuwani ay ahaayeen irbado kali ah.</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2466,6 +2466,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_new_doses">%1$d nya doser</string>
     <string name="insulin_pen_no_new_doses">Pennan avläst. Inga nya doser.</string>
     <string name="insulin_pen_duplicates_removed">Tog bort %1$d dubblerade doser från tidigare avläsningar</string>
+    <string name="insulin_pen_duplicates_found">%1$d dubblerade doser från tidigare avläsningar. Ta bort dem i pennans inställningar.</string>
+    <string name="insulin_pen_cleanup">Ta bort dubblerade doser</string>
+    <string name="insulin_pen_cleanup_count">Ta bort %1$d dubblerade doser</string>
+    <string name="insulin_pen_cleanup_desc">Tidigare versioner skrev en dos på nytt vid varje avläsning. Pennans egen logg säger att det var enstaka injektioner.</string>
+    <string name="insulin_pen_cleanup_none">Inget att ta bort. Läs av pennan en gång om det inte gjorts sedan uppdateringen.</string>
+    <string name="insulin_pen_cleanup_confirm">Ta bort %1$d dubblerade doser?</string>
     <string name="insulin_pen_doses_label">Doser</string>
     <string name="insulin_pen_select_all">Markera alla</string>
     <string name="insulin_pen_select_none">Rensa</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2467,6 +2467,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_no_new_doses">Pennan avläst. Inga nya doser.</string>
     <string name="insulin_pen_duplicates_removed">Tog bort %1$d dubblerade doser från tidigare avläsningar</string>
     <string name="insulin_pen_duplicates_found">%1$d dubblerade doser från tidigare avläsningar. Ta bort dem i pennans inställningar.</string>
+    <string name="insulin_pen_merged_manual">%1$d dos(er) stämde med det du redan matat in för hand.</string>
     <string name="insulin_pen_cleanup">Ta bort dubblerade doser</string>
     <string name="insulin_pen_cleanup_count">Ta bort %1$d dubblerade doser</string>
     <string name="insulin_pen_cleanup_desc">Tidigare versioner skrev en dos på nytt vid varje avläsning. Pennans egen logg säger att det var enstaka injektioner.</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2477,7 +2477,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_select_all">Markera alla</string>
     <string name="insulin_pen_select_none">Rensa</string>
     <string name="insulin_pen_units">%1$s E</string>
-    <string name="insulin_pen_priming">Luftskott</string>
+    <string name="insulin_pen_replaces">ersätter %1$s</string>
+    <string name="insulin_pen_priming_skipped">%1$d luftning överhoppad</string>
     <string name="insulin_pen_add_doses">Lägg till %1$d doser</string>
     <string name="insulin_pen_doses_added">%1$d doser tillagda i dagboken</string>
     <string name="insulin_pens_journal_off">Dagboken är avstängd, så inlästa doser skulle inte visas någonstans.</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2465,6 +2465,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_forget_desc">Doser som redan finns i dagboken ligger kvar.</string>
     <string name="insulin_pen_new_doses">%1$d nya doser</string>
     <string name="insulin_pen_no_new_doses">Pennan avläst. Inga nya doser.</string>
+    <string name="insulin_pen_duplicates_removed">Tog bort %1$d dubblerade doser från tidigare avläsningar</string>
     <string name="insulin_pen_doses_label">Doser</string>
     <string name="insulin_pen_select_all">Markera alla</string>
     <string name="insulin_pen_select_none">Rensa</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2505,7 +2505,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="insulin_pen_select_all">Tümünü seç</string>
     <string name="insulin_pen_select_none">Temizle</string>
     <string name="insulin_pen_units">%1$s Ü</string>
-    <string name="insulin_pen_priming">Hava atımı</string>
+    <string name="insulin_pen_replaces">%1$s yerine geçer</string>
+    <string name="insulin_pen_priming_skipped">%1$d hava atışı atlandı</string>
     <string name="insulin_pen_add_doses">%1$d doz ekle</string>
     <string name="insulin_pen_doses_added">Günlüğe %1$d doz eklendi</string>
     <string name="insulin_pens_journal_off">Günlük kapalı, bu yüzden aktarılan dozlar hiçbir yerde görünmez.</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2493,6 +2493,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="insulin_pen_forget_desc">Günlükte kayıtlı dozlar kalır.</string>
     <string name="insulin_pen_new_doses">%1$d yeni doz</string>
     <string name="insulin_pen_no_new_doses">Kalem okundu. Yeni doz yok.</string>
+    <string name="insulin_pen_duplicates_removed">Önceki okumalardan kalan %1$d yinelenen doz kaldırıldı</string>
     <string name="insulin_pen_doses_label">Dozlar</string>
     <string name="insulin_pen_select_all">Tümünü seç</string>
     <string name="insulin_pen_select_none">Temizle</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2495,6 +2495,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="insulin_pen_no_new_doses">Kalem okundu. Yeni doz yok.</string>
     <string name="insulin_pen_duplicates_removed">Önceki okumalardan kalan %1$d yinelenen doz kaldırıldı</string>
     <string name="insulin_pen_duplicates_found">Önceki okumalardan kalan %1$d yinelenen doz var. Kalem ayarlarından kaldırabilirsin.</string>
+    <string name="insulin_pen_merged_manual">%1$d doz, elle daha önce girdiklerinizle eşleşti.</string>
     <string name="insulin_pen_cleanup">Yinelenen dozları kaldır</string>
     <string name="insulin_pen_cleanup_count">%1$d yinelenen dozu kaldır</string>
     <string name="insulin_pen_cleanup_desc">Önceki sürümler her okumada dozu yeniden yazıyordu. Kalemin kendi kaydı bunların tek enjeksiyon olduğunu söylüyor.</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2494,6 +2494,12 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="insulin_pen_new_doses">%1$d yeni doz</string>
     <string name="insulin_pen_no_new_doses">Kalem okundu. Yeni doz yok.</string>
     <string name="insulin_pen_duplicates_removed">Önceki okumalardan kalan %1$d yinelenen doz kaldırıldı</string>
+    <string name="insulin_pen_duplicates_found">Önceki okumalardan kalan %1$d yinelenen doz var. Kalem ayarlarından kaldırabilirsin.</string>
+    <string name="insulin_pen_cleanup">Yinelenen dozları kaldır</string>
+    <string name="insulin_pen_cleanup_count">%1$d yinelenen dozu kaldır</string>
+    <string name="insulin_pen_cleanup_desc">Önceki sürümler her okumada dozu yeniden yazıyordu. Kalemin kendi kaydı bunların tek enjeksiyon olduğunu söylüyor.</string>
+    <string name="insulin_pen_cleanup_none">Kaldırılacak bir şey yok. Güncellemeden beri okunmadıysa kalemi bir kez oku.</string>
+    <string name="insulin_pen_cleanup_confirm">%1$d yinelenen doz kaldırılsın mı?</string>
     <string name="insulin_pen_doses_label">Dozlar</string>
     <string name="insulin_pen_select_all">Tümünü seç</string>
     <string name="insulin_pen_select_none">Temizle</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2538,6 +2538,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_new_doses">нових доз: %1$d</string>
     <string name="insulin_pen_no_new_doses">Ручку зчитано. Нових доз немає.</string>
     <string name="insulin_pen_duplicates_removed">Вилучено дубльованих доз від попередніх зчитувань: %1$d</string>
+    <string name="insulin_pen_duplicates_found">Дубльованих доз від попередніх зчитувань: %1$d. Вилучіть їх у налаштуваннях ручки.</string>
+    <string name="insulin_pen_cleanup">Вилучити дубльовані дози</string>
+    <string name="insulin_pen_cleanup_count">Вилучити дубльовані дози: %1$d</string>
+    <string name="insulin_pen_cleanup_desc">Попередні версії записували дозу знову під час кожного зчитування. Власний журнал ручки каже, що це були поодинокі ін’єкції.</string>
+    <string name="insulin_pen_cleanup_none">Немає чого вилучати. Зчитайте ручку, якщо після оновлення її не читали.</string>
+    <string name="insulin_pen_cleanup_confirm">Вилучити дубльовані дози (%1$d)?</string>
     <string name="insulin_pen_doses_label">Дози</string>
     <string name="insulin_pen_select_all">Вибрати все</string>
     <string name="insulin_pen_select_none">Зняти вибір</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2539,6 +2539,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_no_new_doses">Ручку зчитано. Нових доз немає.</string>
     <string name="insulin_pen_duplicates_removed">Вилучено дубльованих доз від попередніх зчитувань: %1$d</string>
     <string name="insulin_pen_duplicates_found">Дубльованих доз від попередніх зчитувань: %1$d. Вилучіть їх у налаштуваннях ручки.</string>
+    <string name="insulin_pen_merged_manual">%1$d доза(и) збіглися з тим, що ви вже ввели вручну.</string>
     <string name="insulin_pen_cleanup">Вилучити дубльовані дози</string>
     <string name="insulin_pen_cleanup_count">Вилучити дубльовані дози: %1$d</string>
     <string name="insulin_pen_cleanup_desc">Попередні версії записували дозу знову під час кожного зчитування. Власний журнал ручки каже, що це були поодинокі ін’єкції.</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2537,6 +2537,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_forget_desc">Дози, які вже є в журналі, залишаться.</string>
     <string name="insulin_pen_new_doses">нових доз: %1$d</string>
     <string name="insulin_pen_no_new_doses">Ручку зчитано. Нових доз немає.</string>
+    <string name="insulin_pen_duplicates_removed">Вилучено дубльованих доз від попередніх зчитувань: %1$d</string>
     <string name="insulin_pen_doses_label">Дози</string>
     <string name="insulin_pen_select_all">Вибрати все</string>
     <string name="insulin_pen_select_none">Зняти вибір</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2549,7 +2549,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_select_all">Вибрати все</string>
     <string name="insulin_pen_select_none">Зняти вибір</string>
     <string name="insulin_pen_units">%1$s од.</string>
-    <string name="insulin_pen_priming">Прокачування</string>
+    <string name="insulin_pen_replaces">замінює %1$s</string>
+    <string name="insulin_pen_priming_skipped">Продувок пропущено: %1$d</string>
     <string name="insulin_pen_add_doses">Додати доз: %1$d</string>
     <string name="insulin_pen_doses_added">Додано доз у журнал: %1$d</string>
     <string name="insulin_pens_journal_off">Журнал вимкнено, тому імпортовані дози ніде не з\'являться.</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2482,6 +2482,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_new_doses">%1$d 条新剂量</string>
     <string name="insulin_pen_no_new_doses">已读取胰岛素笔，没有新剂量。</string>
     <string name="insulin_pen_duplicates_removed">已删除先前扫描留下的 %1$d 条重复剂量</string>
+    <string name="insulin_pen_duplicates_found">先前扫描留下 %1$d 条重复剂量，可在胰岛素笔设置中删除。</string>
+    <string name="insulin_pen_cleanup">删除重复剂量</string>
+    <string name="insulin_pen_cleanup_count">删除 %1$d 条重复剂量</string>
+    <string name="insulin_pen_cleanup_desc">旧版本每次扫描都会重新写入同一次注射。胰岛素笔自己的记录显示这些只注射过一次。</string>
+    <string name="insulin_pen_cleanup_none">没有需要删除的内容。若更新后还没读取过，请先读取一次胰岛素笔。</string>
+    <string name="insulin_pen_cleanup_confirm">删除 %1$d 条重复剂量？</string>
     <string name="insulin_pen_doses_label">剂量</string>
     <string name="insulin_pen_select_all">全选</string>
     <string name="insulin_pen_select_none">清除</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2493,7 +2493,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_select_all">全选</string>
     <string name="insulin_pen_select_none">清除</string>
     <string name="insulin_pen_units">%1$s U</string>
-    <string name="insulin_pen_priming">排气</string>
+    <string name="insulin_pen_replaces">替换 %1$s</string>
+    <string name="insulin_pen_priming_skipped">已跳过 %1$d 次排气</string>
     <string name="insulin_pen_add_doses">添加 %1$d 条剂量</string>
     <string name="insulin_pen_doses_added">已向日志添加 %1$d 条剂量</string>
     <string name="insulin_pens_journal_off">日志已关闭，导入的剂量将无处显示。</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2481,6 +2481,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_forget_desc">日志中已有的剂量会保留。</string>
     <string name="insulin_pen_new_doses">%1$d 条新剂量</string>
     <string name="insulin_pen_no_new_doses">已读取胰岛素笔，没有新剂量。</string>
+    <string name="insulin_pen_duplicates_removed">已删除先前扫描留下的 %1$d 条重复剂量</string>
     <string name="insulin_pen_doses_label">剂量</string>
     <string name="insulin_pen_select_all">全选</string>
     <string name="insulin_pen_select_none">清除</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2483,6 +2483,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_no_new_doses">已读取胰岛素笔，没有新剂量。</string>
     <string name="insulin_pen_duplicates_removed">已删除先前扫描留下的 %1$d 条重复剂量</string>
     <string name="insulin_pen_duplicates_found">先前扫描留下 %1$d 条重复剂量，可在胰岛素笔设置中删除。</string>
+    <string name="insulin_pen_merged_manual">%1$d 剂与您手动记录的内容匹配。</string>
     <string name="insulin_pen_cleanup">删除重复剂量</string>
     <string name="insulin_pen_cleanup_count">删除 %1$d 条重复剂量</string>
     <string name="insulin_pen_cleanup_desc">旧版本每次扫描都会重新写入同一次注射。胰岛素笔自己的记录显示这些只注射过一次。</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2702,7 +2702,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_select_all">Select all</string>
     <string name="insulin_pen_select_none">Clear</string>
     <string name="insulin_pen_units">%1$s U</string>
-    <string name="insulin_pen_priming">Air shot</string>
+    <string name="insulin_pen_replaces">replaces %1$s</string>
+    <string name="insulin_pen_priming_skipped">%1$d air shot skipped</string>
     <string name="insulin_pen_add_doses">Add %1$d doses</string>
     <string name="insulin_pen_doses_added">%1$d doses added to the journal</string>
     <string name="insulin_pens_journal_off">The journal is switched off, so imported doses would not be shown anywhere.</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2692,6 +2692,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_no_new_doses">Pen read. No new doses.</string>
     <string name="insulin_pen_duplicates_removed">Removed %1$d duplicate dose(s) left by earlier scans</string>
     <string name="insulin_pen_duplicates_found">%1$d duplicate doses from earlier scans. Remove them in the pen\'s settings.</string>
+    <string name="insulin_pen_merged_manual">%1$d dose(s) matched what you had already entered by hand.</string>
     <string name="insulin_pen_cleanup">Remove duplicate doses</string>
     <string name="insulin_pen_cleanup_count">Remove %1$d duplicate doses</string>
     <string name="insulin_pen_cleanup_desc">Earlier versions wrote a dose again on every scan. The pen\'s own log says these were single injections.</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2690,6 +2690,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_forget_desc">Doses already in the journal stay there.</string>
     <string name="insulin_pen_new_doses">%1$d new doses</string>
     <string name="insulin_pen_no_new_doses">Pen read. No new doses.</string>
+    <string name="insulin_pen_duplicates_removed">Removed %1$d duplicate dose(s) left by earlier scans</string>
     <string name="insulin_pen_doses_label">Doses</string>
     <string name="insulin_pen_select_all">Select all</string>
     <string name="insulin_pen_select_none">Clear</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2691,6 +2691,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="insulin_pen_new_doses">%1$d new doses</string>
     <string name="insulin_pen_no_new_doses">Pen read. No new doses.</string>
     <string name="insulin_pen_duplicates_removed">Removed %1$d duplicate dose(s) left by earlier scans</string>
+    <string name="insulin_pen_duplicates_found">%1$d duplicate doses from earlier scans. Remove them in the pen\'s settings.</string>
+    <string name="insulin_pen_cleanup">Remove duplicate doses</string>
+    <string name="insulin_pen_cleanup_count">Remove %1$d duplicate doses</string>
+    <string name="insulin_pen_cleanup_desc">Earlier versions wrote a dose again on every scan. The pen\'s own log says these were single injections.</string>
+    <string name="insulin_pen_cleanup_none">Nothing to remove. Read the pen once if it has not been read since the update.</string>
+    <string name="insulin_pen_cleanup_confirm">Remove %1$d duplicate doses?</string>
     <string name="insulin_pen_doses_label">Doses</string>
     <string name="insulin_pen_select_all">Select all</string>
     <string name="insulin_pen_select_none">Clear</string>

--- a/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
@@ -18,6 +18,7 @@ import tk.glucodata.NovoPen.PenDropTally
 import tk.glucodata.NovoPen.PenDuplicateReconciler
 import tk.glucodata.NovoPen.PenImportCursor
 import tk.glucodata.NovoPen.PenJournalEntry
+import tk.glucodata.NovoPen.PenManualMergePlanner
 import tk.glucodata.NovoPen.PenReconcilePlan
 import tk.glucodata.NovoPen.PenSourceIds
 import tk.glucodata.NovoPen.opennov.OpContext
@@ -176,26 +177,44 @@ object InsulinPenManager {
             val fresh = inWindow
                 .filterNot { it.relativeSeconds in present }
                 .filter { PenImportCursor.isAhead(it, cursor, fullRead) }
+            // A dose the reader wrote down before injecting is already in the journal, just
+            // not under the pen's name. Merging it onto that entry has to happen before the
+            // sheet is built, so the same injection is not offered as a second row. A full
+            // read is the reader asking to see the whole log and decide on it themselves,
+            // so it merges nothing: that is the one scan that can carry weeks of doses.
+            val merged = if (fullRead) {
+                emptySet()
+            } else {
+                mergeManualEntries(serial, fresh, known?.insulinPresetId, repository)
+            }
+            val offer = fresh.filterNot { it.relativeSeconds in merged }
+            val held = present + merged
             Log.i(
                 LOG_ID,
                 "Pen $serial: ${chunks.size} chunk(s), ${parsed.sumOf { it.size }} parsed, " +
                     "${doses.size} after merge, newest rel=${doses.maxOfOrNull(PenDose::relativeSeconds)}, " +
                     "cursor rel=$cursor${if (fullRead) " (full read)" else ""}, " +
                     "${inWindow.size} within ${REVIEW_WINDOW_SECONDS / 86_400} days, " +
-                    "${inWindow.size - present.size} not in the journal, ${fresh.size} to offer; " +
+                    "${inWindow.size - present.size} not in the journal, ${merged.size} merged " +
+                    "onto hand-written entries, ${offer.size} to offer; " +
                     dropped.describe(),
             )
+            // Duplicates to clean up and doses merged onto entries are separate news, and
+            // the cleanup is the one that asks for something, so it is said first.
             if (duplicates > 0) {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_duplicates_found, duplicates))
-            } else if (fresh.isEmpty()) {
+            }
+            if (merged.isNotEmpty()) {
+                Applic.Toaster(Applic.app.getString(R.string.insulin_pen_merged_manual, merged.size))
+            } else if (duplicates == 0 && offer.isEmpty()) {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_no_new_doses))
             }
-            if (fresh.isEmpty()) {
+            if (offer.isEmpty()) {
                 // A scan with nothing to offer still says how far the journal reaches, so the
                 // next tap does not walk the pen's whole log again — but only as far as it was
                 // seen to reach. A dose this scan never found in the journal stays ahead of the
                 // cursor, whatever kept it out, so the next scan looks at it again.
-                PenImportCursor.provenUpTo(inWindow) { it.relativeSeconds in present }
+                PenImportCursor.provenUpTo(inWindow) { it.relativeSeconds in held }
                     ?.let { advanceCursor(serial, it) }
                 return@launch
             }
@@ -203,7 +222,7 @@ object InsulinPenManager {
             InsulinPenScanBus.offer(
                 PenScanResult(
                     serial = serial,
-                    doses = fresh.sortedByDescending(PenDose::timestampSeconds),
+                    doses = offer.sortedByDescending(PenDose::timestampSeconds),
                     preselectFromSeconds = preselectFrom,
                 )
             )
@@ -326,6 +345,58 @@ object InsulinPenManager {
         }.getOrElse { error ->
             Log.e(LOG_ID, "Pen reconcile failed: ${Log.stackline(error)}")
             0
+        }
+    }
+
+    /**
+     * Merges doses onto insulin entries the reader wrote by hand shortly before injecting,
+     * so one injection stays one row. The decision is [PenManualMergePlanner]'s; this reads
+     * the candidates and writes the outcome.
+     *
+     * @return the pen counters of the doses that found an entry — they are in the journal
+     *   now and must not be offered again
+     */
+    private suspend fun mergeManualEntries(
+        serial: String,
+        doses: List<PenDose>,
+        penInsulinPresetId: Long?,
+        repository: JournalRepository,
+    ): Set<Long> {
+        if (doses.isEmpty()) return emptySet()
+        return runCatching {
+            val window = PenManualMergePlanner.MATCH_WINDOW_SECONDS
+            val from = (doses.minOf(PenDose::timestampSeconds) - window) * 1000L
+            val to = (doses.maxOf(PenDose::timestampSeconds) + window) * 1000L
+            val entries = PenManualMergePlanner.candidates(
+                repository.entriesFromSourceBetween(JournalEntrySource.MANUAL, from, to),
+            )
+            val plan = PenManualMergePlanner.plan(serial, doses, entries, penInsulinPresetId)
+            plan.alignmentBreak?.let { stop ->
+                Log.i(
+                    LOG_ID,
+                    "Pen $serial: hand-written entries stop lining up at #${stop.position + 1} " +
+                        "(pen ${stop.doseUnits} U against journal ${stop.entryUnits} U, " +
+                        "${stop.secondsApart}s apart); matching the rest by time and amount",
+                )
+            }
+            val merged = LinkedHashSet<Long>()
+            plan.merges.forEach { merge ->
+                val adopted = repository.adoptPenDose(
+                    merge.entryId,
+                    merge.sourceRecordId,
+                    merge.timestampSeconds * 1000L,
+                )
+                if (adopted) merged.add(merge.doseRelativeSeconds)
+            }
+            if (merged.isNotEmpty()) {
+                Log.i(LOG_ID, "Pen $serial: ${merged.size} dose(s) merged onto hand-written entries")
+                UiRefreshBus.requestDataRefresh()
+                if (Natives.getpostTreatments()) Natives.wakeuploader()
+            }
+            merged as Set<Long>
+        }.getOrElse { error ->
+            Log.e(LOG_ID, "Pen manual merge failed: ${Log.stackline(error)}")
+            emptySet()
         }
     }
 

--- a/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
@@ -14,6 +14,9 @@ import org.json.JSONArray
 import org.json.JSONObject
 import tk.glucodata.NovoPen.PenDose
 import tk.glucodata.NovoPen.PenDoseParser
+import tk.glucodata.NovoPen.PenDuplicateReconciler
+import tk.glucodata.NovoPen.PenJournalEntry
+import tk.glucodata.NovoPen.PenSourceIds
 import tk.glucodata.NovoPen.opennov.OpContext
 import tk.glucodata.data.journal.JournalEntryInput
 import tk.glucodata.data.journal.JournalEntrySource
@@ -27,8 +30,13 @@ data class InsulinPen(
     val insulinName: String? = null,
     val addedAt: Long = 0L,
     val lastScanAt: Long = 0L,
-    /** Newest dose second imported from this pen; the "nothing new" gate reads it. */
-    val lastImportedDoseSeconds: Long = 0L,
+    /**
+     * Newest dose this pen has been imported up to, on the pen's own counter; the
+     * "nothing new" gate reads it. Kept in the pen's timeline rather than in epoch
+     * seconds, because that is the only one of the two that means the same thing on the
+     * next scan.
+     */
+    val lastImportedDoseRelativeSeconds: Long = 0L,
     val importedDoseCount: Int = 0,
     /** One-shot: ignore the cursor on the next scan and offer the pen's whole log. */
     val fullReadArmed: Boolean = false,
@@ -104,10 +112,10 @@ object InsulinPenManager {
     fun isFullyImported(serial: String?, referenceTimeSeconds: Long, raw: ByteArray?): Boolean {
         val known = serial?.let(::pen) ?: return false
         if (known.fullReadArmed) return false
-        val cursor = known.lastImportedDoseSeconds
+        val cursor = known.lastImportedDoseRelativeSeconds
         if (cursor <= 0L) return false
         val newest = PenDoseParser.parse(referenceTimeSeconds, raw, nowSeconds())
-            .maxOfOrNull(PenDose::timestampSeconds)
+            .maxOfOrNull(PenDose::relativeSeconds)
             ?: return false
         return newest <= cursor
     }
@@ -128,11 +136,19 @@ object InsulinPenManager {
             )
             val cutoff = now - REVIEW_WINDOW_SECONDS
             val repository = JournalRepository()
+            val removed = reconcile(serial, doses, repository)
             val fresh = doses
                 .filter { it.timestampSeconds > cutoff }
                 .filterNot { repository.hasEntryWithSourceRecordId(sourceRecordId(serial, it)) }
-            if (fresh.isEmpty()) {
+            if (removed > 0) {
+                Applic.Toaster(Applic.app.getString(R.string.insulin_pen_duplicates_removed, removed))
+            } else if (fresh.isEmpty()) {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_no_new_doses))
+            }
+            if (fresh.isEmpty()) {
+                // A scan with nothing to offer still says how far the journal reaches. Without
+                // recording that, the next tap would walk the pen's whole log again.
+                doses.maxOfOrNull(PenDose::relativeSeconds)?.let { advanceCursor(serial, it) }
                 return@launch
             }
             val preselectFrom = if (known == null) now - FIRST_SCAN_PRESELECT_SECONDS else 0L
@@ -200,12 +216,12 @@ object InsulinPenManager {
         // The cursor is the "stop reading" mark for the next tap, not the dedupe rule —
         // that is the source record id. Anything older the reader left unticked stays
         // declined unless they ask for a full read.
-        val newest = doses.maxOf(PenDose::timestampSeconds)
+        val newest = doses.maxOf(PenDose::relativeSeconds)
         update(serial) {
             it.copy(
                 insulinPresetId = presetId,
                 insulinName = presetName,
-                lastImportedDoseSeconds = maxOf(it.lastImportedDoseSeconds, newest),
+                lastImportedDoseRelativeSeconds = maxOf(it.lastImportedDoseRelativeSeconds, newest),
                 importedDoseCount = it.importedDoseCount + saved,
             )
         }
@@ -216,7 +232,57 @@ object InsulinPenManager {
         saved
     }
 
-    private fun sourceRecordId(serial: String, dose: PenDose) = "pen:$serial:${dose.timestampSeconds}"
+    private fun sourceRecordId(serial: String, dose: PenDose) = PenSourceIds.stable(serial, dose)
+
+    /** Moves the "stop reading here" mark up the pen's own counter. */
+    private fun advanceCursor(serial: String, relativeSeconds: Long) {
+        update(serial) {
+            it.copy(
+                lastImportedDoseRelativeSeconds =
+                    maxOf(it.lastImportedDoseRelativeSeconds, relativeSeconds),
+            )
+        }
+    }
+
+    /**
+     * Repairs what builds before the stable record id left in the journal: the same
+     * injection written once per scan, and entries named after an anchor that no longer
+     * exists. Runs on every scan because a pen only reveals its log when it is tapped,
+     * and it stops costing anything once nothing legacy is left.
+     *
+     * @return how many duplicate entries were removed
+     */
+    private suspend fun reconcile(
+        serial: String,
+        doses: List<PenDose>,
+        repository: JournalRepository,
+    ): Int {
+        if (doses.isEmpty()) return 0
+        return runCatching {
+            val window = PenDuplicateReconciler.MATCH_WINDOW_SECONDS
+            val from = (doses.minOf(PenDose::timestampSeconds) - window) * 1000L
+            val to = (doses.maxOf(PenDose::timestampSeconds) + window) * 1000L
+            val entries = repository
+                .entriesFromSourceBetween(JournalEntrySource.PEN, from, to)
+                .mapNotNull { entry ->
+                    val recordId = entry.sourceRecordId ?: return@mapNotNull null
+                    val units = entry.amount ?: return@mapNotNull null
+                    PenJournalEntry(entry.id, entry.timestamp / 1000L, units, recordId)
+                }
+            val plan = PenDuplicateReconciler.plan(serial, doses, entries)
+            if (plan.isEmpty) return@runCatching 0
+            plan.adopt.forEach { (entryId, recordId) ->
+                repository.retagSourceRecordId(entryId, recordId)
+            }
+            plan.delete.forEach { repository.deleteEntry(it) }
+            Log.i(LOG_ID, "Pen $serial: renamed ${plan.adopt.size}, dropped ${plan.delete.size} duplicate(s)")
+            if (plan.delete.isNotEmpty()) UiRefreshBus.requestDataRefresh()
+            plan.delete.size
+        }.getOrElse { error ->
+            Log.e(LOG_ID, "Pen duplicate cleanup failed: ${Log.stackline(error)}")
+            0
+        }
+    }
 
     private fun nowSeconds() = System.currentTimeMillis() / 1000L
 
@@ -242,7 +308,7 @@ object InsulinPenManager {
                     .put("insulinName", pen.insulinName ?: JSONObject.NULL)
                     .put("addedAt", pen.addedAt)
                     .put("lastScanAt", pen.lastScanAt)
-                    .put("lastDose", pen.lastImportedDoseSeconds)
+                    .put("lastRel", pen.lastImportedDoseRelativeSeconds)
                     .put("count", pen.importedDoseCount)
                     .put("fullRead", pen.fullReadArmed)
             )
@@ -263,7 +329,7 @@ object InsulinPenManager {
                     insulinName = item.optString("insulinName").takeIf { it.isNotBlank() },
                     addedAt = item.optLong("addedAt", 0L),
                     lastScanAt = item.optLong("lastScanAt", 0L),
-                    lastImportedDoseSeconds = item.optLong("lastDose", 0L),
+                    lastImportedDoseRelativeSeconds = item.optLong("lastRel", 0L),
                     importedDoseCount = item.optInt("count", 0),
                     fullReadArmed = item.optBoolean("fullRead", false),
                 )

--- a/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
@@ -16,6 +16,7 @@ import tk.glucodata.NovoPen.PenDose
 import tk.glucodata.NovoPen.PenDoseParser
 import tk.glucodata.NovoPen.PenDuplicateReconciler
 import tk.glucodata.NovoPen.PenJournalEntry
+import tk.glucodata.NovoPen.PenReconcilePlan
 import tk.glucodata.NovoPen.PenSourceIds
 import tk.glucodata.NovoPen.opennov.OpContext
 import tk.glucodata.data.journal.JournalEntryInput
@@ -54,6 +55,10 @@ object InsulinPenManager {
     private const val PREFS_NAME = "tk.glucodata_preferences"
     private const val ENABLED_KEY = "insulin_pen_enabled"
     private const val PENS_KEY = "insulin_pen_registry"
+    private const val SNAPSHOT_KEY_PREFIX = "insulin_pen_last_scan_"
+
+    /** Enough of a read to reconcile against; a pen holding more than this is rare. */
+    private const val SNAPSHOT_MAX_DOSES = 500
 
     /** A newly paired pen only offers this much of its stored log pre-selected. */
     const val FIRST_SCAN_PRESELECT_SECONDS = 24L * 60 * 60
@@ -93,6 +98,7 @@ object InsulinPenManager {
 
     fun forget(serial: String) {
         _pens.value = _pens.value.filterNot { it.serial == serial }
+        prefs.edit().remove(SNAPSHOT_KEY_PREFIX + serial).apply()
         persist()
     }
 
@@ -136,12 +142,13 @@ object InsulinPenManager {
             )
             val cutoff = now - REVIEW_WINDOW_SECONDS
             val repository = JournalRepository()
-            val removed = reconcile(serial, doses, repository)
+            rememberScan(serial, doses)
+            val duplicates = reconcile(serial, doses, repository)
             val fresh = doses
                 .filter { it.timestampSeconds > cutoff }
                 .filterNot { repository.hasEntryWithSourceRecordId(sourceRecordId(serial, it)) }
-            if (removed > 0) {
-                Applic.Toaster(Applic.app.getString(R.string.insulin_pen_duplicates_removed, removed))
+            if (duplicates > 0) {
+                Applic.Toaster(Applic.app.getString(R.string.insulin_pen_duplicates_found, duplicates))
             } else if (fresh.isEmpty()) {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_no_new_doses))
             }
@@ -245,12 +252,16 @@ object InsulinPenManager {
     }
 
     /**
-     * Repairs what builds before the stable record id left in the journal: the same
-     * injection written once per scan, and entries named after an anchor that no longer
-     * exists. Runs on every scan because a pen only reveals its log when it is tapped,
-     * and it stops costing anything once nothing legacy is left.
+     * Renames the entries builds before the stable record id left behind, so a rescan
+     * stops seeing them as doses it has never imported. Runs on every scan because a pen
+     * only reveals its log when it is tapped, and it stops costing anything once nothing
+     * legacy is left.
      *
-     * @return how many duplicate entries were removed
+     * Renaming is all this does. Where those builds wrote the same injection more than
+     * once the extra copies are only counted here, never deleted: dropping journal
+     * entries is the reader's call, from the pen's own screen.
+     *
+     * @return how many duplicate entries a cleanup would remove
      */
     private suspend fun reconcile(
         serial: String,
@@ -259,28 +270,115 @@ object InsulinPenManager {
     ): Int {
         if (doses.isEmpty()) return 0
         return runCatching {
-            val window = PenDuplicateReconciler.MATCH_WINDOW_SECONDS
-            val from = (doses.minOf(PenDose::timestampSeconds) - window) * 1000L
-            val to = (doses.maxOf(PenDose::timestampSeconds) + window) * 1000L
-            val entries = repository
-                .entriesFromSourceBetween(JournalEntrySource.PEN, from, to)
-                .mapNotNull { entry ->
-                    val recordId = entry.sourceRecordId ?: return@mapNotNull null
-                    val units = entry.amount ?: return@mapNotNull null
-                    PenJournalEntry(entry.id, entry.timestamp / 1000L, units, recordId)
-                }
-            val plan = PenDuplicateReconciler.plan(serial, doses, entries)
+            val (plan, _) = planFor(serial, doses, repository)
             if (plan.isEmpty) return@runCatching 0
             plan.adopt.forEach { (entryId, recordId) ->
                 repository.retagSourceRecordId(entryId, recordId)
             }
+            Log.i(LOG_ID, "Pen $serial: renamed ${plan.adopt.size}, ${plan.delete.size} duplicate(s) to review")
+            plan.delete.size
+        }.getOrElse { error ->
+            Log.e(LOG_ID, "Pen reconcile failed: ${Log.stackline(error)}")
+            0
+        }
+    }
+
+    /** Matches the pen's log against what earlier scans of it wrote to the journal. */
+    private suspend fun planFor(
+        serial: String,
+        doses: List<PenDose>,
+        repository: JournalRepository,
+    ): Pair<PenReconcilePlan, Map<Long, PenJournalEntry>> {
+        if (doses.isEmpty()) return PenReconcilePlan.EMPTY to emptyMap()
+        val window = PenDuplicateReconciler.MATCH_WINDOW_SECONDS
+        val from = (doses.minOf(PenDose::timestampSeconds) - window) * 1000L
+        val to = (doses.maxOf(PenDose::timestampSeconds) + window) * 1000L
+        val entries = repository
+            .entriesFromSourceBetween(JournalEntrySource.PEN, from, to)
+            .mapNotNull { entry ->
+                val recordId = entry.sourceRecordId ?: return@mapNotNull null
+                val units = entry.amount ?: return@mapNotNull null
+                PenJournalEntry(entry.id, entry.timestamp / 1000L, units, recordId)
+            }
+        return PenDuplicateReconciler.plan(serial, doses, entries) to entries.associateBy { it.id }
+    }
+
+    /**
+     * What a cleanup would remove, worked out from the pen's last read.
+     *
+     * The pen's log is the only thing that can tell a duplicate from two real injections
+     * of the same size minutes apart, so a pen that has not been read since this version
+     * arrived has nothing to answer with, and says so by finding nothing.
+     */
+    suspend fun findDuplicates(serial: String): List<PenDuplicateEntry> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val (plan, byId) = planFor(serial, lastScan(serial), JournalRepository())
+                plan.delete.mapNotNull { id ->
+                    byId[id]?.let { PenDuplicateEntry(it.id, it.timestampSeconds * 1000L, it.units) }
+                }
+            }.getOrElse { error ->
+                Log.e(LOG_ID, "Pen duplicate search failed: ${Log.stackline(error)}")
+                emptyList()
+            }
+        }
+
+    /**
+     * Deletes the extra copies. Recomputed rather than taking the list the sheet showed,
+     * so a journal edited between the preview and the tap cannot lose the wrong row.
+     */
+    suspend fun removeDuplicates(serial: String): Int = withContext(Dispatchers.IO) {
+        runCatching {
+            val repository = JournalRepository()
+            val (plan, _) = planFor(serial, lastScan(serial), repository)
+            plan.adopt.forEach { (entryId, recordId) ->
+                repository.retagSourceRecordId(entryId, recordId)
+            }
             plan.delete.forEach { repository.deleteEntry(it) }
-            Log.i(LOG_ID, "Pen $serial: renamed ${plan.adopt.size}, dropped ${plan.delete.size} duplicate(s)")
             if (plan.delete.isNotEmpty()) UiRefreshBus.requestDataRefresh()
+            Log.i(LOG_ID, "Pen $serial: dropped ${plan.delete.size} duplicate(s)")
             plan.delete.size
         }.getOrElse { error ->
             Log.e(LOG_ID, "Pen duplicate cleanup failed: ${Log.stackline(error)}")
             0
+        }
+    }
+
+    /**
+     * Keeps the doses of the last read, so the cleanup can be asked for later without the
+     * pen in hand. Only the newest [SNAPSHOT_MAX_DOSES] are kept; older entries than that
+     * are past every window the cleanup looks at anyway.
+     */
+    private fun rememberScan(serial: String, doses: List<PenDose>) {
+        if (doses.isEmpty()) return
+        val array = JSONArray()
+        doses.takeLast(SNAPSHOT_MAX_DOSES).forEach { dose ->
+            array.put(
+                JSONArray()
+                    .put(dose.relativeSeconds)
+                    .put(dose.timestampSeconds)
+                    .put(Math.round(dose.units * 10f))
+            )
+        }
+        prefs.edit().putString(SNAPSHOT_KEY_PREFIX + serial, array.toString()).apply()
+    }
+
+    private fun lastScan(serial: String): List<PenDose> {
+        val stored = prefs.getString(SNAPSHOT_KEY_PREFIX + serial, null) ?: return emptyList()
+        return runCatching {
+            val array = JSONArray(stored)
+            (0 until array.length()).mapNotNull { index ->
+                val row = array.optJSONArray(index) ?: return@mapNotNull null
+                PenDose(
+                    relativeSeconds = row.optLong(0),
+                    timestampSeconds = row.optLong(1),
+                    units = row.optInt(2) / 10f,
+                    flags = 0,
+                )
+            }
+        }.getOrElse { error ->
+            Log.e(LOG_ID, "Unreadable pen scan snapshot: ${Log.stackline(error)}")
+            emptyList()
         }
     }
 
@@ -340,6 +438,13 @@ object InsulinPenManager {
         }
     }
 }
+
+/** One journal entry a cleanup would drop, as the confirmation dialog lists it. */
+data class PenDuplicateEntry(
+    val entryId: Long,
+    val timestampMillis: Long,
+    val units: Float,
+)
 
 /** A finished pen read waiting for the reader to confirm what goes into the journal. */
 data class PenScanResult(

--- a/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
@@ -17,8 +17,11 @@ import tk.glucodata.NovoPen.PenDoseParser
 import tk.glucodata.NovoPen.PenDropTally
 import tk.glucodata.NovoPen.PenDuplicateReconciler
 import tk.glucodata.NovoPen.PenImportCursor
+import tk.glucodata.NovoPen.PenImportPlan
 import tk.glucodata.NovoPen.PenJournalEntry
+import tk.glucodata.NovoPen.PenManualMerge
 import tk.glucodata.NovoPen.PenManualMergePlanner
+import tk.glucodata.NovoPen.PenSheetOffer
 import tk.glucodata.NovoPen.PenReconcilePlan
 import tk.glucodata.NovoPen.PenSourceIds
 import tk.glucodata.NovoPen.opennov.OpContext
@@ -178,43 +181,41 @@ object InsulinPenManager {
                 .filterNot { it.relativeSeconds in present }
                 .filter { PenImportCursor.isAhead(it, cursor, fullRead) }
             // A dose the reader wrote down before injecting is already in the journal, just
-            // not under the pen's name. Merging it onto that entry has to happen before the
-            // sheet is built, so the same injection is not offered as a second row. A full
-            // read is the reader asking to see the whole log and decide on it themselves,
-            // so it merges nothing: that is the one scan that can carry weeks of doses.
-            val merged = if (fullRead) {
-                emptySet()
+            // not under the pen's name. What that would merge onto is worked out here and
+            // carried out on confirmation, since the sheet is the one place the reader can
+            // say the pairing is wrong. A full read proposes nothing: it is the reader
+            // asking to see the whole log, and the one scan that can carry weeks of doses.
+            val mergeable = if (fullRead) {
+                emptyMap()
             } else {
-                mergeManualEntries(serial, fresh, known?.insulinPresetId, repository)
+                planManualMerges(serial, fresh, known?.insulinPresetId, repository)
             }
-            val offer = fresh.filterNot { it.relativeSeconds in merged }
-            val held = present + merged
+            // Air shots are never written, so they are not something to offer or to count.
+            val offer = PenSheetOffer.offerable(fresh).sortedByDescending(PenDose::timestampSeconds)
             Log.i(
                 LOG_ID,
                 "Pen $serial: ${chunks.size} chunk(s), ${parsed.sumOf { it.size }} parsed, " +
                     "${doses.size} after merge, newest rel=${doses.maxOfOrNull(PenDose::relativeSeconds)}, " +
                     "cursor rel=$cursor${if (fullRead) " (full read)" else ""}, " +
                     "${inWindow.size} within ${REVIEW_WINDOW_SECONDS / 86_400} days, " +
-                    "${inWindow.size - present.size} not in the journal, ${merged.size} merged " +
-                    "onto hand-written entries, ${offer.size} to offer; " +
+                    "${inWindow.size - present.size} not in the journal, " +
+                    "${PenSheetOffer.skipped(fresh)} air shot(s) skipped, " +
+                    "${mergeable.size} to propose merging, ${offer.size} to offer; " +
                     dropped.describe(),
             )
-            // Duplicates to clean up and doses merged onto entries are separate news, and
-            // the cleanup is the one that asks for something, so it is said first.
             if (duplicates > 0) {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_duplicates_found, duplicates))
-            }
-            if (merged.isNotEmpty()) {
-                Applic.Toaster(Applic.app.getString(R.string.insulin_pen_merged_manual, merged.size))
-            } else if (duplicates == 0 && offer.isEmpty()) {
+            } else if (offer.isEmpty()) {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_no_new_doses))
             }
             if (offer.isEmpty()) {
-                // A scan with nothing to offer still says how far the journal reaches, so the
-                // next tap does not walk the pen's whole log again — but only as far as it was
-                // seen to reach. A dose this scan never found in the journal stays ahead of the
-                // cursor, whatever kept it out, so the next scan looks at it again.
-                PenImportCursor.provenUpTo(inWindow) { it.relativeSeconds in held }
+                // Nothing to confirm, so no sheet: a dialog with an empty list and a disabled
+                // button is a dead end. A scan with nothing to offer still says how far the
+                // journal reaches, so the next tap does not walk the pen's whole log again —
+                // but only as far as it was seen to reach. A dose this scan never found in
+                // the journal stays ahead of the cursor, whatever kept it out, so the next
+                // scan looks at it again.
+                PenImportCursor.provenUpTo(inWindow) { it.relativeSeconds in present }
                     ?.let { advanceCursor(serial, it) }
                 return@launch
             }
@@ -222,8 +223,10 @@ object InsulinPenManager {
             InsulinPenScanBus.offer(
                 PenScanResult(
                     serial = serial,
-                    doses = offer.sortedByDescending(PenDose::timestampSeconds),
+                    doses = offer,
                     preselectFromSeconds = preselectFrom,
+                    merges = mergeable,
+                    skippedPrimingDoses = PenSheetOffer.skipped(fresh),
                 )
             )
         }
@@ -238,10 +241,21 @@ object InsulinPenManager {
         doses: List<PenDose>,
         presetId: Long,
         presetName: String,
+        merges: Map<Long, PenManualMerge> = emptyMap(),
     ) {
         scope.launch {
-            val saved = importDoses(serial, doses, presetId, presetName)
-            Applic.Toaster(Applic.app.getString(R.string.insulin_pen_doses_added, saved))
+            val outcome = importDoses(serial, doses, presetId, presetName, merges)
+            if (outcome.inserted > 0) {
+                Applic.Toaster(Applic.app.getString(R.string.insulin_pen_doses_added, outcome.inserted))
+            }
+            if (outcome.merged > 0) {
+                Applic.Toaster(Applic.app.getString(R.string.insulin_pen_merged_manual, outcome.merged))
+            }
+            if (outcome.total == 0) {
+                // Confirming and being told nothing is worse than being told it was already
+                // there, which is what an empty outcome means.
+                Applic.Toaster(Applic.app.getString(R.string.insulin_pen_no_new_doses))
+            }
         }
     }
 
@@ -255,11 +269,25 @@ object InsulinPenManager {
         doses: List<PenDose>,
         presetId: Long,
         presetName: String,
-    ): Int = withContext(Dispatchers.IO) {
-        if (doses.isEmpty()) return@withContext 0
+        merges: Map<Long, PenManualMerge> = emptyMap(),
+    ): PenImportOutcome = withContext(Dispatchers.IO) {
+        if (doses.isEmpty()) return@withContext PenImportOutcome.NOTHING
         val repository = JournalRepository()
+        // What to take over and what to write, worked out before anything is written: a
+        // dose that lands on the entry the reader already wrote must not also become a row
+        // of its own.
+        val written = doses
+            .filter { repository.hasEntryWithSourceRecordId(sourceRecordId(serial, it)) }
+            .mapTo(HashSet(), PenDose::relativeSeconds)
+        val plan = PenImportPlan.of(doses, merges) { it.relativeSeconds in written }
+        val mergedRelatives = applyManualMerges(serial, plan.adopt, repository)
+        // A proposal that no longer holds is not a reason to lose the dose: it is written
+        // as a row of its own instead.
+        val toInsert = plan.insert + plan.adopt
+            .filterNot { it.doseRelativeSeconds in mergedRelatives }
+            .mapNotNull { merge -> doses.firstOrNull { it.relativeSeconds == merge.doseRelativeSeconds } }
         var saved = 0
-        doses.forEach { dose ->
+        toInsert.forEach { dose ->
             val recordId = sourceRecordId(serial, dose)
             runCatching {
                 if (repository.hasEntryWithSourceRecordId(recordId)) return@forEach
@@ -289,19 +317,20 @@ object InsulinPenManager {
                 insulinPresetId = presetId,
                 insulinName = presetName,
                 lastImportedDoseRelativeSeconds = maxOf(it.lastImportedDoseRelativeSeconds, newest),
-                importedDoseCount = it.importedDoseCount + saved,
+                importedDoseCount = it.importedDoseCount + saved + mergedRelatives.size,
             )
         }
         Log.i(
             LOG_ID,
             "Pen $serial: ${doses.size} dose(s) confirmed, $saved written, " +
+                "${mergedRelatives.size} merged onto hand-written entries, " +
                 "cursor rel=${pen(serial)?.lastImportedDoseRelativeSeconds}",
         )
         if (saved > 0) {
             UiRefreshBus.requestDataRefresh()
             if (Natives.getpostTreatments()) Natives.wakeuploader()
         }
-        saved
+        PenImportOutcome(inserted = saved, merged = mergedRelatives.size)
     }
 
     private fun sourceRecordId(serial: String, dose: PenDose) = PenSourceIds.stable(serial, dose)
@@ -349,20 +378,17 @@ object InsulinPenManager {
     }
 
     /**
-     * Merges doses onto insulin entries the reader wrote by hand shortly before injecting,
-     * so one injection stays one row. The decision is [PenManualMergePlanner]'s; this reads
-     * the candidates and writes the outcome.
-     *
-     * @return the pen counters of the doses that found an entry — they are in the journal
-     *   now and must not be offered again
+     * What could be merged, worked out but not carried out. The sheet shows this as a
+     * proposal; only confirming it writes anything, since the sheet is the one place the
+     * reader can say the pairing is wrong.
      */
-    private suspend fun mergeManualEntries(
+    private suspend fun planManualMerges(
         serial: String,
         doses: List<PenDose>,
         penInsulinPresetId: Long?,
         repository: JournalRepository,
-    ): Set<Long> {
-        if (doses.isEmpty()) return emptySet()
+    ): Map<Long, PenManualMerge> {
+        if (doses.isEmpty()) return emptyMap()
         return runCatching {
             val window = PenManualMergePlanner.MATCH_WINDOW_SECONDS
             val from = (doses.minOf(PenDose::timestampSeconds) - window) * 1000L
@@ -379,25 +405,47 @@ object InsulinPenManager {
                         "${stop.secondsApart}s apart); matching the rest by time and amount",
                 )
             }
-            val merged = LinkedHashSet<Long>()
-            plan.merges.forEach { merge ->
-                val adopted = repository.adoptPenDose(
+            plan.merges.associateBy(PenManualMerge::doseRelativeSeconds)
+        }.getOrElse { error ->
+            Log.e(LOG_ID, "Pen manual merge planning failed: ${Log.stackline(error)}")
+            emptyMap()
+        }
+    }
+
+    /**
+     * Carries out what [planManualMerges] proposed. Each adoption is guarded on its own, so
+     * an entry deleted or already claimed since the plan was made simply does not merge and
+     * its dose is written as a new row instead.
+     *
+     * @return the pen counters of the doses whose entry was adopted
+     */
+    private suspend fun applyManualMerges(
+        serial: String,
+        merges: Collection<PenManualMerge>,
+        repository: JournalRepository,
+    ): Set<Long> {
+        if (merges.isEmpty()) return emptySet()
+        val merged = LinkedHashSet<Long>()
+        merges.forEach { merge ->
+            val adopted = runCatching {
+                repository.adoptPenDose(
                     merge.entryId,
                     merge.sourceRecordId,
                     merge.timestampSeconds * 1000L,
+                    merge.entryUnits,
                 )
-                if (adopted) merged.add(merge.doseRelativeSeconds)
+            }.getOrElse { error ->
+                Log.e(LOG_ID, "Pen manual merge failed: ${Log.stackline(error)}")
+                false
             }
-            if (merged.isNotEmpty()) {
-                Log.i(LOG_ID, "Pen $serial: ${merged.size} dose(s) merged onto hand-written entries")
-                UiRefreshBus.requestDataRefresh()
-                if (Natives.getpostTreatments()) Natives.wakeuploader()
-            }
-            merged as Set<Long>
-        }.getOrElse { error ->
-            Log.e(LOG_ID, "Pen manual merge failed: ${Log.stackline(error)}")
-            emptySet()
+            if (adopted) merged.add(merge.doseRelativeSeconds)
         }
+        if (merged.isNotEmpty()) {
+            Log.i(LOG_ID, "Pen $serial: ${merged.size} dose(s) merged onto hand-written entries")
+            UiRefreshBus.requestDataRefresh()
+            if (Natives.getpostTreatments()) Natives.wakeuploader()
+        }
+        return merged
     }
 
     /** Matches the pen's log against what earlier scans of it wrote to the journal. */
@@ -566,9 +614,23 @@ data class PenDuplicateEntry(
 /** A finished pen read waiting for the reader to confirm what goes into the journal. */
 data class PenScanResult(
     val serial: String,
+    /** What the sheet may offer: air shots are not among them. */
     val doses: List<PenDose>,
     val preselectFromSeconds: Long,
+    /** Per dose counter, the hand-written entry it would be merged onto if confirmed. */
+    val merges: Map<Long, PenManualMerge> = emptyMap(),
+    /** Air shots this read found and left out, so the sheet can say so. */
+    val skippedPrimingDoses: Int = 0,
 )
+
+/** What confirming a sheet did: rows written, and rows the pen took over. */
+data class PenImportOutcome(val inserted: Int, val merged: Int) {
+    val total: Int get() = inserted + merged
+
+    companion object {
+        val NOTHING = PenImportOutcome(0, 0)
+    }
+}
 
 /**
  * A pen is tapped against the phone from wherever the user happens to be, so the review

--- a/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
@@ -167,14 +167,23 @@ object InsulinPenManager {
             val present = inWindow
                 .filter { repository.hasEntryWithSourceRecordId(sourceRecordId(serial, it)) }
                 .mapTo(HashSet(), PenDose::relativeSeconds)
-            val fresh = inWindow.filterNot { it.relativeSeconds in present }
+            // Not in the journal is not enough to be offered: a dose the reader unticked at
+            // the last import was never written, and would otherwise come back as new on
+            // every tap. The cursor says where that review ended; only what lies past it is
+            // new, unless the reader asked to see the whole log again.
+            val cursor = known?.lastImportedDoseRelativeSeconds ?: 0L
+            val fullRead = known?.fullReadArmed ?: false
+            val fresh = inWindow
+                .filterNot { it.relativeSeconds in present }
+                .filter { PenImportCursor.isAhead(it, cursor, fullRead) }
             Log.i(
                 LOG_ID,
                 "Pen $serial: ${chunks.size} chunk(s), ${parsed.sumOf { it.size }} parsed, " +
                     "${doses.size} after merge, newest rel=${doses.maxOfOrNull(PenDose::relativeSeconds)}, " +
-                    "cursor rel=${known?.lastImportedDoseRelativeSeconds ?: 0L}, " +
+                    "cursor rel=$cursor${if (fullRead) " (full read)" else ""}, " +
                     "${inWindow.size} within ${REVIEW_WINDOW_SECONDS / 86_400} days, " +
-                    "${fresh.size} not in the journal; ${dropped.describe()}",
+                    "${inWindow.size - present.size} not in the journal, ${fresh.size} to offer; " +
+                    dropped.describe(),
             )
             if (duplicates > 0) {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_duplicates_found, duplicates))

--- a/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
@@ -14,6 +14,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import tk.glucodata.NovoPen.PenDose
 import tk.glucodata.NovoPen.PenDoseParser
+import tk.glucodata.NovoPen.PenDropTally
 import tk.glucodata.NovoPen.PenDuplicateReconciler
 import tk.glucodata.NovoPen.PenJournalEntry
 import tk.glucodata.NovoPen.PenReconcilePlan
@@ -111,19 +112,36 @@ object InsulinPenManager {
      * Called from the NFC protocol thread while the pen is still in the field, to stop
      * reading segments once everything they hold is already in the journal.
      *
-     * The pen sends newest first, so once a chunk's newest dose is one we already have,
-     * everything behind it is older and known too.
+     * The pen sends newest first — a real NovoPen 6 segment in `PenDoseParserTests` shows
+     * it, and native's `oldnovopenvalue` relied on it by testing a chunk's last record —
+     * so once a chunk's newest dose is one we already have, everything behind it is older
+     * and known too. The cursor is on the pen's own counter, the same number the chunk is
+     * compared on; it is 0 for a pen never imported on this build, and then the whole log
+     * is walked once on purpose.
      */
     @JvmStatic
     fun isFullyImported(serial: String?, referenceTimeSeconds: Long, raw: ByteArray?): Boolean {
         val known = serial?.let(::pen) ?: return false
-        if (known.fullReadArmed) return false
+        if (known.fullReadArmed) {
+            if (Log.doLog) Log.i(LOG_ID, "Pen $serial: full read armed, reading on")
+            return false
+        }
         val cursor = known.lastImportedDoseRelativeSeconds
-        if (cursor <= 0L) return false
-        val newest = PenDoseParser.parse(referenceTimeSeconds, raw, nowSeconds())
-            .maxOfOrNull(PenDose::relativeSeconds)
-            ?: return false
-        return newest <= cursor
+        if (cursor <= 0L) {
+            if (Log.doLog) Log.i(LOG_ID, "Pen $serial: no cursor yet, reading the whole log")
+            return false
+        }
+        val chunk = PenDoseParser.parse(referenceTimeSeconds, raw, nowSeconds())
+        val newest = chunk.maxOfOrNull(PenDose::relativeSeconds)
+        val done = newest != null && newest <= cursor
+        if (Log.doLog) {
+            Log.i(
+                LOG_ID,
+                "Pen $serial: chunk of ${chunk.size} dose(s), newest rel=$newest, " +
+                    "cursor rel=$cursor -> ${if (done) "all known, stop reading" else "reading on"}",
+            )
+        }
+        return done
     }
 
     /**
@@ -137,16 +155,24 @@ object InsulinPenManager {
         update(serial) { it.copy(lastScanAt = System.currentTimeMillis(), fullReadArmed = false) }
         scope.launch {
             val now = nowSeconds()
-            val doses = PenDoseParser.merge(
-                chunks.map { PenDoseParser.parse(it.referencetime, it.rawdoses, now) }
-            )
+            val dropped = PenDropTally()
+            val parsed = chunks.map { PenDoseParser.parse(it.referencetime, it.rawdoses, now, dropped) }
+            val doses = PenDoseParser.merge(parsed)
             val cutoff = now - REVIEW_WINDOW_SECONDS
             val repository = JournalRepository()
             rememberScan(serial, doses)
             val duplicates = reconcile(serial, doses, repository)
-            val fresh = doses
-                .filter { it.timestampSeconds > cutoff }
+            val inWindow = doses.filter { it.timestampSeconds > cutoff }
+            val fresh = inWindow
                 .filterNot { repository.hasEntryWithSourceRecordId(sourceRecordId(serial, it)) }
+            Log.i(
+                LOG_ID,
+                "Pen $serial: ${chunks.size} chunk(s), ${parsed.sumOf { it.size }} parsed, " +
+                    "${doses.size} after merge, newest rel=${doses.maxOfOrNull(PenDose::relativeSeconds)}, " +
+                    "cursor rel=${known?.lastImportedDoseRelativeSeconds ?: 0L}, " +
+                    "${inWindow.size} within ${REVIEW_WINDOW_SECONDS / 86_400} days, " +
+                    "${fresh.size} not in the journal; ${dropped.describe()}",
+            )
             if (duplicates > 0) {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_duplicates_found, duplicates))
             } else if (fresh.isEmpty()) {
@@ -232,6 +258,11 @@ object InsulinPenManager {
                 importedDoseCount = it.importedDoseCount + saved,
             )
         }
+        Log.i(
+            LOG_ID,
+            "Pen $serial: ${doses.size} dose(s) confirmed, $saved written, " +
+                "cursor rel=${pen(serial)?.lastImportedDoseRelativeSeconds}",
+        )
         if (saved > 0) {
             UiRefreshBus.requestDataRefresh()
             if (Natives.getpostTreatments()) Natives.wakeuploader()

--- a/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
+++ b/Common/src/mobile/java/tk/glucodata/InsulinPenManager.kt
@@ -16,6 +16,7 @@ import tk.glucodata.NovoPen.PenDose
 import tk.glucodata.NovoPen.PenDoseParser
 import tk.glucodata.NovoPen.PenDropTally
 import tk.glucodata.NovoPen.PenDuplicateReconciler
+import tk.glucodata.NovoPen.PenImportCursor
 import tk.glucodata.NovoPen.PenJournalEntry
 import tk.glucodata.NovoPen.PenReconcilePlan
 import tk.glucodata.NovoPen.PenSourceIds
@@ -163,8 +164,10 @@ object InsulinPenManager {
             rememberScan(serial, doses)
             val duplicates = reconcile(serial, doses, repository)
             val inWindow = doses.filter { it.timestampSeconds > cutoff }
-            val fresh = inWindow
-                .filterNot { repository.hasEntryWithSourceRecordId(sourceRecordId(serial, it)) }
+            val present = inWindow
+                .filter { repository.hasEntryWithSourceRecordId(sourceRecordId(serial, it)) }
+                .mapTo(HashSet(), PenDose::relativeSeconds)
+            val fresh = inWindow.filterNot { it.relativeSeconds in present }
             Log.i(
                 LOG_ID,
                 "Pen $serial: ${chunks.size} chunk(s), ${parsed.sumOf { it.size }} parsed, " +
@@ -179,9 +182,12 @@ object InsulinPenManager {
                 Applic.Toaster(Applic.app.getString(R.string.insulin_pen_no_new_doses))
             }
             if (fresh.isEmpty()) {
-                // A scan with nothing to offer still says how far the journal reaches. Without
-                // recording that, the next tap would walk the pen's whole log again.
-                doses.maxOfOrNull(PenDose::relativeSeconds)?.let { advanceCursor(serial, it) }
+                // A scan with nothing to offer still says how far the journal reaches, so the
+                // next tap does not walk the pen's whole log again — but only as far as it was
+                // seen to reach. A dose this scan never found in the journal stays ahead of the
+                // cursor, whatever kept it out, so the next scan looks at it again.
+                PenImportCursor.provenUpTo(inWindow) { it.relativeSeconds in present }
+                    ?.let { advanceCursor(serial, it) }
                 return@launch
             }
             val preselectFrom = if (known == null) now - FIRST_SCAN_PRESELECT_SECONDS else 0L

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenDose.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenDose.kt
@@ -8,6 +8,14 @@ package tk.glucodata.NovoPen
  * pen's relative time). [timestampSeconds] is that anchored epoch second.
  */
 data class PenDose(
+    /**
+     * The pen's own uptime counter at the moment of the dose, straight off the wire.
+     *
+     * This is the dose's identity: it is what the pen stores, so it reads back the same on
+     * every scan, while [timestampSeconds] moves with whatever anchor the scan happened to
+     * land on.
+     */
+    val relativeSeconds: Long,
     val timestampSeconds: Long,
     val units: Float,
     /** Pen-reported status byte. Non-zero means the pen flagged something about the dose. */
@@ -66,11 +74,16 @@ object PenDoseParser {
         return markPriming(decoded)
     }
 
-    /** Merges the chunks one scan produced, dropping duplicates the segments overlap on. */
+    /**
+     * Merges the chunks one scan produced, dropping duplicates the segments overlap on.
+     *
+     * Keyed on the pen's own counter rather than the anchored second, so an overlap is
+     * still recognised as an overlap when the segments were anchored a moment apart.
+     */
     fun merge(chunks: List<List<PenDose>>): List<PenDose> {
-        val byTime = LinkedHashMap<Long, PenDose>()
-        chunks.forEach { chunk -> chunk.forEach { dose -> byTime[dose.timestampSeconds] = dose } }
-        return markPriming(byTime.values.sortedBy(PenDose::timestampSeconds))
+        val byRelative = LinkedHashMap<Long, PenDose>()
+        chunks.forEach { chunk -> chunk.forEach { dose -> byRelative[dose.relativeSeconds] = dose } }
+        return markPriming(byRelative.values.sortedBy(PenDose::timestampSeconds))
     }
 
     private fun decode(referenceTimeSeconds: Long, raw: ByteArray, offset: Int): PenDose? {
@@ -91,6 +104,7 @@ object PenDoseParser {
         val units = tenths / 10f
         if (units <= 0f || units > MAX_UNITS) return null
         return PenDose(
+            relativeSeconds = relativeSeconds,
             timestampSeconds = referenceTimeSeconds + relativeSeconds,
             units = units,
             flags = raw[offset + 11].toInt() and 0xFF,

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenDose.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenDose.kt
@@ -55,18 +55,33 @@ object PenDoseParser {
 
     /**
      * @param referenceTimeSeconds epoch second the segment's relative time was anchored to
-     * @param nowSeconds epoch second used to reject records outside the plausible window
+     * @param nowSeconds epoch second used to reject records outside the plausible window:
+     *   older than [MAX_AGE_SECONDS], or after now
+     * @param dropped receives every well-formed record the window rejected, so the caller
+     *   can say what it threw away rather than losing it in silence
      * @return decoded doses, oldest first, with priming shots flagged
      */
-    fun parse(referenceTimeSeconds: Long, raw: ByteArray?, nowSeconds: Long): List<PenDose> {
+    fun parse(
+        referenceTimeSeconds: Long,
+        raw: ByteArray?,
+        nowSeconds: Long,
+        dropped: PenDropTally? = null,
+    ): List<PenDose> {
         if (raw == null) return emptyList()
         val oldest = nowSeconds - MAX_AGE_SECONDS
+        val newest = nowSeconds
         val decoded = ArrayList<PenDose>(raw.size / RECORD_SIZE)
         var offset = 0
         while (offset + RECORD_SIZE <= raw.size) {
             val record = decode(referenceTimeSeconds, raw, offset)
-            if (record != null && record.timestampSeconds in oldest..nowSeconds) {
-                decoded.add(record)
+            if (record != null) {
+                when {
+                    record.timestampSeconds < oldest ->
+                        dropped?.record(PenDropReason.TOO_OLD, record, referenceTimeSeconds, nowSeconds)
+                    record.timestampSeconds > newest ->
+                        dropped?.record(PenDropReason.IN_THE_FUTURE, record, referenceTimeSeconds, nowSeconds)
+                    else -> decoded.add(record)
+                }
             }
             offset += RECORD_SIZE
         }
@@ -124,5 +139,50 @@ object PenDoseParser {
                 next.timestampSeconds - dose.timestampSeconds in 0..PRIMING_WINDOW_SECONDS
             if (priming) dose.copy(priming = true) else dose
         }
+    }
+}
+
+/** Why a well-formed record was left out of a parse. */
+enum class PenDropReason { TOO_OLD, IN_THE_FUTURE }
+
+/**
+ * What one parse, or one whole scan, refused.
+ *
+ * A pen holds hundreds of doses and most of a long log is past [PenDoseParser.MAX_AGE_SECONDS],
+ * so this counts per reason and keeps the details of only the first few, enough to show
+ * where a rejected record sat relative to the anchor and the clock without flooding the log.
+ */
+class PenDropTally {
+    private val counts = IntArray(PenDropReason.values().size)
+    private val samples = ArrayList<String>(SAMPLE_LIMIT)
+
+    fun record(reason: PenDropReason, dose: PenDose, referenceTimeSeconds: Long, nowSeconds: Long) {
+        counts[reason.ordinal]++
+        if (samples.size < SAMPLE_LIMIT) {
+            samples.add(
+                "${reason.name.lowercase()} rel=${dose.relativeSeconds} ts=${dose.timestampSeconds} " +
+                    "ref=$referenceTimeSeconds now=$nowSeconds (${dose.timestampSeconds - nowSeconds}s from now) " +
+                    "${dose.units}U"
+            )
+        }
+    }
+
+    fun count(reason: PenDropReason): Int = counts[reason.ordinal]
+
+    val total: Int get() = counts.sum()
+
+    val isEmpty: Boolean get() = total == 0
+
+    /** One line for the log: counts per reason, then the first few records in full. */
+    fun describe(): String {
+        if (isEmpty) return "dropped none"
+        val perReason = PenDropReason.values()
+            .filter { count(it) > 0 }
+            .joinToString(", ") { "${count(it)} ${it.name.lowercase()}" }
+        return "dropped $perReason; first: ${samples.joinToString(" | ")}"
+    }
+
+    private companion object {
+        const val SAMPLE_LIMIT = 3
     }
 }

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenDuplicateReconciler.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenDuplicateReconciler.kt
@@ -1,0 +1,143 @@
+package tk.glucodata.NovoPen
+
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/** How a pen dose is named in the journal, so a rescan recognises what it already wrote. */
+object PenSourceIds {
+
+    /**
+     * Keyed on the pen's own counter, which is the one number about a dose that survives
+     * being read twice. Earlier builds keyed on the anchored epoch second instead; those
+     * ids are the [isLegacy] ones and every rescan minted a fresh one for the same dose.
+     */
+    fun stable(serial: String, dose: PenDose): String = "pen:$serial:rel:${dose.relativeSeconds}"
+
+    fun belongsTo(serial: String, sourceRecordId: String?): Boolean =
+        sourceRecordId != null && sourceRecordId.startsWith("pen:$serial:")
+
+    fun isLegacy(serial: String, sourceRecordId: String?): Boolean =
+        belongsTo(serial, sourceRecordId) && !sourceRecordId!!.startsWith("pen:$serial:rel:")
+}
+
+/** The parts of a journal entry the reconciler reasons about. */
+data class PenJournalEntry(
+    val id: Long,
+    val timestampSeconds: Long,
+    val units: Float,
+    val sourceRecordId: String,
+)
+
+/**
+ * @param adopt entry id to the stable record id it should carry from now on
+ * @param delete entries the pen's own log says were never separate doses
+ */
+data class PenReconcilePlan(
+    val adopt: Map<Long, String>,
+    val delete: List<Long>,
+) {
+    val isEmpty: Boolean get() = adopt.isEmpty() && delete.isEmpty()
+
+    companion object {
+        val EMPTY = PenReconcilePlan(emptyMap(), emptyList())
+    }
+}
+
+/**
+ * Reconciles what a pen just reported against what earlier scans of it wrote to the journal.
+ *
+ * Two things need repairing, both left behind by keying entries on the anchored epoch second.
+ * Entries written by those builds cannot be recomputed into stable ids, because the anchor
+ * they used is gone, so they have to be recognised by shape instead: same pen, same units, a
+ * timestamp near the dose. And where a dose was imported more than once, each anchor shifted
+ * the copy a little, so the journal holds several rows for one injection — which inflates
+ * IOB, not just the list.
+ *
+ * The pen's log is treated as the truth about how many injections there were. Doses and old
+ * entries are matched one to one, closest in time first; a matched entry is renamed rather
+ * than rewritten, so an edited amount or note survives. What is left over inside the span the
+ * scan covered, next to an entry of the same size, is the extra copy, and only that is
+ * deleted. An entry standing on its own is never touched, so an amount the reader corrected
+ * by hand cannot be mistaken for a duplicate of a dose it no longer matches.
+ */
+object PenDuplicateReconciler {
+
+    /**
+     * How far a legacy entry may sit from the dose it stands for.
+     *
+     * It covers the anchor jitter of a single read plus the drift between the phone clock
+     * and the pen counter since the entry was written, and stays well short of how far
+     * apart two real injections of the same size normally are.
+     */
+    const val MATCH_WINDOW_SECONDS = 300L
+
+    fun plan(
+        serial: String,
+        doses: List<PenDose>,
+        entries: List<PenJournalEntry>,
+    ): PenReconcilePlan {
+        if (doses.isEmpty()) return PenReconcilePlan.EMPTY
+        val mine = entries.filter { PenSourceIds.belongsTo(serial, it.sourceRecordId) }
+        val legacy = mine.filter { PenSourceIds.isLegacy(serial, it.sourceRecordId) }
+        if (legacy.isEmpty()) return PenReconcilePlan.EMPTY
+
+        // Only the stretch of time this read actually covered; anything outside it was not
+        // reported on, so there is nothing to compare it against.
+        val from = doses.minOf(PenDose::timestampSeconds) - MATCH_WINDOW_SECONDS
+        val to = doses.maxOf(PenDose::timestampSeconds) + MATCH_WINDOW_SECONDS
+        val candidates = legacy.filter { it.timestampSeconds in from..to }
+        if (candidates.isEmpty()) return PenReconcilePlan.EMPTY
+
+        val alreadyStable = mine.mapTo(HashSet()) { it.sourceRecordId }
+        val pairs = doses.flatMap { dose ->
+            candidates.mapNotNull { entry ->
+                val distance = abs(entry.timestampSeconds - dose.timestampSeconds)
+                if (distance <= MATCH_WINDOW_SECONDS && tenths(entry.units) == tenths(dose.units)) {
+                    Triple(distance, dose, entry)
+                } else {
+                    null
+                }
+            }
+        }.sortedWith(compareBy({ it.first }, { it.third.id }))
+
+        val adopt = LinkedHashMap<Long, String>()
+        val delete = ArrayList<Long>()
+        val claimedDoses = HashSet<Long>()
+        val claimedEntries = HashSet<Long>()
+        pairs.forEach { (_, dose, entry) ->
+            if (!claimedDoses.add(dose.relativeSeconds)) return@forEach
+            if (!claimedEntries.add(entry.id)) {
+                claimedDoses.remove(dose.relativeSeconds)
+                return@forEach
+            }
+            val stable = PenSourceIds.stable(serial, dose)
+            if (stable in alreadyStable) {
+                // The dose is already in the journal under its stable id, so this row is
+                // the copy an earlier scan added.
+                delete.add(entry.id)
+            } else {
+                adopt[entry.id] = stable
+                alreadyStable.add(stable)
+            }
+        }
+
+        // Whatever no dose claimed is only a duplicate if the row it was copied from is
+        // still there: same size, right beside it, and standing for a dose of its own.
+        // A leftover on its own is a record the pen no longer explains, and guessing at
+        // that would throw away therapy.
+        val originals = mine.filter { it.id in adopt || !PenSourceIds.isLegacy(serial, it.sourceRecordId) }
+        candidates.filterNot { it.id in claimedEntries }.forEach { leftover ->
+            val original = originals.any { other ->
+                other.id != leftover.id &&
+                    tenths(other.units) == tenths(leftover.units) &&
+                    abs(other.timestampSeconds - leftover.timestampSeconds) <= MATCH_WINDOW_SECONDS
+            }
+            if (original) delete.add(leftover.id)
+        }
+
+        return PenReconcilePlan(adopt, delete.distinct())
+    }
+
+    /** Doses come off the pen in tenths of a unit; compare them there, not as floats. */
+    private fun tenths(units: Float): Int = (units * 10f).roundToInt()
+}

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportCursor.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportCursor.kt
@@ -1,0 +1,23 @@
+package tk.glucodata.NovoPen
+
+/**
+ * Where the "stop reading here" mark may move after a scan that had nothing to offer.
+ *
+ * The cursor tells the next scan to stop once it reaches a dose at or below it, so every
+ * dose behind the cursor is one the app will never look at again unless a full read is
+ * asked for. That makes moving it past a dose nobody imported the one mistake a scan cannot
+ * take back: a dose that slipped through once — anchored wrongly, dropped by the window,
+ * never checked against the journal — would be skipped on every scan after.
+ */
+object PenImportCursor {
+
+    /**
+     * The newest dose the scan saw in the journal, or null when it vouched for none.
+     *
+     * Only doses whose record id was looked up and found count. Doses the scan never
+     * checked — outside the review window, or missing from the read — are not vouched for,
+     * so a newer one of those keeps the cursor below it, and the next scan sees it again.
+     */
+    fun provenUpTo(doses: List<PenDose>, inJournal: (PenDose) -> Boolean): Long? =
+        doses.filter(inJournal).maxOfOrNull(PenDose::relativeSeconds)
+}

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportCursor.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportCursor.kt
@@ -20,4 +20,15 @@ object PenImportCursor {
      */
     fun provenUpTo(doses: List<PenDose>, inJournal: (PenDose) -> Boolean): Long? =
         doses.filter(inJournal).maxOfOrNull(PenDose::relativeSeconds)
+
+    /**
+     * Whether a dose is still up for review: strictly past the cursor, or any dose at all
+     * when a full read was asked for.
+     *
+     * The cursor is where the last import ended. A dose the reader left unticked then is
+     * at or below it, and stays declined rather than being offered again on every tap; a
+     * pen never imported on this build has a cursor of 0, so everything it holds is ahead.
+     */
+    fun isAhead(dose: PenDose, cursor: Long, fullRead: Boolean): Boolean =
+        fullRead || dose.relativeSeconds > cursor
 }

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportPlan.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenImportPlan.kt
@@ -1,0 +1,46 @@
+package tk.glucodata.NovoPen
+
+/**
+ * What confirming a review sheet has to write: which doses take over an entry the reader
+ * wrote by hand, and which are written as rows of their own.
+ *
+ * The two are exclusive, which is the whole point of keeping this apart from the writing:
+ * a dose that lands on an entry must not also be inserted, or the duplicate the merge
+ * exists to prevent is created by the merge itself.
+ */
+data class PenImportPlan(
+    val adopt: List<PenManualMerge>,
+    val insert: List<PenDose>,
+) {
+    companion object {
+        val EMPTY = PenImportPlan(emptyList(), emptyList())
+
+        /**
+         * @param doses what the reader confirmed, air shots already gone
+         * @param merges the proposals, by dose counter; only doses in [doses] are honoured
+         * @param alreadyWritten source record ids the journal already holds, which are
+         *   neither adopted nor inserted: an earlier scan wrote that dose.
+         */
+        fun of(
+            doses: List<PenDose>,
+            merges: Map<Long, PenManualMerge>,
+            alreadyWritten: (PenDose) -> Boolean,
+        ): PenImportPlan {
+            if (doses.isEmpty()) return EMPTY
+            val adopt = ArrayList<PenManualMerge>()
+            val insert = ArrayList<PenDose>()
+            val claimedEntries = HashSet<Long>()
+            doses.forEach { dose ->
+                if (alreadyWritten(dose)) return@forEach
+                val merge = merges[dose.relativeSeconds]
+                // One entry cannot stand for two doses, whatever a stale proposal says.
+                if (merge != null && claimedEntries.add(merge.entryId)) {
+                    adopt.add(merge)
+                } else {
+                    insert.add(dose)
+                }
+            }
+            return PenImportPlan(adopt, insert)
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenManualMerge.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenManualMerge.kt
@@ -22,6 +22,10 @@ data class PenManualMerge(
     val timestampSeconds: Long,
     /** The dose it stands for, so the caller can drop it from what it offers. */
     val doseRelativeSeconds: Long,
+    /** When that entry was written, so a sheet can say which one it would replace. */
+    val entryTimestampSeconds: Long,
+    /** What it said at the time, so the amount can decide again when this is carried out. */
+    val entryUnits: Float,
 )
 
 /**
@@ -180,6 +184,8 @@ object PenManualMergePlanner {
         sourceRecordId = PenSourceIds.stable(serial, dose),
         timestampSeconds = dose.timestampSeconds,
         doseRelativeSeconds = dose.relativeSeconds,
+        entryTimestampSeconds = entry.timestampSeconds,
+        entryUnits = entry.units,
     )
 
     /** Doses come off the pen in tenths of a unit; compare them there, not as floats. */

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenManualMerge.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenManualMerge.kt
@@ -1,0 +1,187 @@
+package tk.glucodata.NovoPen
+
+import tk.glucodata.data.journal.JournalEntry
+import tk.glucodata.data.journal.JournalEntrySource
+import tk.glucodata.data.journal.JournalEntryType
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/** An insulin dose somebody wrote down themselves, before the pen was read. */
+data class ManualInsulinEntry(
+    val id: Long,
+    val timestampSeconds: Long,
+    val units: Float,
+    /** The insulin chosen for it; the editor cannot save an insulin entry without one. */
+    val insulinPresetId: Long?,
+)
+
+/** One entry the pen has now confirmed: it keeps its row and takes the dose's name and time. */
+data class PenManualMerge(
+    val entryId: Long,
+    val sourceRecordId: String,
+    val timestampSeconds: Long,
+    /** The dose it stands for, so the caller can drop it from what it offers. */
+    val doseRelativeSeconds: Long,
+)
+
+/**
+ * @param merges what to adopt, in the order the doses were injected
+ * @param alignmentBreak where the sequence stopped lining up, for the log; null when it held
+ */
+data class PenManualMergePlan(
+    val merges: List<PenManualMerge>,
+    val alignmentBreak: AlignmentBreak? = null,
+) {
+    val isEmpty: Boolean get() = merges.isEmpty()
+
+    /** Position in the walk, and the two amounts that disagreed there. */
+    data class AlignmentBreak(
+        val position: Int,
+        val doseUnits: Float,
+        val entryUnits: Float,
+        val secondsApart: Long,
+    )
+
+    companion object {
+        val EMPTY = PenManualMergePlan(emptyList(), null)
+    }
+}
+
+/**
+ * Matches a pen's doses against insulin entries the reader wrote by hand.
+ *
+ * Deciding to correct while looking at the chart, writing the dose down, and injecting a
+ * minute later without the app is one injection with two records: the entry, and later the
+ * dose the scan reads off the pen. [PenDuplicateReconciler] already merges the equivalent
+ * case for earlier pen imports, but only for entries that carry a `pen:` id, so a hand-written
+ * one falls through and the journal ends up holding the injection twice, with twice its IOB.
+ *
+ * Because only minutes pass between writing a dose down and giving it, the two sequences line
+ * up: the n-th dose the pen reports is the n-th entry in the journal. That is steadier than
+ * hunting for the nearest entry in time, and it fails differently — one wrong pairing shifts
+ * every pairing after it, silently, onto wrong times and amounts. So the order proposes the
+ * pairing and **the amount decides it**: at the first pair whose amounts differ, or that sits
+ * further apart than [MATCH_WINDOW_SECONDS], the alignment counts as lost. The walk stops
+ * there, the rest is matched pairwise instead — nearest in time, same amount, each side
+ * claimed once, the way [PenDuplicateReconciler] matches — and whatever stays unmatched is
+ * offered as a new dose, so a person decides it rather than this.
+ *
+ * Priming shots are left out before the walk: they exist in the pen's log and never in the
+ * journal, so counting them would shift the sequence by one from the start.
+ */
+object PenManualMergePlanner {
+
+    /**
+     * How far a hand-written entry may sit from the dose it stands for.
+     *
+     * Generous on purpose: the sequence decides the pairing, and this only asks whether the
+     * result is plausible. Fifteen minutes covers writing a dose down, walking to the pen and
+     * injecting, and stays far short of the gap between two separate corrections.
+     */
+    const val MATCH_WINDOW_SECONDS = 15L * 60L
+
+    /**
+     * @param penInsulinPresetId the insulin this pen is known to hold. A pen that has none
+     *   recorded yet merges nothing: bolus and basal cannot be told apart without it, and a
+     *   pen is only without one on its first read, when the reader is at the review sheet
+     *   anyway and can untick what they already wrote down.
+     */
+    /**
+     * The entries a merge may consider: insulin somebody wrote by hand, with an amount to
+     * check against. Anything an importer wrote is left out, the pen's own rows included,
+     * so a dose already imported can never be read as a hand-written record of itself.
+     */
+    fun candidates(entries: List<JournalEntry>): List<ManualInsulinEntry> = entries.mapNotNull { entry ->
+        if (entry.source != JournalEntrySource.MANUAL || entry.type != JournalEntryType.INSULIN) {
+            return@mapNotNull null
+        }
+        val units = entry.amount ?: return@mapNotNull null
+        ManualInsulinEntry(entry.id, entry.timestamp / 1000L, units, entry.insulinPresetId)
+    }
+
+    fun plan(
+        serial: String,
+        doses: List<PenDose>,
+        entries: List<ManualInsulinEntry>,
+        penInsulinPresetId: Long?,
+    ): PenManualMergePlan {
+        val insulin = penInsulinPresetId?.takeIf { it > 0L } ?: return PenManualMergePlan.EMPTY
+        val injections = doses.filterNot(PenDose::priming).sortedBy(PenDose::timestampSeconds)
+        if (injections.isEmpty() || entries.isEmpty()) return PenManualMergePlan.EMPTY
+
+        // Only the stretch the doses cover, and only this pen's insulin: a second pen of
+        // another kind has a sequence of its own and must not join this one.
+        val from = injections.first().timestampSeconds - MATCH_WINDOW_SECONDS
+        val to = injections.last().timestampSeconds + MATCH_WINDOW_SECONDS
+        val candidates = entries
+            .filter { it.timestampSeconds in from..to && it.insulinPresetId == insulin }
+            .sortedWith(compareBy(ManualInsulinEntry::timestampSeconds, ManualInsulinEntry::id))
+        if (candidates.isEmpty()) return PenManualMergePlan.EMPTY
+
+        val merges = ArrayList<PenManualMerge>()
+        var breakAt: PenManualMergePlan.AlignmentBreak? = null
+        var walked = 0
+        while (walked < injections.size && walked < candidates.size) {
+            val dose = injections[walked]
+            val entry = candidates[walked]
+            val apart = abs(entry.timestampSeconds - dose.timestampSeconds)
+            if (tenths(entry.units) != tenths(dose.units) || apart > MATCH_WINDOW_SECONDS) {
+                breakAt = PenManualMergePlan.AlignmentBreak(walked, dose.units, entry.units, apart)
+                break
+            }
+            merges.add(merge(serial, dose, entry))
+            walked++
+        }
+
+        if (breakAt != null) {
+            merges.addAll(
+                pairwise(serial, injections.drop(walked), candidates.drop(walked)),
+            )
+        }
+        return PenManualMergePlan(merges, breakAt)
+    }
+
+    /**
+     * What is left once the order can no longer be trusted: the same one-to-one, closest
+     * first, same-amount matching [PenDuplicateReconciler] uses. Anything it cannot pair
+     * confidently is left alone and offered as a new dose.
+     */
+    private fun pairwise(
+        serial: String,
+        doses: List<PenDose>,
+        entries: List<ManualInsulinEntry>,
+    ): List<PenManualMerge> {
+        if (doses.isEmpty() || entries.isEmpty()) return emptyList()
+        val pairs = doses.flatMap { dose ->
+            entries.mapNotNull { entry ->
+                val apart = abs(entry.timestampSeconds - dose.timestampSeconds)
+                if (apart <= MATCH_WINDOW_SECONDS && tenths(entry.units) == tenths(dose.units)) {
+                    Triple(apart, dose, entry)
+                } else {
+                    null
+                }
+            }
+        }.sortedWith(compareBy({ it.first }, { it.third.id }))
+
+        val claimedDoses = HashSet<Long>()
+        val claimedEntries = HashSet<Long>()
+        val merges = ArrayList<PenManualMerge>()
+        pairs.forEach { (_, dose, entry) ->
+            if (dose.relativeSeconds in claimedDoses || entry.id in claimedEntries) return@forEach
+            claimedDoses.add(dose.relativeSeconds)
+            claimedEntries.add(entry.id)
+            merges.add(merge(serial, dose, entry))
+        }
+        return merges.sortedBy(PenManualMerge::timestampSeconds)
+    }
+
+    private fun merge(serial: String, dose: PenDose, entry: ManualInsulinEntry) = PenManualMerge(
+        entryId = entry.id,
+        sourceRecordId = PenSourceIds.stable(serial, dose),
+        timestampSeconds = dose.timestampSeconds,
+        doseRelativeSeconds = dose.relativeSeconds,
+    )
+
+    /** Doses come off the pen in tenths of a unit; compare them there, not as floats. */
+    private fun tenths(units: Float): Int = (units * 10f).roundToInt()
+}

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/PenSheetOffer.kt
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/PenSheetOffer.kt
@@ -1,0 +1,35 @@
+package tk.glucodata.NovoPen
+
+/**
+ * What the review sheet offers, and what it starts out with ticked.
+ *
+ * One rule, asked once, so the heading, the list and the button cannot disagree about how
+ * many doses a scan found. They did: the heading counted every dose the read returned, air
+ * shots included, while the button counted what was actually going to be written, so a scan
+ * that read nothing but an air shot opened a sheet saying "1 new dose" with a disabled
+ * "add 0 doses" underneath it and no way out but dismissing.
+ */
+object PenSheetOffer {
+
+    /**
+     * An air shot is not therapy and is never written, so it is not something to offer or
+     * count. It is still reported, as a line under the list, rather than quietly dropped.
+     */
+    fun offerable(doses: List<PenDose>): List<PenDose> = doses.filterNot(PenDose::priming)
+
+    fun skipped(doses: List<PenDose>): Int = doses.count(PenDose::priming)
+
+    /**
+     * What starts out ticked: a dose that stands for an entry the reader already wrote by
+     * hand always does, since leaving it unticked would keep the duplicate it was found to
+     * be. Otherwise the pen's own rule applies, which holds back the log of a pen nobody has
+     * read before rather than offering weeks of it as new.
+     */
+    fun preselection(
+        doses: List<PenDose>,
+        mergeable: Set<Long>,
+        preselectFromSeconds: Long,
+    ): Set<Long> = offerable(doses)
+        .filter { it.relativeSeconds in mergeable || it.timestampSeconds >= preselectFromSeconds }
+        .mapTo(LinkedHashSet(), PenDose::relativeSeconds)
+}

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/Message.java
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/Message.java
@@ -106,7 +106,7 @@ private final static String LOG_ID="OpenNovMessage";
                 }
                 break;
             case CONFIRMED_EVENT_REPORT_CHOSEN: 
-                var er = EventReport.parse(buffer,context.doses);
+                var er = EventReport.parse(buffer,context);
                 if (er != null) {
 /*                    for (var ds : er.doses) {
                         if (d) log("dose: " + ds.toJson() + " " + tk.glucodata.util.timestring(ds.absoluteTime) + " valid: " + ds.isValid());

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/OpContext.java
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/OpContext.java
@@ -1,7 +1,11 @@
 package tk.glucodata.NovoPen.opennov;
 
+import static tk.glucodata.Log.doLog;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import tk.glucodata.Log;
 
 import tk.glucodata.NovoPen.opennov.mt.ARequest;
 import tk.glucodata.NovoPen.opennov.mt.Apdu;
@@ -18,6 +22,7 @@ import tk.glucodata.NovoPen.opennov.mt.TrigSegmDataXfer;
  */
 
 public class OpContext {
+    private static final String TAG = "OpenNov";
 
     public Specification specification;
 //    public RelativeTime relativeTime;
@@ -56,7 +61,9 @@ public class OpContext {
      */
     public long referenceTime(long relativeTime) {
         if (referencetime == UNSET_REFERENCE_TIME) {
-            referencetime = (System.currentTimeMillis() / 1000L) - relativeTime;
+            long now = System.currentTimeMillis() / 1000L;
+            referencetime = now - relativeTime;
+            if (doLog) Log.i(TAG, "Anchor pinned: now=" + now + " rt=" + relativeTime + " reference=" + referencetime);
         }
         return referencetime;
     }

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/OpContext.java
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/OpContext.java
@@ -41,6 +41,25 @@ public class OpContext {
         }
     }
     public final List<Doses> doses=new ArrayList<>();
+
+    private long referencetime=UNSET_REFERENCE_TIME;
+    private static final long UNSET_REFERENCE_TIME=Long.MIN_VALUE;
+
+    /**
+     * Epoch second the pen's uptime counter is pinned to, captured once per scan.
+     *
+     * The pen has no clock of its own, so an absolute dose time only exists as
+     * "phone clock now minus pen counter now". Reading that pair again for every event
+     * report would land a second or two away each time, because NFC transfer latency
+     * varies, and the doses of one scan would then disagree with each other about when
+     * they happened. Pinning it on the first report keeps a whole read on one timeline.
+     */
+    public long referenceTime(long relativeTime) {
+        if (referencetime == UNSET_REFERENCE_TIME) {
+            referencetime = (System.currentTimeMillis() / 1000L) - relativeTime;
+        }
+        return referencetime;
+    }
     public Configuration getConfiguration() {
         if (configuration != null) {
             return configuration;

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/mt/EventReport.java
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/mt/EventReport.java
@@ -30,7 +30,7 @@ public class EventReport extends BaseMessage {
     public Configuration configuration;
 
 
-    public static EventReport parse(final ByteBuffer buffer, List<OpContext.Doses> doses) {
+    public static EventReport parse(final ByteBuffer buffer, OpContext context) {
 
         var handle = getUnsignedShort(buffer);
         var relativeTime = getUnsignedInt(buffer);
@@ -39,7 +39,9 @@ public class EventReport extends BaseMessage {
 
         log("EventReport: handle: " + handle + " rt: " + relativeTime + " " + eventType);
 
-        long referencetime=(System.currentTimeMillis()/1000L)-relativeTime;
+        // Anchored once for the whole scan, not per report: see OpContext.referenceTime.
+        long referencetime=context.referenceTime(relativeTime);
+        List<OpContext.Doses> doses=context.doses;
         var er = new EventReport();
         er.handle = handle;
 

--- a/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/mt/EventReport.java
+++ b/Common/src/mobile/java/tk/glucodata/NovoPen/opennov/mt/EventReport.java
@@ -39,14 +39,17 @@ public class EventReport extends BaseMessage {
 
         log("EventReport: handle: " + handle + " rt: " + relativeTime + " " + eventType);
 
-        // Anchored once for the whole scan, not per report: see OpContext.referenceTime.
-        long referencetime=context.referenceTime(relativeTime);
         List<OpContext.Doses> doses=context.doses;
         var er = new EventReport();
         er.handle = handle;
 
         switch (eventType) {
             case MDC_NOTI_SEGMENT_DATA:
+                // Anchored once for the whole scan, not per report: see OpContext.referenceTime.
+                // Pinned here and not above, because the configuration report that opens a
+                // scan arrives first and its time field is not the pen's live counter; an
+                // anchor taken from it puts every dose of the read out of the window.
+                long referencetime=context.referenceTime(relativeTime);
                 er.instance = getUnsignedShort(buffer);
                 er.index = getUnsignedInt(buffer);
                 er.count = (int)getUnsignedInt(buffer);

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
@@ -25,6 +25,16 @@ interface JournalDao {
     suspend fun getEntriesBetween(startMillis: Long, endMillis: Long): List<JournalEntryEntity>
 
     @Query(
+        "SELECT * FROM journal_entries WHERE source = :source AND timestamp BETWEEN :startMillis AND :endMillis " +
+            "ORDER BY timestamp ASC, id ASC"
+    )
+    suspend fun getEntriesBySourceBetween(
+        source: String,
+        startMillis: Long,
+        endMillis: Long
+    ): List<JournalEntryEntity>
+
+    @Query(
         "SELECT * FROM journal_entries WHERE glucoseValueMgDl IS NOT NULL AND timestamp >= :startMillis " +
             "ORDER BY timestamp ASC, id ASC"
     )

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
@@ -114,6 +114,44 @@ class JournalRepository {
         }
     }
 
+    /**
+     * Adopts an entry a pen has now confirmed as one of its doses: the row stays, with its
+     * amount, its insulin and whatever note was written on it, and takes the dose's stable
+     * name and the time the pen measured. Keeping the row rather than replacing it is what
+     * saves the note, and Nightscout knows the treatment by that row, so re-timing it there
+     * is a correction rather than a second treatment.
+     *
+     * @return false when the entry is gone, or another row already carries that name
+     */
+    suspend fun adoptPenDose(entryId: Long, sourceRecordId: String, timestampMillis: Long): Boolean {
+        val id = sourceRecordId.trim().takeIf { it.isNotBlank() } ?: return false
+        val adopted = database.withTransaction {
+            val existing = dao.getEntryById(entryId) ?: return@withTransaction false
+            // Only insulin is a pen's to claim; anything else would also need the glucose
+            // side of a change told about it.
+            if (existing.entryType != JournalEntryType.INSULIN.storageValue) return@withTransaction false
+            val taken = dao.getEntryBySourceRecordId(id)
+            // sourceRecordId is unique and the upsert replaces on conflict, so a name
+            // already in use has to stop the adoption rather than overwrite that row.
+            if (taken != null && taken.id != entryId) return@withTransaction false
+            dao.upsertEntry(
+                existing.copy(
+                    timestamp = timestampMillis,
+                    source = JournalEntrySource.PEN.storageValue,
+                    sourceRecordId = id,
+                    updatedAt = System.currentTimeMillis()
+                )
+            )
+            true
+        }
+        if (adopted) {
+            // The dose moved in time and is insulin, so IOB and the treatment upload both
+            // have to look again; updatedAt is what marks the row for a fresh upload.
+            tk.glucodata.OutboundApiJournalSnapshot.journalChanged()
+        }
+        return adopted
+    }
+
     suspend fun deleteEntriesBySourceRecordIds(sourceRecordIds: List<String>) {
         val ids = sourceRecordIds
             .map { it.trim() }

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
@@ -2,6 +2,7 @@ package tk.glucodata.data.journal
 
 import androidx.room.withTransaction
 import kotlinx.coroutines.flow.Flow
+import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.map
 import android.content.Context
 import tk.glucodata.Applic
@@ -123,13 +124,26 @@ class JournalRepository {
      *
      * @return false when the entry is gone, or another row already carries that name
      */
-    suspend fun adoptPenDose(entryId: Long, sourceRecordId: String, timestampMillis: Long): Boolean {
+    suspend fun adoptPenDose(
+        entryId: Long,
+        sourceRecordId: String,
+        timestampMillis: Long,
+        expectedUnits: Float,
+    ): Boolean {
         val id = sourceRecordId.trim().takeIf { it.isNotBlank() } ?: return false
         val adopted = database.withTransaction {
             val existing = dao.getEntryById(entryId) ?: return@withTransaction false
             // Only insulin is a pen's to claim; anything else would also need the glucose
             // side of a change told about it.
             if (existing.entryType != JournalEntryType.INSULIN.storageValue) return@withTransaction false
+            // Only a row still written by hand, and only while it still says what it said
+            // when the pairing was worked out: the amount is what decided that pairing, and
+            // between proposing and confirming there is a sheet open and time to edit.
+            if (existing.source != JournalEntrySource.MANUAL.storageValue) return@withTransaction false
+            val amount = existing.amount ?: return@withTransaction false
+            if ((amount * 10f).roundToInt() != (expectedUnits * 10f).roundToInt()) {
+                return@withTransaction false
+            }
             val taken = dao.getEntryBySourceRecordId(id)
             // sourceRecordId is unique and the upsert replaces on conflict, so a name
             // already in use has to stop the adoption rather than overwrite that row.

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
@@ -87,6 +87,33 @@ class JournalRepository {
         return dao.getEntryBySourceRecordId(id) != null
     }
 
+    /** What one importer has already written in a stretch of time, so it can reconcile. */
+    suspend fun entriesFromSourceBetween(
+        source: JournalEntrySource,
+        startMillis: Long,
+        endMillis: Long
+    ): List<JournalEntry> {
+        return dao.getEntriesBySourceBetween(source.storageValue, startMillis, endMillis)
+            .map(JournalEntryEntity::toModel)
+    }
+
+    /**
+     * Renames an entry an importer can now identify more stably, leaving everything else
+     * alone — the point is to keep the row, including edits made to it, not to rewrite it.
+     *
+     * @return false when the entry is gone or the name is already taken
+     */
+    suspend fun retagSourceRecordId(entryId: Long, sourceRecordId: String): Boolean {
+        val id = sourceRecordId.trim().takeIf { it.isNotBlank() } ?: return false
+        return database.withTransaction {
+            val existing = dao.getEntryById(entryId) ?: return@withTransaction false
+            if (existing.sourceRecordId == id) return@withTransaction true
+            if (dao.getEntryBySourceRecordId(id) != null) return@withTransaction false
+            dao.upsertEntry(existing.copy(sourceRecordId = id, updatedAt = System.currentTimeMillis()))
+            true
+        }
+    }
+
     suspend fun deleteEntriesBySourceRecordIds(sourceRecordIds: List<String>) {
         val ids = sourceRecordIds
             .map { it.trim() }

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
@@ -216,5 +216,5 @@ private fun DoseRow(dose: PenDose, checked: Boolean, onCheckedChange: (Boolean) 
     }
 }
 
-private fun formatUnits(units: Float): String =
+internal fun formatUnits(units: Float): String =
     if (units % 1f == 0f) units.toInt().toString() else String.format("%.1f", units)

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
@@ -19,7 +19,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.automirrored.filled.ArrowRightAlt
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.material.icons.filled.EditNote
@@ -248,7 +248,10 @@ private fun DoseRow(
                 val at = hourFormat.format(Date(replacesEntryAtSeconds * 1000L))
                 val label = stringResource(R.string.insulin_pen_replaces, at)
                 // What becomes what, said in the two icons the journal already uses for those
-                // sources: a hand-written entry turns into this pen's dose. The icons need no
+                // sources: a hand-written entry turns into this pen's dose. The arrow between
+                // them points one way, because that is what happens: the entry is adopted by
+                // the dose, nothing is traded. It is auto-mirrored so the reading order and
+                // the arrow still agree in a right-to-left layout. The icons need no
                 // translating and no room to speak, so the words beside them only have to
                 // carry which entry it is, and that is a time.
                 Row(
@@ -256,6 +259,9 @@ private fun DoseRow(
                         .weight(1f, fill = false)
                         .semantics(mergeDescendants = true) { contentDescription = label },
                     verticalAlignment = Alignment.CenterVertically,
+                    // Enough that the three marks read as three and not as one shape. One
+                    // step is all it takes; the marker still has to fit its share of the row.
+                    horizontalArrangement = Arrangement.spacedBy(1.dp),
                 ) {
                     Icon(
                         imageVector = Icons.Default.EditNote,
@@ -264,7 +270,7 @@ private fun DoseRow(
                         modifier = Modifier.size(18.dp),
                     )
                     Icon(
-                        imageVector = Icons.Default.SwapHoriz,
+                        imageVector = Icons.AutoMirrored.Filled.ArrowRightAlt,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(16.dp),
@@ -275,7 +281,7 @@ private fun DoseRow(
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(18.dp),
                     )
-                    Spacer(Modifier.width(4.dp))
+                    Spacer(Modifier.width(3.dp))
                     Text(
                         at,
                         style = MaterialTheme.typography.labelMedium,

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
@@ -18,8 +18,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -34,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -41,6 +45,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import tk.glucodata.InsulinPenManager
 import tk.glucodata.InsulinPenScanBus
 import tk.glucodata.NovoPen.PenDose
+import tk.glucodata.NovoPen.PenSheetOffer
 import tk.glucodata.R
 import tk.glucodata.data.journal.JournalInsulinPreset
 import java.text.DateFormat
@@ -63,12 +68,17 @@ fun InsulinPenScanSheetHost() {
     val chosenInsulin = selectableInsulins.firstOrNull { it.id == chosenInsulinId }
         ?: selectableInsulins.firstOrNull()
 
+    // One list, one count: what the sheet may offer at all. A dose standing for an entry
+    // the reader already wrote starts out ticked, since leaving it unticked would keep the
+    // duplicate it was found to be.
+    val offered = remember(result) { PenSheetOffer.offerable(result.doses) }
     var selected by remember(result) {
         mutableStateOf(
-            result.doses
-                .filter { !it.priming && it.timestampSeconds >= result.preselectFromSeconds }
-                .map(PenDose::relativeSeconds)
-                .toSet()
+            PenSheetOffer.preselection(
+                result.doses,
+                result.merges.keys,
+                result.preselectFromSeconds,
+            )
         )
     }
 
@@ -85,7 +95,7 @@ fun InsulinPenScanSheetHost() {
             )
             Spacer(Modifier.size(4.dp))
             Text(
-                stringResource(R.string.insulin_pen_new_doses, result.doses.size),
+                stringResource(R.string.insulin_pen_new_doses, offered.size),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -120,16 +130,16 @@ fun InsulinPenScanSheetHost() {
                 )
                 TextButton(
                     onClick = {
-                        selected = if (selected.size == result.doses.size) {
+                        selected = if (selected.size == offered.size) {
                             emptySet()
                         } else {
-                            result.doses.map(PenDose::relativeSeconds).toSet()
+                            offered.map(PenDose::relativeSeconds).toSet()
                         }
                     }
                 ) {
                     Text(
                         stringResource(
-                            if (selected.size == result.doses.size) {
+                            if (selected.size == offered.size) {
                                 R.string.insulin_pen_select_none
                             } else {
                                 R.string.insulin_pen_select_all
@@ -143,9 +153,10 @@ fun InsulinPenScanSheetHost() {
                 modifier = Modifier.heightIn(max = 280.dp),
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                items(result.doses, key = PenDose::relativeSeconds) { dose ->
+                items(offered, key = PenDose::relativeSeconds) { dose ->
                     DoseRow(
                         dose = dose,
+                        replacesEntryAtSeconds = result.merges[dose.relativeSeconds]?.entryTimestampSeconds,
                         checked = dose.relativeSeconds in selected,
                         onCheckedChange = { checked ->
                             selected = if (checked) {
@@ -158,15 +169,34 @@ fun InsulinPenScanSheetHost() {
                 }
             }
 
+            if (result.skippedPrimingDoses > 0) {
+                Spacer(Modifier.size(8.dp))
+                Text(
+                    stringResource(R.string.insulin_pen_priming_skipped, result.skippedPrimingDoses),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
             Spacer(Modifier.size(16.dp))
             Button(
                 onClick = {
                     val insulin = chosenInsulin ?: return@Button
+                    val confirmed = offered.filter { it.relativeSeconds in selected }
                     InsulinPenManager.importDosesAsync(
                         serial = result.serial,
-                        doses = result.doses.filter { it.relativeSeconds in selected },
+                        doses = confirmed,
                         presetId = insulin.id,
                         presetName = insulin.displayName,
+                        // Only what was left ticked is merged; unticking is how the reader
+                        // says the pairing is wrong, and then the entry stays as it was. A
+                        // different insulin than the one the pairing was worked out for
+                        // drops the proposals too: they were matched on that insulin.
+                        merges = if (insulin.id == storedPreset) {
+                            result.merges.filterKeys { rel -> confirmed.any { it.relativeSeconds == rel } }
+                        } else {
+                            emptyMap()
+                        },
                     )
                     InsulinPenScanBus.clear()
                 },
@@ -180,8 +210,14 @@ fun InsulinPenScanSheetHost() {
 }
 
 @Composable
-private fun DoseRow(dose: PenDose, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+private fun DoseRow(
+    dose: PenDose,
+    replacesEntryAtSeconds: Long?,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
     val timeFormat = remember { DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT) }
+    val hourFormat = remember { DateFormat.getTimeInstance(DateFormat.SHORT) }
     Surface(
         onClick = { onCheckedChange(!checked) },
         shape = RoundedCornerShape(12.dp),
@@ -205,12 +241,43 @@ private fun DoseRow(dose: PenDose, checked: Boolean, onCheckedChange: (Boolean) 
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            if (dose.priming) {
-                Text(
-                    stringResource(R.string.insulin_pen_priming),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+            if (replacesEntryAtSeconds != null) {
+                val label = stringResource(
+                    R.string.insulin_pen_replaces,
+                    hourFormat.format(Date(replacesEntryAtSeconds * 1000L)),
                 )
+                // Which entry it replaces is the point of the marker, so the time is never
+                // cut short: it is either there in full or the icon carries it alone.
+                val screenWidth = LocalConfiguration.current.screenWidthDp
+                var roomForText by remember(dose.relativeSeconds, screenWidth) { mutableStateOf(true) }
+                Row(
+                    // A share of the row, not first claim on it: the amount and the time are
+                    // what the row is about, and they may not be squeezed into wrapping by a
+                    // long translation. What does not fit here becomes the icon alone.
+                    modifier = Modifier.weight(0.5f, fill = false),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.SwapHoriz,
+                        // Said once: the text beside it carries the same words when it fits.
+                        contentDescription = label.takeUnless { roomForText },
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    if (roomForText) {
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            label,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            softWrap = false,
+                            onTextLayout = { layout ->
+                                if (layout.hasVisualOverflow) roomForText = false
+                            },
+                        )
+                    }
+                }
             }
         }
     }

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
@@ -23,7 +23,7 @@ import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.material.icons.filled.EditNote
-import androidx.compose.material.icons.filled.Contactless
+import androidx.compose.material.icons.filled.Nfc
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
@@ -270,7 +270,7 @@ private fun DoseRow(
                         modifier = Modifier.size(16.dp),
                     )
                     Icon(
-                        imageVector = Icons.Default.Contactless,
+                        imageVector = Icons.Default.Nfc,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(18.dp),

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
@@ -20,6 +20,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.material.icons.filled.EditNote
+import androidx.compose.material.icons.filled.Contactless
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
@@ -37,7 +41,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -242,41 +245,43 @@ private fun DoseRow(
                 )
             }
             if (replacesEntryAtSeconds != null) {
-                val label = stringResource(
-                    R.string.insulin_pen_replaces,
-                    hourFormat.format(Date(replacesEntryAtSeconds * 1000L)),
-                )
-                // Which entry it replaces is the point of the marker, so the time is never
-                // cut short: it is either there in full or the icon carries it alone.
-                val screenWidth = LocalConfiguration.current.screenWidthDp
-                var roomForText by remember(dose.relativeSeconds, screenWidth) { mutableStateOf(true) }
+                val at = hourFormat.format(Date(replacesEntryAtSeconds * 1000L))
+                val label = stringResource(R.string.insulin_pen_replaces, at)
+                // What becomes what, said in the two icons the journal already uses for those
+                // sources: a hand-written entry turns into this pen's dose. The icons need no
+                // translating and no room to speak, so the words beside them only have to
+                // carry which entry it is, and that is a time.
                 Row(
-                    // A share of the row, not first claim on it: the amount and the time are
-                    // what the row is about, and they may not be squeezed into wrapping by a
-                    // long translation. What does not fit here becomes the icon alone.
-                    modifier = Modifier.weight(0.5f, fill = false),
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .semantics(mergeDescendants = true) { contentDescription = label },
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
+                        imageVector = Icons.Default.EditNote,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Icon(
                         imageVector = Icons.Default.SwapHoriz,
-                        // Said once: the text beside it carries the same words when it fits.
-                        contentDescription = label.takeUnless { roomForText },
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Icon(
+                        imageVector = Icons.Default.Contactless,
+                        contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(18.dp),
                     )
-                    if (roomForText) {
-                        Spacer(Modifier.width(4.dp))
-                        Text(
-                            label,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                            maxLines = 1,
-                            softWrap = false,
-                            onTextLayout = { layout ->
-                                if (layout.hasVisualOverflow) roomForText = false
-                            },
-                        )
-                    }
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        at,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                    )
                 }
             }
         }

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenScanSheet.kt
@@ -67,7 +67,7 @@ fun InsulinPenScanSheetHost() {
         mutableStateOf(
             result.doses
                 .filter { !it.priming && it.timestampSeconds >= result.preselectFromSeconds }
-                .map(PenDose::timestampSeconds)
+                .map(PenDose::relativeSeconds)
                 .toSet()
         )
     }
@@ -123,7 +123,7 @@ fun InsulinPenScanSheetHost() {
                         selected = if (selected.size == result.doses.size) {
                             emptySet()
                         } else {
-                            result.doses.map(PenDose::timestampSeconds).toSet()
+                            result.doses.map(PenDose::relativeSeconds).toSet()
                         }
                     }
                 ) {
@@ -143,15 +143,15 @@ fun InsulinPenScanSheetHost() {
                 modifier = Modifier.heightIn(max = 280.dp),
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                items(result.doses, key = PenDose::timestampSeconds) { dose ->
+                items(result.doses, key = PenDose::relativeSeconds) { dose ->
                     DoseRow(
                         dose = dose,
-                        checked = dose.timestampSeconds in selected,
+                        checked = dose.relativeSeconds in selected,
                         onCheckedChange = { checked ->
                             selected = if (checked) {
-                                selected + dose.timestampSeconds
+                                selected + dose.relativeSeconds
                             } else {
-                                selected - dose.timestampSeconds
+                                selected - dose.relativeSeconds
                             }
                         },
                     )
@@ -164,7 +164,7 @@ fun InsulinPenScanSheetHost() {
                     val insulin = chosenInsulin ?: return@Button
                     InsulinPenManager.importDosesAsync(
                         serial = result.serial,
-                        doses = result.doses.filter { it.timestampSeconds in selected },
+                        doses = result.doses.filter { it.relativeSeconds in selected },
                         presetId = insulin.id,
                         presetName = insulin.displayName,
                     )

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -39,6 +40,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,8 +54,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import kotlinx.coroutines.launch
+import tk.glucodata.Applic
 import tk.glucodata.InsulinPen
 import tk.glucodata.InsulinPenManager
+import tk.glucodata.PenDuplicateEntry
 import tk.glucodata.R
 import tk.glucodata.data.journal.JournalInsulinPreset
 import tk.glucodata.data.journal.JournalRepository
@@ -80,6 +85,8 @@ fun InsulinPenSettingsScreen(navController: NavController) {
     // copy would keep the dialog showing the old selection.
     var editingSerial by remember { mutableStateOf<String?>(null) }
     var forgetTarget by remember { mutableStateOf<InsulinPen?>(null) }
+    var cleanupTarget by remember { mutableStateOf<Pair<String, List<PenDuplicateEntry>>?>(null) }
+    val scope = rememberCoroutineScope()
     val editing = pens.firstOrNull { it.serial == editingSerial }
     val selectableInsulins = presets.filterNot(JournalInsulinPreset::isArchived)
 
@@ -170,9 +177,29 @@ fun InsulinPenSettingsScreen(navController: NavController) {
                 InsulinPenManager.setInsulin(pen.serial, preset.id, preset.displayName)
             },
             onArmFullRead = { InsulinPenManager.armFullRead(pen.serial) },
+            onCleanup = { duplicates ->
+                editingSerial = null
+                cleanupTarget = pen.serial to duplicates
+            },
             onForget = {
                 editingSerial = null
                 forgetTarget = pen
+            },
+        )
+    }
+
+    cleanupTarget?.let { (serial, duplicates) ->
+        DuplicateCleanupDialog(
+            duplicates = duplicates,
+            onDismiss = { cleanupTarget = null },
+            onConfirm = {
+                cleanupTarget = null
+                scope.launch {
+                    val removed = InsulinPenManager.removeDuplicates(serial)
+                    Applic.Toaster(
+                        Applic.app.getString(R.string.insulin_pen_duplicates_removed, removed)
+                    )
+                }
             },
         )
     }
@@ -195,6 +222,50 @@ fun InsulinPenSettingsScreen(navController: NavController) {
             },
         )
     }
+}
+
+/**
+ * Names every entry it would drop, because this deletes insulin somebody's journal says
+ * was injected. A count alone would ask the reader to trust the matching sight unseen.
+ */
+@Composable
+private fun DuplicateCleanupDialog(
+    duplicates: List<PenDuplicateEntry>,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val timeFormat = remember { DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.insulin_pen_cleanup_confirm, duplicates.size)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(stringResource(R.string.insulin_pen_cleanup_desc))
+                Spacer(Modifier.size(4.dp))
+                LazyColumn(
+                    modifier = Modifier.heightIn(max = 200.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    items(duplicates, key = PenDuplicateEntry::entryId) { entry ->
+                        Text(
+                            stringResource(
+                                R.string.insulin_pen_units,
+                                formatUnits(entry.units)
+                            ) + " \u00b7 " + timeFormat.format(Date(entry.timestampMillis)),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text(stringResource(R.string.remove)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        },
+    )
 }
 
 @Composable
@@ -247,8 +318,14 @@ private fun PenDetailSheet(
     onDismiss: () -> Unit,
     onSelected: (JournalInsulinPreset) -> Unit,
     onArmFullRead: () -> Unit,
+    onCleanup: (List<PenDuplicateEntry>) -> Unit,
     onForget: () -> Unit,
 ) {
+    // Worked out against the pen's last read, so the sheet can say how many rather than
+    // sending the reader to a dialog that then finds nothing. Null until the check is in.
+    var duplicates by remember(pen.serial) { mutableStateOf<List<PenDuplicateEntry>?>(null) }
+    LaunchedEffect(pen.serial) { duplicates = InsulinPenManager.findDuplicates(pen.serial) }
+    val found = duplicates.orEmpty()
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 16.dp)) {
             Text(
@@ -298,6 +375,32 @@ private fun PenDetailSheet(
             }
             Text(
                 stringResource(R.string.insulin_pen_full_read_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+
+            Spacer(Modifier.size(16.dp))
+            OutlinedButton(
+                onClick = { onCleanup(found) },
+                enabled = found.isNotEmpty(),
+                modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+            ) {
+                Text(
+                    if (found.isEmpty()) {
+                        stringResource(R.string.insulin_pen_cleanup)
+                    } else {
+                        stringResource(R.string.insulin_pen_cleanup_count, found.size)
+                    }
+                )
+            }
+            // Blank until the count is in, rather than claiming there is nothing to remove.
+            Text(
+                when {
+                    duplicates == null -> ""
+                    found.isEmpty() -> stringResource(R.string.insulin_pen_cleanup_none)
+                    else -> stringResource(R.string.insulin_pen_cleanup_desc)
+                },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 8.dp),

--- a/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/InsulinPenSettingsScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Contactless
+import androidx.compose.material.icons.filled.Nfc
 import androidx.compose.material.icons.filled.Vaccines
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilterChip
@@ -287,7 +287,7 @@ private fun HowToScanCard() {
                 shape = RoundedCornerShape(18.dp),
             ) {
                 Icon(
-                    Icons.Default.Contactless,
+                    Icons.Default.Nfc,
                     contentDescription = null,
                     modifier = Modifier.padding(14.dp).size(28.dp),
                 )

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenDoseParserTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenDoseParserTests.kt
@@ -152,6 +152,25 @@ class PenDoseParserTests {
     }
 
     @Test
+    fun exposesThePenOwnCounterAsTheDoseIdentity() {
+        val doses = PenDoseParser.parse(reference, record(relativeSeconds = 600, tenths = 85), now)
+
+        assertEquals(600L, doses[0].relativeSeconds)
+    }
+
+    @Test
+    fun mergeDropsAnOverlapEvenWhenTheSegmentsWereAnchoredApart() {
+        // What issue #195 hit: two segments of one scan, anchored a second apart, so the
+        // same injection came out with two different epoch seconds.
+        val first = PenDoseParser.parse(reference, record(600, 50), now)
+        val second = PenDoseParser.parse(reference + 1, record(600, 50), now)
+
+        val merged = PenDoseParser.merge(listOf(first, second))
+
+        assertEquals(1, merged.size)
+    }
+
+    @Test
     fun mergeReclassifiesPrimingAcrossChunkBoundaries() {
         // The air shot and the bolus it precedes arrived in different segments; only the
         // merged view can see that they belong together.

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenDoseParserTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenDoseParserTests.kt
@@ -95,6 +95,48 @@ class PenDoseParserTests {
     }
 
     @Test
+    fun tallyNamesWhatTheWindowRefused() {
+        // One ancient chunk, one chunk with a record far ahead and a good one: a tally
+        // spans a scan, and the caller learns about the two it lost without diffing.
+        val tally = PenDropTally()
+        val ancient = PenDoseParser.parse(
+            reference - PenDoseParser.MAX_AGE_SECONDS - 60L, record(0, 50), now, tally,
+        )
+        val kept = PenDoseParser.parse(reference, records(record(7_200, 40), record(600, 30)), now, tally)
+
+        assertTrue(ancient.isEmpty())
+        assertEquals(1, kept.size)
+        assertEquals(1, tally.count(PenDropReason.TOO_OLD))
+        assertEquals(1, tally.count(PenDropReason.IN_THE_FUTURE))
+        assertTrue(tally.describe(), tally.describe().contains("1 too_old, 1 in_the_future"))
+        assertTrue(tally.describe(), tally.describe().contains("rel=7200"))
+    }
+
+    @Test
+    fun tallyIgnoresRecordsThatNeverDecoded() {
+        // Garbage is not a dropped dose; only well-formed records the window rejected count.
+        val tally = PenDropTally()
+        val broken = record(600, 85).also { it[4] = 0x00 }
+
+        PenDoseParser.parse(reference, broken, now, tally)
+
+        assertTrue(tally.isEmpty)
+        assertEquals("dropped none", tally.describe())
+    }
+
+    @Test
+    fun tallyKeepsOnlyTheFirstFewInDetail() {
+        // A long log has hundreds past the age limit; count them all, spell out three.
+        val tally = PenDropTally()
+        val raw = records(*Array(10) { record(it.toLong(), 50) })
+
+        PenDoseParser.parse(reference - PenDoseParser.MAX_AGE_SECONDS - 60L, raw, now, tally)
+
+        assertEquals(10, tally.count(PenDropReason.TOO_OLD))
+        assertEquals(3, tally.describe().split(" | ").size)
+    }
+
+    @Test
     fun ignoresTrailingPartialRecord() {
         val raw = records(record(600, 50), byteArrayOf(0x00, 0x01, 0x02))
 

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenDuplicateReconcilerTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenDuplicateReconcilerTests.kt
@@ -1,0 +1,167 @@
+package tk.glucodata.NovoPen
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The reconciler deletes insulin out of somebody's journal, so the cases that matter are
+ * the ones where it would delete an injection that really happened.
+ */
+class PenDuplicateReconcilerTests {
+
+    private val serial = "G252101365"
+    private val anchor = 1_700_000_000L
+
+    private fun dose(relative: Long, units: Float, at: Long = anchor) =
+        PenDose(relativeSeconds = relative, timestampSeconds = at + relative, units = units, flags = 0)
+
+    private fun entry(id: Long, timestampSeconds: Long, units: Float, recordId: String) =
+        PenJournalEntry(id, timestampSeconds, units, recordId)
+
+    private fun legacy(id: Long, timestampSeconds: Long, units: Float) =
+        entry(id, timestampSeconds, units, "pen:$serial:$timestampSeconds")
+
+    private fun stable(id: Long, timestampSeconds: Long, units: Float, relative: Long) =
+        entry(id, timestampSeconds, units, "pen:$serial:rel:$relative")
+
+    /** The bug in issue #195: a second tap renamed every dose and so re-imported it. */
+    @Test
+    fun aDoseKeepsItsNameWhenTheNextScanAnchorsElsewhere() {
+        val raw = byteArrayOf(0x00, 0x00, 0x02, 0x58, 0xFF.toByte(), 0x00, 0x00, 0x55, 0x08, 0x00, 0x00, 0x00)
+        val firstScan = PenDoseParser.parse(anchor, raw, anchor + 10_000)
+        val secondScan = PenDoseParser.parse(anchor + 7, raw, anchor + 10_000)
+
+        assertEquals(
+            PenSourceIds.stable(serial, firstScan.single()),
+            PenSourceIds.stable(serial, secondScan.single()),
+        )
+        // The displayed time is still allowed to move; only the identity may not.
+        assertEquals(7L, secondScan.single().timestampSeconds - firstScan.single().timestampSeconds)
+    }
+
+    @Test
+    fun renamesALegacyEntryOntoTheDoseItStandsFor() {
+        val doses = listOf(dose(600, 8.5f))
+        val plan = PenDuplicateReconciler.plan(serial, doses, listOf(legacy(1, anchor + 597, 8.5f)))
+
+        assertEquals(mapOf(1L to "pen:$serial:rel:600"), plan.adopt)
+        assertTrue(plan.delete.isEmpty())
+    }
+
+    @Test
+    fun dropsTheCopyASecondScanLeftBehind() {
+        // Same injection, imported twice three seconds apart because the anchor moved.
+        // The row nearest to where the pen says the injection was is the one that stays.
+        val doses = listOf(dose(600, 8.5f))
+        val entries = listOf(legacy(1, anchor + 597, 8.5f), legacy(2, anchor + 600, 8.5f))
+
+        val plan = PenDuplicateReconciler.plan(serial, doses, entries)
+
+        assertEquals(mapOf(2L to "pen:$serial:rel:600"), plan.adopt)
+        assertEquals(listOf(1L), plan.delete)
+    }
+
+    @Test
+    fun collapsesThreeGenerationsOfTheSameDose() {
+        val doses = listOf(dose(600, 4.0f))
+        val entries = listOf(
+            legacy(1, anchor + 598, 4.0f),
+            legacy(2, anchor + 600, 4.0f),
+            legacy(3, anchor + 603, 4.0f),
+        )
+
+        val plan = PenDuplicateReconciler.plan(serial, doses, entries)
+
+        assertEquals(1, plan.adopt.size)
+        assertEquals(2, plan.delete.size)
+        assertTrue(plan.adopt.keys.first() !in plan.delete)
+    }
+
+    @Test
+    fun keepsTwoRealInjectionsOfTheSameSizeAMinuteApart() {
+        // The 14:03 / 14:04 pair from the report: the pen lists both, so both are real.
+        val doses = listOf(dose(600, 6.0f), dose(660, 6.0f))
+        val entries = listOf(legacy(1, anchor + 600, 6.0f), legacy(2, anchor + 660, 6.0f))
+
+        val plan = PenDuplicateReconciler.plan(serial, doses, entries)
+
+        assertEquals(2, plan.adopt.size)
+        assertTrue(plan.delete.isEmpty())
+    }
+
+    @Test
+    fun dropsTheLegacyCopyOfADoseAlreadyStoredUnderItsStableId() {
+        val doses = listOf(dose(600, 8.5f))
+        val entries = listOf(
+            stable(1, anchor + 600, 8.5f, relative = 600),
+            legacy(2, anchor + 604, 8.5f),
+        )
+
+        val plan = PenDuplicateReconciler.plan(serial, doses, entries)
+
+        assertTrue(plan.adopt.isEmpty())
+        assertEquals(listOf(2L), plan.delete)
+    }
+
+    @Test
+    fun leavesAnEntryWhoseAmountTheReaderEdited() {
+        // 8.5 U corrected to 9.0 by hand: nothing in the pen matches it any more, and it
+        // has no same-sized neighbour, so it is somebody's record, not a duplicate.
+        val doses = listOf(dose(600, 8.5f))
+        val plan = PenDuplicateReconciler.plan(serial, doses, listOf(legacy(1, anchor + 600, 9.0f)))
+
+        assertTrue(plan.adopt.isEmpty())
+        assertTrue(plan.delete.isEmpty())
+    }
+
+    @Test
+    fun leavesEntriesOutsideTheStretchTheScanCovered() {
+        val doses = listOf(dose(600, 8.5f))
+        val far = legacy(1, anchor + 600 - PenDuplicateReconciler.MATCH_WINDOW_SECONDS - 60, 8.5f)
+
+        val plan = PenDuplicateReconciler.plan(serial, doses, listOf(far))
+
+        assertTrue(plan.isEmpty)
+    }
+
+    @Test
+    fun ignoresEntriesFromAnotherPen() {
+        val doses = listOf(dose(600, 8.5f))
+        val other = entry(1, anchor + 600, 8.5f, "pen:OTHER123:${anchor + 600}")
+
+        assertTrue(PenDuplicateReconciler.plan(serial, doses, listOf(other)).isEmpty)
+    }
+
+    @Test
+    fun doesNothingWhenEverythingAlreadyCarriesAStableId() {
+        val doses = listOf(dose(600, 8.5f))
+        val entries = listOf(stable(1, anchor + 600, 8.5f, relative = 600))
+
+        assertTrue(PenDuplicateReconciler.plan(serial, doses, entries).isEmpty)
+    }
+
+    @Test
+    fun doesNothingWithoutDoses() {
+        assertTrue(PenDuplicateReconciler.plan(serial, emptyList(), listOf(legacy(1, anchor, 8.5f))).isEmpty)
+    }
+
+    @Test
+    fun givesEachDoseItsOwnEntryRatherThanPilingOntoTheNearestOne() {
+        val doses = listOf(dose(600, 2.0f), dose(700, 2.0f), dose(800, 2.0f))
+        val entries = listOf(
+            legacy(1, anchor + 601, 2.0f),
+            legacy(2, anchor + 701, 2.0f),
+            legacy(3, anchor + 801, 2.0f),
+        )
+
+        val plan = PenDuplicateReconciler.plan(serial, doses, entries)
+
+        assertEquals(3, plan.adopt.size)
+        assertEquals(
+            listOf("pen:$serial:rel:600", "pen:$serial:rel:700", "pen:$serial:rel:800").sorted(),
+            plan.adopt.values.sorted(),
+        )
+        assertTrue(plan.delete.isEmpty())
+    }
+}

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenImportCursorTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenImportCursorTests.kt
@@ -1,0 +1,44 @@
+package tk.glucodata.NovoPen
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PenImportCursorTests {
+
+    private fun dose(relativeSeconds: Long) =
+        PenDose(relativeSeconds = relativeSeconds, timestampSeconds = 1_700_000_000L + relativeSeconds, units = 4f, flags = 0)
+
+    @Test
+    fun staysBelowADoseTheJournalWasNotSeenToHold() {
+        // The newest dose was never found in the journal — here because nothing checked
+        // it. Were the cursor to pass it, no later scan would offer it again.
+        val doses = listOf(dose(100), dose(200), dose(300))
+        val present = setOf(100L, 200L)
+
+        val cursor = PenImportCursor.provenUpTo(doses) { it.relativeSeconds in present }
+
+        assertEquals(200L, cursor)
+    }
+
+    @Test
+    fun doesNotMoveWhenNothingWasVouchedFor() {
+        // A whole read landing outside the review window — what a wrong anchor looks like —
+        // says nothing about the journal, so it moves nothing.
+        val doses = listOf(dose(100), dose(200))
+
+        assertNull(PenImportCursor.provenUpTo(doses) { false })
+    }
+
+    @Test
+    fun reachesTheNewestDoseWhenEveryDoseWasFound() {
+        val doses = listOf(dose(100), dose(300), dose(200))
+
+        assertEquals(300L, PenImportCursor.provenUpTo(doses) { true })
+    }
+
+    @Test
+    fun hasNothingToSayAboutAnEmptyRead() {
+        assertNull(PenImportCursor.provenUpTo(emptyList()) { true })
+    }
+}

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenImportCursorTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenImportCursorTests.kt
@@ -1,7 +1,9 @@
 package tk.glucodata.NovoPen
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PenImportCursorTests {
@@ -35,6 +37,27 @@ class PenImportCursorTests {
         val doses = listOf(dose(100), dose(300), dose(200))
 
         assertEquals(300L, PenImportCursor.provenUpTo(doses) { true })
+    }
+
+    @Test
+    fun aDoseLeftUntickedAtTheLastImportIsNotOfferedAgain() {
+        // The reader imported up to 300 and left 200 out. It sits below the cursor now and
+        // stays declined; only what came after the import is new.
+        val cursor = 300L
+
+        assertFalse(PenImportCursor.isAhead(dose(200), cursor, fullRead = false))
+        assertFalse(PenImportCursor.isAhead(dose(300), cursor, fullRead = false))
+        assertTrue(PenImportCursor.isAhead(dose(400), cursor, fullRead = false))
+    }
+
+    @Test
+    fun aPenNeverImportedOffersEverything() {
+        assertTrue(PenImportCursor.isAhead(dose(1), cursor = 0L, fullRead = false))
+    }
+
+    @Test
+    fun aFullReadOffersWhatWasDeclinedToo() {
+        assertTrue(PenImportCursor.isAhead(dose(200), cursor = 300L, fullRead = true))
     }
 
     @Test

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenImportPlanTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenImportPlanTests.kt
@@ -1,0 +1,111 @@
+package tk.glucodata.NovoPen
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * What confirming the sheet writes. The rule that matters is exclusivity: a dose that takes
+ * over an entry the reader wrote by hand must not also be written as a row of its own, or
+ * the merge creates the duplicate it exists to prevent.
+ */
+class PenImportPlanTests {
+
+    private val anchor = 1_700_000_000L
+
+    private fun dose(relative: Long, units: Float = 4f) =
+        PenDose(relative, anchor + relative, units, flags = 0)
+
+    private fun proposal(dose: PenDose, entryId: Long) = PenManualMerge(
+        entryId = entryId,
+        sourceRecordId = "pen:S:rel:${dose.relativeSeconds}",
+        timestampSeconds = dose.timestampSeconds,
+        doseRelativeSeconds = dose.relativeSeconds,
+        entryTimestampSeconds = dose.timestampSeconds - 120,
+        entryUnits = dose.units,
+    )
+
+    @Test
+    fun aDoseThatTakesOverAnEntryIsNotAlsoWritten() {
+        val merged = dose(relative = 100)
+        val plain = dose(relative = 200, units = 6f)
+
+        val plan = PenImportPlan.of(
+            listOf(merged, plain),
+            mapOf(merged.relativeSeconds to proposal(merged, entryId = 7)),
+        ) { false }
+
+        assertEquals(listOf(7L), plan.adopt.map(PenManualMerge::entryId))
+        assertEquals(listOf(200L), plan.insert.map(PenDose::relativeSeconds))
+        // The one that was taken over appears exactly once, on the adopt side.
+        assertTrue(plan.insert.none { it.relativeSeconds == merged.relativeSeconds })
+    }
+
+    @Test
+    fun aDoseWithoutAProposalIsWritten() {
+        val plain = dose(relative = 100)
+
+        val plan = PenImportPlan.of(listOf(plain), emptyMap()) { false }
+
+        assertTrue(plan.adopt.isEmpty())
+        assertEquals(listOf(100L), plan.insert.map(PenDose::relativeSeconds))
+    }
+
+    /** An earlier scan already wrote it: neither written again nor merged onto anything. */
+    @Test
+    fun aDoseTheJournalAlreadyHoldsIsLeftAlone() {
+        val known = dose(relative = 100)
+
+        val plan = PenImportPlan.of(
+            listOf(known),
+            mapOf(known.relativeSeconds to proposal(known, entryId = 7)),
+        ) { it.relativeSeconds == 100L }
+
+        assertTrue(plan.adopt.isEmpty())
+        assertTrue(plan.insert.isEmpty())
+    }
+
+    /** A proposal for a dose nobody confirmed is not carried out by the back door. */
+    @Test
+    fun onlyConfirmedDosesAreLookedUp() {
+        val confirmed = dose(relative = 100)
+        val unticked = dose(relative = 200)
+
+        val plan = PenImportPlan.of(
+            listOf(confirmed),
+            mapOf(
+                confirmed.relativeSeconds to proposal(confirmed, entryId = 7),
+                unticked.relativeSeconds to proposal(unticked, entryId = 8),
+            ),
+        ) { false }
+
+        assertEquals(listOf(7L), plan.adopt.map(PenManualMerge::entryId))
+        assertTrue(plan.insert.isEmpty())
+    }
+
+    /** Two doses cannot both take over the same entry, whatever a stale proposal says. */
+    @Test
+    fun oneEntryStandsForOneDose() {
+        val first = dose(relative = 100)
+        val second = dose(relative = 200)
+
+        val plan = PenImportPlan.of(
+            listOf(first, second),
+            mapOf(
+                first.relativeSeconds to proposal(first, entryId = 7),
+                second.relativeSeconds to proposal(second, entryId = 7),
+            ),
+        ) { false }
+
+        assertEquals(1, plan.adopt.size)
+        assertEquals(listOf(200L), plan.insert.map(PenDose::relativeSeconds))
+    }
+
+    @Test
+    fun nothingConfirmedWritesNothing() {
+        val plan = PenImportPlan.of(emptyList(), mapOf(100L to proposal(dose(100), 7))) { false }
+
+        assertTrue(plan.adopt.isEmpty())
+        assertTrue(plan.insert.isEmpty())
+    }
+}

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenManualMergeTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenManualMergeTests.kt
@@ -1,0 +1,301 @@
+package tk.glucodata.NovoPen
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.data.journal.JournalEntry
+import tk.glucodata.data.journal.JournalEntrySource
+import tk.glucodata.data.journal.JournalEntryType
+
+/**
+ * The merge rewrites insulin somebody wrote in their own journal, so the cases that matter
+ * are the ones where the sequence does not line up: a wrong pairing there moves an entry to
+ * the wrong time and hides an injection that was never confirmed.
+ */
+class PenManualMergeTests {
+
+    private val serial = "G252101365"
+    private val anchor = 1_700_000_000L
+    private val rapid = 7L
+    private val basal = 9L
+    private val minute = 60L
+
+    private fun dose(relative: Long, units: Float, atMinute: Long, priming: Boolean = false) =
+        PenDose(
+            relativeSeconds = relative,
+            timestampSeconds = anchor + atMinute * minute,
+            units = units,
+            flags = 0,
+            priming = priming,
+        )
+
+    private fun entry(id: Long, units: Float, atMinute: Long, preset: Long? = rapid) =
+        ManualInsulinEntry(id, anchor + atMinute * minute, units, preset)
+
+    private fun plan(
+        doses: List<PenDose>,
+        entries: List<ManualInsulinEntry>,
+        penInsulin: Long? = rapid,
+    ) = PenManualMergePlanner.plan(serial, doses, entries, penInsulin)
+
+    /** The case this exists for: written down, injected a minute later, scanned afterwards. */
+    @Test
+    fun aDoseWrittenDownBeforeInjectingBecomesTheSameEntry() {
+        val dose = dose(relative = 3_600, units = 4f, atMinute = 10)
+        val written = entry(id = 42, units = 4f, atMinute = 8)
+
+        val plan = plan(listOf(dose), listOf(written))
+
+        assertEquals(1, plan.merges.size)
+        val merge = plan.merges.single()
+        assertEquals(42L, merge.entryId)
+        assertEquals(PenSourceIds.stable(serial, dose), merge.sourceRecordId)
+        // The pen's time is the measured one, so the entry moves onto it.
+        assertEquals(dose.timestampSeconds, merge.timestampSeconds)
+        assertEquals(3_600L, merge.doseRelativeSeconds)
+        assertNull(plan.alignmentBreak)
+    }
+
+    @Test
+    fun threeInARowMergeInOrder() {
+        val doses = listOf(
+            dose(relative = 100, units = 6f, atMinute = 0),
+            dose(relative = 200, units = 4f, atMinute = 300),
+            dose(relative = 300, units = 8f, atMinute = 700),
+        )
+        val entries = listOf(
+            entry(id = 1, units = 6f, atMinute = -2),
+            entry(id = 2, units = 4f, atMinute = 297),
+            entry(id = 3, units = 8f, atMinute = 695),
+        )
+
+        val plan = plan(doses, entries)
+
+        assertNull(plan.alignmentBreak)
+        assertEquals(listOf(1L, 2L, 3L), plan.merges.map(PenManualMerge::entryId))
+        assertEquals(listOf(100L, 200L, 300L), plan.merges.map(PenManualMerge::doseRelativeSeconds))
+    }
+
+    /** Air shots are in the pen's log and never in the journal, so they cannot take a place. */
+    @Test
+    fun anAirShotBetweenTwoDosesDoesNotShiftTheSequence() {
+        val doses = listOf(
+            dose(relative = 100, units = 6f, atMinute = 0),
+            dose(relative = 150, units = 1f, atMinute = 299, priming = true),
+            dose(relative = 200, units = 4f, atMinute = 300),
+        )
+        val entries = listOf(
+            entry(id = 1, units = 6f, atMinute = -1),
+            entry(id = 2, units = 4f, atMinute = 298),
+        )
+
+        val plan = plan(doses, entries)
+
+        assertNull(plan.alignmentBreak)
+        assertEquals(listOf(1L, 2L), plan.merges.map(PenManualMerge::entryId))
+        assertTrue(plan.merges.none { it.doseRelativeSeconds == 150L })
+    }
+
+    /**
+     * An entry that was written and never injected — the reader changed their mind. It sits
+     * inside the stretch the read covers, so it takes a place in the walk that no dose has,
+     * and everything after it would shift by one.
+     */
+    @Test
+    fun anEntryWithoutADoseStopsTheWalkAndTheRestIsMatchedByTimeAndAmount() {
+        val doses = listOf(
+            dose(relative = 200, units = 4f, atMinute = 300),
+            dose(relative = 300, units = 8f, atMinute = 700),
+        )
+        val entries = listOf(
+            entry(id = 1, units = 6f, atMinute = 299), // decided against, never injected
+            entry(id = 2, units = 4f, atMinute = 302),
+            entry(id = 3, units = 8f, atMinute = 699),
+        )
+
+        val plan = plan(doses, entries)
+
+        val stop = plan.alignmentBreak
+        assertNotNull("the walk has to notice the extra entry", stop)
+        assertEquals(0, stop!!.position)
+        assertEquals(4f, stop.doseUnits, 0.001f)
+        assertEquals(6f, stop.entryUnits, 0.001f)
+        // Nothing is merged onto the abandoned entry, and the two real ones still pair.
+        assertTrue(plan.merges.none { it.entryId == 1L })
+        assertEquals(listOf(2L, 3L), plan.merges.map(PenManualMerge::entryId).sorted())
+        assertEquals(
+            listOf(200L, 300L),
+            plan.merges.map(PenManualMerge::doseRelativeSeconds).sorted(),
+        )
+    }
+
+    /** 4 U written, 4.5 U given: the amounts are the checksum, so this is not a merge. */
+    @Test
+    fun anAmountThatDisagreesIsNeverMergedSilently() {
+        val doses = listOf(dose(relative = 200, units = 4.5f, atMinute = 300))
+        val entries = listOf(entry(id = 2, units = 4f, atMinute = 298))
+
+        val plan = plan(doses, entries)
+
+        assertTrue("nothing may be merged", plan.isEmpty)
+        val stop = plan.alignmentBreak
+        assertNotNull(stop)
+        assertEquals(4.5f, stop!!.doseUnits, 0.001f)
+        assertEquals(4f, stop.entryUnits, 0.001f)
+    }
+
+    /**
+     * The order proposes the pairing, the clock still has to agree: an entry this far from
+     * the dose the sequence hands it is not that dose being written down.
+     */
+    @Test
+    fun aPairTooFarApartStopsTheWalk() {
+        val doses = listOf(
+            dose(relative = 100, units = 4f, atMinute = 0),
+            dose(relative = 200, units = 4f, atMinute = 100),
+        )
+        // Written between the two, so it is inside the read the scan covers, but nowhere
+        // near the dose the order hands it.
+        val entries = listOf(entry(id = 1, units = 4f, atMinute = 50))
+
+        val plan = plan(doses, entries)
+
+        assertTrue(plan.isEmpty)
+        val stop = plan.alignmentBreak
+        assertNotNull(stop)
+        assertEquals(50 * minute, stop!!.secondsApart)
+    }
+
+    /** An entry from outside the stretch the read covers never enters the walk at all. */
+    @Test
+    fun anEntryOutsideTheReadIsIgnored() {
+        val doses = listOf(dose(relative = 100, units = 6f, atMinute = 0))
+        val entries = listOf(entry(id = 1, units = 6f, atMinute = -60))
+
+        val plan = plan(doses, entries)
+
+        assertTrue(plan.isEmpty)
+        assertNull(plan.alignmentBreak)
+    }
+
+    /** A spare pen of the same insulin: its entries interleave, so the walk has to give up. */
+    @Test
+    fun aSecondPenOfTheSameInsulinDoesNotShiftTheAlignment() {
+        // This pen gave 6 U and 8 U; the spare gave 3 U in between, written down like the rest.
+        val doses = listOf(
+            dose(relative = 100, units = 6f, atMinute = 0),
+            dose(relative = 300, units = 8f, atMinute = 700),
+        )
+        val entries = listOf(
+            entry(id = 1, units = 6f, atMinute = -1),
+            entry(id = 2, units = 3f, atMinute = 350), // the spare pen's dose
+            entry(id = 3, units = 8f, atMinute = 698),
+        )
+
+        val plan = plan(doses, entries)
+
+        assertNotNull("the spare pen's entry has to break the walk", plan.alignmentBreak)
+        assertEquals(1, plan.alignmentBreak!!.position)
+        // The spare pen's entry is left alone, and the 8 U dose still finds its own.
+        assertTrue(plan.merges.none { it.entryId == 2L })
+        assertEquals(listOf(1L, 3L), plan.merges.map(PenManualMerge::entryId).sorted())
+    }
+
+    @Test
+    fun withoutHandWrittenEntriesNothingHappens() {
+        val doses = listOf(dose(relative = 100, units = 6f, atMinute = 0))
+
+        assertTrue(plan(doses, emptyList()).isEmpty)
+        assertNull(plan(doses, emptyList()).alignmentBreak)
+        assertTrue(plan(emptyList(), listOf(entry(id = 1, units = 6f, atMinute = 0))).isEmpty)
+    }
+
+    /** Bolus and basal are told apart by the insulin, which is the only thing that can. */
+    @Test
+    fun anotherInsulinIsNeverMerged() {
+        val doses = listOf(dose(relative = 100, units = 6f, atMinute = 0))
+        val entries = listOf(entry(id = 1, units = 6f, atMinute = -1, preset = basal))
+
+        assertTrue(plan(doses, entries).isEmpty)
+    }
+
+    /** A pen read for the first time has no insulin yet, so it cannot know what it gave. */
+    @Test
+    fun aPenWithNoInsulinRecordedMergesNothing() {
+        val doses = listOf(dose(relative = 100, units = 6f, atMinute = 0))
+        val entries = listOf(entry(id = 1, units = 6f, atMinute = -1))
+
+        assertTrue(plan(doses, entries, penInsulin = null).isEmpty)
+        assertTrue(plan(doses, entries, penInsulin = 0L).isEmpty)
+    }
+
+    /** The window is a boundary, and a boundary is where a rule quietly changes meaning. */
+    @Test
+    fun exactlyTheWindowStillMerges() {
+        val doses = listOf(dose(relative = 100, units = 4f, atMinute = 0))
+        val onTheLine = ManualInsulinEntry(1, anchor - PenManualMergePlanner.MATCH_WINDOW_SECONDS, 4f, rapid)
+        val justOver = ManualInsulinEntry(1, anchor - PenManualMergePlanner.MATCH_WINDOW_SECONDS - 1, 4f, rapid)
+
+        assertEquals(1, plan(doses, listOf(onTheLine)).merges.size)
+        assertTrue(plan(doses, listOf(justOver)).isEmpty)
+    }
+
+    /**
+     * What may be considered at all. A dose already imported is a pen row, and reading it
+     * back as somebody's hand-written record of itself would merge a dose onto itself.
+     */
+    @Test
+    fun onlyHandWrittenInsulinWithAnAmountIsACandidate() {
+        fun journalEntry(
+            id: Long,
+            type: JournalEntryType = JournalEntryType.INSULIN,
+            source: JournalEntrySource = JournalEntrySource.MANUAL,
+            amount: Float? = 4f,
+        ) = JournalEntry(
+            id = id,
+            timestamp = (anchor + 60) * 1000L,
+            sensorSerial = null,
+            type = type,
+            title = "Rapid",
+            note = null,
+            amount = amount,
+            glucoseValueMgDl = null,
+            durationMinutes = null,
+            intensity = null,
+            insulinPresetId = rapid,
+            foodId = null,
+            proteinGrams = null,
+            fatGrams = null,
+            source = source,
+            sourceRecordId = null,
+            createdAt = 0L,
+            updatedAt = 0L,
+        )
+
+        val candidates = PenManualMergePlanner.candidates(
+            listOf(
+                journalEntry(id = 1),
+                journalEntry(id = 2, source = JournalEntrySource.PEN),
+                journalEntry(id = 3, type = JournalEntryType.CARBS),
+                journalEntry(id = 4, amount = null),
+                journalEntry(id = 5, source = JournalEntrySource.NIGHTSCOUT),
+            ),
+        )
+
+        assertEquals(listOf(1L), candidates.map(ManualInsulinEntry::id))
+        // Seconds, not milliseconds: the planner compares against the pen's own clock.
+        assertEquals(anchor + 60, candidates.single().timestampSeconds)
+        assertEquals(rapid, candidates.single().insulinPresetId)
+    }
+
+    /** Tenths, like the pen reports them: 4.0 and 4.04 are the same dose, 4.0 and 4.1 are not. */
+    @Test
+    fun amountsAreComparedInTenths() {
+        val dose = dose(relative = 100, units = 4.04f, atMinute = 0)
+
+        assertEquals(1, plan(listOf(dose), listOf(entry(id = 1, units = 4f, atMinute = 0))).merges.size)
+        assertTrue(plan(listOf(dose), listOf(entry(id = 1, units = 4.1f, atMinute = 0))).isEmpty)
+    }
+}

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenManualMergeTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenManualMergeTests.kt
@@ -55,6 +55,8 @@ class PenManualMergeTests {
         // The pen's time is the measured one, so the entry moves onto it.
         assertEquals(dose.timestampSeconds, merge.timestampSeconds)
         assertEquals(3_600L, merge.doseRelativeSeconds)
+        // The entry's own time comes along, so the sheet can say which one it replaces.
+        assertEquals(written.timestampSeconds, merge.entryTimestampSeconds)
         assertNull(plan.alignmentBreak)
     }
 

--- a/Common/src/test/java/tk/glucodata/NovoPen/PenSheetOfferTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/PenSheetOfferTests.kt
@@ -1,0 +1,94 @@
+package tk.glucodata.NovoPen
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The field report this exists for: a scan that read one air shot opened a sheet headed
+ * "1 new dose" with a single unticked row and a disabled "add 0 doses" button under it.
+ * Three numbers from three different filter states, and no way out of the dialog.
+ */
+class PenSheetOfferTests {
+
+    private val anchor = 1_700_000_000L
+
+    private fun dose(relative: Long, units: Float, minutesAgo: Long, priming: Boolean = false) =
+        PenDose(
+            relativeSeconds = relative,
+            timestampSeconds = anchor - minutesAgo * 60L,
+            units = units,
+            flags = 0,
+            priming = priming,
+        )
+
+    @Test
+    fun airShotsAreNeitherOfferedNorCounted() {
+        val doses = listOf(
+            dose(relative = 100, units = 6f, minutesAgo = 30),
+            dose(relative = 150, units = 1f, minutesAgo = 20, priming = true),
+            dose(relative = 200, units = 4f, minutesAgo = 10),
+        )
+
+        val offered = PenSheetOffer.offerable(doses)
+
+        assertEquals(listOf(100L, 200L), offered.map(PenDose::relativeSeconds))
+        assertEquals(1, PenSheetOffer.skipped(doses))
+    }
+
+    /** The reported case: nothing to confirm, so the caller knows not to open a sheet. */
+    @Test
+    fun aReadOfNothingButAnAirShotOffersNothing() {
+        val doses = listOf(dose(relative = 150, units = 1f, minutesAgo = 20, priming = true))
+
+        assertTrue(PenSheetOffer.offerable(doses).isEmpty())
+        assertTrue(PenSheetOffer.preselection(doses, emptySet(), 0L).isEmpty())
+        assertEquals(1, PenSheetOffer.skipped(doses))
+    }
+
+    @Test
+    fun headingListAndButtonCountTheSameThing() {
+        val doses = listOf(
+            dose(relative = 100, units = 6f, minutesAgo = 30),
+            dose(relative = 150, units = 1f, minutesAgo = 20, priming = true),
+            dose(relative = 200, units = 4f, minutesAgo = 10),
+        )
+
+        val offered = PenSheetOffer.offerable(doses)
+        val ticked = PenSheetOffer.preselection(doses, emptySet(), preselectFromSeconds = 0L)
+
+        // What the heading says, what the list holds and what the button would add.
+        assertEquals(offered.size, ticked.size)
+        assertEquals(2, offered.size)
+    }
+
+    /** A dose that stands for an entry already written starts ticked, whatever its age. */
+    @Test
+    fun aDoseReplacingAnEntryIsTickedEvenOutsideThePreselectWindow() {
+        val old = dose(relative = 100, units = 6f, minutesAgo = 60 * 48)
+        val recent = dose(relative = 200, units = 4f, minutesAgo = 10)
+        val doses = listOf(old, recent)
+        val preselectFrom = anchor - 24 * 60 * 60L
+
+        val withoutProposal = PenSheetOffer.preselection(doses, emptySet(), preselectFrom)
+        val withProposal = PenSheetOffer.preselection(doses, setOf(100L), preselectFrom)
+
+        assertEquals(setOf(200L), withoutProposal)
+        assertEquals(setOf(100L, 200L), withProposal)
+    }
+
+    /** An air shot is never ticked, not even if something proposed it. */
+    @Test
+    fun anAirShotIsNeverTicked() {
+        val doses = listOf(dose(relative = 150, units = 1f, minutesAgo = 20, priming = true))
+
+        assertTrue(PenSheetOffer.preselection(doses, setOf(150L), 0L).isEmpty())
+    }
+
+    @Test
+    fun nothingReadOffersNothing() {
+        assertTrue(PenSheetOffer.offerable(emptyList()).isEmpty())
+        assertTrue(PenSheetOffer.preselection(emptyList(), emptySet(), 0L).isEmpty())
+        assertEquals(0, PenSheetOffer.skipped(emptyList()))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/NovoPen/opennov/mt/EventReportAnchorTests.kt
+++ b/Common/src/test/java/tk/glucodata/NovoPen/opennov/mt/EventReportAnchorTests.kt
@@ -1,0 +1,106 @@
+package tk.glucodata.NovoPen.opennov.mt
+
+import java.nio.ByteBuffer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import tk.glucodata.Log
+import tk.glucodata.NovoPen.opennov.OpContext
+
+/**
+ * The anchor turns the pen's counter into clock time for every dose of a scan, so which
+ * report it is taken from decides whether the whole read lands inside the time window or
+ * entirely outside it.
+ */
+class EventReportAnchorTests {
+
+    private var loggingWasOn = false
+
+    /** The segment parser dumps raw bytes through a native call when logging is on. */
+    @Before
+    fun quietLogging() {
+        loggingWasOn = Log.doLog
+        Log.doLog = false
+    }
+
+    @After
+    fun restoreLogging() {
+        Log.doLog = loggingWasOn
+    }
+
+    /** Event report header: handle, relative time, event type, length of what follows. */
+    private fun header(relativeTime: Long, eventType: Int, bodyLength: Int): ByteBuffer =
+        ByteBuffer.allocate(10 + bodyLength).apply {
+            putShort(256)
+            putInt(relativeTime.toInt())
+            putShort(eventType.toShort())
+            putShort(bodyLength.toShort())
+        }
+
+    /** A configuration report carrying no objects: id, count 0, length 0. */
+    private fun configReport(relativeTime: Long): ByteBuffer =
+        header(relativeTime, EventReport.MDC_NOTI_CONFIG, 6).apply {
+            putShort(0x4000)
+            putShort(0)
+            putShort(0)
+            flip()
+        }
+
+    /** A segment-data report holding one well-formed dose record. */
+    private fun segmentReport(relativeTime: Long, doseRelativeSeconds: Long): ByteBuffer =
+        header(relativeTime, EventReport.MDC_NOTI_SEGMENT_DATA, 14 + 12).apply {
+            putShort(16) // instance
+            putInt(0) // index
+            putInt(1) // count
+            putShort(0) // status
+            putShort(12) // bcount
+            putInt(doseRelativeSeconds.toInt())
+            put(0xFF.toByte()); put(0x00)
+            putShort(40) // 4.0 U
+            put(0x08); put(0x00); put(0x00); put(0x00)
+            flip()
+        }
+
+    @Test
+    fun anchorIsTakenFromTheSegmentReportNotTheConfigurationReport() {
+        // What a real scan looks like: the configuration report opens it with a time
+        // field of 0, the log data follows with the pen's live counter.
+        val context = OpContext()
+        val penClock = 11_019_281L
+        val before = System.currentTimeMillis() / 1000L
+
+        EventReport.parse(configReport(relativeTime = 0L), context)
+        EventReport.parse(segmentReport(relativeTime = penClock, doseRelativeSeconds = penClock - 60L), context)
+
+        val after = System.currentTimeMillis() / 1000L
+        assertEquals(1, context.doses.size)
+        val reference = context.doses[0].referencetime
+        assertTrue("anchor $reference should be clock minus pen counter", reference in (before - penClock)..(after - penClock))
+    }
+
+    @Test
+    fun configurationReportAloneDoesNotPinTheAnchor() {
+        val context = OpContext()
+
+        EventReport.parse(configReport(relativeTime = 0L), context)
+        val penClock = 11_019_281L
+        val before = System.currentTimeMillis() / 1000L
+        EventReport.parse(segmentReport(relativeTime = penClock, doseRelativeSeconds = penClock - 60L), context)
+
+        // Had the configuration report pinned it, the reference would be "now - 0" and the
+        // dose would sit the pen's whole uptime in the future.
+        assertTrue(context.doses[0].referencetime < before)
+    }
+
+    @Test
+    fun laterSegmentReportsReuseTheFirstAnchor() {
+        val context = OpContext()
+
+        EventReport.parse(segmentReport(relativeTime = 1_000L, doseRelativeSeconds = 900L), context)
+        EventReport.parse(segmentReport(relativeTime = 1_002L, doseRelativeSeconds = 800L), context)
+
+        assertEquals(context.doses[0].referencetime, context.doses[1].referencetime)
+    }
+}


### PR DESCRIPTION
Builds on #203, whose `PenSourceIds` and reconciler this extends; until that lands the diff here shows its commits too. The last commit is the one to read.

Deciding to correct while looking at the chart, writing the dose in the app, injecting a minute later without it, and reading the pen over NFC afterwards leaves the journal holding that injection twice: once as the entry, once from the import. Twice the IOB, and a statistic that says so. `PenDuplicateReconciler` already merges the equivalent case for earlier pen imports, but it only looks at entries carrying a `pen:` source id, so a hand-written one falls through.

Since only minutes pass between writing a dose down and giving it, the two sequences line up: the n-th dose the pen reports is the n-th insulin entry in the journal. That is steadier than hunting for the nearest entry in time, and it fails differently: one wrong pairing shifts every pairing after it, silently, onto wrong times and amounts. So the order proposes the pairing and the amount decides it. At the first pair whose amounts differ, or that sits more than fifteen minutes apart, the alignment counts as lost. The walk stops there and says so in the log with the position and both amounts, the rest is matched pairwise instead (nearest in time, same amount, each side claimed once, the way the duplicate reconciler matches), and whatever stays unmatched is offered as a new dose, so a person decides it rather than this.

Priming shots are left out before the walk, since they are in the pen's log and never in the journal and would shift the sequence from the start. Only entries carrying this pen's insulin take part, so basal and bolus cannot mix. Two scans merge nothing at all: a pen with no insulin recorded yet, because on a first read there is nothing to tell bolus from basal with and the reader is at the review sheet anyway, and a full read, because that is the reader asking to see the whole log and decide on it themselves, and it is the one scan that can carry weeks of doses.

Two things this cannot do, both inherent to pairing by order and amount. Two injections of the same amount within fifteen minutes of each other, where only one was written down, can pair the written one with the wrong injection: the amounts agree and the clock allows it. And the handoff asks for the doses after a break to go to the sheet for confirmation, while also asking for the sheet itself to be left alone; what is implemented is the narrower reading, which is that the doses the fallback cannot pair go to the sheet, and the ones it pairs by time and amount are merged like any other match.

On a match the entry is kept and adopted rather than replaced, so a note or an edited amount survives, and Nightscout keeps knowing the treatment by that row, which makes the new time a correction there rather than a second treatment. The entry takes the dose's stable id and the pen's time, which is the measured one, and its source becomes the pen. The adoption goes through a guarded transaction: `sourceRecordId` is unique and the upsert replaces on conflict, so a name already in use stops the adoption instead of overwriting that row. Doses that found an entry are dropped from what the sheet offers and count as held by the journal for the cursor.

### The sheet proposes it, confirming does it

Second commit, from a field report on the first. The merge used to run while the review sheet was being built: 0.5 U written down by hand, injected, scanned with the app open, and the sheet came up headed "1 new dose" with one unticked air shot in the list and a disabled "add 0 doses" button, while the pill above it already counted the dose. The pen dose had been taken and the entry replaced before anything was shown, leaving a dialog with nothing to confirm and nothing to undo. It happened to pair correctly, which is luck rather than design: had it landed on the wrong entry there would have been no way to say so, and saying so is the one thing the sheet is for.

So the merge is planned at the scan and carried out on confirmation. The dose appears as an ordinary row, ticked, marked in the slot the air-shot label used to occupy, with three marks and a time: a hand-written entry, a one-way arrow, and the NFC badge a pen-sourced journal row already carries, then the time of the entry it would replace. The arrow points one way because that is what happens, the entry is adopted by the dose rather than traded with it, and it is auto-mirrored so it still agrees with the reading order in a right-to-left layout. The badge rather than the payment contactless arcs, so one idea does not get two marks a screen apart. The how-to card on the pen settings screen follows in its own commit, which leaves no payment arcs on the pen screens at all: the mark for reading a pen is the same one everywhere it appears. The two cases exclude each other, since an air shot is never offered. Icons rather than a sentence because a sentence did not fit: on a phone the marker gets a share of the row and "ersetzt 17:47" landed right on the boundary, so the first thing a real device showed was a bare arrow. The icons need no translating and almost no room, which leaves the words with one job, naming which entry, and that is a time. Unticking leaves both the dose and the entry alone, nothing in the journal is touched until the button is pressed, and each adoption is still guarded, so an entry deleted in between writes its dose as a new row instead.

The heading, the list and the button now come from one filtered set. Air shots are not in it, since they are never written: they are reported under the list as skipped rather than sitting in it as a row nobody may tick. A read that leaves nothing to confirm no longer opens a dialog at all and says there were no new doses instead.

Deciding the pairing long before carrying it out means the amount has to decide again at the moment of writing: an entry that no longer says what it said, is no longer written by hand, or has been claimed since is not taken over, and its dose is written as a row of its own. The row's marker takes a share of the width rather than first claim on it, so a long translation at a large font size cannot push the amount and the time into wrapping; what does not fit becomes the icon alone, carrying the full text for a screen reader.

### Tests

Fourteen in `PenManualMergeTests`: the plain case (written down, injected two minutes later, one row, moved to the pen's time), three in a row, an air shot between two doses, an entry written and never injected, an amount that disagrees, a pair too far apart, a spare pen of the same insulin, another insulin, a pen without one, an entry from outside the read, amounts compared in tenths, the window to the second, and what may be considered a candidate at all. Six in `PenSheetOfferTests` for what the sheet offers and starts out with ticked: air shots neither offered nor counted, a read of nothing but an air shot offering nothing, heading and list and button counting the same thing, a proposed dose ticked whatever its age, an air shot never ticked, and an empty read. Six in `PenImportPlanTests` for what confirming writes: a dose that takes over an entry is not also written, one without a proposal is, one the journal already holds is left alone, a proposal for a dose nobody confirmed is not carried out, one entry stands for one dose, and nothing confirmed writes nothing. `PenDuplicateReconcilerTests`, `PenDoseParserTests` and `PenImportCursorTests` are unchanged and green.

The scan is only exercised by a real pen. On one: a dose entered by hand, injected, then scanned with the app open shows the row ticked and marked with the time it replaces, while the journal still holds the entry unchanged; confirming leaves one row at the pen's time with the note kept; scanning again offers nothing.





