### PR TITLE
Keep dashboard chart expansion on its own gesture

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChartExpansionGestureGate.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChartExpansionGestureGate.kt
@@ -1,0 +1,37 @@
+package tk.glucodata.ui
+
+/**
+ * Keeps chart expansion owned by a deliberate pull-down gesture that began at
+ * the top of the dashboard. Fling/animation deltas and gestures that merely
+ * reach the top remain part of the list scroll that produced them.
+ */
+internal class DashboardChartExpansionGestureGate {
+    private var gestureActive = false
+    private var startedAtTop = false
+    private var expansionIntent = false
+    private var intentResolved = false
+
+    fun onGestureStarted(startedAtTop: Boolean, chartExpanded: Boolean) {
+        gestureActive = true
+        this.startedAtTop = startedAtTop
+        expansionIntent = startedAtTop && chartExpanded
+        intentResolved = chartExpanded || !startedAtTop
+    }
+
+    /** The first direct scroll delta decides whether a collapsed chart may expand. */
+    fun onDirectScrollDelta(deltaY: Float) {
+        if (!gestureActive || intentResolved || deltaY == 0f) return
+        expansionIntent = startedAtTop && deltaY > 0f
+        intentResolved = true
+    }
+
+    fun allowsExpansion(directUserInput: Boolean): Boolean =
+        directUserInput && gestureActive && expansionIntent
+
+    fun onGestureEnded() {
+        gestureActive = false
+        startedAtTop = false
+        expansionIntent = false
+        intentResolved = false
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -1033,12 +1034,16 @@ fun DashboardScreen(
             val maxChartBoostPx = with(density) { maxChartBoostDp.toPx() }
 
             val chartBoostState = rememberSaveable { mutableFloatStateOf(0f) }
+            val chartExpansionGestureGate = remember { DashboardChartExpansionGestureGate() }
 
             val scope = rememberCoroutineScope()
 
             val nestedScrollConnection = remember(maxChartBoostPx, middleChartBoostPx, listState) {
                 object : NestedScrollConnection {
                     override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                        if (source == NestedScrollSource.UserInput) {
+                            chartExpansionGestureGate.onDirectScrollDelta(available.y)
+                        }
                         // Dragging UP (scroll delta < 0): Shrink chart first.
                         // 100% absorption means chart shrinks EXACTLY as finger moves, keeping top fixed.
                         // Once boost hits 0, remainders pass to the list for uninterrupted scrolling.
@@ -1061,6 +1066,9 @@ fun DashboardScreen(
                         // Removing artificial damping so it feels completely free, not restrictive or jiggly.
                         val currentBoostPx = chartBoostState.floatValue * maxChartBoostPx
                         if (
+                            chartExpansionGestureGate.allowsExpansion(
+                                directUserInput = source == NestedScrollSource.UserInput
+                            ) &&
                             available.y > 0 &&
                             maxChartBoostPx > 0f &&
                             listState.firstVisibleItemIndex == 0 &&
@@ -1596,6 +1604,26 @@ fun DashboardScreen(
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
+                    .pointerInput(listState, chartExpansionGestureGate) {
+                        awaitEachGesture {
+                            awaitFirstDown(
+                                requireUnconsumed = false,
+                                pass = PointerEventPass.Initial
+                            )
+                            chartExpansionGestureGate.onGestureStarted(
+                                startedAtTop = listState.firstVisibleItemIndex == 0 &&
+                                    listState.firstVisibleItemScrollOffset == 0,
+                                chartExpanded = chartBoostState.floatValue > 0f
+                            )
+                            try {
+                                do {
+                                    val event = awaitPointerEvent(PointerEventPass.Final)
+                                } while (event.changes.any { it.pressed })
+                            } finally {
+                                chartExpansionGestureGate.onGestureEnded()
+                            }
+                        }
+                    }
                     .nestedScroll(nestedScrollConnection)
                     .padding(padding),
                 state = listState,

--- a/Common/src/test/java/tk/glucodata/ui/DashboardChartExpansionGestureGateTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/DashboardChartExpansionGestureGateTests.kt
@@ -1,0 +1,64 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DashboardChartExpansionGestureGateTests {
+
+    @Test
+    fun inheritedFlingMomentumNeverExpandsTheChart() {
+        val gate = DashboardChartExpansionGestureGate()
+        gate.onGestureStarted(startedAtTop = true, chartExpanded = false)
+        gate.onDirectScrollDelta(deltaY = 20f)
+
+        assertFalse(gate.allowsExpansion(directUserInput = false))
+    }
+
+    @Test
+    fun dragStartedBelowTopCannotHandOffIntoChartExpansion() {
+        val gate = DashboardChartExpansionGestureGate()
+        gate.onGestureStarted(startedAtTop = false, chartExpanded = false)
+        gate.onDirectScrollDelta(deltaY = 20f)
+
+        assertFalse(gate.allowsExpansion(directUserInput = true))
+    }
+
+    @Test
+    fun freshPullDownStartedAtTopCanExpandTheChart() {
+        val gate = DashboardChartExpansionGestureGate()
+        gate.onGestureStarted(startedAtTop = true, chartExpanded = false)
+        gate.onDirectScrollDelta(deltaY = 20f)
+
+        assertTrue(gate.allowsExpansion(directUserInput = true))
+    }
+
+    @Test
+    fun upwardListScrollCannotReverseIntoExpansionWithoutANewGesture() {
+        val gate = DashboardChartExpansionGestureGate()
+        gate.onGestureStarted(startedAtTop = true, chartExpanded = false)
+        gate.onDirectScrollDelta(deltaY = -20f)
+        gate.onDirectScrollDelta(deltaY = 20f)
+
+        assertFalse(gate.allowsExpansion(directUserInput = true))
+    }
+
+    @Test
+    fun existingChartDragCanCollapseAndExpandWithinOneGesture() {
+        val gate = DashboardChartExpansionGestureGate()
+        gate.onGestureStarted(startedAtTop = true, chartExpanded = true)
+        gate.onDirectScrollDelta(deltaY = -20f)
+
+        assertTrue(gate.allowsExpansion(directUserInput = true))
+    }
+
+    @Test
+    fun liftingTheFingerRequiresANewExplicitGesture() {
+        val gate = DashboardChartExpansionGestureGate()
+        gate.onGestureStarted(startedAtTop = true, chartExpanded = false)
+        gate.onDirectScrollDelta(deltaY = 20f)
+        gate.onGestureEnded()
+
+        assertFalse(gate.allowsExpansion(directUserInput = true))
+    }
+}


### PR DESCRIPTION
## What changed

The Home dashboard now expands the chart only from a pull-down gesture that starts while the journal list is already at the top.

The nested-scroll handler rejects `NestedScrollSource.SideEffect` deltas, so fling and animation momentum cannot drive chart expansion. For a collapsed chart, the first direct scroll delta must also be downward. An already expanded chart remains draggable in both directions during the same gesture.

## Why

The dashboard previously treated any unused downward nested-scroll delta as chart expansion. A scroll that began lower in the list could therefore reach the top and continue into the chart. Compose Foundation has also forwarded fling velocity at scroll bounds since 1.8.0-alpha03, which made this handoff easier to trigger after the dependency update. That Compose behavior is intentional; the dashboard needs to keep list scrolling and chart expansion as separate gestures.

This is separate from the toolchain PR because it fixes application behavior and can be reviewed or backported independently.

Compose change: https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.8.0-alpha03

## Verification

- Added six regression tests covering inherited fling momentum, drags started below the top, direction changes, chart re-expansion, and gesture reset.
- `:Common:testMobileReleaseUnitTest` on the PR branch: 1,853 tests, zero failures, errors, or skips.
- The same change passed the current `local-build` toolchain suite: 2,104 tests, zero failures, errors, or skips.

On-device gesture testing is still recommended because unit tests cover the ownership state machine rather than physical pointer dispatch.