### PR TITLE
Nightscout follower: the poll wakes the phone, and its interval is a setting

### DIFF
--- a/Common/src/main/AndroidManifest.xml
+++ b/Common/src/main/AndroidManifest.xml
@@ -170,6 +170,10 @@
             android:enabled="true"
             android:exported="false" />
         <receiver
+            android:name=".drivers.nightscout.NightscoutFollowerPollReceiver"
+            android:enabled="true"
+            android:exported="false" />
+        <receiver
             android:name=".drivers.sibionics.SibionicsResetReminderReceiver"
             android:enabled="true"
             android:exported="false" />

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
@@ -1,9 +1,15 @@
 package tk.glucodata.drivers.nightscout
 
+import android.app.AlarmManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
+import android.os.PowerManager
+import android.os.SystemClock
 import java.net.HttpURLConnection
 import java.net.URLEncoder
 import java.net.URL
@@ -35,6 +41,8 @@ class NightscoutFollowerManager(
         private const val SENSOR_GEN = 0
         private const val POLL_INTERVAL_MS = 60_000L
         private const val RETRY_INTERVAL_MS = 30_000L
+        /** A server that is down overnight must not wake the phone twice a minute until morning. */
+        private const val RETRY_BACKOFF_CEILING_MS = 15L * 60_000L
         private const val PROBE_INTERVAL_MS = 59_000L
         private const val DEVICE_STATUS_COUNT = 5
         private const val MMOL_TO_MGDL = 18.0182f
@@ -54,6 +62,7 @@ class NightscoutFollowerManager(
 
     @Volatile private var phase: Phase = Phase.IDLE
     @Volatile private var status: String = localizedString(R.string.nightscout_follow_status_idle, "Nightscout follower idle")
+    @Volatile private var consecutiveFailures: Int = 0
     @Volatile private var lastImportedHistoryTailMs: Long = 0L
     @Volatile private var latestReadingTimeMs: Long = 0L
     @Volatile private var latestReadingMgdl: Float = Float.NaN
@@ -139,6 +148,7 @@ class NightscoutFollowerManager(
 
     override fun close() {
         handler.removeCallbacksAndMessages(null)
+        cancelPollAlarm()
         if (stop) {
             // Permanent shutdown: free() sets stop=true before calling close().
             // Quit the HandlerThread so it doesn't outlive the sensor object.
@@ -156,6 +166,7 @@ class NightscoutFollowerManager(
     override fun softDisconnect() {
         stop = true
         handler.removeCallbacksAndMessages(null)
+        cancelPollAlarm()
         mainHandler.removeCallbacks(probeRunnable)
         NightscoutFollowerDeviceStatus.clear()
         setStatus(Phase.IDLE, localizedString(R.string.nightscout_follow_status_paused, "Nightscout follower paused"))
@@ -198,10 +209,86 @@ class NightscoutFollowerManager(
         UiRefreshBus.requestStatusRefresh()
     }
 
+    /** What the user asked for, read fresh so a change applies from the next poll on. */
+    private fun pollIntervalMillis(): Long =
+        NightscoutFollowerPollPolicy.intervalMillis(
+            NightscoutFollowerRegistry.loadPollMinutes(Applic.app)
+        )
+
+    private fun pollIntent(): PendingIntent? {
+        val app = Applic.app ?: return null
+        val intent = Intent(app, NightscoutFollowerPollReceiver::class.java).apply {
+            action = NightscoutFollowerPollReceiver.ACTION_POLL
+            putExtra(NightscoutFollowerPollReceiver.EXTRA_SERIAL, SerialNumber)
+        }
+        return PendingIntent.getBroadcast(
+            app,
+            SerialNumber.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    /**
+     * The next poll is an alarm, not a delayed message. A handler measures in uptime, which
+     * stops while the phone sleeps, so on a follower phone (nothing else wakes it: no sensor,
+     * no bluetooth) the minute became however long the phone was left alone. An alarm wakes
+     * the device for it.
+     *
+     * An immediate poll stays on the handler: there is nothing to wake for, and it keeps the
+     * connect and reconnect paths as responsive as they were.
+     */
     private fun scheduleRefresh(delayMillis: Long) {
         handler.removeCallbacks(pollRunnable)
-        if (!stop) {
+        if (stop) return
+        if (delayMillis <= 0L) {
+            handler.post(pollRunnable)
+            return
+        }
+        val app = Applic.app
+        val alarms = app?.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+        val pending = pollIntent()
+        if (alarms == null || pending == null) {
             handler.postDelayed(pollRunnable, delayMillis)
+            return
+        }
+        val at = SystemClock.elapsedRealtime() + delayMillis
+        val exact = Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarms.canScheduleExactAlarms()
+        runCatching {
+            if (exact) {
+                alarms.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, at, pending)
+            } else {
+                // Without the exact-alarm permission this is the strongest thing left, and it
+                // still wakes the device; only its timing is the system's to choose.
+                alarms.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, at, pending)
+            }
+        }.onFailure {
+            Log.w(TAG, "Poll alarm refused, falling back to an in-process timer: ${it.message}")
+            handler.postDelayed(pollRunnable, delayMillis)
+        }
+    }
+
+    private fun cancelPollAlarm() {
+        val alarms = Applic.app?.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+        pollIntent()?.let { pending -> runCatching { alarms?.cancel(pending) } }
+    }
+
+    /**
+     * Called from the alarm. The receiver's wakelock is handed over here because the fetch
+     * runs on this driver's thread and outlives onReceive; whatever happens, it is released
+     * once, after the poll has scheduled its successor.
+     */
+    internal fun onPollAlarm(wakelock: PowerManager.WakeLock?) {
+        if (stop) {
+            runCatching { if (wakelock?.isHeld == true) wakelock.release() }
+            return
+        }
+        handler.post {
+            try {
+                refresh("alarm")
+            } finally {
+                runCatching { if (wakelock?.isHeld == true) wakelock.release() }
+            }
         }
     }
 
@@ -219,7 +306,7 @@ class NightscoutFollowerManager(
             refreshRemoteDeviceStatus()
             if (readings.isEmpty()) {
                 setStatus(Phase.IDLE, localizedString(R.string.nightscout_follow_status_no_readings, "No Nightscout readings yet"))
-                scheduleRefresh(POLL_INTERVAL_MS)
+                scheduleRefresh(pollIntervalMillis())
                 return
             }
             if (!fetched.historyImported) {
@@ -239,11 +326,21 @@ class NightscoutFollowerManager(
                 ),
             )
             UiRefreshBus.requestDataRefresh()
-            scheduleRefresh(POLL_INTERVAL_MS)
+            consecutiveFailures = 0
+            scheduleRefresh(pollIntervalMillis())
         } catch (t: Throwable) {
             Log.stack(TAG, "refresh($reason)", t)
             setStatus(Phase.IDLE, localizedString(R.string.nightscout_follow_status_sync_failed, "Nightscout sync failed"))
-            scheduleRefresh(RETRY_INTERVAL_MS)
+            // The first retry stays quick, since most failures are a moment without network.
+            // One that keeps failing doubles its way up to the ceiling instead: a poll now
+            // wakes the phone rather than waiting until something else does, so an unreachable
+            // server would otherwise cost a wake-up every thirty seconds all night. The retry
+            // never waits longer than the interval the user asked for.
+            consecutiveFailures = (consecutiveFailures + 1).coerceAtMost(9)
+            val backoff = (RETRY_INTERVAL_MS shl (consecutiveFailures - 1))
+                .coerceAtMost(RETRY_BACKOFF_CEILING_MS)
+                .coerceAtMost(pollIntervalMillis().coerceAtLeast(RETRY_INTERVAL_MS))
+            scheduleRefresh(backoff)
         }
     }
 

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerPollPolicy.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerPollPolicy.kt
@@ -1,0 +1,45 @@
+package tk.glucodata.drivers.nightscout
+
+/**
+ * How often a follower asks its Nightscout server, and what a stored value is allowed to mean.
+ *
+ * The interval is the follower's whole relationship with the data: a reading that arrived at
+ * the server thirty seconds ago is not on this phone until the next poll, and an alert raised
+ * on a followed value is late by the same amount. So it is a setting rather than a constant,
+ * and the numbers offered are the cadences a CGM source actually publishes at.
+ *
+ * Kept free of Android so the rules can be tested; the manager and the settings screen both
+ * read them from here rather than each having their own idea of what is allowed.
+ */
+object NightscoutFollowerPollPolicy {
+
+    /** What the picker offers, in minutes. */
+    val CHOICES_MINUTES: List<Int> = listOf(1, 2, 5, 10, 15, 30)
+
+    /**
+     * Five minutes: most sources publish on that cadence or slower, and a follower phone has
+     * no sensor of its own keeping it awake, so every poll is a wake-up it pays for. Someone
+     * following a one-minute source, or relying on the follower for alerts, moves it down.
+     */
+    const val DEFAULT_MINUTES: Int = 5
+
+    /**
+     * A stored or hand-edited value that is not on the list is pulled onto the nearest one.
+     * No whole number sits exactly between two of these choices, so nearest is unambiguous
+     * and there is no tie to break.
+     */
+    fun sanitizeMinutes(minutes: Int): Int =
+        CHOICES_MINUTES.minByOrNull { choice -> kotlin.math.abs(choice - minutes) } ?: DEFAULT_MINUTES
+
+    fun intervalMillis(minutes: Int): Long = sanitizeMinutes(minutes) * 60_000L
+
+    /**
+     * What Doze does to this. An allow-while-idle alarm fires at most about every nine
+     * minutes while the phone is idle, unless the app is exempt from battery optimisation.
+     * A shorter interval is therefore a ceiling rather than a promise, which is worth saying
+     * in the settings row instead of leaving someone to wonder why their minute became ten.
+     */
+    const val DOZE_FLOOR_MINUTES: Int = 9
+
+    fun isThrottledByDoze(minutes: Int): Boolean = sanitizeMinutes(minutes) < DOZE_FLOOR_MINUTES
+}

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerPollReceiver.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerPollReceiver.kt
@@ -1,0 +1,55 @@
+package tk.glucodata.drivers.nightscout
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.PowerManager
+import tk.glucodata.Log
+import tk.glucodata.SensorBluetooth
+
+/**
+ * Wake-up for the follower's poll.
+ *
+ * A follower has no sensor of its own, so nothing else wakes the phone on its behalf. The
+ * in-process timer the driver used measures in uptime, which stops while the device sleeps,
+ * so a poll due in a minute happened whenever something else woke the phone instead: the app
+ * being opened, most visibly, which is why a stale follower repaired itself seconds after
+ * being looked at. An alarm wakes the device on its own.
+ *
+ * The alarm's own wakelock ends when this method returns, and the fetch runs on the driver's
+ * thread, so this takes one of its own and hands responsibility for releasing it to the poll.
+ */
+class NightscoutFollowerPollReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "NightscoutFollower"
+        const val ACTION_POLL = "tk.glucodata.drivers.nightscout.ACTION_FOLLOWER_POLL"
+        const val EXTRA_SERIAL = "serial"
+
+        /** Long enough for a slow server, short enough that a lost release cannot drain a phone. */
+        private const val WAKELOCK_TIMEOUT_MS = 60_000L
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_POLL) return
+        val serial = intent.getStringExtra(EXTRA_SERIAL)?.trim().orEmpty()
+        if (serial.isEmpty()) return
+
+        // mygatts() copies under the list's own lock; the list itself is mutated from the
+        // scan and connect paths, which can run while an alarm arrives.
+        val follower = SensorBluetooth.mygatts().firstOrNull { callback ->
+            callback is NightscoutFollowerManager && callback.SerialNumber.equals(serial, ignoreCase = true)
+        } as? NightscoutFollowerManager
+        if (follower == null) {
+            Log.w(TAG, "Poll alarm for $serial with no follower running")
+            return
+        }
+
+        val wakelock = (context.getSystemService(Context.POWER_SERVICE) as? PowerManager)
+            ?.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Juggluco::NightscoutFollowerPoll")
+            ?.apply {
+                setReferenceCounted(false)
+                acquire(WAKELOCK_TIMEOUT_MS)
+            }
+        follower.onPollAlarm(wakelock)
+    }
+}

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
@@ -17,6 +17,7 @@ object NightscoutFollowerRegistry {
     private const val PREF_URL = "nightscout_follower_url"
     private const val PREF_SECRET = "nightscout_follower_secret"
     private const val PREF_COMPLETE_HISTORY_PREFIX = "nightscout_follower_complete_history_v1_"
+    private const val PREF_POLL_MINUTES = "nightscout_follower_poll_minutes"
     const val SENSOR_PREFIX = "NSF-"
 
     data class Config(
@@ -70,6 +71,20 @@ object NightscoutFollowerRegistry {
             .putString(PREF_SECRET, secret?.trim()?.takeIf { it.isNotEmpty() })
             .apply()
         ManagedSensorUiSignals.markDeviceListDirty()
+    }
+
+    /** How often the follower asks, in minutes. Sanitized on the way out and on the way in. */
+    fun loadPollMinutes(context: Context?): Int =
+        context?.let {
+            NightscoutFollowerPollPolicy.sanitizeMinutes(
+                prefs(it).getInt(PREF_POLL_MINUTES, NightscoutFollowerPollPolicy.DEFAULT_MINUTES)
+            )
+        } ?: NightscoutFollowerPollPolicy.DEFAULT_MINUTES
+
+    fun savePollMinutes(context: Context, minutes: Int) {
+        prefs(context).edit()
+            .putInt(PREF_POLL_MINUTES, NightscoutFollowerPollPolicy.sanitizeMinutes(minutes))
+            .apply()
     }
 
     fun persistedSensorIds(context: Context): List<String> =

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2564,4 +2564,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="glucosechartvaluecomplicationlabel">Графік + значэнне</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Графік + значэнне + стрэлка</string>
     <string name="glucosechartfullcomplicationlabel">Графік + значэнне + стрэлка + час</string>
+    <string name="nightscout_follow_interval_title">Правяраць новыя значэнні</string>
+    <string name="nightscout_follow_interval_desc">Як часта падпісчык апытвае сервер. Гэта таксама тое, наколькі старым можа быць значэнне, а значыць і наколькі позна прыйдзе трывога па сачыльным значэнні. У падпісчыка няма свайго сэнсара, які трымаў бы тэлефон абуджаным, таму кожная праверка — гэта абуджэнне.</string>
+    <string name="nightscout_follow_interval_doze">Менш за 9 хвілін Android усё роўна можа разводзіць праверкі, пакуль тэлефон бяздзейнічае. Выключэнне Juggluco з аптымізацыі батарэі захоўвае выбраны інтэрвал.</string>
 </resources>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2536,4 +2536,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="glucosechartvaluecomplicationlabel">Diagramm + Wert</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Diagramm + Wert + Pfeil</string>
     <string name="glucosechartfullcomplicationlabel">Diagramm + Wert + Pfeil + Zeit</string>
+    <string name="nightscout_follow_interval_title">Neue Werte abrufen</string>
+    <string name="nightscout_follow_interval_desc">Wie oft der Follower den Server fragt. Das ist zugleich, wie alt ein Wert sein kann, und damit auch, wie spät ein Alarm auf einen gefolgten Wert kommen kann. Ein Follower hat keinen eigenen Sensor, der das Telefon wach hält, also ist jede Abfrage ein Aufwecken.</string>
+    <string name="nightscout_follow_interval_doze">Unter 9 Minuten kann Android die Abfragen im Ruhezustand trotzdem weiter auseinanderziehen. Juggluco von der Akku-Optimierung auszunehmen hält das eingestellte Intervall.</string>
 </resources>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2503,4 +2503,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="glucosechartvaluecomplicationlabel">Courbe + valeur</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Courbe + valeur + flèche</string>
     <string name="glucosechartfullcomplicationlabel">Courbe + valeur + flèche + heure</string>
+    <string name="nightscout_follow_interval_title">Rechercher de nouvelles valeurs</string>
+    <string name="nightscout_follow_interval_desc">À quelle fréquence le suiveur interroge le serveur. C\'est aussi l\'âge que peut avoir une valeur, et donc le retard possible d\'une alarme déclenchée sur une valeur suivie. Un suiveur n\'a pas de capteur à lui pour garder le téléphone éveillé, donc chaque interrogation est un réveil.</string>
+    <string name="nightscout_follow_interval_doze">En dessous de 9 minutes, Android peut malgré tout espacer les interrogations lorsque le téléphone est inactif. Exclure Juggluco de l\'optimisation de la batterie préserve l\'intervalle choisi.</string>
 </resources>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2487,4 +2487,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="glucosechartvaluecomplicationlabel">Grafico + valore</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Grafico + valore + freccia</string>
     <string name="glucosechartfullcomplicationlabel">Grafico + valore + freccia + ora</string>
+    <string name="nightscout_follow_interval_title">Cerca nuovi valori</string>
+    <string name="nightscout_follow_interval_desc">Ogni quanto il follower interroga il server. È anche quanto può essere vecchio un valore, e quindi quanto può ritardare un allarme su un valore seguito. Un follower non ha un sensore proprio che tenga sveglio il telefono, quindi ogni controllo è un risveglio.</string>
+    <string name="nightscout_follow_interval_doze">Sotto i 9 minuti Android può comunque distanziare i controlli mentre il telefono è inattivo. Escludere Juggluco dall\'ottimizzazione della batteria mantiene l\'intervallo scelto.</string>
 </resources>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2612,4 +2612,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="glucosechartvaluecomplicationlabel">График + утга</string>
     <string name="glucosechartvaluearrowcomplicationlabel">График + утга + сум</string>
     <string name="glucosechartfullcomplicationlabel">График + утга + сум + цаг</string>
+    <string name="nightscout_follow_interval_title">Шинэ утга шалгах</string>
+    <string name="nightscout_follow_interval_desc">Дагагч сервер рүү ямар давтамжтай хандахыг заана. Энэ нь мөн утга хэр хуучин байж болохыг, тиймээс дагасан утган дээр сэрэмжлүүлэг хэр хожуу ирэхийг тодорхойлно. Дагагчид утсыг сэрүүн байлгах өөрийн мэдрэгч байхгүй тул шалгалт бүр нь сэрээх үйлдэл юм.</string>
+    <string name="nightscout_follow_interval_doze">9 минутаас бага бол утас сул зогсож байх үед Android шалгалтуудыг улам сунгаж болно. Juggluco-г батерейны оновчлолоос хасвал сонгосон интервал хэвээр үлдэнэ.</string>
 </resources>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2540,4 +2540,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="glucosechartvaluecomplicationlabel">Grafiek + waarde</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Grafiek + waarde + pijl</string>
     <string name="glucosechartfullcomplicationlabel">Grafiek + waarde + pijl + tijd</string>
+    <string name="nightscout_follow_interval_title">Naar nieuwe waarden kijken</string>
+    <string name="nightscout_follow_interval_desc">Hoe vaak de volger de server bevraagt. Dat is ook hoe oud een waarde kan zijn, en dus hoe laat een alarm op een gevolgde waarde kan komen. Een volger heeft geen eigen sensor die de telefoon wakker houdt, dus elke controle is een wekmoment.</string>
+    <string name="nightscout_follow_interval_doze">Onder 9 minuten kan Android de controles alsnog verder uit elkaar leggen terwijl de telefoon inactief is. Juggluco uitsluiten van batterijoptimalisatie behoudt het gekozen interval.</string>
 </resources>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2531,4 +2531,7 @@
     <string name="glucosechartvaluecomplicationlabel">Wykres + wartość</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Wykres + wartość + strzałka</string>
     <string name="glucosechartfullcomplicationlabel">Wykres + wartość + strzałka + czas</string>
+    <string name="nightscout_follow_interval_title">Sprawdzanie nowych wartości</string>
+    <string name="nightscout_follow_interval_desc">Jak często obserwator odpytuje serwer. To zarazem wiek, jaki może mieć wartość, a więc i opóźnienie alarmu opartego na obserwowanej wartości. Obserwator nie ma własnego sensora, który utrzymywałby telefon wybudzony, więc każde sprawdzenie to wybudzenie.</string>
+    <string name="nightscout_follow_interval_doze">Poniżej 9 minut Android i tak może rozsuwać sprawdzenia, gdy telefon jest bezczynny. Wyłączenie Juggluco z optymalizacji baterii zachowuje wybrany odstęp.</string>
 </resources>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2498,4 +2498,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="glucosechartvaluecomplicationlabel">Gráfico + valor</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Gráfico + valor + seta</string>
     <string name="glucosechartfullcomplicationlabel">Gráfico + valor + seta + hora</string>
+    <string name="nightscout_follow_interval_title">Procurar novos valores</string>
+    <string name="nightscout_follow_interval_desc">Com que frequência o seguidor pergunta ao servidor. É também a idade que um valor pode ter e, portanto, o atraso possível de um alarme baseado num valor seguido. Um seguidor não tem sensor próprio para manter o telemóvel acordado, por isso cada verificação é um despertar.</string>
+    <string name="nightscout_follow_interval_doze">Abaixo de 9 minutos, o Android pode ainda assim afastar as verificações enquanto o telemóvel está inativo. Excluir o Juggluco da otimização da bateria mantém o intervalo escolhido.</string>
 </resources>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2540,4 +2540,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="glucosechartvaluecomplicationlabel">График + значение</string>
     <string name="glucosechartvaluearrowcomplicationlabel">График + значение + стрелка</string>
     <string name="glucosechartfullcomplicationlabel">График + значение + стрелка + время</string>
+    <string name="nightscout_follow_interval_title">Проверять новые значения</string>
+    <string name="nightscout_follow_interval_desc">Как часто подписчик опрашивает сервер. Это же определяет, насколько старым может быть значение, а значит и насколько поздно придёт тревога по отслеживаемому значению. У подписчика нет своего сенсора, который держал бы телефон активным, поэтому каждая проверка — это пробуждение.</string>
+    <string name="nightscout_follow_interval_doze">Меньше 9 минут Android всё равно может разносить проверки, пока телефон простаивает. Исключение Juggluco из оптимизации батареи сохраняет выбранный интервал.</string>
 </resources>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2697,4 +2697,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="glucosechartvaluecomplicationlabel">Garaaf + qiime</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Garaaf + qiime + fallaadh</string>
     <string name="glucosechartfullcomplicationlabel">Garaaf + qiime + fallaadh + waqti</string>
+    <string name="nightscout_follow_interval_title">Hubi qiimayaal cusub</string>
+    <string name="nightscout_follow_interval_desc">Inta jeer ee raacuhu weydiiyo server-ka. Waxay sidoo kale tahay sida uu qiime u duugoobi karo, sidaas darteedna sida uu digniin ku salaysan qiime la raacayo u soo daahi karto. Raacuhu ma laha dareeme u gaar ah oo taleefanka soo jeeda ka dhiga, sidaas darteed hubin kastaa waa toosin.</string>
+    <string name="nightscout_follow_interval_doze">Ka hooseeya 9 daqiiqo, Android weli wuu kala fogayn karaa hubinnada inta taleefanku shaqo la\'yahay. In Juggluco laga saaro wanaajinta baytariga waxay ilaalinaysaa waqtiga aad dooratay.</string>
 </resources>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2497,4 +2497,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="glucosechartvaluecomplicationlabel">Diagram + värde</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Diagram + värde + pil</string>
     <string name="glucosechartfullcomplicationlabel">Diagram + värde + pil + tid</string>
+    <string name="nightscout_follow_interval_title">Leta efter nya värden</string>
+    <string name="nightscout_follow_interval_desc">Hur ofta följaren frågar servern. Det är också hur gammalt ett värde kan vara, och därmed hur sent ett larm på ett följt värde kan komma. En följare har ingen egen sensor som håller telefonen vaken, så varje kontroll är en väckning.</string>
+    <string name="nightscout_follow_interval_doze">Under 9 minuter kan Android ändå glesa ut kontrollerna medan telefonen är inaktiv. Att undanta Juggluco från batterioptimering behåller det valda intervallet.</string>
 </resources>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2525,4 +2525,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="glucosechartvaluecomplicationlabel">Grafik + değer</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Grafik + değer + ok</string>
     <string name="glucosechartfullcomplicationlabel">Grafik + değer + ok + saat</string>
+    <string name="nightscout_follow_interval_title">Yeni değerleri kontrol et</string>
+    <string name="nightscout_follow_interval_desc">Takipçinin sunucuya ne sıklıkla sorduğu. Bu aynı zamanda bir değerin ne kadar eski olabileceği, dolayısıyla takip edilen bir değere dayanan alarmın ne kadar geç gelebileceğidir. Takipçinin telefonu uyanık tutan kendi sensörü yoktur, bu yüzden her kontrol bir uyandırmadır.</string>
+    <string name="nightscout_follow_interval_doze">9 dakikanın altında Android, telefon boştayken kontrolleri yine de aralayabilir. Juggluco\'yu pil optimizasyonundan çıkarmak seçilen aralığı korur.</string>
 </resources>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2569,4 +2569,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="glucosechartvaluecomplicationlabel">Графік + значення</string>
     <string name="glucosechartvaluearrowcomplicationlabel">Графік + значення + стрілка</string>
     <string name="glucosechartfullcomplicationlabel">Графік + значення + стрілка + час</string>
+    <string name="nightscout_follow_interval_title">Перевіряти нові значення</string>
+    <string name="nightscout_follow_interval_desc">Як часто підписник опитує сервер. Це водночас і те, наскільки старим може бути значення, а отже і наскільки пізно надійде тривога за відстежуваним значенням. Підписник не має власного сенсора, який тримав би телефон активним, тож кожна перевірка — це пробудження.</string>
+    <string name="nightscout_follow_interval_doze">Менше 9 хвилин Android усе одно може розсувати перевірки, поки телефон бездіяльний. Виключення Juggluco з оптимізації батареї зберігає вибраний інтервал.</string>
 </resources>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2513,4 +2513,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="glucosechartvaluecomplicationlabel">图表 + 数值</string>
     <string name="glucosechartvaluearrowcomplicationlabel">图表 + 数值 + 箭头</string>
     <string name="glucosechartfullcomplicationlabel">图表 + 数值 + 箭头 + 时间</string>
+    <string name="nightscout_follow_interval_title">检查新数值</string>
+    <string name="nightscout_follow_interval_desc">跟随者向服务器询问的频率。它同时决定数值可能有多旧，因此也决定基于跟随数值的警报可能有多晚。跟随者没有自己的传感器让手机保持唤醒，所以每次检查都是一次唤醒。</string>
+    <string name="nightscout_follow_interval_doze">低于 9 分钟时，手机闲置期间 Android 仍可能拉长检查间隔。将 Juggluco 排除在电池优化之外可保持所选间隔。</string>
 </resources>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1572,6 +1572,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Use Nightscout v3 API</string>
     <string name="nightscout_follow_desc">Create a read-only virtual sensor from this Nightscout URL.</string>
+    <string name="nightscout_follow_interval_title">Check for new values</string>
+    <string name="nightscout_follow_interval_desc">How often the follower asks the server. This is also how late a value can be, so it is how late an alarm raised on a followed value can be. A follower has no sensor of its own to keep the phone awake, so every check is a wake-up.</string>
+    <string name="nightscout_follow_interval_doze">Below 9 minutes, Android may still space checks further apart while the phone is idle. Excluding Juggluco from battery optimisation keeps the interval you chose.</string>
     <string name="nightscout_follow_url_required">Enter a Nightscout URL first</string>
     <string name="nightscout_mode_upload">Upload</string>
     <string name="nightscout_mode_follow">Follow</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material3.FilterChip
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CloudUpload
@@ -74,6 +76,7 @@ import tk.glucodata.Natives
 import tk.glucodata.NightPost
 import tk.glucodata.R
 import tk.glucodata.data.journal.JournalTreatmentUploader
+import tk.glucodata.drivers.nightscout.NightscoutFollowerPollPolicy
 import tk.glucodata.drivers.nightscout.NightscoutFollowerRegistry
 import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.MasterSwitchCard
@@ -434,6 +437,56 @@ fun NightscoutSettingsScreen(navController: NavController) {
                             modifier = Modifier.padding(horizontal = 4.dp)
                         )
                         else -> {}
+                    }
+                }
+            }
+
+            // Follow-only items
+            if (mode == NightscoutMode.FOLLOW) {
+                item("nightscout_follow_interval") {
+                    // How often it asks is the whole of what a follower does, and every poll
+                    // is a wake-up on a phone with no sensor of its own to pay for it.
+                    var pollMinutes by remember {
+                        mutableStateOf(NightscoutFollowerRegistry.loadPollMinutes(context))
+                    }
+                    Card(
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+                        shape = cardShape(CardPosition.SINGLE),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                    ) {
+                        Column(
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 16.dp),
+                            verticalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.nightscout_follow_interval_title),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Text(
+                                text = stringResource(R.string.nightscout_follow_interval_desc),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                NightscoutFollowerPollPolicy.CHOICES_MINUTES.forEach { minutes ->
+                                    FilterChip(
+                                        selected = pollMinutes == minutes,
+                                        onClick = {
+                                            pollMinutes = minutes
+                                            NightscoutFollowerRegistry.savePollMinutes(context, minutes)
+                                        },
+                                        label = { Text(stringResource(R.string.minutes_short_format, minutes)) }
+                                    )
+                                }
+                            }
+                            if (NightscoutFollowerPollPolicy.isThrottledByDoze(pollMinutes)) {
+                                Text(
+                                    text = stringResource(R.string.nightscout_follow_interval_doze),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerPollPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerPollPolicyTests.kt
@@ -1,0 +1,67 @@
+package tk.glucodata.drivers.nightscout
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The interval is the follower's latency and its battery cost at once, so what a stored
+ * number is allowed to mean is worth pinning down: nothing off the list reaches the alarm.
+ */
+class NightscoutFollowerPollPolicyTests {
+
+    @Test
+    fun everyOfferedChoiceSurvivesSanitizing() {
+        NightscoutFollowerPollPolicy.CHOICES_MINUTES.forEach { minutes ->
+            assertEquals(minutes, NightscoutFollowerPollPolicy.sanitizeMinutes(minutes))
+        }
+    }
+
+    @Test
+    fun theDefaultIsOneOfTheChoices() {
+        assertTrue(
+            NightscoutFollowerPollPolicy.DEFAULT_MINUTES in NightscoutFollowerPollPolicy.CHOICES_MINUTES
+        )
+    }
+
+    @Test
+    fun nonsenseIsPulledOntoTheList() {
+        // Zero or negative would be a poll with no wait at all, which is the one outcome a
+        // stored number must never produce.
+        assertEquals(1, NightscoutFollowerPollPolicy.sanitizeMinutes(0))
+        assertEquals(1, NightscoutFollowerPollPolicy.sanitizeMinutes(-30))
+        assertEquals(30, NightscoutFollowerPollPolicy.sanitizeMinutes(Int.MAX_VALUE))
+    }
+
+    @Test
+    fun aValueOffTheListLandsOnTheNearestChoice() {
+        assertEquals(2, NightscoutFollowerPollPolicy.sanitizeMinutes(3))
+        assertEquals(5, NightscoutFollowerPollPolicy.sanitizeMinutes(4))
+        assertEquals(15, NightscoutFollowerPollPolicy.sanitizeMinutes(13))
+        assertEquals(30, NightscoutFollowerPollPolicy.sanitizeMinutes(24))
+    }
+
+    @Test
+    fun noWholeNumberSitsBetweenTwoChoices() {
+        // What lets nearest be unambiguous: every midpoint falls on a half minute.
+        NightscoutFollowerPollPolicy.CHOICES_MINUTES.zipWithNext { low, high ->
+            assertTrue("$low..$high has a whole midpoint", (low + high) % 2 != 0)
+        }
+    }
+
+    @Test
+    fun theIntervalIsTheSanitizedNumberInMillis() {
+        assertEquals(5L * 60_000L, NightscoutFollowerPollPolicy.intervalMillis(5))
+        assertEquals(60_000L, NightscoutFollowerPollPolicy.intervalMillis(0))
+        assertEquals(30L * 60_000L, NightscoutFollowerPollPolicy.intervalMillis(45))
+    }
+
+    @Test
+    fun onlyIntervalsUnderTheDozeFloorAreWarnedAbout() {
+        assertTrue(NightscoutFollowerPollPolicy.isThrottledByDoze(1))
+        assertTrue(NightscoutFollowerPollPolicy.isThrottledByDoze(5))
+        assertFalse(NightscoutFollowerPollPolicy.isThrottledByDoze(10))
+        assertFalse(NightscoutFollowerPollPolicy.isThrottledByDoze(30))
+    }
+}


### PR DESCRIPTION
A follower phone shows "no new value since ..." several times a day, and opening Juggluco clears it within seconds. That second part is the tell: the app did not need to fetch anything it could not have fetched a minute earlier, it needed the phone to be awake.

`NightscoutFollowerManager` scheduled its next poll with `Handler.postDelayed`. That measures in `SystemClock.uptimeMillis()`, which stops advancing in deep sleep, and a plain handler cannot wake the device the way an alarm can. A follower has no sensor of its own and no bluetooth traffic, so nothing else wakes it either: the wakelock in `keeprunning.java` is commented out and the one in `Applic.java` is held only around processing a value. So the sixty seconds became however long the phone was left alone, and opening the app was itself the wake-up that let the pending poll run.

This is worse on a follower than anywhere else in the app precisely because there is no sensor keeping the process busy, which is why it shows up on a partner's phone and not on the one wearing the CGM.

### The poll is an alarm

`setExactAndAllowWhileIdle` on `ELAPSED_REALTIME_WAKEUP`, delivered to a receiver in the shape `ICanHealthReconnectReceiver` already uses. The permissions were already there, `USE_EXACT_ALARM` and `SCHEDULE_EXACT_ALARM` for older versions, and a phone that refuses exact alarms falls back to `setAndAllowWhileIdle`, which still wakes the device and lets the system choose the moment. An immediate refresh stays on the handler, since there is nothing to wake for, and both connect and reconnect keep the responsiveness they had.

The alarm's own wakelock ends when `onReceive` returns, while the fetch is still running on the driver's thread. So the receiver takes one with a timeout and hands it over, and the poll releases it once the next one is scheduled, whatever happened in between. A stopped or disconnected follower cancels its alarm rather than leaving one to fire into nothing.

### Two things follow from the poll being real

A server that is unreachable used to be retried every thirty seconds, which cost nothing while the phone was asleep because the retry did not happen either. Now it would wake the phone twice a minute all night, so retries double from thirty seconds up to a fifteen minute ceiling, never waiting longer than the interval itself, and a success resets them.

And every poll is now a wake-up somebody pays for, so how often it asks is a setting: 1, 2, 5, 10, 15 or 30 minutes. The default is five, the cadence most sources publish at, where a one minute default would have meant 1440 wake-ups a day for data that changed 288 times.

The interval is also how old a value may be, and therefore how late an alert raised on a followed value can be. Somebody following for hypo alerts should choose one minute and pay the battery, and the setting says so rather than leaving it to be found out. Below nine minutes it also says that Android may space checks further apart while the phone is idle unless Juggluco is excluded from battery optimisation, since an allow-while-idle alarm is throttled to roughly that in Doze. Below that, the number is a ceiling rather than a promise.

### Tests

`NightscoutFollowerPollPolicyTests`, seven: every offered choice survives sanitizing, the default is one of them, zero and negative and `Int.MAX_VALUE` land on the list rather than producing a poll with no wait, a value off the list lands on the nearest choice, no whole number sits exactly between two choices so nearest is unambiguous, the interval is the sanitized number in milliseconds, and only intervals under the Doze floor carry the warning. The scheduling itself is `AlarmManager` and a receiver, which the tree has no harness for, so it is read off the log: `Nightscout follower refreshed (alarm)` arriving on the chosen interval with the screen off, and the poll continuing across a sleep the old timer did not survive.

Not yet observed over a long idle stretch on a phone that is not exempt from battery optimisation, where the nine minute throttle rather than the setting decides the cadence.
