### PR TITLE
Colour the dashboard preview navigator by glucose range

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
@@ -167,6 +167,8 @@ private const val PREVIEW_WINDOW_DURATION_MS = 24L * 60L * 60L * 1000L
 private const val ACTIVE_INSULIN_MAX_WIDTH_FRACTION = 0.46f
 private const val ACTIVE_INSULIN_EXPANDED_MAX_WIDTH_FRACTION = 0.58f
 private val PreviewWindowHeight = 58.dp
+// Band edges soften over this fraction of the preview strip's height.
+private const val PREVIEW_BAND_FADE_FRACTION = 0.025f
 private val PreviewWindowOuterPadding = 12.dp
 
 private data class ChartRangeThresholds(
@@ -213,17 +215,26 @@ private fun chartRangeThresholds(
     )
 }
 
-// The dashboard trace and the preview navigator resolve their five band colors
-// here so both surfaces answer the range-color setting the same way.
+// The five band colors a glucose trace is stroked with. The dashboard resolves
+// this once and hands it to the preview navigator, so the strip cannot drift
+// from the trace above it.
+//
+// [lowTintBase] / [highTintBase] are the out-of-range tones used when the
+// app-range-color setting is off. They are parameters rather than
+// GlucoseRangeColors lookups because the caller owns them: today the dashboard
+// happens to define them as exactly that, but retuning them there must move
+// both surfaces, not silently split them.
 private fun chartRangePalette(
     isDark: Boolean,
     appChartRangeColors: Boolean,
-    primaryColor: Color
+    primaryColor: Color,
+    lowTintBase: Color,
+    highTintBase: Color
 ): ChartRangePalette = ChartRangePalette(
     veryLow = Color(GlucoseRangeColors.veryLow(isDark)),
-    low = Color(GlucoseRangeColors.low(isDark)),
+    low = if (appChartRangeColors) Color(GlucoseRangeColors.low(isDark)) else lowTintBase,
     inRange = if (appChartRangeColors) Color(GlucoseRangeColors.inRange(isDark)) else primaryColor,
-    high = Color(GlucoseRangeColors.high(isDark)),
+    high = if (appChartRangeColors) Color(GlucoseRangeColors.high(isDark)) else highTintBase,
     veryHigh = Color(GlucoseRangeColors.veryHigh(isDark))
 )
 
@@ -361,10 +372,8 @@ private fun PreviewWindowNavigator(
     calibratedValueResolver: CalibratedValueResolver,
     previewCenterTime: Long,
     viewMode: Int,
-    targetLow: Float,
-    targetHigh: Float,
     rangeThresholds: ChartRangeThresholds,
-    appChartRangeColors: Boolean,
+    rangePalette: ChartRangePalette,
     isMmol: Boolean,
     currentCenterTime: Long,
     currentVisibleDuration: Long
@@ -373,7 +382,6 @@ private fun PreviewWindowNavigator(
     val previewHalfDuration = previewDuration / 2
     val previewStart = previewCenterTime - previewHalfDuration
     val previewEnd = previewCenterTime + previewHalfDuration
-    val primaryLineColor = MaterialTheme.colorScheme.primary
     val secondaryLineColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
     val isDark = isSystemInDarkTheme()
     val paletteRevision = GlucosePaletteState.revision
@@ -386,9 +394,6 @@ private fun PreviewWindowNavigator(
     val minimumWindowWidthPx = with(LocalDensity.current) { 12.dp.toPx() }
     val isRawMode = viewMode == 1 || viewMode == 3
     val hasCalibration = calibratedValueResolver.hasCalibration(isRawMode)
-    val previewRangeColors = remember(isDark, appChartRangeColors, primaryLineColor, paletteRevision) {
-        chartRangePalette(isDark, appChartRangeColors, primaryLineColor)
-    }
 
     fun activeValue(index: Int): Float {
         return if (hasCalibration) {
@@ -434,8 +439,8 @@ private fun PreviewWindowNavigator(
                     .let { if (it < 0) -it else it + 1 }
                     .coerceIn(startIdx + 1, renderData.size)
 
-                var minValue = targetLow
-                var maxValue = targetHigh
+                var minValue = rangeThresholds.low
+                var maxValue = rangeThresholds.high
                 for (index in startIdx until endExclusive) {
                     val value = activeValue(index)
                     if (value.isFinite() && value > 0.1f) {
@@ -463,17 +468,26 @@ private fun PreviewWindowNavigator(
 
                 // Same band geometry as the main chart, so the preview reads as a
                 // miniature of the trace above it instead of a flat primary line.
+                // GlucoseChartBands fades a band into the in-range tone over a
+                // fixed pixel distance, tuned for the full-height chart. This
+                // strip squeezes the same value span into ~42.dp, where 18px is
+                // most of a mmol/L: the low tone would start bleeding in around
+                // 4.5 on a 3.5 target, which reads as the preview ignoring the
+                // target range. Fade over a slice of the strip instead.
+                val previewFadePx = (heightPx * PREVIEW_BAND_FADE_FRACTION)
+                    .coerceIn(1f, GlucoseChartBands.DEFAULT_FADE_PX)
                 val rangeStops = GlucoseChartBands.verticalStops(
-                    veryHigh = previewRangeColors.veryHigh,
-                    high = previewRangeColors.high,
-                    inRange = previewRangeColors.inRange,
-                    low = previewRangeColors.low,
-                    veryLow = previewRangeColors.veryLow,
+                    veryHigh = rangePalette.veryHigh,
+                    high = rangePalette.high,
+                    inRange = rangePalette.inRange,
+                    low = rangePalette.low,
+                    veryLow = rangePalette.veryLow,
                     yVeryHigh = valueToY(rangeThresholds.veryHigh),
                     yHigh = valueToY(rangeThresholds.high),
                     yLow = valueToY(rangeThresholds.low),
                     yVeryLow = valueToY(rangeThresholds.veryLow),
-                    chartHeightPx = heightPx
+                    chartHeightPx = heightPx,
+                    fadePx = previewFadePx
                 )
                 val rangeBrush = Brush.verticalGradient(
                     *rangeStops.toTypedArray(),
@@ -481,8 +495,8 @@ private fun PreviewWindowNavigator(
                     endY = heightPx
                 )
 
-                val bandTop = valueToY(targetHigh).coerceIn(0f, heightPx)
-                val bandBottom = valueToY(targetLow).coerceIn(0f, heightPx)
+                val bandTop = valueToY(rangeThresholds.high).coerceIn(0f, heightPx)
+                val bandBottom = valueToY(rangeThresholds.low).coerceIn(0f, heightPx)
                 drawRoundRect(
                     color = targetBandColor,
                     topLeft = Offset(0f, minOf(bandTop, bandBottom)),
@@ -809,6 +823,23 @@ fun InteractiveGlucoseChart(
     // Adjusting alpha for visibility on graph background
     val lowOutOfRangeTintBase = TirLowColor
     val highOutOfRangeTintBase = TirHighColor
+    // Resolved once for the trace and the preview strip below it.
+    val chartBandPalette = remember(
+        isDark,
+        appChartRangeColors,
+        primaryColor,
+        lowOutOfRangeTintBase,
+        highOutOfRangeTintBase,
+        glucosePaletteRevision
+    ) {
+        chartRangePalette(
+            isDark,
+            appChartRangeColors,
+            primaryColor,
+            lowOutOfRangeTintBase,
+            highOutOfRangeTintBase
+        )
+    }
     // Neutral target for desaturating peer (secondary sensor) traces — theme
     // token so it adapts to light/dark and dynamic color.
     val peerNeutralBase = MaterialTheme.colorScheme.onSurfaceVariant
@@ -2160,21 +2191,15 @@ fun InteractiveGlucoseChart(
             // Multi-sensor: the primary trace carries a subtle identity tint so
             // it pairs with its (tinted) values, like the peer traces do.
             val primaryLineTintFraction = if (peerChartSeries.isNotEmpty()) 0.22f else 0f
-            val appRangeDark = isSystemInDarkTheme()
             val gradientBrush = remember(
                 limitYVeryHigh,
                 limitYHigh,
                 limitYLow,
                 limitYVeryLow,
                 chartHeightPx,
-                primaryColor,
-                highOutOfRangeTintBase,
-                lowOutOfRangeTintBase,
+                chartBandPalette,
                 primaryLineTintFraction,
-                primaryIdentityColor,
-                appChartRangeColors,
-                appRangeDark,
-                glucosePaletteRevision
+                primaryIdentityColor
             ) {
                 if (chartHeightPx <= 0f) {
                     Brush.linearGradient(listOf(Color.Transparent, Color.Transparent))
@@ -2188,12 +2213,11 @@ fun InteractiveGlucoseChart(
 
                     // Range-color mode uses the same five effective colors shown
                     // in settings, including every per-band override.
-                    val rangePalette = chartRangePalette(appRangeDark, appChartRangeColors, primaryColor)
-                    val veryHighTint = identityTinted(rangePalette.veryHigh)
-                    val highTint = identityTinted(rangePalette.high)
-                    val lowTint = identityTinted(rangePalette.low)
-                    val veryLowTint = identityTinted(rangePalette.veryLow)
-                    val inRangeTint = identityTinted(rangePalette.inRange)
+                    val veryHighTint = identityTinted(chartBandPalette.veryHigh)
+                    val highTint = identityTinted(chartBandPalette.high)
+                    val lowTint = identityTinted(chartBandPalette.low)
+                    val veryLowTint = identityTinted(chartBandPalette.veryLow)
+                    val inRangeTint = identityTinted(chartBandPalette.inRange)
                     // Stop geometry lives in GlucoseChartBands so the watch's
                     // curve bands on the same lines this one does.
                     val stops = GlucoseChartBands.verticalStops(
@@ -4321,10 +4345,8 @@ fun InteractiveGlucoseChart(
                     calibratedValueResolver = calibratedValueResolver,
                     previewCenterTime = previewCenterTime,
                     viewMode = viewMode,
-                    targetLow = targetLow,
-                    targetHigh = targetHigh,
                     rangeThresholds = rangeThresholds,
-                    appChartRangeColors = appChartRangeColors,
+                    rangePalette = chartBandPalette,
                     isMmol = isMmol,
                     currentCenterTime = centerTime,
                     currentVisibleDuration = visibleDuration

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
@@ -176,6 +176,14 @@ private data class ChartRangeThresholds(
     val veryHigh: Float
 )
 
+private data class ChartRangePalette(
+    val veryLow: Color,
+    val low: Color,
+    val inRange: Color,
+    val high: Color,
+    val veryHigh: Color
+)
+
 private data class PeerSensorChartSeries(
     val sensorId: String,
     val viewMode: Int,
@@ -204,6 +212,20 @@ private fun chartRangeThresholds(
         veryHigh = veryHigh
     )
 }
+
+// The dashboard trace and the preview navigator resolve their five band colors
+// here so both surfaces answer the range-color setting the same way.
+private fun chartRangePalette(
+    isDark: Boolean,
+    appChartRangeColors: Boolean,
+    primaryColor: Color
+): ChartRangePalette = ChartRangePalette(
+    veryLow = Color(GlucoseRangeColors.veryLow(isDark)),
+    low = Color(GlucoseRangeColors.low(isDark)),
+    inRange = if (appChartRangeColors) Color(GlucoseRangeColors.inRange(isDark)) else primaryColor,
+    high = Color(GlucoseRangeColors.high(isDark)),
+    veryHigh = Color(GlucoseRangeColors.veryHigh(isDark))
+)
 
 internal fun coerceChartYToDrawableRange(
     value: Float,
@@ -341,6 +363,8 @@ private fun PreviewWindowNavigator(
     viewMode: Int,
     targetLow: Float,
     targetHigh: Float,
+    rangeThresholds: ChartRangeThresholds,
+    appChartRangeColors: Boolean,
     isMmol: Boolean,
     currentCenterTime: Long,
     currentVisibleDuration: Long
@@ -349,7 +373,7 @@ private fun PreviewWindowNavigator(
     val previewHalfDuration = previewDuration / 2
     val previewStart = previewCenterTime - previewHalfDuration
     val previewEnd = previewCenterTime + previewHalfDuration
-    val lineColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.88f)
+    val primaryLineColor = MaterialTheme.colorScheme.primary
     val secondaryLineColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
     val isDark = isSystemInDarkTheme()
     val paletteRevision = GlucosePaletteState.revision
@@ -362,6 +386,9 @@ private fun PreviewWindowNavigator(
     val minimumWindowWidthPx = with(LocalDensity.current) { 12.dp.toPx() }
     val isRawMode = viewMode == 1 || viewMode == 3
     val hasCalibration = calibratedValueResolver.hasCalibration(isRawMode)
+    val previewRangeColors = remember(isDark, appChartRangeColors, primaryLineColor, paletteRevision) {
+        chartRangePalette(isDark, appChartRangeColors, primaryLineColor)
+    }
 
     fun activeValue(index: Int): Float {
         return if (hasCalibration) {
@@ -434,6 +461,26 @@ private fun PreviewWindowNavigator(
                 fun valueToY(value: Float): Float =
                     heightPx - (((value - minValue) / yRange) * heightPx)
 
+                // Same band geometry as the main chart, so the preview reads as a
+                // miniature of the trace above it instead of a flat primary line.
+                val rangeStops = GlucoseChartBands.verticalStops(
+                    veryHigh = previewRangeColors.veryHigh,
+                    high = previewRangeColors.high,
+                    inRange = previewRangeColors.inRange,
+                    low = previewRangeColors.low,
+                    veryLow = previewRangeColors.veryLow,
+                    yVeryHigh = valueToY(rangeThresholds.veryHigh),
+                    yHigh = valueToY(rangeThresholds.high),
+                    yLow = valueToY(rangeThresholds.low),
+                    yVeryLow = valueToY(rangeThresholds.veryLow),
+                    chartHeightPx = heightPx
+                )
+                val rangeBrush = Brush.verticalGradient(
+                    *rangeStops.toTypedArray(),
+                    startY = 0f,
+                    endY = heightPx
+                )
+
                 val bandTop = valueToY(targetHigh).coerceIn(0f, heightPx)
                 val bandBottom = valueToY(targetLow).coerceIn(0f, heightPx)
                 drawRoundRect(
@@ -479,11 +526,11 @@ private fun PreviewWindowNavigator(
                 val previewStroke = 2.5.dp.toPx()
                 drawPath(
                     path = previewPath,
-                    color = lineColor,
+                    brush = rangeBrush,
                     style = Stroke(width = previewStroke, cap = StrokeCap.Round, join = StrokeJoin.Round)
                 )
                 previewRun.isolatedPoints.forEach { point ->
-                    drawCircle(color = lineColor, radius = previewStroke / 2f, center = point)
+                    drawCircle(brush = rangeBrush, radius = previewStroke / 2f, center = point)
                 }
 
                 val currentStart = currentCenterTime - currentVisibleDuration / 2
@@ -2141,26 +2188,12 @@ fun InteractiveGlucoseChart(
 
                     // Range-color mode uses the same five effective colors shown
                     // in settings, including every per-band override.
-                    val veryHighTint = identityTinted(
-                        if (appChartRangeColors) Color(GlucoseRangeColors.veryHigh(appRangeDark))
-                        else Color(GlucoseRangeColors.veryHigh(isDark))
-                    )
-                    val highTint = identityTinted(
-                        if (appChartRangeColors) Color(GlucoseRangeColors.high(appRangeDark))
-                        else highOutOfRangeTintBase
-                    )
-                    val lowTint = identityTinted(
-                        if (appChartRangeColors) Color(GlucoseRangeColors.low(appRangeDark))
-                        else lowOutOfRangeTintBase
-                    )
-                    val veryLowTint = identityTinted(
-                        if (appChartRangeColors) Color(GlucoseRangeColors.veryLow(appRangeDark))
-                        else Color(GlucoseRangeColors.veryLow(isDark))
-                    )
-                    val inRangeTint = identityTinted(
-                        if (appChartRangeColors) Color(GlucoseRangeColors.inRange(appRangeDark))
-                        else primaryColor
-                    )
+                    val rangePalette = chartRangePalette(appRangeDark, appChartRangeColors, primaryColor)
+                    val veryHighTint = identityTinted(rangePalette.veryHigh)
+                    val highTint = identityTinted(rangePalette.high)
+                    val lowTint = identityTinted(rangePalette.low)
+                    val veryLowTint = identityTinted(rangePalette.veryLow)
+                    val inRangeTint = identityTinted(rangePalette.inRange)
                     // Stop geometry lives in GlucoseChartBands so the watch's
                     // curve bands on the same lines this one does.
                     val stops = GlucoseChartBands.verticalStops(
@@ -4290,6 +4323,8 @@ fun InteractiveGlucoseChart(
                     viewMode = viewMode,
                     targetLow = targetLow,
                     targetHigh = targetHigh,
+                    rangeThresholds = rangeThresholds,
+                    appChartRangeColors = appChartRangeColors,
                     isMmol = isMmol,
                     currentCenterTime = centerTime,
                     currentVisibleDuration = visibleDuration

--- a/Common/src/test/java/tk/glucodata/GlucoseChartBandsTests.kt
+++ b/Common/src/test/java/tk/glucodata/GlucoseChartBandsTests.kt
@@ -1,6 +1,7 @@
 package tk.glucodata
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -117,6 +118,49 @@ class GlucoseChartBandsTests {
             assertTrue("collapsed to ${ascending.size} from $list", ascending.size >= 2)
             assertEquals(ascending.sorted(), ascending)
         }
+    }
+
+    @Test
+    fun aShortStripNeedsAFadeScaledToIt() {
+        // The dashboard's preview navigator squeezes a whole day into ~42.dp.
+        // The shared 18px fade is tuned for the full-height chart; on the strip
+        // it spans most of a mmol/L, so the low tone bleeds well above the
+        // target low and the strip reads as if it ignored the target range.
+        val stripHeight = 115f // ~42.dp at 2.75x
+        val minValue = 2.52f
+        val valueRange = 6.66f
+        fun y(value: Float) = stripHeight - ((value - minValue) / valueRange) * stripHeight
+
+        fun stripStops(fade: Float) = GlucoseChartBands.verticalStops(
+            veryHigh = veryHigh, high = high, inRange = inRange, low = low, veryLow = veryLow,
+            yVeryHigh = y(13.9f), yHigh = y(8.3f), yLow = y(3.5f), yVeryLow = y(3.0f),
+            chartHeightPx = stripHeight, fadePx = fade,
+        )
+
+        // 4.3 sits comfortably inside a 3.5-8.3 target and must read neutral.
+        val sample = y(4.3f) / stripHeight
+        assertTrue(
+            "the shared fade should be the thing that breaks here",
+            sampleAt(stripStops(GlucoseChartBands.DEFAULT_FADE_PX), sample) != inRange
+        )
+        assertEquals(inRange, sampleAt(stripStops(stripHeight * 0.025f), sample))
+    }
+
+    /** The gradient's colour at a normalised position, as a shader would read it. */
+    private fun sampleAt(stops: List<Pair<Float, Color>>, position: Float): Color {
+        if (stops.isEmpty()) return Color.Transparent
+        if (position <= stops.first().first) return stops.first().second
+        if (position >= stops.last().first) return stops.last().second
+        for (index in 0 until stops.size - 1) {
+            val (startAt, startColor) = stops[index]
+            val (endAt, endColor) = stops[index + 1]
+            if (position in startAt..endAt) {
+                val span = endAt - startAt
+                if (span <= 0f) return endColor
+                return lerp(startColor, endColor, (position - startAt) / span)
+            }
+        }
+        return stops.last().second
     }
 
     @Test


### PR DESCRIPTION
The 24 h preview strip under the dashboard chart drew its whole trace in one primary-tinted colour. Scrubbing through it gave no hint of where the lows and highs sat — which is usually the thing you are navigating *to*.

## What changed

`PreviewWindowNavigator` now receives the chart's `ChartRangeThresholds` and the app-range-colours setting, builds the same five-band palette the main trace uses, and strokes the preview path (and its isolated dots) with a `Brush.verticalGradient` built from `GlucoseChartBands.verticalStops` instead of a flat colour. Because the preview scales its own y-axis, the stops are computed from the preview's `valueToY`, so the bands land on the right pixels there too.

Palette edits apply live: `GlucosePaletteState.revision` is in the `remember` key.

## The shared helper

The five-colour selection the main trace already did is pulled out into `chartRangePalette()` so both surfaces resolve the bands identically.

That extraction is behaviour-preserving. The old non-app-range fallbacks were `highOutOfRangeTintBase` / `lowOutOfRangeTintBase`, which are `TirHighColor` / `TirLowColor` — already defined as `Color(GlucoseRangeColors.high(isDark))` and `Color(GlucoseRangeColors.low(isDark))`, exactly what the helper returns. `appRangeDark` and `isDark` are both `isSystemInDarkTheme()` in that composable, so collapsing them onto one parameter changes nothing.

One deliberate visual change: the preview's in-range colour is now `colorScheme.primary` rather than `primary.copy(alpha = 0.88f)`, matching the main chart.

## Verification

- `./gradlew :Common:compileMobileDebugKotlin` — clean
- `./gradlew :Common:testMobileDebugUnitTest` — green
- `git diff --check` — clean

Not yet checked on a device; that is the reason this is a draft.

One file, 58 insertions / 23 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)