### PR TITLE
Build: one architecture on request

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -50,6 +50,15 @@ android {
     }
 
     defaultConfig {
+        // Build for one architecture when asked: -PjugglucoAbi=arm64-v8a. A phone needs one
+        // of the four, and the other three are most of the download. Unset, nothing changes
+        // and the APK stays universal, which is what a release has to be.
+        if (project.hasProperty('jugglucoAbi')) {
+            ndk {
+                abiFilters(*project.property('jugglucoAbi').split(',').collect { it.trim() })
+            }
+        }
+
         applicationId "tk.glucodata.ng"
         versionName appVersionName
         versionCode appVersionCode


### PR DESCRIPTION
A release APK carries four ABIs and a phone runs one of them, so three quarters of the native payload is dead weight on any given device, and every local build compiles all four.

`-PjugglucoAbi=arm64-v8a` keeps just that one. Several can be named, separated by commas. Unset, nothing changes: the build is exactly what it was, and a published release stays universal, which it has to be.

Measured on this tree, phone release: 95.7 MB universal, 39.9 MB with `-PjugglucoAbi=arm64-v8a`. The native build is correspondingly shorter, which is the part that shows up on every rebuild while working on something.

If you would rather ship per-architecture downloads than one universal file, `splits { abi { ... } }` is the usual next step, but it changes the release artifact set and version-code handling, so it seemed like your call rather than something to fold in here.
