### PR TITLE
Nightscout: show v3 entry permission refusals

### DIFF
--- a/Common/src/main/cpp/net/watchserver/uploader.cpp
+++ b/Common/src/main/cpp/net/watchserver/uploader.cpp
@@ -358,7 +358,8 @@ static int nightupload(jstring jnightuploadurl,const char *data,int len,bool put
         lastNightUploadConfigError = true;
         return -2;
         }
-    const static jmethodID  upload=getenv()->GetStaticMethodID(nightpostclass,"upload","(Ljava/lang/String;[BLjava/lang/String;Z)I");
+    const static jmethodID upload=getenv()->GetStaticMethodID(
+        nightpostclass,"uploadNative","(Ljava/lang/String;[BLjava/lang/String;Z)I");
     auto env=getenv();
     jbyteArray uit=env->NewByteArray(len);
         env->SetByteArrayRegion(uit, 0, len,(const jbyte *)data);

--- a/Common/src/main/java/tk/glucodata/NightPost.java
+++ b/Common/src/main/java/tk/glucodata/NightPost.java
@@ -198,10 +198,17 @@ static private String uploadstatus=nothing;
  * act on it. Empty when the last request never got an answer.
  */
 private static volatile String lastPrimaryResponseBody="";
+/** Response paired with the native uploader's status code, kept separate from treatments. */
+private static volatile String lastNativeUploadResponseBody="";
 
 @Keep
 static public String getLastPrimaryResponseBody() {
     return lastPrimaryResponseBody;
+    }
+
+@Keep
+static public String getLastNativeUploadResponseBody() {
+    return lastNativeUploadResponseBody;
     }
 
 /**
@@ -575,6 +582,14 @@ static public int upload(String httpurl,byte[] postdata,String secret,boolean pu
             true,
             "primary"
     );
+    }
+
+/** Native entries upload, with a response body that stays paired with its native status. */
+@Keep
+static public int uploadNative(String httpurl,byte[] postdata,String secret,boolean put) {
+    final int code=upload(httpurl,postdata,secret,put);
+    lastNativeUploadResponseBody=lastPrimaryResponseBody;
+    return code;
     }
 
 /** Partial API v3 document update at a concrete identifier endpoint. */

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1218,6 +1218,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_label">URL начнога разведчыка</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Выкарыстоўвайце Nightscout v3 API</string>
+    <string name="nightscout_use_v3_api_desc">Для загрузкі глюкозы патрэбныя api:entries:create і api:entries:update.</string>
     <string name="nightscout_follow_desc">Стварыць віртуальны датчык толькі для чытання з гэтага URL Nightscout.</string>
     <string name="nightscout_follow_url_required">Спачатку ўвядзіце URL Nightscout</string>
     <string name="nightscout_test_testing">Праверка...</string>
@@ -1410,6 +1411,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_retry_in">Паўтор праз %1$d хв</string>
     <string name="nightscout_status_response_ok">Апошні адказ: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Апошні адказ: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Апошні адказ: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Крыніца Nightscout</string>
     <string name="nightscout_follow_status_idle">Крыніца Nightscout чакае</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1291,6 +1291,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightscout_url_label">Nightscout-URL</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Nightscout-v3-API verwenden</string>
+    <string name="nightscout_use_v3_api_desc">Glukose-Uploads benötigen api:entries:create und api:entries:update.</string>
     <string name="nightscout_follow_desc">Erstellt einen schreibgeschützten virtuellen Sensor aus dieser Nightscout-URL.</string>
     <string name="nightscout_follow_url_required">Zuerst eine Nightscout-URL eingeben</string>
     <string name="nightscout_test_testing">Test läuft...</string>
@@ -1485,6 +1486,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightscout_status_retry_in">Nächster Versuch in %1$d Min.</string>
     <string name="nightscout_status_response_ok">Letzte Antwort: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Letzte Antwort: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Letzte Antwort: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Letzte Antwort: ungültige Nightscout-URL</string>
     <string name="nightscout_follow_title">Nightscout-Follower</string>
     <string name="nightscout_follow_status_idle">Nightscout-Follower bereit</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1225,6 +1225,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_label">URL de Nightscout</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Utiliser l\'API Nightscout v3</string>
+    <string name="nightscout_use_v3_api_desc">L\'envoi de la glycémie nécessite api:entries:create et api:entries:update.</string>
     <string name="nightscout_follow_desc">Crée un capteur virtuel en lecture seule à partir de cette URL Nightscout.</string>
     <string name="nightscout_follow_url_required">Saisissez d\'abord une URL Nightscout</string>
     <string name="nightscout_test_testing">Test...</string>
@@ -1417,6 +1418,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_retry_in">Nouvelle tentative dans %1$d min</string>
     <string name="nightscout_status_response_ok">Dernière réponse : HTTP %1$d</string>
     <string name="nightscout_status_response_error">Dernière réponse : HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Dernière réponse : HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Suivi Nightscout</string>
     <string name="nightscout_follow_status_idle">Suivi Nightscout inactif</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1209,6 +1209,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_label">URL dell\'esploratore notturno</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Utilizza l\'API Nightscout v3</string>
+    <string name="nightscout_use_v3_api_desc">I caricamenti della glicemia richiedono api:entries:create e api:entries:update.</string>
     <string name="nightscout_follow_desc">Crea un sensore virtuale di sola lettura da questo URL Nightscout.</string>
     <string name="nightscout_follow_url_required">Inserisci prima un URL Nightscout</string>
     <string name="nightscout_test_testing">Test...</string>
@@ -1401,6 +1402,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_retry_in">Nuovo tentativo tra %1$d min</string>
     <string name="nightscout_status_response_ok">Ultima risposta: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Ultima risposta: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Ultima risposta: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Follower Nightscout</string>
     <string name="nightscout_follow_status_idle">Follower Nightscout inattivo</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1224,6 +1224,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="nightscout_status_retry_in">%1$d мин дараа дахин оролдохоор товлосон</string>
     <string name="nightscout_status_response_ok">Сүүлчийн хариу: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Сүүлчийн хариу: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Сүүлчийн хариу: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Сүүлчийн хариу: буруу Nightscout URL</string>
     <string name="nightscout_follow_title">Nightscout дагагч</string>
     <string name="nightscout_follow_status_idle">Nightscout дагагч идэвхгүй байна</string>
@@ -1252,6 +1253,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="nightscout_url_label">Nightscout URL</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Nightscout v3 API ашиглах</string>
+    <string name="nightscout_use_v3_api_desc">Глюкозын байршуулалтад api:entries:create болон api:entries:update хэрэгтэй.</string>
     <string name="nightscout_follow_desc">Энэ Nightscout URL-аас зөвхөн унших боломжтой виртуал мэдрэгч үүсгэх.</string>
     <string name="nightscout_follow_url_required">Эхлээд Nightscout URL-г оруулна уу</string>
     <string name="no_active_sensor_selected">No active sensor selected</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1262,6 +1262,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="nightscout_url_label">Nightscout-URL</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Gebruik de Nightscout v3-API</string>
+    <string name="nightscout_use_v3_api_desc">Glucose-uploads hebben api:entries:create en api:entries:update nodig.</string>
     <string name="nightscout_follow_desc">Maak een alleen-lezen virtuele sensor van deze Nightscout-URL.</string>
     <string name="nightscout_follow_url_required">Voer eerst een Nightscout-URL in</string>
     <string name="nightscout_test_testing">Testen...</string>
@@ -1454,6 +1455,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="nightscout_status_retry_in">Nieuwe poging over %1$d min</string>
     <string name="nightscout_status_response_ok">Laatste reactie: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Laatste reactie: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Laatste reactie: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Nightscout-volger</string>
     <string name="nightscout_follow_status_idle">Nightscout-volger inactief</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1254,6 +1254,7 @@
     <string name="nightscout_url_label">Adres URL Nightscouta</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Skorzystaj z API Nightscout v3</string>
+    <string name="nightscout_use_v3_api_desc">Przesyłanie glukozy wymaga api:entries:create i api:entries:update.</string>
     <string name="nightscout_follow_desc">Utwórz wirtualny czujnik tylko do odczytu z tego adresu URL Nightscout.</string>
     <string name="nightscout_follow_url_required">Najpierw wpisz adres URL Nightscout</string>
     <string name="nightscout_test_testing">Testowanie...</string>
@@ -1446,6 +1447,7 @@
     <string name="nightscout_status_retry_in">Ponowna próba za %1$d min</string>
     <string name="nightscout_status_response_ok">Ostatnia odpowiedź: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Ostatnia odpowiedź: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Ostatnia odpowiedź: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Obserwator Nightscout</string>
     <string name="nightscout_follow_status_idle">Obserwator Nightscout bezczynny</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1220,6 +1220,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_label">URL do Nightscout</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Use a API Nightscout v3</string>
+    <string name="nightscout_use_v3_api_desc">Os envios de glicose precisam de api:entries:create e api:entries:update.</string>
     <string name="nightscout_follow_desc">Cria um sensor virtual apenas de leitura a partir deste URL Nightscout.</string>
     <string name="nightscout_follow_url_required">Introduza primeiro um URL Nightscout</string>
     <string name="nightscout_test_testing">A testar...</string>
@@ -1412,6 +1413,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_retry_in">Nova tentativa em %1$d min</string>
     <string name="nightscout_status_response_ok">Última resposta: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Última resposta: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Última resposta: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Seguidor Nightscout</string>
     <string name="nightscout_follow_status_idle">Seguidor Nightscout inativo</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1256,6 +1256,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_label">URL ночного скаута</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Используйте API Nightscout v3</string>
+    <string name="nightscout_use_v3_api_desc">Для загрузки глюкозы нужны api:entries:create и api:entries:update.</string>
     <string name="nightscout_follow_desc">Создать виртуальный датчик только для чтения из этого URL Nightscout.</string>
     <string name="nightscout_follow_url_required">Сначала введите URL Nightscout</string>
     <string name="nightscout_test_testing">Проверка...</string>
@@ -1454,6 +1455,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_retry_in">Повтор через %1$d мин</string>
     <string name="nightscout_status_response_ok">Последний ответ: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Последний ответ: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Последний ответ: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Источник Nightscout</string>
     <string name="nightscout_follow_status_idle">Источник Nightscout простаивает</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1497,6 +1497,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="nightscout_status_retry_in">Isku day in aad isku daydo in la qorsheeyay %1$d daqiiqo</string>
     <string name="nightscout_status_response_ok">Jawaabtii u dambaysay: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Jawaabtii u dambaysay: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Jawaabtii u dambaysay: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Jawaabtii u dambaysay: URL aan sax ahayn Nightscoout</string>
     <string name="nightscout_follow_title">Nightscoout raaca</string>
     <string name="nightscout_follow_status_idle">Nightscoout raaca</string>
@@ -1527,6 +1528,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="nightscout_url_label">Nightscout URL</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Isticmaal Nightscout v3 API</string>
+    <string name="nightscout_use_v3_api_desc">Soo rarista gulukoosku waxay u baahan tahay api:entries:create iyo api:entries:update.</string>
     <string name="nightscout_follow_desc">Ka samee dareemaha akhriska-kaliya ee URL-kan Nightscout.</string>
     <string name="nightscout_follow_url_required">Geli URL Nightscout marka hore</string>
     <string name="nightscout_mode_upload">Soo rar</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1219,6 +1219,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_label">Nightscout URL</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Använd Nightscout v3 API</string>
+    <string name="nightscout_use_v3_api_desc">Glukosuppladdningar behöver api:entries:create och api:entries:update.</string>
     <string name="nightscout_follow_desc">Skapa en skrivskyddad virtuell sensor från denna Nightscout-URL.</string>
     <string name="nightscout_follow_url_required">Ange en Nightscout-URL först</string>
     <string name="nightscout_test_testing">Testar...</string>
@@ -1411,6 +1412,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_retry_in">Nytt försök om %1$d min</string>
     <string name="nightscout_status_response_ok">Senaste svar: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Senaste svar: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Senaste svar: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Nightscout-följare</string>
     <string name="nightscout_follow_status_idle">Nightscout-följare inaktiv</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1247,6 +1247,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="nightscout_url_label">Gece İzci URL\'si</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Nightscout v3 API\'sini kullanın</string>
+    <string name="nightscout_use_v3_api_desc">Glikoz yüklemeleri api:entries:create ve api:entries:update gerektirir.</string>
     <string name="nightscout_follow_desc">Bu Nightscout URL\'sinden salt okunur sanal sensör oluşturur.</string>
     <string name="nightscout_follow_url_required">Önce bir Nightscout URL\'si girin</string>
     <string name="nightscout_test_testing">Test ediliyor...</string>
@@ -1439,6 +1440,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="nightscout_status_retry_in">%1$d dk sonra yeniden denenecek</string>
     <string name="nightscout_status_response_ok">Son yanıt: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Son yanıt: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Son yanıt: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Nightscout takipçisi</string>
     <string name="nightscout_follow_status_idle">Nightscout takipçisi boşta</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1233,6 +1233,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_label">URL-адреса нічного розвідки</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Використовуйте API Nightscout v3</string>
+    <string name="nightscout_use_v3_api_desc">Для завантаження глюкози потрібні api:entries:create і api:entries:update.</string>
     <string name="nightscout_follow_desc">Створити віртуальний датчик лише для читання з цієї URL-адреси Nightscout.</string>
     <string name="nightscout_follow_url_required">Спочатку введіть URL Nightscout</string>
     <string name="nightscout_test_testing">Перевірка...</string>
@@ -1425,6 +1426,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_retry_in">Повтор через %1$d хв</string>
     <string name="nightscout_status_response_ok">Остання відповідь: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Остання відповідь: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Остання відповідь: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Джерело Nightscout</string>
     <string name="nightscout_follow_status_idle">Джерело Nightscout очікує</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1235,6 +1235,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_label">夜巡网址</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">使用 Nightscout v3 API</string>
+    <string name="nightscout_use_v3_api_desc">上传血糖数据需要 api:entries:create 和 api:entries:update。</string>
     <string name="nightscout_follow_desc">从此 Nightscout URL 创建只读虚拟传感器。</string>
     <string name="nightscout_follow_url_required">请先输入 Nightscout URL</string>
     <string name="nightscout_test_testing">正在测试...</string>
@@ -1427,6 +1428,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_retry_in">将在 %1$d 分钟后重试</string>
     <string name="nightscout_status_response_ok">上次响应：HTTP %1$d</string>
     <string name="nightscout_status_response_error">上次响应：HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">上次响应：HTTP %1$d，%2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Nightscout 跟随器</string>
     <string name="nightscout_follow_status_idle">Nightscout 跟随器空闲</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -1568,6 +1568,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_status_retry_in">Retry scheduled in %1$d min</string>
     <string name="nightscout_status_response_ok">Last response: HTTP %1$d</string>
     <string name="nightscout_status_response_error">Last response: HTTP %1$d</string>
+    <string name="nightscout_status_response_error_detail">Last response: HTTP %1$d, %2$s</string>
     <string name="nightscout_status_response_invalid_url">Last response: invalid Nightscout URL</string>
     <string name="nightscout_follow_title">Nightscout follower</string>
     <string name="nightscout_follow_status_idle">Nightscout follower idle</string>
@@ -1600,6 +1601,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_url_label">Nightscout URL</string>
     <string name="nightscout_url_placeholder">https://my-nightscout.herokuapp.com</string>
     <string name="nightscout_use_v3_api">Use Nightscout v3 API</string>
+    <string name="nightscout_use_v3_api_desc">Glucose uploads need api:entries:create and api:entries:update.</string>
     <string name="nightscout_follow_desc">Create a read-only virtual sensor from this Nightscout URL.</string>
     <string name="nightscout_follow_url_required">Enter a Nightscout URL first</string>
     <string name="nightscout_mode_upload">Upload</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/NightscoutSettingsScreen.kt
@@ -64,7 +64,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import kotlinx.coroutines.Dispatchers
@@ -73,6 +72,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tk.glucodata.Natives
 import tk.glucodata.NightPost
+import tk.glucodata.NightscoutTokenGrant
 import tk.glucodata.R
 import tk.glucodata.data.journal.JournalSyncFailure
 import tk.glucodata.data.journal.JournalSyncStatus
@@ -121,6 +121,13 @@ private fun failureDetail(context: android.content.Context, code: Int): String =
  */
 internal fun nightscoutTestEndpointPath(useV3: Boolean): String =
     if (useV3) "api/v3/status" else "api/v1/status.json"
+
+internal fun nightscoutResponseDetail(body: String): String {
+    return NightscoutTokenGrant.refusalMessage(body)
+        .replace(Regex("\\s+"), " ")
+        .trim()
+        .take(240)
+}
 
 private fun applyNightscoutTestAuth(
     connection: java.net.HttpURLConnection,
@@ -176,6 +183,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
     var isV3 by rememberSaveable { mutableStateOf(Natives.getnightscoutV3()) }
     var showSecret by rememberSaveable { mutableStateOf(false) }
     var lastResponseCode by rememberSaveable { mutableStateOf(0) }
+    var lastResponseBody by rememberSaveable { mutableStateOf("") }
     var lastAttemptTime by rememberSaveable { mutableStateOf(0L) }
     var lastSuccessTime by rememberSaveable { mutableStateOf(0L) }
     var retryMinutes by rememberSaveable { mutableStateOf(0) }
@@ -227,6 +235,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
 
     fun refreshStatus() {
         lastResponseCode = Natives.getnightscoutlastresponsecode()
+        lastResponseBody = NightPost.getLastNativeUploadResponseBody()
         lastAttemptTime = Natives.getnightscoutlastattempttime()
         lastSuccessTime = Natives.getnightscoutlastsuccesstime()
         retryMinutes = Natives.getnightscoutretryminutes()
@@ -336,7 +345,18 @@ fun NightscoutSettingsScreen(navController: NavController) {
         lastResponseCode in 200..299 -> context.getString(R.string.nightscout_status_response_ok, lastResponseCode)
         lastResponseCode == 404 -> context.getString(R.string.nightscout_status_response_404)
         lastResponseCode == 413 -> context.getString(R.string.nightscout_status_response_413)
-        lastResponseCode > 0 -> context.getString(R.string.nightscout_status_response_error, lastResponseCode)
+        lastResponseCode > 0 -> {
+            val detail = nightscoutResponseDetail(lastResponseBody)
+            if (detail.isBlank()) {
+                context.getString(R.string.nightscout_status_response_error, lastResponseCode)
+            } else {
+                context.getString(
+                    R.string.nightscout_status_response_error_detail,
+                    lastResponseCode,
+                    detail
+                )
+            }
+        }
         else -> context.getString(R.string.nightscout_status_waiting)
     }
 
@@ -599,7 +619,11 @@ fun NightscoutSettingsScreen(navController: NavController) {
                         ) {
                             Text(text = stringResource(R.string.status), style = MaterialTheme.typography.titleMedium)
                             Text(text = uploaderSummary, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface)
-                            Text(text = responseSummary, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                            Text(
+                                text = responseSummary,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                             Text(
                                 text = stringResource(R.string.nightscout_status_last_attempt, formatStatusTime(lastAttemptTime)),
                                 style = MaterialTheme.typography.bodySmall,
@@ -618,18 +642,14 @@ fun NightscoutSettingsScreen(navController: NavController) {
                                         MaterialTheme.colorScheme.error
                                     } else {
                                         MaterialTheme.colorScheme.onSurfaceVariant
-                                    },
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis
+                                    }
                                 )
                             }
                             if (deviceStatusSummary != null) {
                                 Text(
                                     text = deviceStatusSummary,
                                     style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.error,
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis
+                                    color = MaterialTheme.colorScheme.error
                                 )
                             }
                         }
@@ -697,6 +717,7 @@ fun NightscoutSettingsScreen(navController: NavController) {
                         )
                         SettingsSwitchItem(
                             title = stringResource(R.string.nightscout_use_v3_api),
+                            subtitle = stringResource(R.string.nightscout_use_v3_api_desc),
                             checked = isV3,
                             onCheckedChange = { isV3 = it },
                             icon = Icons.Default.Api,

--- a/Common/src/test/java/tk/glucodata/ui/NightscoutSettingsLogicTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/NightscoutSettingsLogicTests.kt
@@ -1,0 +1,24 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NightscoutSettingsLogicTests {
+    @Test
+    fun v3RefusalShowsTheServersPermissionMessage() {
+        assertEquals(
+            "Missing permission api:entries:update",
+            nightscoutResponseDetail(
+                """{"status":403,"message":"Missing permission api:entries:update"}"""
+            )
+        )
+    }
+
+    @Test
+    fun responseWhitespaceIsCollapsedForTheStatusCard() {
+        assertEquals(
+            "Bad gateway response",
+            nightscoutResponseDetail("  Bad gateway\n response  ")
+        )
+    }
+}


### PR DESCRIPTION
## What was wrong

The Nightscout settings screen could show only `Last response: HTTP 403` for the native glucose-entry uploader. The useful part of the response stayed in the Java request layer, while the native status path retained only the code. A later treatment request could also replace the shared response body before the screen read it.

A device trace made the cause concrete:

```text
POST /api/v3/entries
403 {"message":"Missing permission api:entries:update"}
```

The access token had `api:entries:create` and `api:entries:read`, but not `api:entries:update`. Nightscout v3 treats a collection POST with an existing identifier as an update. Its API documentation states that this deduplication path requires update permission.

Treating this response as success would be unsafe. NG sometimes needs to replace a previously uploaded glucose value, so advancing the cursor without updating Nightscout could leave an older value on the server.

## What changes

- Native uploads now use a dedicated Java entry point that snapshots the response body belonging to the native status code.
- The status card displays Nightscout's response message alongside the HTTP code, for example `HTTP 403, Missing permission api:entries:update`.
- Status, treatment, and device-status diagnostics wrap to their full height instead of being cut off after two lines.
- The existing screen scroll handles the extra height, with no nested scrolling area.
- The v3 setting now states that glucose uploads need both `api:entries:create` and `api:entries:update`.
- All maintained translations include the new status and permission text.

## Treatment duplicate seen in the same report

The accompanying trace also covered a pen scan that replaced a hand-written 5 IU entry. Nightscout accepted the replacement treatment with HTTP 201, then accepted deletion of the old identifier with HTTP 200 in the same second. Nightscout's v3 schema confirms that NG used the correct DELETE endpoint and identifier. This PR therefore does not change treatment replacement behavior without evidence that its successful delete was ineffective.

## Verification

- `./gradlew :Common:testMobileReleaseUnitTest`: 1,849 tests passed with no failures, errors, or skips.
- The focused status parser, token grant, and treatment uploader tests pass.
- `:Common:buildCMakeRelWithDebInfo[arm64-v8a]` passes for the changed native-to-Java bridge.
- All 15 maintained string sets contain the two new resources.

The wrapped layout and a live server refusal still need an on-device check.
