### PR TITLE
Nightscout: journal entries wake the uploader, and a refused upload is retried

### DIFF
--- a/Common/src/main/cpp/datbackup.hpp
+++ b/Common/src/main/cpp/datbackup.hpp
@@ -246,6 +246,10 @@ static constexpr const uintptr_t wakeend = 64;
 static constexpr const uintptr_t wakesend = 128;
 static constexpr const uintptr_t wakereconnect = 256;
 static constexpr const uintptr_t wakestreamsend = 512;
+/* Journal treatments. Their own reason: they used to travel on wakenums, which is raised by
+   the native number paths, so whether a dose reached Nightscout depended on a calibration or
+   a backup happening to come along. */
+static constexpr const uintptr_t waketreatments = 1024;
 
 class Backup {
 
@@ -262,6 +266,7 @@ public:
   static constexpr const uintptr_t wakesend = ::wakesend;
   static constexpr const uintptr_t wakereconnect = ::wakereconnect;
   static constexpr const uintptr_t wakestreamsend = ::wakestreamsend;
+  static constexpr const uintptr_t waketreatments = ::waketreatments;
   struct condvar_t {
     uintptr_t dobackup = 0;
     std::mutex backupmutex;

--- a/Common/src/main/cpp/net/watchserver/uploader.cpp
+++ b/Common/src/main/cpp/net/watchserver/uploader.cpp
@@ -1028,7 +1028,7 @@ static void uploaderthread() {
                 continue;
                 }
             }
-        if(current&(Backup::wakenums|Backup::wakeall)) {
+        if(current&(Backup::wakenums|Backup::wakeall|Backup::waketreatments)) {
             bool treatmentsOk = uploadJournalTreatmentsViaJava(useV3);
             if(!treatmentsOk && !useV3 && lastNightUploadCode==404) {
                 LOGSTRING("Nightscout v1 treatments endpoint returned 404, retrying with v3\n");
@@ -1072,6 +1072,24 @@ void wakeuploader() {
     }
     }
 
+/* A journal entry was written, changed or deleted. Its own reason, so treatments no longer
+   depend on a number path raising wakenums for reasons of its own. */
+void waketreatmentsuploader() {
+    bool ready=uploaderrunning.load();
+    if(!ready && settings->data()->nightuploadon) {
+        auto env=getenv();
+        if(env && inituploader(env)) {
+            lastNightUploadConfigError = false;
+            ready=true;
+            }
+    }
+    if(ready) {
+        lastNightUploadWaitMinutes = 0;
+        uploadercondition.wakebackup(Backup::waketreatments);
+        LOGSTRING("Nightscout wake source=journal mask=treatments\n");
+    }
+    }
+
 static bool wakestreamuploader(JNIEnv *env,const char *source,const long long timestampMillis) {
     if(!settings->data()->nightuploadon)
         return false;
@@ -1099,6 +1117,9 @@ void wakestreamuploader() {
 #include "fromjava.h"    
 extern "C" JNIEXPORT void JNICALL fromjava(wakeuploader) (JNIEnv *env, jclass clazz) {
     wakeuploader();
+    } 
+extern "C" JNIEXPORT void JNICALL fromjava(waketreatments) (JNIEnv *env, jclass clazz) {
+    waketreatmentsuploader();
     } 
 extern "C" JNIEXPORT jboolean JNICALL fromjava(wakeNightscoutForLiveReading)
     (JNIEnv *env,jclass clazz,jstring jsource,jlong timestampMillis) {

--- a/Common/src/main/cpp/net/watchserver/uploader.cpp
+++ b/Common/src/main/cpp/net/watchserver/uploader.cpp
@@ -975,8 +975,14 @@ static bool uploadJournalTreatmentsViaJava(bool useV3) {
         }
     return res==JNI_TRUE;
     }
+/* What a failed pass wants tried again, and how long the treatments branch waits before it
+   does. Only the uploader thread touches these. */
+static uintptr_t retrypending=0;
+static int treatmentbackoffmin=0;
+
 static void uploaderthread() {
     int waitmin=0;
+    bool glucosefailed=false;
     uploaderrunning=true;
     lastNightUploadWaitMinutes = waitmin;
     const char view[]{"UPLOADER"};
@@ -1006,9 +1012,17 @@ static void uploaderthread() {
             LOGSTRING("end uploaderthread\n");
             return;
             }
-        const auto current=uploadercondition.dobackup;
+        /* What was asked for, plus what the last pass could not deliver. Clearing dobackup
+           used to be the whole of a failed attempt: the branch set waitmin and continued,
+           and the pass that woke a quarter of an hour later found the mask empty and did
+           nothing at all. The reading stream hides that for glucose by raising wakestream
+           every minute; treatments have no such heartbeat, so a backlog sat there until
+           something unrelated came along. */
+        const auto current=(uploadercondition.dobackup|retrypending);
         uploadercondition.dobackup=0;
+        retrypending=0;
         bool useV3=settings->data()->nightscoutV3;
+        glucosefailed=false;
         const bool prioritizeRecent=(current&Backup::wakestream);
         if(current&(Backup::wakestream|Backup::wakeall)) {
             bool uploaded = useV3?uploadCGM3(prioritizeRecent):uploadCGM(prioritizeRecent);
@@ -1023,11 +1037,13 @@ static void uploaderthread() {
                 uploaded = uploadCGM3(prioritizeRecent);
             }
             if(!uploaded) {
-                waitmin=lastNightUploadConfigError?0:15;
-                lastNightUploadWaitMinutes = waitmin;
-                continue;
+                glucosefailed=true;
+                retrypending|=(current&(Backup::wakestream|Backup::wakeall));
                 }
             }
+        /* Treatments are attempted even when the glucose upload has just failed. They are
+           separate endpoints failing for separate reasons, and returning here meant one bad
+           reading upload also swallowed the wake a journal entry had raised. */
         if(current&(Backup::wakenums|Backup::wakeall|Backup::waketreatments)) {
             bool treatmentsOk = uploadJournalTreatmentsViaJava(useV3);
             if(!treatmentsOk && !useV3 && lastNightUploadCode==404) {
@@ -1041,10 +1057,23 @@ static void uploaderthread() {
                 treatmentsOk = uploadJournalTreatmentsViaJava(true);
             }
             if(!treatmentsOk) {
-                waitmin=lastNightUploadConfigError?0:15;
-                lastNightUploadWaitMinutes = waitmin;
-                continue;
+                /* Ask again without waiting for anything else to happen, and more slowly
+                   each time: an entry the server will never accept must not be retried
+                   every quarter of an hour for the rest of the day. */
+                retrypending|=Backup::waketreatments;
+                treatmentbackoffmin=treatmentbackoffmin?(treatmentbackoffmin<120?treatmentbackoffmin*2:240):15;
                 }
+            else
+                treatmentbackoffmin=0;
+            }
+        if(glucosefailed||(retrypending&Backup::waketreatments)) {
+            /* Whichever wants looking at sooner decides when this thread wakes again. */
+            int failwait=lastNightUploadConfigError?0:15;
+            if(!glucosefailed)
+                failwait=lastNightUploadConfigError?0:treatmentbackoffmin;
+            waitmin=failwait;
+            lastNightUploadWaitMinutes = waitmin;
+            continue;
             }
         //Best effort: Java posts this on a bounded, dedicated executor. Its endpoint status never
         //overwrites the primary glucose uploader status or blocks this serialized upload loop.

--- a/Common/src/main/cpp/net/watchserver/uploader.cpp
+++ b/Common/src/main/cpp/net/watchserver/uploader.cpp
@@ -999,11 +999,16 @@ static void uploaderthread() {
                 std::unique_lock<std::mutex> lck(uploadercondition.backupmutex);
             LOGGER("UPLOADER before lock waitmin=%d\n",waitmin);
              auto now = std::chrono::system_clock::now();
+            /* The mask is asked about again here, holding the lock. It was read without it
+               above, so a wake landing in between set its bit, called notify_one with nobody
+               waiting yet, and was then slept through for as long as the wait lasts. That is
+               a request to send now, answered hours later or not at all. */
             #ifndef NOLOG
             auto status=
             #endif
-                        uploadercondition.backupcond.wait_until(lck, now + std::chrono::minutes(waitmin));
-            LOGGER("UPLOADER after lock %stimeout\n",(status==std::cv_status::no_timeout)?"no-":"");
+                        uploadercondition.backupcond.wait_until(lck, now + std::chrono::minutes(waitmin),
+                                [](){ return uploadercondition.dobackup!=0; });
+            LOGGER("UPLOADER after lock %stimeout\n",status?"no-":"");
             }
         if(uploadercondition.dobackup&Backup::wakeend) {
             uploadercondition.dobackup=0;

--- a/Common/src/main/cpp/net/watchserver/uploader.cpp
+++ b/Common/src/main/cpp/net/watchserver/uploader.cpp
@@ -975,14 +975,20 @@ static bool uploadJournalTreatmentsViaJava(bool useV3) {
         }
     return res==JNI_TRUE;
     }
-/* What a failed pass wants tried again, and how long the treatments branch waits before it
-   does. Only the uploader thread touches these. */
+/* What a failed pass wants tried again, how long the treatments branch waits before it does,
+   and when that wait is up. The wait needs its own clock: waitmin only applies when this
+   thread actually sleeps, and with a sensor streaming it is woken every minute, so a backoff
+   expressed as a sleep would throttle nothing at all. Only the uploader thread touches these. */
 static uintptr_t retrypending=0;
 static int treatmentbackoffmin=0;
+static std::chrono::steady_clock::time_point treatmentnextattempt{};
 
 static void uploaderthread() {
     int waitmin=0;
     bool glucosefailed=false;
+    retrypending=0;
+    treatmentbackoffmin=0;
+    treatmentnextattempt=std::chrono::steady_clock::time_point{};
     uploaderrunning=true;
     lastNightUploadWaitMinutes = waitmin;
     const char view[]{"UPLOADER"};
@@ -1022,9 +1028,17 @@ static void uploaderthread() {
            and the pass that woke a quarter of an hour later found the mask empty and did
            nothing at all. The reading stream hides that for glucose by raising wakestream
            every minute; treatments have no such heartbeat, so a backlog sat there until
-           something unrelated came along. */
-        const auto current=(uploadercondition.dobackup|retrypending);
-        uploadercondition.dobackup=0;
+           something unrelated came along.
+
+           Read and cleared under the same lock the raising side takes: a wake landing
+           between the read and the clear would otherwise be wiped out by the clear, and
+           since its branch never ran, nothing would carry it forward either. */
+        uintptr_t current;
+            {
+            std::lock_guard<std::mutex> lck(uploadercondition.backupmutex);
+            current=(uploadercondition.dobackup|retrypending);
+            uploadercondition.dobackup=0;
+            }
         retrypending=0;
         bool useV3=settings->data()->nightscoutV3;
         glucosefailed=false;
@@ -1046,10 +1060,17 @@ static void uploaderthread() {
                 retrypending|=(current&(Backup::wakestream|Backup::wakeall));
                 }
             }
+        const auto nowsteady=std::chrono::steady_clock::now();
+        const bool treatmentsdue=(nowsteady>=treatmentnextattempt);
         /* Treatments are attempted even when the glucose upload has just failed. They are
            separate endpoints failing for separate reasons, and returning here meant one bad
            reading upload also swallowed the wake a journal entry had raised. */
-        if(current&(Backup::wakenums|Backup::wakeall|Backup::waketreatments)) {
+        if((current&(Backup::wakenums|Backup::wakeall|Backup::waketreatments))&&!treatmentsdue) {
+            /* Still holding off after a refusal. Keep the reason so it is asked again once
+               the hold is up, rather than losing it to this pass. */
+            retrypending|=Backup::waketreatments;
+            }
+        else if(current&(Backup::wakenums|Backup::wakeall|Backup::waketreatments)) {
             bool treatmentsOk = uploadJournalTreatmentsViaJava(useV3);
             if(!treatmentsOk && !useV3 && lastNightUploadCode==404) {
                 LOGSTRING("Nightscout v1 treatments endpoint returned 404, retrying with v3\n");
@@ -1067,24 +1088,31 @@ static void uploaderthread() {
                    every quarter of an hour for the rest of the day. */
                 retrypending|=Backup::waketreatments;
                 treatmentbackoffmin=treatmentbackoffmin?(treatmentbackoffmin<120?treatmentbackoffmin*2:240):15;
+                treatmentnextattempt=nowsteady+std::chrono::minutes(treatmentbackoffmin);
                 }
-            else
+            else {
                 treatmentbackoffmin=0;
+                treatmentnextattempt=std::chrono::steady_clock::time_point{};
+                }
             }
-        if(glucosefailed||(retrypending&Backup::waketreatments)) {
-            /* Whichever wants looking at sooner decides when this thread wakes again. */
-            int failwait=lastNightUploadConfigError?0:15;
-            if(!glucosefailed)
-                failwait=lastNightUploadConfigError?0:treatmentbackoffmin;
-            waitmin=failwait;
-            lastNightUploadWaitMinutes = waitmin;
-            continue;
+        /* Device status is not the treatments endpoint and does not fail with it. Skipping it
+           while a treatment is being refused would stop reporting IOB for as long as that
+           lasts, which can be indefinitely. A failed reading upload still skips it, as it
+           always has: that one shares its endpoint and its answer. */
+        if(!glucosefailed) {
+            //Best effort: Java posts this on a bounded, dedicated executor. Its endpoint status never
+            //overwrites the primary glucose uploader status or blocks this serialized upload loop.
+            uploadDeviceStatus();
+            uploadIobDeviceStatus();
             }
-        //Best effort: Java posts this on a bounded, dedicated executor. Its endpoint status never
-        //overwrites the primary glucose uploader status or blocks this serialized upload loop.
-        uploadDeviceStatus();
-        uploadIobDeviceStatus();
-        waitmin=5*60;
+        if(glucosefailed)
+            waitmin=lastNightUploadConfigError?1:15;
+        else if(retrypending&Backup::waketreatments)
+            /* Never zero while something is carried forward: a wait of nothing with work
+               pending is a loop that never sleeps. */
+            waitmin=treatmentbackoffmin?treatmentbackoffmin:15;
+        else
+            waitmin=5*60;
         lastNightUploadWaitMinutes = waitmin;
         }
     }

--- a/Common/src/main/java/tk/glucodata/Natives.java
+++ b/Common/src/main/java/tk/glucodata/Natives.java
@@ -1022,6 +1022,13 @@ public class Natives {
 
         public static native void wakeuploader();
 
+        /**
+         * A journal entry was written, changed or deleted. Wakes the treatments branch of
+         * the uploader on its own reason, so a dose no longer waits for a calibration or a
+         * backup to come along and wake it by accident.
+         */
+        public static native void waketreatments();
+
         public static native boolean wakeNightscoutForLiveReading(String source, long timestampMillis);
 
         public static native void resetuploader();

--- a/Common/src/main/java/tk/glucodata/NightscoutUploadWake.kt
+++ b/Common/src/main/java/tk/glucodata/NightscoutUploadWake.kt
@@ -10,6 +10,23 @@ package tk.glucodata
 object NightscoutUploadWake {
     private const val TAG = "NightscoutWake"
 
+    /**
+     * A journal entry was written, changed or deleted.
+     *
+     * Cheap enough to call per row: the uploader collapses everything raised before its next
+     * pass into one, and one pass sends the whole backlog. Silent when treatments are not
+     * being sent, so nothing wakes a network thread for a setting that is off.
+     */
+    @JvmStatic
+    fun afterJournalChange() {
+        if (!runCatching { Natives.getpostTreatments() }.getOrDefault(false)) return
+        runCatching {
+            Natives.waketreatments()
+        }.onFailure {
+            Log.stack(TAG, "journal wake failed", it)
+        }
+    }
+
     @JvmStatic
     fun afterLiveNativeWrite(source: String, timestampMillis: Long) {
         if (timestampMillis <= 0L || !Natives.getuseuploader()) return

--- a/Common/src/mobile/java/tk/glucodata/data/ExportPackageExporter.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/ExportPackageExporter.kt
@@ -419,6 +419,10 @@ object ExportPackageExporter {
         }
         if (entries.isNotEmpty()) {
             database.journalDao().upsertEntries(entries)
+            // Written straight to the table rather than through the repository, so the wake
+            // it raises has to be raised here: a restored journal is a backlog like any
+            // other and would otherwise sit until something unrelated woke the uploader.
+            tk.glucodata.NightscoutUploadWake.afterJournalChange()
         }
 
         // Serial to key the dashboard on: the newest reading's serial (already

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
@@ -78,6 +78,9 @@ class JournalRepository {
         if (entity.glucoseValueMgDl != null || existing?.glucoseValueMgDl != null) {
             tk.glucodata.data.calibration.JournalCalibrationSync.onJournalChanged()
         }
+        // Every kind of entry, not only the ones that move IOB: a fingerstick or a note is
+        // sent to Nightscout too, and nothing else will wake the uploader for it.
+        tk.glucodata.NightscoutUploadWake.afterJournalChange()
         return id
     }
 
@@ -96,6 +99,7 @@ class JournalRepository {
             dao.deleteEntriesBySourceRecordIds(ids)
             tk.glucodata.OutboundApiJournalSnapshot.journalChanged()
             tk.glucodata.data.calibration.JournalCalibrationSync.onJournalChanged()
+            tk.glucodata.NightscoutUploadWake.afterJournalChange()
         }
     }
 
@@ -124,6 +128,8 @@ class JournalRepository {
         if (deletedGlucose != null) {
             tk.glucodata.data.calibration.JournalCalibrationSync.onJournalChanged()
         }
+        // A deletion queues a tombstone, which is the uploader's to carry out.
+        tk.glucodata.NightscoutUploadWake.afterJournalChange()
     }
 
     suspend fun upsertInsulinPreset(input: JournalInsulinPresetInput): Long {

--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalRepository.kt
@@ -79,8 +79,11 @@ class JournalRepository {
             tk.glucodata.data.calibration.JournalCalibrationSync.onJournalChanged()
         }
         // Every kind of entry, not only the ones that move IOB: a fingerstick or a note is
-        // sent to Nightscout too, and nothing else will wake the uploader for it.
-        tk.glucodata.NightscoutUploadWake.afterJournalChange()
+        // sent to Nightscout too, and nothing else will wake the uploader for it. What came
+        // from another system is never sent back, so importing from one does not wake it.
+        if (!isMirroredSource(input.source)) {
+            tk.glucodata.NightscoutUploadWake.afterJournalChange()
+        }
         return id
     }
 
@@ -160,6 +163,12 @@ class JournalRepository {
         dao.deleteInsulinPresetById(presetId)
         tk.glucodata.OutboundApiJournalSnapshot.journalChanged()
     }
+
+    /** Rows this app mirrors from elsewhere; the uploader skips them, so a wake is wasted. */
+    private fun isMirroredSource(source: JournalEntrySource): Boolean =
+        source == JournalEntrySource.AAPS ||
+            source == JournalEntrySource.NIGHTSCOUT ||
+            source == JournalEntrySource.API
 
     private fun affectsIob(entryType: String?): Boolean {
         return entryType == JournalEntryType.INSULIN.storageValue ||


### PR DESCRIPTION
Journal entries reach Nightscout only when something unrelated happens to wake the uploader. The entries branch runs on `wakestream`, raised by the reading stream every minute; the treatments branch runs on `wakenums` or `wakeall`, raised by the native number and calibration paths, LibreView and the sensor drivers. Writing a journal entry raises neither: the journal lives in Room on the JVM side and never signals the native uploader at all. So treatments ride along on whatever else comes past, and in a normal day that happens often enough that it usually works. The most dependable carrier turns out to be leaving the app, since `onPause` wakes the uploader for a full sync.

Field case: an upload that failed during a network outage was never retried, and a dose entered hours later on a good connection did not go either. Over five minutes of trace the entries upload returns 201 every minute while not one `JournalTreatmentUploader` line appears. Nothing failed, because nothing was attempted.

Three things were wrong, and they are three commits.

**A journal change raises nothing.** It now raises a reason of its own rather than borrowing the one the number paths raise, so a later change there cannot quietly take the uploads with it. Writing, changing and deleting an entry all raise it, whatever the entry is: a fingerstick or a note goes to Nightscout as much as a dose, while the existing IOB refresh covers only insulin and carbs. Raising it per row is cheap, because everything raised before the next pass collapses into one pass and one pass sends the whole backlog.

**A refused upload was forgotten rather than retried.** A failed pass set a fifteen minute wait and started over, but the mask it woke on had already been cleared, so the pass fifteen minutes later found nothing to do and slept for five hours. The retry was a wait, not a retry. Glucose survived that because the reading stream re-asks the question every minute; treatments have no heartbeat, which is why a backlog could sit indefinitely behind one bad minute of network. What a pass could not deliver is now carried into the next one, with treatments backing off as they keep failing, doubling from a quarter of an hour up to four, so an entry the server will never accept stops hammering while a network that comes back is still picked up quickly. Treatments are also no longer skipped when the glucose upload fails first: they are separate endpoints failing for separate reasons, and returning early there discarded the wake a journal entry had just raised.

**"Send now" could be slept through.** The thread read the wake mask without holding the lock, then took the lock and waited; a wake arriving in that gap set its bit and notified with nobody waiting yet, so it went nowhere and the thread slept the full wait anyway. The wait now asks the same question again while holding the lock. The button itself was already raising the right reason, contrary to my first reading of the report.

### Verification

The native library builds for all four ABIs, the mobile and wear flavours compile, and the journal and Nightscout unit suites stay green. The uploader is C++ with no test harness in the tree and its observability is its log lines, so what it does has to be read off a trace rather than asserted. Two of the three things worth looking for are there: `Nightscout wake source=journal mask=treatments` after an entry written with no sensor event nearby, and a `JournalTreatmentUploader` line following it. Confirmed in use since: treatments reach Nightscout on their own, with no manual send and nothing unrelated waking the uploader for them. The third has not been seen yet, and neither has the rest of the failure side: a backlog clearing itself once the network returns, and the backoff under a server that keeps refusing.



