### PR TITLE
Alerts and rows: the arrow says what the number beside it says

### DIFF
--- a/Common/src/main/java/tk/glucodata/logic/TrendEngine.kt
+++ b/Common/src/main/java/tk/glucodata/logic/TrendEngine.kt
@@ -35,6 +35,21 @@ object TrendEngine {
         Unknown
     }
 
+    /**
+     * Which arrow a rate in mg/dL per minute is. Named so that anything drawing an arrow
+     * from a rate this engine did not measure still lands on the same boundaries.
+     */
+    @JvmStatic
+    fun stateFor(velocity: Float): TrendState = when {
+        velocity > 2.0f -> TrendState.DoubleUp
+        velocity > 1.0f -> TrendState.SingleUp
+        velocity > 0.5f -> TrendState.FortyFiveUp
+        velocity > -0.5f -> TrendState.Flat
+        velocity > -1.0f -> TrendState.FortyFiveDown
+        velocity > -2.0f -> TrendState.SingleDown
+        else -> TrendState.DoubleDown
+    }
+
     data class TrendResult(
         val state: TrendState,
         val velocity: Float,     // mg/dL per minute
@@ -350,18 +365,7 @@ object TrendEngine {
         } else 0f
         val noiseLevel = noiseLevel2
 
-        // Map to State
-        val state = when {
-            velocity > 2.0 -> TrendState.DoubleUp
-            velocity > 1.0 -> TrendState.SingleUp
-            velocity > 0.5 -> TrendState.FortyFiveUp
-            velocity > -0.5 -> TrendState.Flat
-            velocity > -1.0 -> TrendState.FortyFiveDown
-            velocity > -2.0 -> TrendState.SingleDown
-            else -> TrendState.DoubleDown
-        }
-
-        return TrendResult(state, velocity, acceleration, 1.0f, noiseLevel)
+        return TrendResult(stateFor(velocity), velocity, acceleration, 1.0f, noiseLevel)
     }
 }
 

--- a/Common/src/mobile/java/tk/glucodata/ui/AlarmActivity.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/AlarmActivity.kt
@@ -145,11 +145,17 @@ class AlarmActivity : ComponentActivity() {
         } catch (_: Throwable) {
             null
         }
-        val fallbackRate = selectAlarmRate(
-            intent.getFloatExtra(EXTRA_RATE, Float.NaN).takeIf { it.isFinite() },
-            latestRate
-        )
-        val trendResult = computeAlarmTrendResult(fallbackRate)
+        // The rate the alert fired on, carried in the intent. An alarm has to point the way
+        // the movement it fired on was going: read again here it can describe the run-up
+        // instead, and a "high" arriving with a falling arrow argues against itself in the
+        // one moment it needs to be believed.
+        val firedRate = intent.getFloatExtra(EXTRA_RATE, Float.NaN).takeIf { it.isFinite() }
+        val fallbackRate = selectAlarmRate(firedRate, latestRate)
+        val trendResult = if (firedRate != null) {
+            alarmTrendResult(firedRate)
+        } else {
+            computeAlarmTrendResult(fallbackRate)
+        }
         val alertType = AlertType.fromId(intent.getIntExtra(EXTRA_ALERT_TYPE_ID, -1))
         val customAlertId = intent.getStringExtra(Notify.EXTRA_CUSTOM_ALERT_ID)
 
@@ -305,22 +311,19 @@ class AlarmActivity : ComponentActivity() {
         }
     }
 
-    private fun fallbackAlarmTrendResult(rate: Float): TrendEngine.TrendResult {
+    /**
+     * An arrow for a rate somebody else measured. The boundaries are the engine's own, so an
+     * alarm drawn from the fired rate and a row drawn from a measured one mean the same
+     * thing by the same picture.
+     */
+    private fun alarmTrendResult(rate: Float): TrendEngine.TrendResult {
         if (!rate.isFinite()) {
             return TrendEngine.TrendResult(TrendEngine.TrendState.Unknown, 0f, 0f, 0f, 0f)
         }
-
-        val state = when {
-            rate > 2.0f -> TrendEngine.TrendState.DoubleUp
-            rate > 1.0f -> TrendEngine.TrendState.SingleUp
-            rate > 0.05f -> TrendEngine.TrendState.FortyFiveUp
-            rate >= -0.05f -> TrendEngine.TrendState.Flat
-            rate >= -1.0f -> TrendEngine.TrendState.FortyFiveDown
-            rate >= -2.0f -> TrendEngine.TrendState.SingleDown
-            else -> TrendEngine.TrendState.DoubleDown
-        }
-        return TrendEngine.TrendResult(state, rate, 0f, 1f, 0f)
+        return TrendEngine.TrendResult(TrendEngine.stateFor(rate), rate, 0f, 1f, 0f)
     }
+
+    private fun fallbackAlarmTrendResult(rate: Float): TrendEngine.TrendResult = alarmTrendResult(rate)
 
     private fun cancelAlarmNotification() {
         (getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager)?.cancel(81432)

--- a/Common/src/mobile/java/tk/glucodata/ui/AlarmActivity.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/AlarmActivity.kt
@@ -150,11 +150,11 @@ class AlarmActivity : ComponentActivity() {
         // instead, and a "high" arriving with a falling arrow argues against itself in the
         // one moment it needs to be believed.
         val firedRate = intent.getFloatExtra(EXTRA_RATE, Float.NaN).takeIf { it.isFinite() }
-        val fallbackRate = selectAlarmRate(firedRate, latestRate)
         val trendResult = if (firedRate != null) {
             alarmTrendResult(firedRate)
         } else {
-            computeAlarmTrendResult(fallbackRate)
+            // No rate came with the alarm: read one, as before.
+            computeAlarmTrendResult(selectAlarmRate(null, latestRate))
         }
         val alertType = AlertType.fromId(intent.getIntExtra(EXTRA_ALERT_TYPE_ID, -1))
         val customAlertId = intent.getStringExtra(Notify.EXTRA_CUSTOM_ALERT_ID)

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
@@ -252,6 +252,15 @@ internal fun buildTrendHistory(consumerHistory: List<GlucosePoint>): List<Glucos
     buildDisplayReadings(consumerHistory, limit = TREND_HISTORY_LIMIT)
 
 /**
+ * A row's measured change: the text it shows, and the same movement as a rate the arrow
+ * beside it can be drawn from.
+ *
+ * The rate is mg/dL per minute, which is what every arrow in the app rotates by, whatever
+ * unit the reading is displayed in.
+ */
+internal data class ReadingDelta(val text: String, val rateMgdlPerMinute: Float)
+
+/**
  * The "Δ" readout of the hero card, anchored at arbitrary points in time: for each
  * anchor timestamp, the delta the hero would have shown when that reading was the
  * newest one. The hero's own readout is the single-anchor case (the newest point),
@@ -267,14 +276,6 @@ internal fun buildTrendHistory(consumerHistory: List<GlucosePoint>): List<Glucos
  * An anchor with no old-enough partner (start of the data, or a gap wider than
  * the pairing rules allow) yields null, never a NaN text.
  */
-/**
- * A row's measured change: the text it shows, and the same movement as a rate the arrow
- * beside it can be drawn from.
- *
- * The rate is mg/dL per minute, which is what every arrow in the app rotates by, whatever
- * unit the reading is displayed in.
- */
-internal data class ReadingDelta(val text: String, val rateMgdlPerMinute: Float)
 
 internal fun readingDeltaTexts(
     anchorTimestamps: List<Long>,

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
@@ -338,11 +338,11 @@ internal fun readingDeltas(
  * sensor stored under two names stays one — and every row walks back through its
  * own sensor's bucket only. Rows the app cannot attribute ([isShared]: imported and
  * unknown serials) belong to every bucket, which is what the dashboard's per-sensor
- * history holds as well. Within one bucket the text is exactly [readingDeltaTexts]'s,
+ * history holds as well. Within one bucket the delta is exactly [readingDeltas]'s,
  * gaps included: a row with no old-enough partner is absent.
  *
  * Build one index per [history] (oldest-first, unsmoothed) and ask it per visible
- * window: [textsFor] does a binary search per bucket, not a pass over the data.
+ * window: [deltasFor] does a binary search per bucket, not a pass over the data.
  */
 internal class RowDeltaIndex(
     history: List<GlucosePoint>,
@@ -379,10 +379,14 @@ internal class RowDeltaIndex(
         }
     }
 
-    /** [rows] newest-first, the order the history draws them. */
-    fun textsFor(rows: List<GlucosePoint>, isMmol: Boolean, deltaIntervalMinutes: Int): Map<GlucosePoint, String> {
+    /**
+     * [rows] newest-first, the order the history draws them. The rate rides along with
+     * the text so a history row can point its arrow at the number it prints, the same
+     * way the dashboard's rows do.
+     */
+    fun deltasFor(rows: List<GlucosePoint>, isMmol: Boolean, deltaIntervalMinutes: Int): Map<GlucosePoint, ReadingDelta> {
         if (rows.isEmpty() || historyByKey.isEmpty()) return emptyMap()
-        val texts = HashMap<GlucosePoint, String>()
+        val deltas = HashMap<GlucosePoint, ReadingDelta>()
         rows.groupBy { keyOf(it.sensorSerial) }.forEach { (key, sensorRows) ->
             val bucket = historyByKey[key] ?: return@forEach
             // Nothing newer than the newest row takes part in its walk-back: cut the
@@ -390,17 +394,17 @@ internal class RowDeltaIndex(
             val newest = sensorRows.first().timestamp
             var cut = bucket.binarySearchBy(newest) { it.timestamp }.let { if (it >= 0) it + 1 else -it - 1 }
             while (cut < bucket.size && bucket[cut].timestamp == newest) cut++
-            val sensorTexts = readingDeltaTexts(
+            val sensorDeltas = readingDeltas(
                 sensorRows.map { it.timestamp },
                 bucket.subList(0, cut),
                 isMmol,
                 deltaIntervalMinutes
             )
             sensorRows.forEachIndexed { index, row ->
-                sensorTexts.getOrNull(index)?.let { texts[row] = it }
+                sensorDeltas.getOrNull(index)?.let { deltas[row] = it }
             }
         }
-        return texts
+        return deltas
     }
 
     private companion object {

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
@@ -267,12 +267,33 @@ internal fun buildTrendHistory(consumerHistory: List<GlucosePoint>): List<Glucos
  * An anchor with no old-enough partner (start of the data, or a gap wider than
  * the pairing rules allow) yields null, never a NaN text.
  */
+/**
+ * A row's measured change: the text it shows, and the same movement as a rate the arrow
+ * beside it can be drawn from.
+ *
+ * The rate is mg/dL per minute, which is what every arrow in the app rotates by, whatever
+ * unit the reading is displayed in.
+ */
+internal data class ReadingDelta(val text: String, val rateMgdlPerMinute: Float)
+
 internal fun readingDeltaTexts(
     anchorTimestamps: List<Long>,
     history: List<GlucosePoint>,
     isMmol: Boolean,
     deltaIntervalMinutes: Int
-): List<String?> {
+): List<String?> = readingDeltas(anchorTimestamps, history, isMmol, deltaIntervalMinutes)
+    .map { it?.text }
+
+/**
+ * The walk itself. One pairing serves both the number and the arrow, so a row cannot show
+ * a rise beside a falling arrow: they are the same two readings, read once.
+ */
+internal fun readingDeltas(
+    anchorTimestamps: List<Long>,
+    history: List<GlucosePoint>,
+    isMmol: Boolean,
+    deltaIntervalMinutes: Int
+): List<ReadingDelta?> {
     if (anchorTimestamps.isEmpty()) return emptyList()
     val newestFirst = history.asReversed()
     val minGap = tk.glucodata.GlucoseDelta.minGapMillis(deltaIntervalMinutes)
@@ -298,7 +319,9 @@ internal fun readingDeltaTexts(
             previous.timestamp, previous.value,
             deltaIntervalMinutes
         )
-        tk.glucodata.GlucoseDelta.format(delta, isMmol).takeIf { it.isNotEmpty() }
+        val text = tk.glucodata.GlucoseDelta.format(delta, isMmol).takeIf { it.isNotEmpty() }
+            ?: return@map null
+        ReadingDelta(text, perMinuteMgdl(delta, isMmol, deltaIntervalMinutes))
     }
 }
 
@@ -383,4 +406,14 @@ internal class RowDeltaIndex(
         /** The bucket of the rows no sensor owns; a string no serial can be. */
         const val SHARED = "\u0000shared"
     }
+}
+
+/**
+ * The delta is a change over the configured window, in the unit on screen; an arrow turns by
+ * mg/dL per minute. Same movement, said the way the arrow reads it.
+ */
+private fun perMinuteMgdl(delta: Float, isMmol: Boolean, deltaIntervalMinutes: Int): Float {
+    val minutes = tk.glucodata.GlucoseDelta.sanitizeIntervalMinutes(deltaIntervalMinutes)
+    val perMinute = delta / minutes
+    return if (isMmol) perMinute * tk.glucodata.ui.util.GlucoseFormatter.MGDL_PER_MMOL else perMinute
 }

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -1187,19 +1187,22 @@ fun DashboardScreen(
             // Per-row Δ: the hero's delta computation anchored at each row's
             // timestamp — over the same unsmoothed history the hero reads, so the
             // newest row and the hero can never disagree.
-            val recentReadingDeltaTexts = remember(
-                dashboardRowsShowDelta, recentReadings, glucoseHistory, unit, deltaIntervalMinutes
+            // The rows' movement is read once and used twice: the Δ text, and the rate the
+            // row's arrow turns by. The arrow is put on this basis whether or not the text is
+            // shown, so a row always answers one question — what changed just now — while the
+            // hero keeps the longer regression, where stability is wanted.
+            val recentReadingDeltas = remember(
+                recentReadings, glucoseHistory, unit, deltaIntervalMinutes
             ) {
-                if (dashboardRowsShowDelta) {
-                    readingDeltaTexts(
-                        recentReadings.map { it.timestamp },
-                        glucoseHistory,
-                        tk.glucodata.ui.util.GlucoseFormatter.isMmol(unit),
-                        deltaIntervalMinutes
-                    )
-                } else {
-                    emptyList()
-                }
+                readingDeltas(
+                    recentReadings.map { it.timestamp },
+                    glucoseHistory,
+                    tk.glucodata.ui.util.GlucoseFormatter.isMmol(unit),
+                    deltaIntervalMinutes
+                )
+            }
+            val recentReadingDeltaTexts = remember(dashboardRowsShowDelta, recentReadingDeltas) {
+                if (dashboardRowsShowDelta) recentReadingDeltas.map { it?.text } else emptyList()
             }
             val peerSeriesById = remember(multiSensorDisplay) {
                 multiSensorDisplay.series.associateBy { it.sensorId }
@@ -1398,6 +1401,7 @@ fun DashboardScreen(
                                 totalCount = recentReadings.size,
                                 history = recentReadingsTrendHistory,
                                 deltaText = recentReadingDeltaTexts.getOrNull(index),
+                                deltaRateMgdlPerMinute = recentReadingDeltas.getOrNull(index)?.rateMgdlPerMinute,
                                 peerReadings = recentReadingPeers.getOrNull(index).orEmpty(),
                                 peerSeries = peerSeriesById,
                                 multiSensorActive = multiSensorActive,
@@ -1826,6 +1830,7 @@ fun DashboardScreen(
                                 totalCount = recentReadings.size,
                                 history = recentReadingsTrendHistory,
                                 deltaText = recentReadingDeltaTexts.getOrNull(index),
+                                deltaRateMgdlPerMinute = recentReadingDeltas.getOrNull(index)?.rateMgdlPerMinute,
                                 peerReadings = recentReadingPeers.getOrNull(index).orEmpty(),
                                 peerSeries = peerSeriesById,
                                 multiSensorActive = multiSensorActive,

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -1188,21 +1188,25 @@ fun DashboardScreen(
             // timestamp — over the same unsmoothed history the hero reads, so the
             // newest row and the hero can never disagree.
             // The rows' movement is read once and used twice: the Δ text, and the rate the
-            // row's arrow turns by. The arrow is put on this basis whether or not the text is
-            // shown, so a row always answers one question — what changed just now — while the
-            // hero keeps the longer regression, where stability is wanted.
+            // row's arrow turns by. Only where the number is actually shown, though: with the
+            // column off there is nothing for the arrow to contradict, and rebasing it anyway
+            // would let a display setting quietly decide what an arrow means.
             val recentReadingDeltas = remember(
-                recentReadings, glucoseHistory, unit, deltaIntervalMinutes
+                dashboardRowsShowDelta, recentReadings, glucoseHistory, unit, deltaIntervalMinutes
             ) {
-                readingDeltas(
-                    recentReadings.map { it.timestamp },
-                    glucoseHistory,
-                    tk.glucodata.ui.util.GlucoseFormatter.isMmol(unit),
-                    deltaIntervalMinutes
-                )
+                if (dashboardRowsShowDelta) {
+                    readingDeltas(
+                        recentReadings.map { it.timestamp },
+                        glucoseHistory,
+                        tk.glucodata.ui.util.GlucoseFormatter.isMmol(unit),
+                        deltaIntervalMinutes
+                    )
+                } else {
+                    emptyList()
+                }
             }
-            val recentReadingDeltaTexts = remember(dashboardRowsShowDelta, recentReadingDeltas) {
-                if (dashboardRowsShowDelta) recentReadingDeltas.map { it?.text } else emptyList()
+            val recentReadingDeltaTexts = remember(recentReadingDeltas) {
+                recentReadingDeltas.map { it?.text }
             }
             val peerSeriesById = remember(multiSensorDisplay) {
                 multiSensorDisplay.series.associateBy { it.sensorId }

--- a/Common/src/mobile/java/tk/glucodata/ui/HistoryBrowseScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/HistoryBrowseScreen.kt
@@ -482,8 +482,8 @@ fun HistoryBrowseScreen(
             )
         } else null
     }
-    val rowDeltaTexts = remember(rowDeltaIndex, visibleTimelineRows, unit, deltaIntervalMinutes) {
-        rowDeltaIndex?.textsFor(
+    val rowDeltas = remember(rowDeltaIndex, visibleTimelineRows, unit, deltaIntervalMinutes) {
+        rowDeltaIndex?.deltasFor(
             visibleTimelineRows.mapNotNull(TimelineRowItem::point),
             tk.glucodata.ui.util.GlucoseFormatter.isMmol(unit),
             deltaIntervalMinutes
@@ -782,7 +782,8 @@ fun HistoryBrowseScreen(
                                 index = index,
                                 totalCount = section.items.size,
                                 history = section.items.mapNotNull(TimelineRowItem::point),
-                                deltaText = rowDeltaTexts[readingPoint],
+                                deltaText = rowDeltas[readingPoint]?.text,
+                                deltaRateMgdlPerMinute = rowDeltas[readingPoint]?.rateMgdlPerMinute,
                                 sensorId = sensorId,
                                 calibrations = calibrations,
                                 highlightLeadRow = false,

--- a/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
@@ -72,6 +72,12 @@ fun ReadingRow(
     history: List<GlucosePoint> = emptyList(), // Advanced Trend: Need history
     // The row's historical "Δ" (see readingDeltaTexts); null hides the slot entirely.
     deltaText: String? = null,
+    /**
+     * The same movement the Δ beside it states, in mg/dL per minute. When it is there the
+     * arrow turns by it, so the two cannot disagree; without it the arrow falls back to the
+     * regression, which is also the case where no number sits next to it.
+     */
+    deltaRateMgdlPerMinute: Float? = null,
     peerReadings: List<GlucosePoint> = emptyList(),
     peerSeries: Map<String, PeerSensorSeries> = emptyMap(),
     // True whenever the dashboard is in multi-sensor mode, even if THIS row has
@@ -212,10 +218,16 @@ fun ReadingRow(
 
     // --- ADVANCED TREND ENGINE ---
     // Calculate on the fly using the passed history subset
-    val trendResult = remember(history, index) {
+    val regressed = remember(history, index) {
         val relevantHistory = if (history.isNotEmpty()) history.drop(index) else listOf(point)
         val nativeList = relevantHistory.map { tk.glucodata.GlucosePoint(it.timestamp, it.value, it.rawValue) }
         tk.glucodata.logic.TrendEngine.calculateTrend(nativeList, useRaw = (viewMode == 1 || viewMode == 3), isMmol = tk.glucodata.ui.util.GlucoseFormatter.isMmol(unit))
+    }
+    // A row states one movement. Where the Δ knows it, the arrow says the same thing rather
+    // than the longer regression, which answers a different question and can point the other
+    // way during a reversal — Δ −5 beside an arrow up is the app contradicting itself.
+    val trendResult = remember(regressed, deltaRateMgdlPerMinute) {
+        rowTrendResult(regressed, deltaRateMgdlPerMinute)
     }
 
     Surface(
@@ -876,4 +888,18 @@ fun JournalTimelineRow(
             }
         }
     }
+}
+
+/**
+ * The arrow's own reading of a row: the movement the Δ beside it states when there is one,
+ * the regression otherwise. Only the velocity and the state it maps to are replaced; how
+ * confident and how noisy the neighbourhood is are properties of the data, not of which
+ * window was measured.
+ */
+internal fun rowTrendResult(
+    regressed: tk.glucodata.logic.TrendEngine.TrendResult,
+    deltaRateMgdlPerMinute: Float?,
+): tk.glucodata.logic.TrendEngine.TrendResult {
+    val rate = deltaRateMgdlPerMinute?.takeIf { it.isFinite() } ?: return regressed
+    return regressed.copy(state = tk.glucodata.logic.TrendEngine.stateFor(rate), velocity = rate)
 }

--- a/Common/src/test/java/tk/glucodata/ui/HistoryRowDeltaTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/HistoryRowDeltaTests.kt
@@ -48,6 +48,14 @@ class HistoryRowDeltaTests {
     private fun dashboardTexts(rows: List<GlucosePoint>, history: List<GlucosePoint>): List<String?> =
         readingDeltaTexts(rows.map { it.timestamp }, history, false, 5)
 
+    /** Most tests here are about which reading gets which text; the rate is checked on its own. */
+    private fun RowDeltaIndex.textsFor(
+        rows: List<GlucosePoint>,
+        isMmol: Boolean,
+        deltaIntervalMinutes: Int
+    ): Map<GlucosePoint, String> =
+        deltasFor(rows, isMmol, deltaIntervalMinutes).mapValues { (_, delta) -> delta.text }
+
     @Test
     fun everyRowShowsWhatTheDashboardShowsForTheSameReading() {
         val history = oneMinuteCadence(count = 30) { minutesAgo -> 100f + minutesAgo * 2f }
@@ -194,6 +202,25 @@ class HistoryRowDeltaTests {
 
         rows.forEachIndexed { i, row -> assertEquals(dashboardTexts(rows, history)[i], texts[row]) }
         assertEquals(7, texts.size)
+    }
+
+    /**
+     * The history's rows print a Δ, so their arrows are drawn from it. The dashboard
+     * already works this way; a rate that stopped at the text would leave the two
+     * lists disagreeing about the same reading.
+     */
+    @Test
+    fun everyRowCarriesTheRateBehindItsText() {
+        val history = oneMinuteCadence(count = 30) { minutesAgo -> 100f + minutesAgo * 2f }
+        val rows = rowsOf(history)
+
+        val deltas = index(history).deltasFor(rows, false, 5)
+
+        val newest = deltas.getValue(rows.first())
+        assertEquals("−10", newest.text)
+        // 10 mg/dL over the five-minute window, falling.
+        assertEquals(-2f, newest.rateMgdlPerMinute, 0.001f)
+        assertTrue("every text carries a rate", deltas.values.all { it.rateMgdlPerMinute.isFinite() })
     }
 
     @Test

--- a/Common/src/test/java/tk/glucodata/ui/ReadingRowArrowBasisTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/ReadingRowArrowBasisTests.kt
@@ -1,0 +1,92 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.logic.TrendEngine
+
+/**
+ * A reading row states one movement twice: as a number and as an arrow. It used to state it
+ * from two different windows — the arrow regressed over the trend engine's window, the Δ
+ * covered the configured interval — so during a reversal a row could read "Δ −5" beside an
+ * arrow pointing up. Both were right about their own question; together they were wrong.
+ */
+class ReadingRowArrowBasisTests {
+
+    private val nowMillis = 1_700_000_000_000L
+    private val minute = 60_000L
+
+    /** Oldest-first, as the pipeline hands history over. */
+    private fun history(vararg valuesNewestLast: Pair<Long, Float>): List<GlucosePoint> =
+        valuesNewestLast.map { (minutesAgo, value) ->
+            GlucosePoint(value = value, time = "", timestamp = nowMillis - minutesAgo * minute)
+        }.sortedBy { it.timestamp }
+
+    private fun regressed(velocity: Float) =
+        TrendEngine.TrendResult(TrendEngine.stateFor(velocity), velocity, 0f, 1f, 0f)
+
+    /** The field case: a fall that the 20-minute regression still reads as a climb. */
+    @Test
+    fun theArrowFollowsTheDeltaBesideIt() {
+        // Climbed for a quarter of an hour, then turned: the regression is still positive
+        // while the last five minutes are clearly down.
+        val points = history(
+            20L to 200f, 15L to 220f, 10L to 240f, 5L to 256f, 0L to 235f,
+        )
+        val deltas = readingDeltas(listOf(nowMillis), points, isMmol = false, deltaIntervalMinutes = 5)
+
+        val delta = deltas.single()
+        assertTrue("the row states a fall", delta!!.text.startsWith("−"))
+        // Same movement as a rate: 21 mg/dL down over five minutes.
+        assertEquals(-21f / 5f, delta.rateMgdlPerMinute, 0.001f)
+
+        val climbing = regressed(velocity = 2.4f)
+        val shown = rowTrendResult(climbing, delta.rateMgdlPerMinute)
+
+        assertTrue("the arrow may not point up beside a fall", shown.velocity < 0f)
+        assertEquals(TrendEngine.TrendState.DoubleDown, shown.state)
+    }
+
+    /** Without a Δ for the row there is no second claim, so the regression stands. */
+    @Test
+    fun withoutADeltaTheRegressionIsKept() {
+        val climbing = regressed(velocity = 2.4f)
+
+        assertSame(climbing, rowTrendResult(climbing, null))
+        assertSame(climbing, rowTrendResult(climbing, Float.NaN))
+    }
+
+    @Test
+    fun theRateIsMilligramsPerMinuteWhateverTheScreenShows() {
+        // 1.1 mmol/L over five minutes is 19.8 mg/dL over five minutes.
+        val points = history(5L to 8.0f, 0L to 9.1f)
+
+        val mmol = readingDeltas(listOf(nowMillis), points, isMmol = true, deltaIntervalMinutes = 5).single()
+
+        assertEquals(1.1f * tk.glucodata.ui.util.GlucoseFormatter.MGDL_PER_MMOL / 5f, mmol!!.rateMgdlPerMinute, 0.05f)
+        assertTrue("the text stays in the unit on screen", mmol.text.contains("1"))
+    }
+
+    /** A one-minute interval is a rate over one minute, not over five. */
+    @Test
+    fun theIntervalSettingIsPartOfTheRate() {
+        val points = history(2L to 100f, 1L to 104f, 0L to 108f)
+
+        val perMinute = readingDeltas(listOf(nowMillis), points, isMmol = false, deltaIntervalMinutes = 1).single()
+
+        assertEquals(4f, perMinute!!.rateMgdlPerMinute, 0.001f)
+    }
+
+    /** The texts are the same ones as before; only their source is now shared. */
+    @Test
+    fun theTextsAreUnchangedByCarryingARate() {
+        val points = history(20L to 200f, 15L to 220f, 10L to 240f, 5L to 256f, 0L to 235f)
+        val anchors = listOf(nowMillis, nowMillis - 5 * minute, nowMillis - 10 * minute)
+
+        val texts = readingDeltaTexts(anchors, points, isMmol = false, deltaIntervalMinutes = 5)
+        val fromDeltas = readingDeltas(anchors, points, isMmol = false, deltaIntervalMinutes = 5).map { it?.text }
+
+        assertEquals(texts, fromDeltas)
+    }
+}


### PR DESCRIPTION
A reading row could read `Δ −5` beside an arrow pointing up, and `Δ +8` beside one pointing down. Both were right about their own question: the arrow regresses over the trend engine's window, around twenty minutes at a five-minute cadence, while the delta covers the configured interval, five minutes by default. Side by side, with nothing saying they are measured over different stretches, a row states a rise and a fall at once. During a sharp reversal, which is when a row is read most carefully, it does exactly that: a dessert answered with thirteen units produced eight rows in a row where the arrow and the number disagreed.

Rows now put the arrow on the same footing as the number, where the number is shown: one walk-back over the pair the delta is computed from serves both, so they cannot come apart. With the delta column switched off nothing is rebased, since there is no second claim to contradict and a display setting should not decide what an arrow means. The hero keeps the longer regression, where steadiness is the point and no competing figure sits beside it. Where a row has no delta to state, from a gap or the start of the data, the regression still draws its arrow, and there is no number next to it to contradict.

Both lists that show a Δ are covered. #212 gave the history screen the same column, and its rows were still drawing the regression beside it, which would have left the dashboard consistent and the history contradicting itself one screen over, with the two lists disagreeing about the same reading. `RowDeltaIndex` computed the rate already and threw it away when it formatted the text. It returns both now, and the history hands the rate to the row the way the dashboard does.

Of the three ways out the report proposes, this is the first, and the reason to prefer it is that nothing is lost: the row keeps both readings, the list keeps its arrows, and the two agree. Dropping the arrow from rows would also have removed the contradiction, but the arrow carries how strongly the value is moving, which is harder to read off a single number. Labelling the two timescales would have been the most honest and the least useful, since it asks somebody to hold two windows in their head at the moment they want one answer.

The alarm had a version of the same split. It drew its own reading, taken at the moment the activity opened, over a wall-clock window of the last twenty minutes, unfiltered by sensor, while the alert had decided on a rate measured over the canonical list. Two readings of the same movement that need not agree, and in the field case did not. The alarm now draws the rate it was fired on, which is already in the intent, and reads its own only when none came with it. Its fallback thresholds, which were not the engine's, are gone with it: below two history points a rate of -0.3 used to draw a tilted arrow and now draws a level one, which is what every other surface does with it.

To be exact about what that does and does not fix: the rate an alert fires on is the same regression, so at the instant of a reversal an alarm can still arrive with an arrow describing the movement that led up to it. What it no longer does is disagree with itself for a reason nobody can see.

`TrendEngine.stateFor` is the engine's own rate-to-arrow mapping, lifted out of the middle of the regression so anything drawing an arrow from a rate it did not measure lands on the same boundaries. It is a pure extraction: same constants, same comparisons, same result for every input including NaN and negative zero. The scope note in the report says not to change the trend engine, and this does not, but the file is in the diff and that is why.

Two consequences worth naming rather than burying. The newest row and the hero can now point differently during a reversal, which is the accepted cost of the option chosen and the reason the hero was left alone. And with the delta interval set to one minute the arrow inherits whatever that minute did, noise included, where the regression used to absorb it; the five minute default is unaffected.

### Tests

Five in `ReadingRowArrowBasisTests`: the reversal from the report, a row without a delta keeping the regression, the rate in mg/dL per minute whatever unit the screen shows, the interval setting being part of the rate, and the delta texts unchanged by now carrying one. `HistoryRowDeltaTests` gains one for the rate arriving alongside the text, its existing cases unchanged. `GlucoseDeltaTests`, `DashboardReadingDeltaTests`, `TrendArrowAngleTests`, `TrendWindowsTests`, `TrendConsumerPointListTests` and the three `logic.Trend*` suites are unchanged and green.

The plain `HIGH` alert still firing during a sustained fall is the other half of the report. It is not here: it is specified to reuse the `fallRateSuppress` field, the prefs key and the settings row that #201 adds for `PERSISTENT_HIGH`, none of which exist on main yet, so it follows as its own change on top of that one rather than duplicating them.

