### PR TITLE
LibreView: expose account ID without enabling upload

### DIFF
--- a/Common/src/main/cpp/settings/javasettings.cpp
+++ b/Common/src/main/cpp/settings/javasettings.cpp
@@ -1117,9 +1117,7 @@ static jlong getlibreaccountidnumber() {
   const jlong num = settings->data()->libreaccountIDnum;
   if (num != -1LL)
     return num;
-  if (!settings->data()->sendtolibreview) {
-    return 0;
-  }
+  // Libre 3 NFC needs the fetched account ID even when LibreView upload is off.
   auto &accountid = settings->data()->libreviewAccountID;
   uint32_t res = 0;
   for (auto el : accountid) {


### PR DESCRIPTION
## Why

On a fresh install, requesting the LibreView account ID could report success while still showing no numeric ID and blocking a Libre 3 NFC scan. Enabling **Send to LibreView** made the same stored ID appear, after which upload could be disabled again.

That behavior contradicts the existing help text and forces users to enable data upload for an operation that is meant to work independently.

## Root cause

`getlibreAccountIDnumber()` returned `0` whenever `sendtolibreview` was false, even after the explicit account-ID request had authenticated successfully and stored the LibreView account ID.

The lookup thread already has the correct upload-disabled behavior: it performs the requested authentication, stores the ID, and then exits without continuing background upload. The numeric getter was the remaining accidental gate.

## What changed

Remove the upload-preference check from the shared numeric account-ID getter.

This keeps the boundaries narrow:

- the LibreView upload preference is not changed;
- no background upload is enabled or scheduled;
- manual account-ID overrides behave as before;
- Libre 3 NFC and both LibreView setup screens can use the fetched ID while upload remains disabled.

## Benefit

Users who only need their LibreView account ID to take over or scan an existing Libre 3 sensor no longer have to temporarily upload glucose data to LibreView.

## Verification

- Uncached arm64 native build: `./gradlew ':Common:buildCMakeRelWithDebInfo[arm64-v8a]' -PjugglucoAbi=arm64-v8a --rerun-tasks`
- Integrated arm64 release build: `./gradlew :Common:assembleMobileRelease -PjugglucoAbi=arm64-v8a`
- Audited every `getlibreAccountIDnumber()` consumer; Libre 3 NFC and the setup screens all use this shared getter.

End-to-end LibreView authentication and NFC takeover still require a real account and sensor, so reporter/device confirmation remains valuable.

Closes #228