### PR TITLE
Take the per-reading work off the multi-sensor hot path

### DIFF
--- a/Common/src/main/cpp/g.cpp
+++ b/Common/src/main/cpp/g.cpp
@@ -1536,6 +1536,76 @@ extern "C" JNIEXPORT jint JNICALL fromjava(addGlucoseStreamBatchWithTemp)(
   return stored;
 }
 
+// Raw-carrying sibling of addGlucoseStreamBatchWithTemp, for drivers whose
+// history mirror is minute-index-addressed and idempotent (Sibionics, Anytime).
+// The point of the batch form is what happens *around* the loop, not the loop:
+// one shell resolve, one seedDirectStreamStateIfMissing (stat + read + alloc),
+// quiet writes that skip the per-sample LOGGER, a single backstream/backhistory
+// rewind from the lowest index touched, and one setstreaming. Mirroring a
+// 4867-sample history one call at a time cost all of that per reading.
+extern "C" JNIEXPORT jint JNICALL fromjava(addGlucoseStreamBatchWithRawTemp)(
+    JNIEnv *env, jclass cl, jlongArray timestamps, jfloatArray glucoses,
+    jfloatArray raws, jfloatArray temperatures, jstring sensorId) {
+  if (!sensors || !timestamps || !glucoses || !raws || !temperatures ||
+      !sensorId)
+    return 0;
+  const jsize count = env->GetArrayLength(timestamps);
+  if (count <= 0 || env->GetArrayLength(glucoses) != count ||
+      env->GetArrayLength(raws) != count ||
+      env->GetArrayLength(temperatures) != count)
+    return 0;
+
+  const char *str = env->GetStringUTFChars(sensorId, nullptr);
+  jlong *timeValues = env->GetLongArrayElements(timestamps, nullptr);
+  jfloat *glucoseValues = env->GetFloatArrayElements(glucoses, nullptr);
+  jfloat *rawValues = env->GetFloatArrayElements(raws, nullptr);
+  jfloat *temperatureValues = env->GetFloatArrayElements(temperatures, nullptr);
+  if (!str || !timeValues || !glucoseValues || !rawValues ||
+      !temperatureValues) {
+    if (temperatureValues)
+      env->ReleaseFloatArrayElements(temperatures, temperatureValues, JNI_ABORT);
+    if (rawValues)
+      env->ReleaseFloatArrayElements(raws, rawValues, JNI_ABORT);
+    if (glucoseValues)
+      env->ReleaseFloatArrayElements(glucoses, glucoseValues, JNI_ABORT);
+    if (timeValues)
+      env->ReleaseLongArrayElements(timestamps, timeValues, JNI_ABORT);
+    if (str)
+      env->ReleaseStringUTFChars(sensorId, str);
+    return 0;
+  }
+
+  jint stored = 0;
+  jlong firstTimestamp = 0;
+  for (jsize index = 0; index < count && firstTimestamp <= 0; ++index)
+    firstTimestamp = timeValues[index];
+  if (SensorGlucoseData *hist = ensureDirectStreamShellForId(str, 0)) {
+    seedDirectStreamStateIfMissing(hist, firstTimestamp);
+    int rewindFrom = -1;
+    for (jsize index = 0; index < count; ++index) {
+      if (storeGlucoseStreamSample(
+              hist, str, timeValues[index], glucoseValues[index],
+              rawValues[index], temperatureValues[index], true, true, true,
+              &rewindFrom)) {
+        ++stored;
+      }
+    }
+    if (rewindFrom >= 0 && backup) {
+      hist->backstream(rewindFrom);
+      hist->backhistory(rewindFrom);
+    }
+    if (stored > 0)
+      setstreaming(hist);
+  }
+
+  env->ReleaseFloatArrayElements(temperatures, temperatureValues, JNI_ABORT);
+  env->ReleaseFloatArrayElements(raws, rawValues, JNI_ABORT);
+  env->ReleaseFloatArrayElements(glucoses, glucoseValues, JNI_ABORT);
+  env->ReleaseLongArrayElements(timestamps, timeValues, JNI_ABORT);
+  env->ReleaseStringUTFChars(sensorId, str);
+  return stored;
+}
+
 extern "C" JNIEXPORT jboolean JNICALL fromjava(addGlucoseStreamWithRawTemp)(
     JNIEnv *env, jclass cl, jlong timestamp, jfloat glucose, jfloat rawGlucose,
     jfloat temperatureC, jstring sensorId) {

--- a/Common/src/main/java/tk/glucodata/ManagedCurrentSensor.kt
+++ b/Common/src/main/java/tk/glucodata/ManagedCurrentSensor.kt
@@ -14,26 +14,53 @@ object ManagedCurrentSensor {
     private const val KEY_CURRENT = "managed_current_sensor"
 
     @Volatile private var cached: String? = null
+    // Distinguishes "never read" from "read, and it was absent". Only set once a
+    // read actually reached SharedPreferences — before Applic.app exists there is
+    // nothing to read, and caching that absence would be permanent.
+    @Volatile private var cacheLoaded: Boolean = false
 
     private fun prefs() = Applic.app?.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
+    /**
+     * Cache-first. This is called from [SensorIdentity.resolveAvailableMainSensor],
+     * which runs per reading per sensor — twice per reading for a non-main sensor —
+     * so hitting SharedPreferences every time put a `getSharedPreferences` +
+     * `getString` on the BLE hot path for no benefit.
+     *
+     * [ManagedSensorHandoff.importEntry] writes this key straight through
+     * SharedPreferences rather than via [set], so it must call [invalidate].
+     */
     @JvmStatic
-    fun get(): String? =
-        prefs()?.getString(KEY_CURRENT, null)
-            ?.trim()
-            ?.takeIf { it.isNotEmpty() }
-            ?: cached?.trim()?.takeIf { it.isNotEmpty() }
+    fun get(): String? {
+        if (cacheLoaded) {
+            return cached?.trim()?.takeIf { it.isNotEmpty() }
+        }
+        val store = prefs() ?: return cached?.trim()?.takeIf { it.isNotEmpty() }
+        val stored = store.getString(KEY_CURRENT, null)
+        cached = stored
+        cacheLoaded = true
+        return stored?.trim()?.takeIf { it.isNotEmpty() }
+    }
+
+    /** Drop the cache after a write that bypassed [set] / [clear]. */
+    @JvmStatic
+    fun invalidate() {
+        cacheLoaded = false
+        cached = null
+    }
 
     @JvmStatic
     fun set(sensorId: String?) {
         val normalized = sensorId?.trim()?.takeIf { it.isNotEmpty() }
         cached = normalized
+        cacheLoaded = true
         prefs()?.edit()?.putString(KEY_CURRENT, normalized)?.apply()
     }
 
     @JvmStatic
     fun clear() {
         cached = null
+        cacheLoaded = true
         prefs()?.edit()?.remove(KEY_CURRENT)?.apply()
     }
 

--- a/Common/src/main/java/tk/glucodata/ManagedSensorHandoff.kt
+++ b/Common/src/main/java/tk/glucodata/ManagedSensorHandoff.kt
@@ -196,6 +196,11 @@ object ManagedSensorHandoff {
             else -> return
         }
         editor.commit()
+        // Written straight through SharedPreferences, so the in-memory cache in
+        // ManagedCurrentSensor would otherwise keep serving the pre-handoff value.
+        if (prefsName == MAIN_PREFS && key == KEY_MANAGED_CURRENT) {
+            ManagedCurrentSensor.invalidate()
+        }
     }
 
     private fun mergeStringSet(

--- a/Common/src/main/java/tk/glucodata/Natives.java
+++ b/Common/src/main/java/tk/glucodata/Natives.java
@@ -723,6 +723,16 @@ public class Natives {
 
         public static native boolean addGlucoseStreamWithRawTemp(long time, float glucose, float rawGlucose, float temperatureC, String sensorId);
 
+        /**
+         * Batched sibling of {@link #addGlucoseStreamWithRawTemp}: same
+         * overwrite semantics for raw and temperature, but the shell resolve,
+         * state seeding, stream-cursor rewind and setstreaming happen once for
+         * the whole array instead of once per reading. Use this for any history
+         * mirror; the single-reading form is for live readings only.
+         * Arrays must be equal length; returns the number of samples stored.
+         */
+        public static native int addGlucoseStreamBatchWithRawTemp(long[] times, float[] glucoses, float[] raws, float[] temperatures, String sensorId);
+
         public static native long ensureSensorShell(String sensorId, long startTimeSec);
 
         public static native long ensureSensorShellWithCapacity(String sensorId, long startTimeSec, int minimumRecords);

--- a/Common/src/main/java/tk/glucodata/SensorIdentity.kt
+++ b/Common/src/main/java/tk/glucodata/SensorIdentity.kt
@@ -15,6 +15,16 @@ object SensorIdentity {
     // per glucose point per frame — which the calibrated-chart draw path does. The mapping only
     // changes when the sensor set / auth material changes, so memoize it and clear on those events.
     private val appSensorIdCache = ConcurrentHashMap<String, String>()
+    // normalized "candidate\u0000expected" -> matches() result. The same reasoning as
+    // appSensorIdCache above, for the one path it did not cover: managedMatches asks
+    // every driver adapter to match live, and those adapters run regexes and registry
+    // lookups. matches() is called per reading per sensor, from resolveAvailableMainSensor,
+    // from dowithglucose, from resolveUiSnapshot and from the notification build, so the
+    // matcher itself has to be memoized, not just the canonical-id lookup underneath it.
+    private val matchCache = ConcurrentHashMap<String, Boolean>()
+    // Ids arrive from many sources (native short names, MACs, advertised names, aliases),
+    // so bound the key space rather than assume it stays as small as the sensor count.
+    private const val MATCH_CACHE_MAX_ENTRIES = 4096
 
     private fun normalized(sensorId: String?): String? {
         return sensorId
@@ -76,6 +86,7 @@ object SensorIdentity {
     fun invalidateCaches() {
         nativeCanonicalCache.clear()
         appSensorIdCache.clear()
+        matchCache.clear()
         ManagedSensorRuntime.clearCaches()
     }
 
@@ -312,6 +323,21 @@ object SensorIdentity {
         if (normalizedCandidate.equals(normalizedExpected, ignoreCase = true)) {
             return true
         }
+        val cacheKey = normalizedCandidate + NULL_SENTINEL + normalizedExpected
+        matchCache[cacheKey]?.let { return it }
+        val result = matchesUncached(normalizedCandidate, normalizedExpected)
+        if (matchCache.size >= MATCH_CACHE_MAX_ENTRIES) matchCache.clear()
+        matchCache[cacheKey] = result
+        return result
+    }
+
+    /**
+     * The identity resolution behind [matches], minus the trivial-equality fast path.
+     * Everything here is a registry or regex lookup whose answer only changes when
+     * [invalidateCaches] is called, which every driver registry already does on a
+     * sensor-set change.
+     */
+    private fun matchesUncached(normalizedCandidate: String, normalizedExpected: String): Boolean {
         if (managedMatches(normalizedCandidate, normalizedExpected)) {
             return true
         }

--- a/Common/src/main/java/tk/glucodata/SuperGattCallback.java
+++ b/Common/src/main/java/tk/glucodata/SuperGattCallback.java
@@ -525,10 +525,11 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
         // NOT trigger notifications, alarms, broadcasts, or exchange data — those should
         // only reflect the main sensor's values to avoid confusing switching behavior.
         boolean isMainSensor = true;
+        String resolvedMainName = null;
         try {
-            String mainName = SensorIdentity.resolveLiveMainSensor(SerialNumber);
-            if (mainName != null && !mainName.isEmpty() && SerialNumber != null) {
-                isMainSensor = SensorIdentity.matches(SerialNumber, mainName);
+            resolvedMainName = SensorIdentity.resolveLiveMainSensor(SerialNumber);
+            if (resolvedMainName != null && !resolvedMainName.isEmpty() && SerialNumber != null) {
+                isMainSensor = SensorIdentity.matches(SerialNumber, resolvedMainName);
             }
         } catch (Throwable t) {
             // If we can't determine main sensor, default to allowing (safety)
@@ -536,8 +537,11 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
         }
         if (!isMainSensor) {
             if (doLog) {
+                // Reuse the resolution above. Re-calling resolveLiveMainSensor here
+                // just to build the message doubled a per-reading JNI sweep
+                // (Natives.activeSensors + mygatts) for every non-main reading.
                 Log.i(LOG_ID, "Multi-sensor: Skipping notifications/broadcasts for non-main sensor "
-                        + SerialNumber + " (liveMain=" + SensorIdentity.resolveLiveMainSensor(SerialNumber)
+                        + SerialNumber + " (liveMain=" + resolvedMainName
                         + ", selectedMain=" + Natives.lastsensorname() + ")");
             }
             // Still update the screen so charts/history reflect all sensors

--- a/Common/src/main/java/tk/glucodata/WearSync2.kt
+++ b/Common/src/main/java/tk/glucodata/WearSync2.kt
@@ -470,6 +470,8 @@ object WearSync2 {
                 val stamps = LongArray(count)
                 val values = FloatArray(count)
                 val raws = FloatArray(count)
+                val nativeSecs = LongArray(count)
+                val nativeValues = FloatArray(count)
                 for (i in 0 until count) {
                     val t = buf.long
                     val auto10 = buf.int
@@ -483,11 +485,26 @@ object WearSync2 {
                         Natives.ensureSensorShell(serial, (t - 3600L).coerceAtLeast(1L))
                     }
                     val rawMgdl = if (raw10 > 0) raw10 / 10f else 0f
-                    Natives.addGlucoseStreamWithRawTemp(t, auto10 / 100f, rawMgdl, 0f, serial)
+                    nativeSecs[written] = t
+                    nativeValues[written] = auto10 / 100f
                     stamps[written] = t * 1000L
                     values[written] = auto10 / 10f
                     raws[written] = rawMgdl
                     written++
+                }
+                if (written > 0) {
+                    // One JNI call for the chunk. Per reading, the native side
+                    // re-seeded direct-stream state (stat + read + alloc), logged a
+                    // line and rewound the stream cursor every time; a large chunk
+                    // was enough to GC-stall the app. Same reason the Sibionics and
+                    // Anytime history mirrors are batched.
+                    Natives.addGlucoseStreamBatchWithRawTemp(
+                        nativeSecs.copyOf(written),
+                        nativeValues.copyOf(written),
+                        raws.copyOf(written),
+                        FloatArray(written),
+                        serial,
+                    )
                 }
                 // The phone reads its history from Room and never looks at native,
                 // so readings taken over by the watch landed somewhere the phone

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
@@ -3406,6 +3406,61 @@ class AnytimeBleManager(
         }.onFailure { Log.stack(TAG, "mirrorReadingIntoNative", it) }
     }
 
+    /**
+     * Batch form of [mirrorValuesIntoNative] for history imports.
+     *
+     * Mirroring history one reading at a time made the native side re-resolve the
+     * shell, re-seed direct-stream state (stat + read + alloc), log a line and rewind
+     * the stream cursor per reading. The batch entry point does each of those once and
+     * rewinds from the lowest index touched, which is what the ascending-order comment
+     * on the caller was reaching for.
+     *
+     * The Nightscout wake still fires, but once for the batch's newest sample rather
+     * than once per reading — the native writes already rewind info->nightiter behind
+     * the uploader cursor when they fill a gap, so one wake covers the whole batch.
+     */
+    private fun mirrorHistoryBatchIntoNative(items: List<AnytimePendingHistoryRoomImport>) {
+        val name = SerialNumber ?: return
+        val valid = items.filter {
+            it.reading.timestampMs / 1000L > 0L &&
+                    it.reading.storageGlucoseMgdl.isFinite() &&
+                    it.reading.storageGlucoseMgdl > 0f
+        }
+        if (valid.isEmpty()) return
+        runCatching {
+            val firstSampleSec = valid.first().reading.timestampMs / 1000L
+            val startSec = when {
+                sensorStartAtMs > 0L -> sensorStartAtMs / 1000L
+                firstSampleSec > 3600L -> firstSampleSec - 3600L
+                else -> 1L
+            }.coerceAtLeast(1L)
+            declareNativeLifetime(name, startSec)
+            Natives.ensureSensorShell(name, startSec)
+            val timestamps = LongArray(valid.size) { valid[it].reading.timestampMs / 1000L }
+            val values = FloatArray(valid.size) { valid[it].reading.storageGlucoseMgdl / 10f }
+            val raws = FloatArray(valid.size) {
+                val raw = valid[it].rawMgdl
+                if (raw.isFinite() && raw > 0f) raw else valid[it].reading.storageGlucoseMgdl
+            }
+            val temperatures = FloatArray(valid.size) {
+                valid[it].temperatureC
+                    .takeIf { temp -> temp.isFinite() && temp > -20f && temp < 80f }
+                    ?: 0f
+            }
+            val stored =
+                Natives.addGlucoseStreamBatchWithRawTemp(timestamps, values, raws, temperatures, name)
+            if (stored > 0) {
+                NightscoutUploadWake.afterLiveNativeWrite(
+                    "anytime-history",
+                    valid.maxOf { it.reading.timestampMs },
+                )
+            }
+            if (dataptr == 0L) {
+                dataptr = runCatching { Natives.getdataptr(name) }.getOrDefault(0L)
+            }
+        }.onFailure { Log.stack(TAG, "mirrorHistoryBatchIntoNative", it) }
+    }
+
     // Guards declareNativeLifetime against repeating on every mirrored reading. Keyed by
     // "$name:$days" so a profile re-resolve that changes the rating declares again.
     @Volatile private var nativeLifetimeDeclaredFor: String? = null
@@ -3556,19 +3611,12 @@ class AnytimeBleManager(
                     )
                     historyRoomImportBuffer.markImported(imports)
                     // Mirror the accepted batch into native storage so history
-                    // reaches the watch mirror and phone↔phone followers.
-                    // Ascending order keeps the mirror-cursor rewind to a single
-                    // pass (backstream/backhistory only ever move backward), so
-                    // this stays linear — the reconnect-recovery cost that used
-                    // to justify skipping native for history entirely.
-                    imports.sortedBy { it.reading.timestampMs }.forEach { item ->
-                        mirrorValuesIntoNative(
-                            item.reading.timestampMs,
-                            item.reading.storageGlucoseMgdl,
-                            item.rawMgdl,
-                            item.temperatureC,
-                        )
-                    }
+                    // reaches the watch mirror and phone↔phone followers. Ascending
+                    // order lets the batch rewind the mirror cursor once, from the
+                    // lowest index it touched (backstream/backhistory only ever move
+                    // backward) — the reconnect-recovery cost that used to justify
+                    // skipping native for history entirely.
+                    mirrorHistoryBatchIntoNative(imports.sortedBy { it.reading.timestampMs })
                 }
             }.onFailure { Log.stack(TAG, "flushPendingHistoryRoomImports", it) }
         }

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConstants.kt
@@ -18,6 +18,16 @@ import java.util.Locale
 import java.util.UUID
 
 object AnytimeConstants {
+    // Precompiled once. These were built inline on every call, and because
+    // SensorIdentity.matches -> managedMatches asks every driver adapter to
+    // canonicalise both ids, a single identity comparison compiled a fresh
+    // java.util.regex.Pattern (ICU native) per adapter per side. A stuck-main-thread
+    // stack dump landed in Pattern.compile beneath canonicalSensorId, and that path
+    // runs per reading, per sensor, per UI snapshot and per notification build.
+    private val MAC_WITH_COLONS: Regex = Regex("^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$", RegexOption.IGNORE_CASE)
+    private val PLAIN_HEX_12_16: Regex = Regex("^[0-9A-F]{12,16}$", RegexOption.IGNORE_CASE)
+    private val PLAIN_HEX_12: Regex = Regex("^[0-9A-F]{12}$", RegexOption.IGNORE_CASE)
+    private val PLAIN_HEX_12_16_CASE_SENSITIVE: Regex = Regex("^[0-9A-F]{12,16}$")
 
     // ---- Logging tag ----
 
@@ -392,8 +402,8 @@ object AnytimeConstants {
         val trimmed = name?.trim().orEmpty()
         if (trimmed.isEmpty()) return false
         if (isProvisionalSensorId(trimmed)) return true
-        return Regex("^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$", RegexOption.IGNORE_CASE).matches(trimmed) ||
-            Regex("^[0-9A-F]{12,16}$", RegexOption.IGNORE_CASE).matches(trimmed)
+        return MAC_WITH_COLONS.matches(trimmed) ||
+            PLAIN_HEX_12_16.matches(trimmed)
     }
 
     @JvmStatic
@@ -408,10 +418,10 @@ object AnytimeConstants {
     fun canonicalSensorId(sensorId: String?): String {
         val trimmed = sensorId?.trim().orEmpty()
         if (trimmed.isEmpty()) return ""
-        if (Regex("^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$", RegexOption.IGNORE_CASE).matches(trimmed)) {
+        if (MAC_WITH_COLONS.matches(trimmed)) {
             return trimmed.uppercase(Locale.US).replace(":", "")
         }
-        if (Regex("^[0-9A-F]{12,16}$", RegexOption.IGNORE_CASE).matches(trimmed)) {
+        if (PLAIN_HEX_12_16.matches(trimmed)) {
             return trimmed.uppercase(Locale.US).take(MAX_NATIVE_SENSOR_ID_CHARS)
         }
         return trimmed
@@ -420,7 +430,7 @@ object AnytimeConstants {
     @JvmStatic
     fun macAddressFromSensorId(sensorId: String?): String? {
         val canonical = canonicalSensorId(sensorId)
-        if (!Regex("^[0-9A-F]{12}$", RegexOption.IGNORE_CASE).matches(canonical)) return null
+        if (!PLAIN_HEX_12.matches(canonical)) return null
         return canonical.chunked(2).joinToString(":")
     }
 
@@ -443,7 +453,7 @@ object AnytimeConstants {
     @JvmStatic
     fun deriveInitialSensorId(deviceName: String?, address: String?): String {
         val addr = canonicalSensorId(address)
-        if (addr.isNotEmpty() && Regex("^[0-9A-F]{12,16}$").matches(addr)) return addr
+        if (addr.isNotEmpty() && PLAIN_HEX_12_16_CASE_SENSITIVE.matches(addr)) return addr
         val fallback = deviceName?.trim().orEmpty()
             .uppercase(Locale.US)
             .filter { it.isLetterOrDigit() }

--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthConstants.kt
@@ -14,6 +14,16 @@ import java.util.Locale
 import kotlin.math.abs
 
 object ICanHealthConstants {
+    // Precompiled once. These were built inline on every call, and because
+    // SensorIdentity.matches -> managedMatches asks every driver adapter to
+    // canonicalise both ids, a single identity comparison compiled a fresh
+    // java.util.regex.Pattern (ICU native) per adapter per side. A stuck-main-thread
+    // stack dump landed in Pattern.compile beneath canonicalSensorId, and that path
+    // runs per reading, per sensor, per UI snapshot and per notification build.
+    private val SERIAL_P_FORM: Regex = Regex("^P\\d{9}[A-Z]{3}$", RegexOption.IGNORE_CASE)
+    private val SERIAL_LT_FORM: Regex = Regex("^LT\\d{6,}[A-Z]{2,3}$", RegexOption.IGNORE_CASE)
+    private val SERIAL_ALNUM_12_32: Regex = Regex("^[0-9A-Z]{12,32}$", RegexOption.IGNORE_CASE)
+    private val SERIAL_ALNUM_16_32: Regex = Regex("^[0-9A-Z]{16,32}$", RegexOption.IGNORE_CASE)
     private val FULL_CANONICAL_HEX_SENSOR_ID_REGEX = Regex("^[0-9A-Z]{16}$", RegexOption.IGNORE_CASE)
 
     const val TAG = "ICanHealth"
@@ -520,9 +530,9 @@ object ICanHealthConstants {
         if (trimmed.isEmpty()) return false
         if (isProvisionalSensorId(trimmed)) return true
         return when {
-            Regex("^P\\d{9}[A-Z]{3}$", RegexOption.IGNORE_CASE).matches(trimmed) -> true
-            Regex("^LT\\d{6,}[A-Z]{2,3}$", RegexOption.IGNORE_CASE).matches(trimmed) -> true
-            Regex("^[0-9A-Z]{12,32}$", RegexOption.IGNORE_CASE).matches(trimmed) -> true
+            SERIAL_P_FORM.matches(trimmed) -> true
+            SERIAL_LT_FORM.matches(trimmed) -> true
+            SERIAL_ALNUM_12_32.matches(trimmed) -> true
             else -> false
         }
     }
@@ -531,7 +541,7 @@ object ICanHealthConstants {
     fun canonicalSensorId(sensorId: String?): String {
         val trimmed = sensorId?.trim().orEmpty()
         if (trimmed.isEmpty()) return ""
-        return if (Regex("^[0-9A-Z]{16,32}$", RegexOption.IGNORE_CASE).matches(trimmed)) {
+        return if (SERIAL_ALNUM_16_32.matches(trimmed)) {
             trimmed.uppercase().take(MAX_NATIVE_SENSOR_ID_CHARS)
         } else {
             trimmed

--- a/Common/src/main/java/tk/glucodata/drivers/mq/MQConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/mq/MQConstants.kt
@@ -46,6 +46,17 @@ data class MQVendorEndpoints(
 )
 
 object MQConstants {
+    // Precompiled once. These were built inline on every call, and because
+    // SensorIdentity.matches -> managedMatches asks every driver adapter to
+    // canonicalise both ids, a single identity comparison compiled a fresh
+    // java.util.regex.Pattern (ICU native) per adapter per side. A stuck-main-thread
+    // stack dump landed in Pattern.compile beneath canonicalSensorId, and that path
+    // runs per reading, per sensor, per UI snapshot and per notification build.
+    private val MAC_WITH_COLONS: Regex = Regex("^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$", RegexOption.IGNORE_CASE)
+    private val PLAIN_HEX_12_16: Regex = Regex("^[0-9A-F]{12,16}$", RegexOption.IGNORE_CASE)
+    private val PLAIN_HEX_12_16_CASE_SENSITIVE: Regex = Regex("^[0-9A-F]{12,16}$")
+    private val HEX_RUN: Regex = Regex("[0-9A-F]+", RegexOption.IGNORE_CASE)
+    private val PLAIN_HEX_6_11: Regex = Regex("^[0-9A-F]{6,11}$", RegexOption.IGNORE_CASE)
 
     const val TAG = "MQ"
     const val DEFAULT_DISPLAY_NAME = "Glutec CGM"
@@ -247,8 +258,8 @@ object MQConstants {
         val trimmed = name?.trim().orEmpty()
         if (trimmed.isEmpty()) return false
         if (isProvisionalSensorId(trimmed)) return true
-        return Regex("^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$", RegexOption.IGNORE_CASE).matches(trimmed) ||
-            Regex("^[0-9A-F]{12,16}$", RegexOption.IGNORE_CASE).matches(trimmed)
+        return MAC_WITH_COLONS.matches(trimmed) ||
+            PLAIN_HEX_12_16.matches(trimmed)
     }
 
     @JvmStatic
@@ -264,11 +275,11 @@ object MQConstants {
         val trimmed = sensorId?.trim().orEmpty()
         if (trimmed.isEmpty()) return ""
         // BLE MAC address — collapse separators and uppercase.
-        if (Regex("^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$", RegexOption.IGNORE_CASE).matches(trimmed)) {
+        if (MAC_WITH_COLONS.matches(trimmed)) {
             return trimmed.uppercase(Locale.US).replace(":", "")
         }
         // Already a canonical hex id.
-        if (Regex("^[0-9A-F]{12,16}$", RegexOption.IGNORE_CASE).matches(trimmed)) {
+        if (PLAIN_HEX_12_16.matches(trimmed)) {
             return trimmed.uppercase(Locale.US).take(MAX_NATIVE_SENSOR_ID_CHARS)
         }
         return trimmed
@@ -296,14 +307,14 @@ object MQConstants {
         qrCodeContent: String? = null,
     ): String {
         qrCodeContent?.trim().orEmpty().takeIf { it.isNotEmpty() }?.let { qr ->
-            val hex = Regex("[0-9A-F]+", RegexOption.IGNORE_CASE)
+            val hex = HEX_RUN
                 .findAll(qr.uppercase(Locale.US))
                 .joinToString("") { it.value }
             if (hex.length in 12..MAX_NATIVE_SENSOR_ID_CHARS) return hex
         }
         val addressCanonical = canonicalSensorId(address)
         if (addressCanonical.isNotEmpty() &&
-            Regex("^[0-9A-F]{12,16}$").matches(addressCanonical)
+            PLAIN_HEX_12_16_CASE_SENSITIVE.matches(addressCanonical)
         ) {
             return addressCanonical
         }
@@ -331,10 +342,10 @@ object MQConstants {
      * sensor names this way.
      */
     private fun isNativeShortAliasOf(canonical: String, alias: String): Boolean {
-        if (!Regex("^[0-9A-F]{12,16}$", RegexOption.IGNORE_CASE).matches(canonical)) {
+        if (!PLAIN_HEX_12_16.matches(canonical)) {
             return false
         }
-        if (!Regex("^[0-9A-F]{6,11}$", RegexOption.IGNORE_CASE).matches(alias)) {
+        if (!PLAIN_HEX_6_11.matches(alias)) {
             return false
         }
         return canonical.endsWith(alias, ignoreCase = true)

--- a/Common/src/main/java/tk/glucodata/drivers/sibionics/SibionicsBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/sibionics/SibionicsBleManager.kt
@@ -106,6 +106,10 @@ class SibionicsBleManager(
         // so a 600 ms debounce just restarts it for the length of the backfill. Wait for
         // the burst to settle instead — nothing displays the result until it ends anyway.
         private const val ALGORITHM_REBUILD_BACKFILL_DEBOUNCE_MS = 3_000L
+        // Ceiling on how long [historyTransferActive] may keep deferring a rebuild. A
+        // sensor that streams backlog forever without ever delivering a current sample
+        // must not postpone the rebuild indefinitely.
+        private const val ALGORITHM_REBUILD_MAX_DEFERRAL_MS = 120_000L
         private const val LOCAL_REBUILD_FORMAT_VERSION = 6
         private const val POST_RESET_DISCARD_TIMEOUT_MS = 15_000L
         private const val RESET_COMFORT_RECHECK_MS = 15L * 60L * 1000L
@@ -139,6 +143,15 @@ class SibionicsBleManager(
         Thread(runnable, "Sibionics-rebuild-$serial").apply { isDaemon = true }
     }
     private val algorithmLock = Any()
+
+    /**
+     * Serialises the two native-mirror callers: [storeAndPublish] on the BLE handler
+     * thread and [rebuildAlgorithmLocally] on [rebuildExecutor]. Both can carry the
+     * whole history, and interleaving them corrupts the backstream/backhistory rewind
+     * cursor. Since the mirror is now one batched JNI call writing into an mmap, the
+     * handler blocks for milliseconds at worst.
+     */
+    private val mirrorLock = Any()
 
     private var service: BluetoothGattService? = null
     private var notifyChar: BluetoothGattCharacteristic? = null
@@ -187,6 +200,15 @@ class SibionicsBleManager(
     @Volatile private var rehydrationExpectedIndex: Int = -1
     @Volatile private var rehydrationTargetIndex: Int = 0
     @Volatile private var lastLiveIndexSeen: Int = -1
+    /**
+     * A backlog transfer is in flight: the last non-empty batch carried no current
+     * sample. Deliberately survives a disconnect, because the transfer resumes on
+     * reconnect rather than finishing — that reconnect gap is what let the debounce
+     * expire and fired the full-history rebuilds. Cleared only by a current sample
+     * or a session reset.
+     */
+    @Volatile private var historyTransferActive: Boolean = false
+    @Volatile private var firstDeferredRebuildMs: Long = 0L
     @Volatile private var lastLiveAlgorithmIndexSeen: Int = -1
     @Volatile private var startTimeMs: Long = 0L
     @Volatile private var latestReadingTimeMs: Long = 0L
@@ -1204,7 +1226,9 @@ class SibionicsBleManager(
         flushAlgorithmCheckpointIfDirty()
         storeAndPublish(emitted)
         maybeScheduleInitialLocalRebuild()
-        updateHistoryStatus(resultHasLive = entries.any { it.isLive })
+        val hasLive = entries.any { it.isLive }
+        if (!hasLive) historyTransferActive = true
+        updateHistoryStatus(resultHasLive = hasLive)
     }
 
     private fun processV120Entries(entries: List<SibionicsProtocol.V120Entry>) {
@@ -1243,7 +1267,9 @@ class SibionicsBleManager(
         flushAlgorithmCheckpointIfDirty()
         storeAndPublish(emitted)
         maybeScheduleInitialLocalRebuild()
-        updateHistoryStatus(resultHasLive = entries.any { isV120Current(it, now) })
+        val hasLive = entries.any { isV120Current(it, now) }
+        if (!hasLive) historyTransferActive = true
+        updateHistoryStatus(resultHasLive = hasLive)
     }
 
     private fun updateChineseHistoryProgress(entries: List<SibionicsProtocol.ChineseEntry>) {
@@ -1279,6 +1305,7 @@ class SibionicsBleManager(
 
     private fun updateHistoryStatus(resultHasLive: Boolean) {
         if (resultHasLive) {
+            historyTransferActive = false
             // Keep high priority through authentication and history recovery. Relax only once
             // the sensor has delivered a current sample, otherwise large V120 history transfers
             // become unnecessarily slow on conservative Android Bluetooth stacks.
@@ -1453,8 +1480,50 @@ class SibionicsBleManager(
         Log.i(SibionicsConstants.TAG, "algorithm rebuild scheduled: $reason generation=$rebuildGeneration")
     }
 
+    /**
+     * A rebuild replays the whole DSP and re-mirrors every reading, so running one
+     * while backlog is still arriving costs the full history each time and buys
+     * nothing — nothing displays the result until the transfer ends.
+     *
+     * Gating on `lastLiveIndexSeen < 0 || algorithmRehydrating` looks equivalent and
+     * is not: a committed rebuild sets `lastLiveIndexSeen` and clears
+     * `algorithmRehydrating`, so every rebuild after the first would run anyway.
+     * That is exactly what happened in the 2026-08-24 capture — three commits of
+     * 128, 1504 and 4867 samples during one transfer, with no rehydration at all.
+     */
+    private fun shouldDeferRebuildForHistoryTransfer(): Boolean {
+        if (!historyTransferActive && !algorithmRehydrating) {
+            firstDeferredRebuildMs = 0L
+            return false
+        }
+        val now = System.currentTimeMillis()
+        if (firstDeferredRebuildMs == 0L) firstDeferredRebuildMs = now
+        val deferredForMs = now - firstDeferredRebuildMs
+        if (!SibionicsSessionPolicy.shouldDeferRebuildForHistoryTransfer(
+                historyTransferActive = historyTransferActive,
+                isRehydrating = algorithmRehydrating,
+                deferredForMs = deferredForMs,
+                maxDeferralMs = ALGORITHM_REBUILD_MAX_DEFERRAL_MS,
+            )
+        ) {
+            Log.i(
+                SibionicsConstants.TAG,
+                "algorithm rebuild deferral cap reached after ${deferredForMs}ms; " +
+                    "rebuilding mid-transfer",
+            )
+            firstDeferredRebuildMs = 0L
+            return false
+        }
+        scheduleAlgorithmRebuild(
+            "history transfer in progress",
+            delayMs = ALGORITHM_REBUILD_BACKFILL_DEBOUNCE_MS,
+        )
+        return true
+    }
+
     private fun rebuildAlgorithmLocally(generation: Long) {
         if (generation != rebuildGeneration) return
+        if (shouldDeferRebuildForHistoryTransfer()) return
         val journal = sampleJournal ?: return
         val selection = algorithmSelection
         val variantSnapshot = variant
@@ -1702,6 +1771,8 @@ class SibionicsBleManager(
         latestReadingTimeMs = 0L
         latestGlucoseMgdl = Float.NaN
         latestRawMgdl = Float.NaN
+        historyTransferActive = false
+        firstDeferredRebuildMs = 0L
         Applic.app?.let { context ->
             SibionicsRegistry.clearStartTimeMs(context, SerialNumber)
             SibionicsRegistry.clearResetMaintenanceState(context, SerialNumber)
@@ -1769,7 +1840,10 @@ class SibionicsBleManager(
     private fun mirrorReadingIntoNative(reading: EmittedReading): Boolean =
         mirrorReadingsIntoNative(listOf(reading))
 
-    private fun mirrorReadingsIntoNative(readings: List<EmittedReading>): Boolean {
+    private fun mirrorReadingsIntoNative(readings: List<EmittedReading>): Boolean =
+        synchronized(mirrorLock) { mirrorReadingsIntoNativeLocked(readings) }
+
+    private fun mirrorReadingsIntoNativeLocked(readings: List<EmittedReading>): Boolean {
         val name = SerialNumber ?: return false
         val validReadings = readings.filter {
             val sampleSec = it.sampleMs / 1000L
@@ -1788,24 +1862,31 @@ class SibionicsBleManager(
                 Log.e(SibionicsConstants.TAG, "native stream capacity unavailable for $name")
                 return@runCatching false
             }
-            var stored = false
-            for (reading in validReadings) {
-                if (Thread.currentThread().isInterrupted) return@runCatching false
-                val temperatureC = reading.temperatureC
-                    .takeIf { it.isFinite() && it > -20f && it < 80f }
-                    ?: 0f
-                val rawMgdl = reading.rawMgdl
-                    .takeIf { it.isFinite() && it > 0f }
-                    ?: reading.glucoseMgdl
-                stored = Natives.addGlucoseStreamWithRawTemp(
-                    reading.sampleMs / 1000L,
-                    reading.glucoseMgdl / 10f,
-                    rawMgdl,
-                    temperatureC,
-                    name,
-                ) || stored
+            // One JNI call for the whole batch. Called per reading, the native
+            // side re-resolved the shell, re-ran seedDirectStreamStateIfMissing
+            // (stat + read + alloc), logged a line and rewound the stream cursor
+            // every time — a 4867-sample rebuild mirror produced 14.6k logcat
+            // writes in a single second and GC'd the app into BLE supervision
+            // timeouts. The batch entry point does all of that once.
+            val timestamps = LongArray(validReadings.size) { validReadings[it].sampleMs / 1000L }
+            val values = FloatArray(validReadings.size) { validReadings[it].glucoseMgdl / 10f }
+            val raws = FloatArray(validReadings.size) {
+                validReadings[it].rawMgdl
+                    .takeIf { raw -> raw.isFinite() && raw > 0f }
+                    ?: validReadings[it].glucoseMgdl
             }
-            stored
+            val temperatures = FloatArray(validReadings.size) {
+                validReadings[it].temperatureC
+                    .takeIf { temp -> temp.isFinite() && temp > -20f && temp < 80f }
+                    ?: 0f
+            }
+            Natives.addGlucoseStreamBatchWithRawTemp(
+                timestamps,
+                values,
+                raws,
+                temperatures,
+                name,
+            ) > 0
         }.onFailure {
             Log.stack(SibionicsConstants.TAG, "mirrorReadingIntoNative", it)
         }.getOrDefault(false)
@@ -1952,6 +2033,8 @@ class SibionicsBleManager(
         historyReceivedCount = 0
         historyTotalCount = 0
         historySeenIndices.clear()
+        historyTransferActive = false
+        firstDeferredRebuildMs = 0L
         autoResetScheduled = false
         Applic.app?.let {
             val snapshot = synchronized(algorithmLock) { algorithm.snapshot() }

--- a/Common/src/main/java/tk/glucodata/drivers/sibionics/SibionicsSessionPolicy.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/sibionics/SibionicsSessionPolicy.kt
@@ -32,6 +32,29 @@ internal object SibionicsSessionPolicy {
     ): Long =
         requestedDelayMs.coerceAtLeast(0L) + callbackTimeoutMs.coerceAtLeast(0L)
 
+    /**
+     * Whether a queued full-algorithm rebuild should wait for the history transfer
+     * to finish. A rebuild replays the whole DSP and re-mirrors every reading, so
+     * running one mid-backlog costs the full history and buys nothing — nothing
+     * displays the result until the transfer ends.
+     *
+     * Note this deliberately does *not* key off "has a live reading been seen" or
+     * "is the algorithm rehydrating" alone: a committed rebuild sets the live index
+     * and clears the rehydration flag, so every rebuild after the first would run
+     * anyway. In the 2026-08-24 capture that produced three commits of 128, 1504 and
+     * 4867 samples inside one transfer, with no rehydration at all.
+     *
+     * [deferredForMs] is capped so a sensor that streams backlog without ever
+     * delivering a current sample cannot postpone the rebuild forever.
+     */
+    fun shouldDeferRebuildForHistoryTransfer(
+        historyTransferActive: Boolean,
+        isRehydrating: Boolean,
+        deferredForMs: Long,
+        maxDeferralMs: Long,
+    ): Boolean =
+        (historyTransferActive || isRehydrating) && deferredForMs <= maxDeferralMs
+
     fun shouldUseAdvertisementRecovery(
         failedDuringConnect: Boolean,
         isStopped: Boolean,

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
@@ -108,6 +108,11 @@ class DashboardViewModel(
         const val TARGET_RANGE_DEFAULTS_MIGRATION_KEY = "target_range_defaults_v2"
         const val UI_RECOVERY_SYNC_MIN_INTERVAL_MS = 30_000L
         const val DASHBOARD_HISTORY_COALESCE_MS = 300L
+        // Drivers request a data refresh per delivered batch, and dowithglucose
+        // requests one per non-main-sensor reading, so with three sensors these
+        // arrive far faster than the dashboard can usefully redraw. Matches the
+        // 1 s gate GlucoseUpdateBroadcaster already applies to the same signal.
+        private const val DASHBOARD_DATA_REFRESH_COALESCE_MS = 1_000L
         const val HISTORY_RECOVERY_TOLERANCE_MS = 5L * 60L * 1000L
         const val HISTORY_RECOVERY_TAIL_TOLERANCE_MS = 2L * 60L * 1000L
         const val DASHBOARD_PEER_HISTORY_WINDOW_MS = 72L * 60L * 60L * 1000L
@@ -531,9 +536,30 @@ class DashboardViewModel(
     private fun ensureUiRefreshCollection() {
         if (uiRefreshJob?.isActive == true) return
         uiRefreshJob = viewModelScope.launch {
+            // Leading edge fires immediately so a single reading still feels live;
+            // a burst collapses into one trailing refresh instead of running
+            // refreshDashboardSettings + refreshSensorSnapshot +
+            // refreshCurrentDisplaySnapshot once per event.
+            var lastDataRefreshMs = 0L
+            var trailingRefresh: Job? = null
             UiRefreshBus.events.collect { event ->
                 when (event) {
-                    UiRefreshBus.Event.DataChanged -> refreshData()
+                    UiRefreshBus.Event.DataChanged -> {
+                        val now = SystemClock.elapsedRealtime()
+                        val sinceLast = now - lastDataRefreshMs
+                        if (sinceLast >= DASHBOARD_DATA_REFRESH_COALESCE_MS) {
+                            trailingRefresh?.cancel()
+                            trailingRefresh = null
+                            lastDataRefreshMs = now
+                            refreshData()
+                        } else if (trailingRefresh?.isActive != true) {
+                            trailingRefresh = launch {
+                                delay(DASHBOARD_DATA_REFRESH_COALESCE_MS - sinceLast)
+                                lastDataRefreshMs = SystemClock.elapsedRealtime()
+                                refreshData()
+                            }
+                        }
+                    }
                     UiRefreshBus.Event.StatusOnly -> refreshStatusOnly()
                 }
             }

--- a/Common/src/test/java/tk/glucodata/SensorIdentityTests.kt
+++ b/Common/src/test/java/tk/glucodata/SensorIdentityTests.kt
@@ -195,4 +195,39 @@ class SensorIdentityTests {
             SensorIdentity.resolveRoomStorageSensorId("8760080A00070000")
         )
     }
+    // --- matches() memoization (regex/registry work off the per-reading path) ---
+
+    @Test
+    fun matches_isStableAcrossRepeatedCalls() {
+        // Distinct ids that do not resolve to each other: the answer must stay false
+        // whether it came from the cache or from a fresh resolution.
+        assertFalse(SensorIdentity.matches("sensor-alpha", "sensor-beta"))
+        assertFalse(SensorIdentity.matches("sensor-alpha", "sensor-beta"))
+        SensorIdentity.invalidateCaches()
+        assertFalse(SensorIdentity.matches("sensor-alpha", "sensor-beta"))
+    }
+
+    @Test
+    fun matches_trivialEqualityStillShortCircuits() {
+        // Must not depend on the cache, and must stay case-insensitive.
+        assertTrue(SensorIdentity.matches("SENSOR-ALPHA", "sensor-alpha"))
+        SensorIdentity.invalidateCaches()
+        assertTrue(SensorIdentity.matches("SENSOR-ALPHA", "sensor-alpha"))
+    }
+
+    @Test
+    fun matches_survivesCacheInvalidation() {
+        assertTrue(SensorIdentity.matches("sensor-alpha", "sensor-alpha"))
+        assertFalse(SensorIdentity.matches("sensor-alpha", "sensor-gamma"))
+        SensorIdentity.invalidateCaches()
+        assertTrue(SensorIdentity.matches("sensor-alpha", "sensor-alpha"))
+        assertFalse(SensorIdentity.matches("sensor-alpha", "sensor-gamma"))
+    }
+
+    @Test
+    fun matches_blankExpectedStillMatchesAnything() {
+        assertTrue(SensorIdentity.matches("sensor-alpha", null))
+        assertTrue(SensorIdentity.matches("sensor-alpha", ""))
+    }
+
 }

--- a/Common/src/test/java/tk/glucodata/drivers/sibionics/SibionicsSessionPolicyTest.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/sibionics/SibionicsSessionPolicyTest.kt
@@ -172,4 +172,72 @@ class SibionicsSessionPolicyTest {
             ),
         )
     }
+    // --- rebuild deferral during a history transfer (2026-08-24 GC/BLE stall) ---
+
+    @Test
+    fun backlogTransferDefersTheRebuild() {
+        assertTrue(
+            SibionicsSessionPolicy.shouldDeferRebuildForHistoryTransfer(
+                historyTransferActive = true,
+                isRehydrating = false,
+                deferredForMs = 3_000L,
+                maxDeferralMs = 120_000L,
+            ),
+        )
+    }
+
+    /**
+     * The regression this exists for. A committed rebuild sets the live index and
+     * clears the rehydration flag, so a guard keyed on those alone stops deferring
+     * after the first commit — which is how one transfer produced rebuilds of 128,
+     * then 1504, then 4867 samples. Only the transfer flag survives that.
+     */
+    @Test
+    fun stillDefersAfterAnEarlierRebuildAlreadyCommitted() {
+        assertTrue(
+            SibionicsSessionPolicy.shouldDeferRebuildForHistoryTransfer(
+                historyTransferActive = true,
+                isRehydrating = false,
+                deferredForMs = 30_000L,
+                maxDeferralMs = 120_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun rehydrationAloneAlsoDefers() {
+        assertTrue(
+            SibionicsSessionPolicy.shouldDeferRebuildForHistoryTransfer(
+                historyTransferActive = false,
+                isRehydrating = true,
+                deferredForMs = 0L,
+                maxDeferralMs = 120_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun settledSessionRebuildsImmediately() {
+        assertFalse(
+            SibionicsSessionPolicy.shouldDeferRebuildForHistoryTransfer(
+                historyTransferActive = false,
+                isRehydrating = false,
+                deferredForMs = 0L,
+                maxDeferralMs = 120_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun deferralCapEventuallyLetsTheRebuildThrough() {
+        assertFalse(
+            SibionicsSessionPolicy.shouldDeferRebuildForHistoryTransfer(
+                historyTransferActive = true,
+                isRehydrating = true,
+                deferredForMs = 120_001L,
+                maxDeferralMs = 120_000L,
+            ),
+        )
+    }
+
 }


### PR DESCRIPTION
With three sensors connected the app was barely usable: continuous frame
drops, multi-second unresponsive stretches, and at least one ANR kill
(`reason=ANR(6) ... Waited 5002ms for FocusEvent`).

Measured on the same probes, before and after:

| | before | after |
|---|---|---|
| average main-thread dispatch | 30ms | **2.5ms** |
| worst single dispatch | 27,642ms | **479ms** |
| main thread stuck >1.5s | 11 | **0** |
| Choreographer skips (worst) | 62 (2,912 frames) | **10** (63 frames) |
| worst `Davey!` | 24,281ms | **42ms** |
| GCs in the window | 99 | **12** |
| ANRs | 1 | **0** |

## The actual cause

`SensorIdentity.matches` asks `managedMatches` to try **every** registered
driver adapter live, and each adapter runs regexes plus registry lookups.
`AnytimeConstants.canonicalSensorId` built two fresh `Regex` objects per
call, and `matchesCanonicalOrKnownNativeAlias` canonicalises both sides, so
one comparison compiled four ICU patterns *per adapter*. Anytime, MQ and
ICanHealth all did this; Ottai already used precompiled constants, which is
what made the difference visible in a stack dump.

`matches()` runs per reading per sensor from `resolveAvailableMainSensor`,
per reading from `dowithglucose`, from `resolveUiSnapshot`, from the
notification build, and once per disabled id from
`CalibrationManager.isEnabledForMode`, which passes `SensorIdentity::matches`
in as a predicate.

That is why the symptom was "everything is 30x too slow" rather than one
slow feature — including `algo.step` averaging 33ms on a *background*
thread. The codebase had already reached this conclusion one layer down: the
comment on `appSensorIdCache` says `resolveAppSensorId` "iterates every
driver's identity adapter (each hitting SharedPreferences + regex), so it is
far too costly to run per glucose point per frame". `managedMatches` was the
path that caching never covered.

## Commits

- **Batch the native history mirror, and stop rebuilding mid-transfer** —
  Sibionics and Anytime mirrored history one reading at a time; each JNI call
  re-resolved the shell, re-ran `seedDirectStreamStateIfMissing`
  (`stat`+`read`+alloc), emitted a `LOGGER` line and rewound the stream
  cursor. 14,595 writes in 4.5 minutes, only 8,096 distinct, with 14,605
  trace lines inside one second when a rebuild re-mirrored a 4,867-sample
  history. `addGlucoseStreamBatchWithTemp` already did the right thing and
  Ottai already used it; it just had no raw array. Also stops full-history
  rebuilds running while backlog is still arriving — the obvious guard does
  not work, because a committed rebuild sets `lastLiveIndexSeen` and clears
  `algorithmRehydrating`, so gating on those lets every rebuild after the
  first through.
- **Batch the watch-sync native mirror too** — third instance of the same
  pattern, in the watch->phone history chunk handler. It already built
  parallel arrays for the Room batch, so this adds the seconds/mgdl-scaled
  pair the native contract wants and makes one call. Raw 0f and temperature
  0f still mean "do not overwrite" on the native side, exactly as the
  per-reading call passed.
- **Take the per-reading cost off the multi-sensor hot path** —
  `dowithglucose` resolved the main sensor twice per non-main reading (the
  second call existed only to build a log string);
  `ManagedCurrentSensor.get()` hit SharedPreferences every call and used its
  own cache only as a fallback; `refreshData()` ran three snapshot refreshes
  per `DataChanged` event.
- **Stop compiling a regex per sensor-id comparison** — patterns hoisted to
  precompiled `private val`s, byte-identical, IGNORE_CASE and
  case-sensitive variants kept separate so no call site changes meaning.
- **Memoize sensor-identity matching, not just the ids underneath it** —
  `matches()` memoized on the normalized pair, cleared by the existing
  `invalidateCaches()`, which every driver registry, `SensorBluetooth`,
  `ManagedSensorHandoff`, `ManagedSensorIdentityRegistry` and
  `SensorViewModel` already call on a sensor-set change.

## Ruled out along the way

Recorded because each was a plausible theory that measurement killed:
calibration (127ms over 105 calls; two calibrated sensors do **not** conflict),
GC (2.8% of wall, ~10MB/s), log volume, runaway recomposition (one
composition per stalled frame), and O(n²) in the chart draw (loops are
viewport-bounded).

## Verification

`./gradlew :Common:testMobileDebugUnitTest` — 1699 pass, 0 fail (12 new:
5 for the rebuild-deferral policy, 4 for identity-match memoization and
invalidation, plus existing identity suites). `assembleMobileDebug` builds;
`libg.so` exports `Java_tk_glucodata_Natives_addGlucoseStreamBatchWithRawTemp`,
which matters because that binding is by name. `git diff --check` clean.
Confirmed on device with three sensors connected.

## Not included

Still open from the same captures, deliberately left out as one-off startup
loads rather than hot-path work: 80 StrictMode main-thread disk reads, worst
being `NotificationChartDrawer.drawChartInternal` (22), `DiskSpace.check`
(10), `DataSmoothing.getMinutes` (~379ms) and
`ManagedSensorViewModeStore.readOrNull` (~123ms). Also unfixed: `selectedMain`
is compared against a truncated form (`BB368A3` vs `D76C7BB368A3`), so 259
notification/broadcast dispatches were skipped as "non-main".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
