### PR TITLE
Nightscout: remove deleted v3 treatment copies

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalTreatmentUploader.kt
@@ -494,8 +494,18 @@ object JournalTreatmentUploader {
             ?: "[]"
     }
 
-    private fun treatmentDeleteUrl(baseUrl: String, remoteId: String, useV3: Boolean): String =
-        baseUrl + (if (useV3) "/api/v3/treatments/" else "/api/v1/treatments/") + remoteId
+    /**
+     * API v3 deletes are soft by default. That is invisible to v3 searches, but Nightscout's
+     * legacy v1 treatment reads can still return the invalid document and show the stale copy
+     * in the web UI. These deletes represent an explicit local deletion or a copy superseded by
+     * a successful write, so remove the v3 document permanently after the safety checks above.
+     */
+    internal fun treatmentDeleteUrl(baseUrl: String, remoteId: String, useV3: Boolean): String =
+        baseUrl + if (useV3) {
+            "/api/v3/treatments/$remoteId?permanent=true"
+        } else {
+            "/api/v1/treatments/$remoteId"
+        }
 
     private fun uploadViaNightPost(
         baseUrl: String,

--- a/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/JournalTreatmentUploaderTests.kt
@@ -229,6 +229,30 @@ class JournalTreatmentUploaderTests {
         )
     }
 
+    @Test
+    fun v3DeletesArePermanentSoLegacyTreatmentReadsCannotShowTheStaleCopy() {
+        assertEquals(
+            "https://ns.example.com/api/v3/treatments/jng-j-1a7-18bcfe56800?permanent=true",
+            JournalTreatmentUploader.treatmentDeleteUrl(
+                "https://ns.example.com",
+                "jng-j-1a7-18bcfe56800",
+                useV3 = true
+            )
+        )
+    }
+
+    @Test
+    fun v1DeletesKeepTheirExistingEndpoint() {
+        assertEquals(
+            "https://ns.example.com/api/v1/treatments/65a1",
+            JournalTreatmentUploader.treatmentDeleteUrl(
+                "https://ns.example.com",
+                "65a1",
+                useV3 = false
+            )
+        )
+    }
+
     /** Written before the time was part of the name: created once under the new name. */
     @Test
     fun anEntryStoredUnderTheOlderNameIsCreatedAfresh() {


### PR DESCRIPTION
## Why

Replacing a manually entered insulin dose with an NFC pen scan can leave both versions visible in Nightscout. Deleting a journal treatment can have the same result even though Nightscout answers the delete request with HTTP 200.

This is caused by an API compatibility gap. Nightscout API v3 uses soft deletion by default and marks the document with `isValid: false`. API v3 searches exclude those documents, but the legacy v1 treatments endpoint does not apply that validity filter. Nightscout views that still read treatments through v1 can therefore show a document that a v3 client has deleted.

Nightscout documents this behavior and provides `permanent=true` for irreversible deletion:

https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/api3/swagger.yaml

The current implementations show the mismatch directly:

* API v3 search requests valid documents only: https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/api3/generic/search/operation.js
* API v3 delete uses soft deletion unless `permanent=true` is supplied: https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/api3/generic/delete/operation.js
* API v1 treatment reads do not add an `isValid` filter: https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/server/treatments.js

## What changed

JugglucoNG now adds `?permanent=true` to API v3 treatment deletion URLs. API v1 deletion is unchanged.

This applies to both deletion paths:

* a journal entry the user explicitly deleted
* an old treatment copy that became obsolete after Nightscout accepted a replacement at a corrected timestamp

The replacement path still writes the new document first. The old document is removed only after Nightscout accepts the new one, so this change does not weaken the existing protection against treatment loss.

## Verification

* Added tests for the API v3 permanent deletion URL and the unchanged API v1 URL.
* Ran `:Common:testMobileReleaseUnitTest`: 1,857 tests, 0 failures, 0 errors.

Live verification against a Nightscout instance is still useful because the reported symptom spans both API versions and the Nightscout web display.
