### PR TITLE
iCan: see what the sensor actually sends

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
@@ -1351,6 +1351,7 @@ class ICanHealthBleManager(
             "Services discovered measurement=${charMeasurement != null} status=${charStatus != null} " +
                 "sessionStart=${charSessionStart != null} racp=${charRacp != null} specificOps=${charSpecificOps != null}"
         )
+        dumpGattSurface(gatt)
 
         if (charMeasurement == null) {
             Log.e(TAG, "CGM measurement characteristic missing")
@@ -1374,6 +1375,7 @@ class ICanHealthBleManager(
     @Deprecated("Deprecated in Java")
     override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
         val data = characteristic.value ?: return
+        Log.i(TAG, "WIRE rx notify ${shortUuid(characteristic.uuid)} ${data.toHexString()}")
         when (characteristic.uuid) {
             ICanHealthConstants.CGM_MEASUREMENT -> handleGlucoseNotification(data)
             ICanHealthConstants.CGM_SPECIFIC_OPS -> handleVendorAuthResponse(data)
@@ -1381,6 +1383,37 @@ class ICanHealthBleManager(
             // Lazy: hex-encodes the whole payload, and this fires per unhandled notification.
             else -> logd(TAG) { "Unhandled notify ${characteristic.uuid}: ${data.toHexString()}" }
         }
+    }
+
+    /** Last four hex digits of a 128-bit BLE UUID: enough to identify it, short enough to scan. */
+    private fun shortUuid(uuid: java.util.UUID): String =
+        uuid.toString().substring(4, 8).uppercase()
+
+    /**
+     * Dump the whole GATT surface once per connection.
+     *
+     * This driver was reverse-engineered from one vendor app against one sensor family, so any
+     * characteristic nobody looked at is somewhere a divergence can hide. Reading the map costs
+     * one log line per characteristic and has already turned up readable characteristics the
+     * driver never touched.
+     */
+    private fun dumpGattSurface(gatt: BluetoothGatt) {
+        runCatching {
+            gatt.services.forEach { service ->
+                Log.i(TAG, "WIRE service ${service.uuid}")
+                service.characteristics.forEach { ch ->
+                    val props = ch.properties
+                    val flags = buildString {
+                        if (props and BluetoothGattCharacteristic.PROPERTY_READ != 0) append("R")
+                        if (props and BluetoothGattCharacteristic.PROPERTY_WRITE != 0) append("W")
+                        if (props and BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE != 0) append("w")
+                        if (props and BluetoothGattCharacteristic.PROPERTY_NOTIFY != 0) append("N")
+                        if (props and BluetoothGattCharacteristic.PROPERTY_INDICATE != 0) append("I")
+                    }
+                    Log.i(TAG, "WIRE   char ${ch.uuid} props=$flags")
+                }
+            }
+        }.onFailure { Log.stack(TAG, "dumpGattSurface", it) }
     }
 
     @Deprecated("Deprecated in Java")
@@ -1399,6 +1432,7 @@ class ICanHealthBleManager(
         }
 
         val data = characteristic.value ?: byteArrayOf()
+        Log.i(TAG, "WIRE rx read ${shortUuid(characteristic.uuid)} ${data.toHexString()}")
         when (characteristic.uuid) {
             ICanHealthConstants.MODEL_NUMBER -> {
                 val model = parseDeviceInfoString(data)
@@ -2180,7 +2214,18 @@ class ICanHealthBleManager(
             !mActiveDeviceAddress.isNullOrBlank() -> mActiveDeviceAddress?.replace(":", "")
             else -> null
         }
-        return ICanHealthConstants.normalizeStandaloneUserId(source)
+        val resolved = ICanHealthConstants.normalizeStandaloneUserId(source)
+        // The head of that fallback chain is cleared by a remove-and-re-add, so the app can
+        // authenticate under a different identity than last time with nothing in the log saying
+        // so. Record what was chosen and everything it was chosen from.
+        Log.i(
+            TAG,
+            "WIRE authUserId=$resolved from source=$source " +
+                "(recovered=$recoveredAuthUserId configured=$configuredAuthUserId " +
+                "onboarding=$onboardingDeviceSn rawSerial=$rawSerialFromDevice " +
+                "serial=$serialFromDevice sensorId=$SerialNumber addr=$mActiveDeviceAddress)"
+        )
+        return resolved
     }
 
     private fun enqueuePreAuthReads() {
@@ -3799,6 +3844,7 @@ class ICanHealthBleManager(
                     drainGattQueue()
                     return
                 }
+                Log.i(TAG, "WIRE tx write ${shortUuid(op.charUuid)} ${op.data.toHexString()}")
                 char.value = op.data
                 char.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
                 if (!gatt.writeCharacteristic(char)) {

--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
@@ -164,6 +164,7 @@ class ICanHealthBleManager(
     @Volatile private var historyBackfillAttemptedThisConnection = false
     @Volatile private var shouldRequestAuthenticatedHistoryBackfill = true
     @Volatile private var suppressAutomaticHistoryBackfill = false
+    @Volatile private var nativeLifetimeDeclaredFor: String? = null
     @Volatile private var sawUnsupportedSnHistoryBatch = false
     @Volatile private var awaitingFreshStatusForHistoryBackfill = false
     @Volatile private var historyBackfillPhase = HistoryBackfillPhase.NONE
@@ -3584,18 +3585,60 @@ class ICanHealthBleManager(
                 .onFailure { Log.stack(TAG, "ensureNativeDataptr(freedataptr)", it) }
             dataptr = 0L
         }
-        runCatching {
-            Natives.ensureSensorShell(
-                nativeCreationSensorName(canonicalSensorId),
-                resolveNativeShellStartTimeSec()
-            )
-        }.onFailure {
-            Log.stack(TAG, "ensureNativeDataptr(ensureSensorShell)", it)
-        }
+        declareNativeLifetime(
+            nativeCreationSensorName(canonicalSensorId),
+            resolveNativeShellStartTimeSec()
+        )
         val nativeName = resolveExistingNativeSensorName(canonicalSensorId)
             ?: nativeCreationSensorName(canonicalSensorId)
         adoptNativeSensorIfAppropriate(canonicalSensorId, nativeName)
         applyNativeSensorMetadata()
+    }
+
+    /**
+     * Create the native shell already sized for how long an iCan sensor actually runs.
+     *
+     * Poll geometry comes from `info->days` with a 15-day floor, so a sensor rated 15 that keeps
+     * going — which iCan hardware does, out to the 28-day status cap this driver already assumes
+     * everywhere else — walks off the end of its own poll map on day 15: `validPollIndex()` starts
+     * refusing and every live write is dropped, with nothing user-visible to say why.
+     * `pollStorageSize()` documents that failure against Ottai's rating extending to 28/30, and
+     * both Ottai and Anytime declare their duration through `setSensorWearDays` to avoid it. iCan
+     * never did, so every iCan sensor was capped at its rated life while the card promised 28
+     * days.
+     *
+     * Geometry is only recomputed when a shell is constructed, so the capacity has to be
+     * requested here, at creation — an already-open mapping cannot grow.
+     */
+    private fun declareNativeLifetime(name: String, startSec: Long) {
+        val days = resolvedProfile().advisoryExpectedDays
+        if (days <= 0) {
+            runCatching { Natives.ensureSensorShell(name, startSec) }
+                .onFailure { Log.stack(TAG, "ensureNativeDataptr(ensureSensorShell)", it) }
+            return
+        }
+        val key = "$name:$days"
+        val alreadyDeclared = nativeLifetimeDeclaredFor == key
+        val minimumRecords = days * 24 * 60
+        runCatching {
+            if (Natives.ensureSensorShellWithCapacity(name, startSec, minimumRecords) == 0L) {
+                Natives.ensureSensorShell(name, startSec)
+            }
+            if (alreadyDeclared) {
+                return@runCatching
+            }
+            Natives.setSensorWearDays(name, days)
+            if (!Natives.hasSensorStreamCapacity(name, minimumRecords)) {
+                Log.e(
+                    TAG,
+                    "native poll capacity below $minimumRecords for $name; readings past day " +
+                        "${minimumRecords / (24 * 60)} will be dropped instead of stored"
+                )
+            } else {
+                Log.i(TAG, "Declared $days-day native lifetime for $name ($minimumRecords records)")
+            }
+            nativeLifetimeDeclaredFor = key
+        }.onFailure { Log.stack(TAG, "declareNativeLifetime", it) }
     }
 
     private fun nativeCreationSensorName(sensorId: String): String =

--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthBleManager.kt
@@ -1435,6 +1435,37 @@ class ICanHealthBleManager(
         val data = characteristic.value ?: byteArrayOf()
         Log.i(TAG, "WIRE rx read ${shortUuid(characteristic.uuid)} ${data.toHexString()}")
         when (characteristic.uuid) {
+            ICanHealthConstants.CGM_FEATURE -> {
+                if (data.size >= 4) {
+                    val features = (data[0].toInt() and 0xFF) or
+                        ((data[1].toInt() and 0xFF) shl 8) or
+                        ((data[2].toInt() and 0xFF) shl 16)
+                    val typeSample = data[3].toInt() and 0xFF
+                    val crcField = if (data.size >= 6) {
+                        (data[4].toInt() and 0xFF) or ((data[5].toInt() and 0xFF) shl 8)
+                    } else {
+                        -1
+                    }
+                    Log.i(
+                        TAG,
+                        "cgmFeature=0x${"%06X".format(features)} " +
+                            "e2eCrcSupported=${(features and (1 shl 12)) != 0} " +
+                            "crcField=0x${"%04X".format(crcField)} " +
+                            "calibrationSupported=${(features and 1) != 0} " +
+                            "multiSession=${(features and (1 shl 14)) != 0} " +
+                            "type=0x${"%X".format(typeSample and 0x0F)} " +
+                            "sampleLocation=0x${"%X".format((typeSample ushr 4) and 0x0F)}"
+                    )
+                }
+            }
+
+            ICanHealthConstants.CGM_SESSION_RUN_TIME -> {
+                if (data.size >= 2) {
+                    val hours = (data[0].toInt() and 0xFF) or ((data[1].toInt() and 0xFF) shl 8)
+                    Log.i(TAG, "cgmSessionRunTime=${hours}h (${hours / 24}d ${hours % 24}h)")
+                }
+            }
+
             ICanHealthConstants.MODEL_NUMBER -> {
                 val model = parseDeviceInfoString(data)
                 if (model.isNotEmpty()) {
@@ -2239,6 +2270,15 @@ class ICanHealthBleManager(
             disService?.getCharacteristic(ICanHealthConstants.SOFTWARE_REVISION)?.let {
                 enqueueOp(GattOp.Read(ICanHealthConstants.SOFTWARE_REVISION, ICanHealthConstants.DEVICE_INFO_SERVICE))
             }
+        }
+        // Both are readable on every unit seen so far and neither has ever been read. CGM Feature
+        // states which optional CGM behaviours the sensor implements; Session Run Time is the
+        // sensor's own statement of how long it means to last, which beats inferring it.
+        cgmService?.getCharacteristic(ICanHealthConstants.CGM_FEATURE)?.let {
+            enqueueOp(GattOp.Read(ICanHealthConstants.CGM_FEATURE, ICanHealthConstants.CGM_SERVICE))
+        }
+        cgmService?.getCharacteristic(ICanHealthConstants.CGM_SESSION_RUN_TIME)?.let {
+            enqueueOp(GattOp.Read(ICanHealthConstants.CGM_SESSION_RUN_TIME, ICanHealthConstants.CGM_SERVICE))
         }
     }
 

--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthConstants.kt
@@ -13,6 +13,16 @@ import java.util.UUID
 import java.util.Locale
 import kotlin.math.abs
 
+/** One decoded glucose field, keeping the wire parts so they can be logged. */
+data class ICanHealthGlucoseField(
+    /** High nibble of the field. Purpose unknown; constant per sensor. Not part of the value. */
+    val nibble: Int,
+    /** Unsigned 12-bit value exactly as it came off the wire, in hundredths of mmol/L. */
+    val mantissa: Int,
+    val glucoseMmolL: Float,
+    val glucoseMgdl: Float,
+)
+
 object ICanHealthConstants {
     private val FULL_CANONICAL_HEX_SENSOR_ID_REGEX = Regex("^[0-9A-Z]{16}$", RegexOption.IGNORE_CASE)
 
@@ -99,6 +109,44 @@ object ICanHealthConstants {
     // Keep iCan aligned with the native stream validator (<552 mg/dL). Values
     // above the normal display maximum still render as HI instead of no data.
     const val MAX_VALID_GLUCOSE_MGDL = 551f
+
+    // ---- Glucose field ----
+
+    /**
+     * Decode the 16-bit glucose field of a CGM measurement.
+     *
+     * The field splits into a 4-bit high nibble and a 12-bit value. The 12 bits are hundredths of
+     * mmol/L, verified against the vendor app's own database. What the nibble carries is not
+     * known: captures show it constant for the life of a sensor and different between sensors
+     * (0x1 on one i6, 0x0 on another), so it is neither an IEEE-11073 exponent nor a per-reading
+     * state. It is decoded out and reported for diagnosis, and deliberately not used for
+     * anything.
+     *
+     * Three call sites — the live frame, the SN history batch, and the encrypted history record —
+     * previously carried byte-identical copies of this arithmetic.
+     */
+    @JvmStatic
+    fun decodeGlucoseField(
+        low: Int,
+        high: Int,
+        directGlucoseEncoding: Boolean,
+    ): ICanHealthGlucoseField {
+        val lowByte = low and 0xFF
+        val highByte = high and 0xFF
+        val nibble = if (directGlucoseEncoding) 0 else (highByte ushr 4) and 0x0F
+        val mantissa = if (directGlucoseEncoding) {
+            lowByte or (highByte shl 8)
+        } else {
+            lowByte or ((highByte and 0x0F) shl 8)
+        }
+        val glucoseMmolL = mantissa / 100.0f
+        return ICanHealthGlucoseField(
+            nibble = nibble,
+            mantissa = mantissa,
+            glucoseMmolL = glucoseMmolL,
+            glucoseMgdl = glucoseMmolL * MMOL_TO_MGDL,
+        )
+    }
 
     private enum class BundledKeyFamily {
         OLD,

--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthConstants.kt
@@ -63,6 +63,18 @@ object ICanHealthConstants {
     /** CGM Status (Read) — time offset from session start */
     val CGM_STATUS: UUID = UUID.fromString("00002aa9-0000-1000-8000-00805f9b34fb")
 
+    /**
+     * CGM Feature (Read) — 3-byte feature bitfield, a type/sample-location byte, then the
+     * characteristic's own E2E-CRC (0xFFFF when that feature is absent).
+     *
+     * Bit 0 is Calibration Supported, bit 12 E2E-CRC Supported, bit 14 Multiple Sessions.
+     * iCGM-t6 answers 0x004001 with 0xFFFF: calibration yes, CRC no.
+     */
+    val CGM_FEATURE: UUID = UUID.fromString("00002aa8-0000-1000-8000-00805f9b34fb")
+
+    /** CGM Session Run Time (Read) — hours the sensor intends to run, from session start. */
+    val CGM_SESSION_RUN_TIME: UUID = UUID.fromString("00002aab-0000-1000-8000-00805f9b34fb")
+
     /** CGM Session Start Time (Read) — sensor activation time */
     val CGM_SESSION_START_TIME: UUID = UUID.fromString("00002aaa-0000-1000-8000-00805f9b34fb")
 

--- a/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthParser.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/icanhealth/ICanHealthParser.kt
@@ -20,7 +20,10 @@ data class ICanHealthGlucoseReading(
     val glucoseMmolL: Float,     // mmol/L (raw sensor value)
     val glucoseMgdl: Float,      // mg/dL (converted)
     val statusByte: Int,         // Session-varying status
+    /** High nibble of the glucose field. Purpose unknown; constant per sensor. */
     val dataState: Int,
+    /** Unsigned 12-bit glucose value exactly as it came off the wire. */
+    val mantissa: Int = 0,
     val currentValue: Float,
     val temperatureC: Float,
 )
@@ -170,16 +173,14 @@ object ICanHealthParser {
         ) ?: return null
         val directGlucoseEncoding =
             ICanHealthConstants.usesDirectSnHistoryGlucoseEncoding(onboardingDeviceSn)
-        val glucLo = glucoseBytes[0].toInt() and 0xFF
-        val glucHi = glucoseBytes[1].toInt() and 0xFF
-        val dataState = if (directGlucoseEncoding) 0 else (glucHi ushr 4) and 0x0F
-        val glucoseRaw = if (directGlucoseEncoding) {
-            glucLo or (glucHi shl 8)
-        } else {
-            glucLo or ((glucHi and 0x0F) shl 8)
-        }
-        val glucoseMmolL = glucoseRaw / 100.0f
-        val glucoseMgdl = glucoseMmolL * ICanHealthConstants.MMOL_TO_MGDL
+        val field = ICanHealthConstants.decodeGlucoseField(
+            low = glucoseBytes[0].toInt(),
+            high = glucoseBytes[1].toInt(),
+            directGlucoseEncoding = directGlucoseEncoding,
+        )
+        val dataState = field.nibble
+        val glucoseMmolL = field.glucoseMmolL
+        val glucoseMgdl = field.glucoseMgdl
         val currentValue = decodeCurrentValue(
             decrypted[ICanHealthConstants.OFFSET_CURRENT_U16LE],
             decrypted[ICanHealthConstants.OFFSET_CURRENT_U16LE + 1]
@@ -201,12 +202,15 @@ object ICanHealthParser {
             logWarn("parseGlucose: glucose out of range ${glucoseMgdl} mg/dL (seq=$headerSeq)")
         }
 
+        logGlucoseFieldDiagnostics(decrypted, headerSeq, field, temperatureC)
+
         return ICanHealthGlucoseReading(
             sequenceNumber = headerSeq,
             glucoseMmolL = glucoseMmolL,
             glucoseMgdl = glucoseMgdl,
             statusByte = statusByte,
             dataState = dataState,
+            mantissa = field.mantissa,
             currentValue = currentValue,
             temperatureC = temperatureC,
         )
@@ -382,16 +386,14 @@ object ICanHealthParser {
                     )
                 }
                 ICanHealthConstants.SN_HISTORY_SUBTYPE_GLUCOSE -> {
-                    val low = decrypted[offset].toInt() and 0xFF
-                    val high = decrypted[offset + 1].toInt() and 0xFF
-                    val dataState = if (directGlucoseEncoding) 0 else (high ushr 4) and 0x0F
-                    val glucoseRaw = if (directGlucoseEncoding) {
-                        low or (high shl 8)
-                    } else {
-                        low or ((high and 0x0F) shl 8)
-                    }
-                    val glucoseMmolL = glucoseRaw / 100.0f
-                    val glucoseMgdl = glucoseMmolL * ICanHealthConstants.MMOL_TO_MGDL
+                    val field = ICanHealthConstants.decodeGlucoseField(
+                        low = decrypted[offset].toInt(),
+                        high = decrypted[offset + 1].toInt(),
+                        directGlucoseEncoding = directGlucoseEncoding,
+                    )
+                    val dataState = field.nibble
+                    val glucoseMmolL = field.glucoseMmolL
+                    val glucoseMgdl = field.glucoseMgdl
                     records += ICanHealthSnHistoryRecord(
                         sequenceNumber = sequenceNumber,
                         subtype = subtype,
@@ -690,16 +692,14 @@ object ICanHealthParser {
                     usesNewBundledCrypto = usesNewBundledCrypto,
                     warmupMinutes = warmupMinutes,
                 ) ?: return null
-                val low = glucoseBytes[0].toInt() and 0xFF
-                val high = glucoseBytes[1].toInt() and 0xFF
-                val dataState = if (directGlucoseEncoding) 0 else (high ushr 4) and 0x0F
-                val glucoseRaw = if (directGlucoseEncoding) {
-                    low or (high shl 8)
-                } else {
-                    low or ((high and 0x0F) shl 8)
-                }
-                val glucoseMmolL = glucoseRaw / 100.0f
-                val glucoseMgdl = glucoseMmolL * ICanHealthConstants.MMOL_TO_MGDL
+                val field = ICanHealthConstants.decodeGlucoseField(
+                    low = glucoseBytes[0].toInt(),
+                    high = glucoseBytes[1].toInt(),
+                    directGlucoseEncoding = directGlucoseEncoding,
+                )
+                val dataState = field.nibble
+                val glucoseMmolL = field.glucoseMmolL
+                val glucoseMgdl = field.glucoseMgdl
                 val currentValue = decodeCurrentValue(decrypted[9], decrypted[10])
                 val temperature = parseLeUnsigned(decrypted, 11) / 10.0f
                 ICanHealthSnHistoryRecord(
@@ -766,6 +766,36 @@ object ICanHealthParser {
         val vendorFormatted = "25${decoded.toString().padStart(5, '0')}"
         return vendorFormatted.toFloatOrNull() ?: Float.NaN
     }
+
+    /**
+     * Dump everything needed to understand one measurement from a single trace.
+     *
+     * The decrypted block is otherwise invisible, which has repeatedly made captures unable to
+     * answer questions about the encoding. Bytes 6..8 come along because the driver parses
+     * nothing from them, and the whole block because the fields it does parse have turned out
+     * not to mean what their names say.
+     */
+    private fun logGlucoseFieldDiagnostics(
+        decrypted: ByteArray,
+        headerSeq: Int,
+        field: ICanHealthGlucoseField,
+        temperatureC: Float,
+    ) {
+        runCatching {
+            Log.i(
+                TAG,
+                "glucose field seq=$headerSeq nibble=${field.nibble} mantissa=${field.mantissa}" +
+                    " -> ${"%.1f".format(field.glucoseMmolL)} mmol/L" +
+                    " (${"%.1f".format(field.glucoseMgdl)} mg/dL)" +
+                    " | flags=0x${"%02X".format(decrypted[1])}" +
+                    " status=${decrypted.copyOfRange(6, minOf(9, decrypted.size)).toHex()}" +
+                    " field11_12=${"%.1f".format(temperatureC)}" +
+                    " block=${decrypted.toHex()}"
+            )
+        }
+    }
+
+    private fun ByteArray.toHex(): String = joinToString(" ") { "%02X".format(it) }
 
     private fun logWarn(message: String) {
         runCatching { Log.w(TAG, message) }

--- a/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthGlucoseFieldTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthGlucoseFieldTests.kt
@@ -1,0 +1,71 @@
+package tk.glucodata.drivers.icanhealth
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the shared glucose-field decode.
+ *
+ * Three call sites used to carry byte-identical copies of this arithmetic; these tests exist so
+ * the single remaining copy cannot drift, and so the high nibble stays out of the value.
+ */
+class ICanHealthGlucoseFieldTests {
+
+    /** Build the two wire bytes for a 12-bit value and a 4-bit high nibble. */
+    private fun decode(mantissa: Int, nibble: Int, direct: Boolean = false) =
+        ICanHealthConstants.decodeGlucoseField(
+            low = mantissa and 0xFF,
+            high = ((nibble and 0x0F) shl 4) or ((mantissa ushr 8) and 0x0F),
+            directGlucoseEncoding = direct,
+        )
+
+    @Test
+    fun twelveBitValueIsHundredthsOfMmol() {
+        val field = decode(780, 0x0)
+        assertEquals(780, field.mantissa)
+        assertEquals(7.80f, field.glucoseMmolL, 0.01f)
+        assertEquals(140.5f, field.glucoseMgdl, 0.5f)
+    }
+
+    @Test
+    fun theHighNibbleNeverChangesTheValue() {
+        // Captures show this nibble constant per sensor and different between sensors (0x1 on one
+        // i6, 0x0 on another), so it cannot be an exponent or a per-reading state. Reading it as
+        // an exponent once scaled 317 to 3170 mg/dL and got every reading discarded as
+        // out-of-range, so every nibble must decode identically.
+        val expected = decode(527, 0x0).glucoseMmolL
+        (0x0..0xF).forEach { nibble ->
+            assertEquals(
+                "nibble 0x${nibble.toString(16)} changed the value",
+                expected,
+                decode(527, nibble).glucoseMmolL,
+                0.0001f
+            )
+        }
+    }
+
+    @Test
+    fun theNibbleIsStillReportedForDiagnosis() {
+        assertEquals(0x1, decode(527, 0x1).nibble)
+        assertEquals(0x0, decode(527, 0x0).nibble)
+        assertEquals(0xF, decode(527, 0xF).nibble)
+    }
+
+    @Test
+    fun valueKeepsAllTwelveBitsUnsigned() {
+        // 2525 has bit 11 set; a signed read would make it negative.
+        assertEquals(2525, decode(2525, 0xF).mantissa)
+        assertEquals(4095, decode(4095, 0x0).mantissa)
+    }
+
+    @Test
+    fun directEncodingUsesAllSixteenBitsAndReportsNoNibble() {
+        val field = ICanHealthConstants.decodeGlucoseField(
+            low = 0xDD,
+            high = 0x09,
+            directGlucoseEncoding = true,
+        )
+        assertEquals(2525, field.mantissa)
+        assertEquals(0, field.nibble)
+    }
+}

--- a/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthLifetimeTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/icanhealth/ICanHealthLifetimeTests.kt
@@ -1,0 +1,66 @@
+package tk.glucodata.drivers.icanhealth
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the native poll geometry against the day-15 cliff.
+ *
+ * Poll storage is sized from the declared wear duration. If a profile ever declares fewer days
+ * than the sensor is expected to run, `validPollIndex()` starts refusing partway through the
+ * wear and live readings are dropped without anything user-visible saying so.
+ */
+class ICanHealthLifetimeTests {
+
+    private val profiles = listOf(
+        ICanHealthProfileResolver.resolve("iCGM-t3"),
+        ICanHealthProfileResolver.resolve("iCGM-t6"),
+        ICanHealthProfileResolver.resolve("iCGM-i7"),
+        ICanHealthProfileResolver.resolve("iCGM-i7e"),
+        ICanHealthProfileResolver.resolve("iCGM-H3"),
+        ICanHealthProfileResolver.resolve(null),
+    )
+
+    @Test
+    fun everyProfileDeclaresAtLeastItsRatedLifetime() {
+        profiles.forEach { profile ->
+            assertTrue(
+                "${profile.familyName} declares ${profile.advisoryExpectedDays}d storage for a " +
+                    "${profile.ratedLifetimeDays}d rating",
+                profile.advisoryExpectedDays >= profile.ratedLifetimeDays
+            )
+        }
+    }
+
+    @Test
+    fun everyProfileClearsTheFifteenDayPollFloor() {
+        // maxstreampos() floors geometry at 15 days; declaring less can only shrink a shell.
+        profiles.forEach { profile ->
+            assertTrue(
+                "${profile.familyName} would cap storage below the 15-day native floor",
+                profile.advisoryExpectedDays >= 15
+            )
+        }
+    }
+
+    @Test
+    fun declaredLifetimeStaysWithinTheNativeShellMaximum() {
+        // Native maxdays is 46; a longer declaration would be silently clamped.
+        profiles.forEach { profile ->
+            assertTrue(
+                "${profile.familyName} declares ${profile.advisoryExpectedDays}d, above native maxdays",
+                profile.advisoryExpectedDays <= 46
+            )
+        }
+    }
+
+    @Test
+    fun i3DeclaresTwentyEightDaysNotItsFifteenDayRating() {
+        // The regression this covers: an i3 sized to its 15-day rating stopped storing on day 15
+        // even though the hardware kept running.
+        val i3 = ICanHealthProfileResolver.resolve("iCGM-t3")
+        assertEquals(15, i3.ratedLifetimeDays)
+        assertEquals(28, i3.advisoryExpectedDays)
+    }
+}


### PR DESCRIPTION
Follow-up to #211 and #216. Diagnostics and one real fix; **no change to how any glucose value is computed.**

## Why

Chasing two iCan field reports (a CN i6 reading far from meter, a CN i3 that stopped at day 15) kept stalling on the same thing: the driver was reverse-engineered from one vendor app against one sensor family, and every capture we took was blind to the parts where units diverge. Several theories were built and refuted purely because the traces could not show the bytes involved.

## What's here

**Log the whole BLE wire.** Every notification and every write as raw hex before anything interprets them, the raw bytes behind each parsed read, and the full service/characteristic map with properties once per connection. Also the resolved auth user id with every candidate it was chosen from — that identity comes from a fallback chain whose head a remove-and-re-add clears, so the app can authenticate under a different identity than last time with nothing saying so.

Reading the GATT map immediately turned up readable characteristics the driver never touched.

**One glucose decode instead of three.** The live frame, the SN history batch and the encrypted history record each carried a byte-identical copy of the same field arithmetic, free to drift apart. They now share `ICanHealthConstants.decodeGlucoseField()`.

The 12-bit value stays hundredths of mmol/L, **unchanged**. What the high nibble carries is still unknown, but captures rule out the obvious readings: it is constant for the life of a sensor and differs between sensors — `0x1` on one i6, `0x0` on another — so it is neither an IEEE-11073 exponent nor a per-reading state. It is decoded out, reported, and used for nothing. A test asserts all sixteen nibble values decode identically, because reading it as an exponent once turned 317 into 3170 mg/dL and got every reading discarded as out of range.

Each measurement now logs its decrypted block, the nibble and value, the flags byte and bytes 6..8.

**Size the poll store for how long the sensor actually runs.** The one behaviour fix. Native poll geometry comes from `info->days` with a 15-day floor, so a sensor rated 15 that keeps going walks off the end of its own poll map on day 15: `validPollIndex()` starts refusing and every live write is dropped silently. `pollStorageSize()` already documents this against Ottai's rating extending to 28/30, and both Ottai and Anytime declare their duration via `setSensorWearDays`. iCan never did.

Geometry is only recomputed when a shell is constructed, so this fixes sensors created from here on; ones already on a 21600-record store keep it.

Confirmed on hardware — a fresh i6 logs `Declared 28-day native lifetime … (40320 records)`.

**Read CGM Feature (`0x2AA8`) and CGM Session Run Time (`0x2AAB`).** Both readable on every unit seen, neither ever read. iCGM-t6 answers `0x004001` with `0xFFFF` in the CRC field: calibration supported, E2E-CRC not. Session Run Time reads 480 hours on an i6 — matching neither the profile's 15-day rating nor the 28-day advisory, and better evidence than either. Logged only; nothing consumes them yet.

## Deliberately not here

- Any change to the decoded glucose value, or a per-sensor scale option. An earlier attempt inferred that CN units used a different scale from a single anchor; a later reading refuted it, and applying it would have made CN sensors read *worse*.
- RACP command fallbacks. A sensor refusing every history request with `0x0A` looked like a firmware trait; a second unit on identical firmware (`V01.05.00.00_B0001`, `cgmFeature=0x004001`) accepted the same request first try. That was one defective sensor, not a protocol gap.
- Any change to `warmupMinutes`. It gates only the XOR descramble boundary in `decodeHistoryGlucoseBytes`, not a warm-up window, and global i6 works today with its current value.

## Tests

`./gradlew :Common:testMobileDebugUnitTest` — **1864 tests, 0 failures**, including 9 new (5 decode, 4 lifetime).
`./gradlew :Common:compileMobileDebugKotlin` clean. `git diff --check` clean.

## Note on log volume

The wire dump is verbose by design — roughly 8 lines per 3-minute reading plus a burst per connection. Worth putting behind a toggle once the outstanding iCan questions are settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)