### PR TITLE
Clone: preserve glucose source and delivery route

### DIFF
--- a/Common/src/main/cpp/cmdline/main.cpp
+++ b/Common/src/main/cpp/cmdline/main.cpp
@@ -987,9 +987,10 @@ static void writeMirrorCalibrationFile(const char *serial, const char *json) {
     }
 }
 
-extern void javaMirrorSyncSensor(const char *serial, bool forceFull);
-void javaMirrorSyncSensor(const char *serial, bool forceFull) {
-    LOGGER("javaMirrorSyncSensor(%s,%d)\n", serial ? serial : "(null)", forceFull);
+extern void javaMirrorSyncSensor(const char *serial, bool forceFull, int cloneTransport);
+void javaMirrorSyncSensor(const char *serial, bool forceFull, int cloneTransport) {
+    LOGGER("javaMirrorSyncSensor(%s,%d,%d)\n", serial ? serial : "(null)", forceFull,
+           cloneTransport);
 }
 extern std::string javaExportCalibrationProfile(const char *serial);
 std::string javaExportCalibrationProfile(const char *serial) {

--- a/Common/src/main/cpp/curve/javacurve.cpp
+++ b/Common/src/main/cpp/curve/javacurve.cpp
@@ -108,7 +108,8 @@ jmethodID jdoglucose = nullptr, jupdateDevices = nullptr,
           jbluetoothEnabled = nullptr, jspeak = nullptr, jresetWearOS = nullptr,
           jbluePermission = nullptr;
 static jclass JNIHistorySyncAccess = nullptr;
-static jmethodID jhistorySyncSensor = nullptr,
+static jmethodID jhistoryMarkCloneSensor = nullptr,
+                 jhistorySyncSensor = nullptr,
                  jhistoryForceFullSyncSensor = nullptr,
                  jhistoryMergeFullSyncSensor = nullptr;
 static jclass JNICalibrationProfileAccess = nullptr;
@@ -288,6 +289,13 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     if (cl) {
       JNIHistorySyncAccess = (jclass)env->NewGlobalRef(cl);
       env->DeleteLocalRef(cl);
+      if (!(jhistoryMarkCloneSensor = env->GetStaticMethodID(
+                JNIHistorySyncAccess, "markCloneSensor",
+                "(Ljava/lang/String;I)V"))) {
+        LOGAR(
+            R"(GetStaticMethodID(JNIHistorySyncAccess,"markCloneSensor","(Ljava/lang/String;I)V") failed)"
+            "");
+      }
       if (!(jhistorySyncSensor = env->GetStaticMethodID(
                 JNIHistorySyncAccess, "syncSensorFromNative",
                 "(Ljava/lang/String;Z)V"))) {
@@ -432,7 +440,7 @@ bool bluetoothEnabled() {
 int bluePermission() {
   return getenv()->CallStaticIntMethod(JNIApplic, jbluePermission);
 }
-void javaMirrorSyncSensor(const char *serial, bool forceFull) {
+void javaMirrorSyncSensor(const char *serial, bool forceFull, int cloneTransport) {
   if (!serial || !*serial) {
     return;
   }
@@ -442,6 +450,14 @@ void javaMirrorSyncSensor(const char *serial, bool forceFull) {
   }
   JNIEnv *env = getenv();
   jstring jserial = env->NewStringUTF(serial);
+  if (jhistoryMarkCloneSensor) {
+    env->CallStaticVoidMethod(JNIHistorySyncAccess, jhistoryMarkCloneSensor,
+                              jserial, cloneTransport);
+    if (env->ExceptionCheck()) {
+      LOGAR("markCloneSensor exception");
+      env->ExceptionClear();
+    }
+  }
   if (forceFull) {
     if (jhistoryMergeFullSyncSensor) {
       env->CallStaticVoidMethod(JNIHistorySyncAccess, jhistoryMergeFullSyncSensor,

--- a/Common/src/main/cpp/net/Connect.hpp
+++ b/Common/src/main/cpp/net/Connect.hpp
@@ -28,6 +28,10 @@
 #include "crypt.h"
 #include "backup.hpp"
 template<int nr> using unique_al= std::unique_ptr<uint8_t[],ardeleter<nr,uint8_t>> ;
+inline constexpr int clone_transport_unknown = 0;
+inline constexpr int clone_transport_local_ice = 1;
+inline constexpr int clone_transport_turn = 2;
+
 class Connect {
 protected:
 public:
@@ -108,6 +112,7 @@ bool receiveConnect(passhost_t *hostptr);
 virtual void setSenderTimeouts()  =0;
 virtual void setReceiverTimeouts()  =0;
 virtual void endConnection()  =0;
+virtual int cloneTransportCode() const { return clone_transport_unknown; }
 
 template <typename T> bool senddata(crypt_t *pass,const int offset,const T *startin,const T* endin,const std::string_view naar,uint16_t dowith=0,const uint8_t *extra=nullptr, int extralen=0) {
 	const senddata_t *start=reinterpret_cast<const senddata_t*>(startin);	

--- a/Common/src/main/cpp/net/ICE/ICE.cpp
+++ b/Common/src/main/cpp/net/ICE/ICE.cpp
@@ -261,6 +261,22 @@ static void on_recv1(juice_agent_t *agent, const char *data, size_t size, void *
     userdata[head->side!=host.side].on_recv(agent,data,size,allindex);
     }
 
+static int selectedCloneTransportCode(juice_agent *agent) {
+    char localAddr[JUICE_MAX_ADDRESS_STRING_LEN];
+    char remoteAddr[JUICE_MAX_ADDRESS_STRING_LEN];
+    if (juice_get_selected_addresses_inc_type(
+            agent,
+            localAddr,
+            JUICE_MAX_ADDRESS_STRING_LEN,
+            remoteAddr,
+            JUICE_MAX_ADDRESS_STRING_LEN) != 0) {
+        return clone_transport_unknown;
+    }
+    return strstr(localAddr, " Relay") || strstr(remoteAddr, " Relay")
+        ? clone_transport_turn
+        : clone_transport_local_ice;
+}
+
 static bool diagnostics(juice_agent *agent,const char *name,bool side) {
     bool success=true;
     // Retrieve candidates
@@ -314,6 +330,7 @@ static void on_state_changed1(juice_agent_t *agent, juice_state_t state, void *u
     switch(state) {
         case	JUICE_STATE_GATHERING:
         case	JUICE_STATE_CONNECTING:
+            con->selectedCloneTransport.store(clone_transport_unknown);
             con->notConnected();
             break;
         case JUICE_STATE_CONNECTED: {
@@ -321,6 +338,7 @@ static void on_state_changed1(juice_agent_t *agent, juice_state_t state, void *u
             con->setConnected();
             con->agent.store(agent);
             con->connectTime=time(nullptr);
+            con->selectedCloneTransport.store(selectedCloneTransportCode(agent));
             struct CONNECTED {
                 static void thread( juice_agent_t *agent, int allindex) {
                    LOGGERICE("start CONNECT::thread allindex=%d\n",allindex);

--- a/Common/src/main/cpp/net/ICE/ICEConnect.hpp
+++ b/Common/src/main/cpp/net/ICE/ICEConnect.hpp
@@ -76,6 +76,7 @@ bool endConnect=false;
 bool isConnected=false;
 ICE_data   icedata[2]{{allindex,side},{allindex,!side}};
 std::atomic<juice_agent*> agent;
+std::atomic<int> selectedCloneTransport{clone_transport_unknown};
 char sdp[JUICE_MAX_SDP_STRING_LEN];
 int sdplen;
 int hostindex;
@@ -107,6 +108,9 @@ virtual int setindex(int in) override{
         icedata[1].allindex=in;
         icedata[0].allindex=in;
         return Connect::setindex(in);
+        }
+int cloneTransportCode() const override {
+        return selectedCloneTransport.load();
         }
 #ifdef RESETAGENT
        bool recreateAgent=false;

--- a/Common/src/main/cpp/net/getcommand.cpp
+++ b/Common/src/main/cpp/net/getcommand.cpp
@@ -45,7 +45,7 @@
 
 extern Backup *backup;
 extern void        processglucosevalue(int sendindex,int newstart=-1);
-extern void javaMirrorSyncSensor(const char *serial, bool forceFull);
+extern void javaMirrorSyncSensor(const char *serial, bool forceFull, int cloneTransport);
 extern void javaImportMirrorCalibrationProfile(const char *serial, const char *json);
 
 //getdata filedata("/data/local/tmp/testdir");
@@ -112,15 +112,15 @@ int alignadd(int was,int bij) {
 //s/it+=comlen/it=alignadd(it,comlen)/g
 extern bool receivelastpos(const lastpos_t *data) ;
 
-static            bool savefileonce(const struct fileonce_t *gegs);
+static bool savefileonce(const struct fileonce_t *gegs, int cloneTransport);
 
-static void mirrorSyncSensor(int sendindex, bool forceFull) {
+static void mirrorSyncSensor(int sendindex, bool forceFull, int cloneTransport) {
     if(sendindex < 0 || !sensors) {
         return;
     }
     if(SensorGlucoseData *hist = sensors->getSensorData(sendindex)) {
         if(const auto *serial = hist->shortsensorname(); serial && serial->data()[0]) {
-            javaMirrorSyncSensor(serial->data(), forceFull);
+            javaMirrorSyncSensor(serial->data(), forceFull, cloneTransport);
         }
     }
 }
@@ -138,12 +138,13 @@ static std::string extractMirrorSensorSerial(std::string_view name) {
     return std::string(rest.substr(0, slash));
 }
 
-static void mirrorSyncSensorForPath(std::string_view path, int sendindex, bool forceFull) {
+static void mirrorSyncSensorForPath(std::string_view path, int sendindex, bool forceFull,
+                                    int cloneTransport) {
     if (std::string serial = extractMirrorSensorSerial(path); !serial.empty()) {
-        javaMirrorSyncSensor(serial.c_str(), forceFull);
+        javaMirrorSyncSensor(serial.c_str(), forceFull, cloneTransport);
         return;
     }
-    mirrorSyncSensor(sendindex, forceFull);
+    mirrorSyncSensor(sendindex, forceFull, cloneTransport);
 }
 
 static std::vector<std::pair<std::string, bool>> pendingMirrorSensorSyncs;
@@ -162,9 +163,9 @@ static void queueMirrorSyncSensorForPath(std::string_view path, bool forceFull) 
     pendingMirrorSensorSyncs.emplace_back(std::move(serial), forceFull);
 }
 
-static void flushPendingMirrorSensorSyncs() {
+static void flushPendingMirrorSensorSyncs(int cloneTransport) {
     for (const auto &entry : pendingMirrorSensorSyncs) {
-        javaMirrorSyncSensor(entry.first.c_str(), entry.second);
+        javaMirrorSyncSensor(entry.first.c_str(), entry.second, cloneTransport);
     }
     pendingMirrorSensorSyncs.clear();
 }
@@ -504,7 +505,7 @@ for(int it=0;it<len;) {
                 }
 extern                bool updateDevices() ;
             ret=updateDevices();
-            flushPendingMirrorSensorSyncs();
+            flushPendingMirrorSensorSyncs(cloneTransportCode());
             LOGGERTAG("updateDevices=%d\n",ret);
             };break;
         case sbackup: 
@@ -574,7 +575,7 @@ extern                bool updateDevices() ;
                 return {it,comlen};
                 }
 
-            ret=savefileonce(gegs);
+            ret=savefileonce(gegs, cloneTransportCode());
             } break;
         default:;
         }
@@ -999,7 +1000,7 @@ static bool startedreceiving() {
 #include        <filesystem>
 #include "strsepconcat.hpp"
 */
-static bool savefileonce(const struct fileonce_t *gegs) {
+static bool savefileonce(const struct fileonce_t *gegs, int cloneTransport) {
     const int nr=gegs->nr;
     const uint8_t *start=reinterpret_cast<const uint8_t*>(&gegs->gegs[nr]);
     const char *name=reinterpret_cast<const char *>(start);
@@ -1031,7 +1032,7 @@ static bool savefileonce(const struct fileonce_t *gegs) {
     if((gegs->dowith&startcalibratedupdate)==startcalibratedupdate) {
         const auto [sendindex,startpos,history]= getcaliinfo(gegs,start);
         setcalibratedstart(sendindex,startpos,history);
-        mirrorSyncSensorForPath(namesv, sendindex, true);
+        mirrorSyncSensorForPath(namesv, sendindex, true, cloneTransport);
 /*
         int namelen=gegs->namelen-1;
         pathconcat fullpathin{filedata.getbase(),std::string_view(name,namelen)};
@@ -1047,14 +1048,14 @@ static bool savefileonce(const struct fileonce_t *gegs) {
         if((gegs->dowith&streamupdatebit)==streamupdatebit) {
                 const auto [sendindex,startpos]=getstartinfo(gegs,start);
                 processglucosevalue(sendindex,startpos);
-                mirrorSyncSensorForPath(namesv, sendindex, false);
+                mirrorSyncSensorForPath(namesv, sendindex, false, cloneTransport);
 
                 }
         else {
                 if((gegs->dowith&starthistoryupdate)==starthistoryupdate) {
                         const auto [sendindex,startpos]=getstartinfo(gegs,start);
                         sethistorystart(sendindex,startpos);
-                        mirrorSyncSensorForPath(namesv, sendindex, true);
+                        mirrorSyncSensorForPath(namesv, sendindex, true, cloneTransport);
                         }
              }
         }

--- a/Common/src/main/java/tk/glucodata/CloneSensorRegistry.kt
+++ b/Common/src/main/java/tk/glucodata/CloneSensorRegistry.kt
@@ -1,0 +1,112 @@
+package tk.glucodata
+
+import android.content.Context
+import java.util.Locale
+
+enum class CloneTransport(val code: Int) {
+    UNKNOWN(0),
+    LOCAL_ICE(1),
+    TURN(2);
+
+    companion object {
+        fun fromCode(code: Int): CloneTransport = entries.firstOrNull { it.code == code } ?: UNKNOWN
+    }
+}
+
+internal object CloneSensorKeyCodec {
+    fun normalize(sensorId: String?): String? = sensorId
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.uppercase(Locale.ROOT)
+
+    fun decode(encoded: String?): Map<String, CloneTransport> = encoded
+        .orEmpty()
+        .lineSequence()
+        .mapNotNull { line ->
+            val key = normalize(line.substringBefore('|')) ?: return@mapNotNull null
+            val transport = CloneTransport.fromCode(line.substringAfter('|', "0").trim().toIntOrNull() ?: 0)
+            key to transport
+        }
+        .toMap()
+
+    fun encode(entries: Map<String, CloneTransport>): String = entries
+        .mapNotNull { (key, transport) -> normalize(key)?.let { it to transport } }
+        .distinctBy { it.first }
+        .sortedBy { it.first }
+        .joinToString("\n") { (key, transport) -> "$key|${transport.code}" }
+}
+
+/** Records which sensor files are being populated by the phone-to-phone clone path. */
+object CloneSensorRegistry {
+    private const val PREFS_NAME = "tk.glucodata_preferences"
+    private const val KEY_SENSOR_IDS = "clone_source_sensor_ids_v1"
+    private val lock = Any()
+
+    private fun prefs() = Applic.app?.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private fun candidateKeys(sensorId: String?): Set<String> {
+        val raw = sensorId?.trim()?.takeIf { it.isNotEmpty() } ?: return emptySet()
+        return buildSet {
+            CloneSensorKeyCodec.normalize(raw)?.let(::add)
+            runCatching { SensorIdentity.canonicalSensorId(raw) }
+                .getOrNull()
+                ?.let(CloneSensorKeyCodec::normalize)
+                ?.let(::add)
+            runCatching { SensorIdentity.resolveNativeSensorName(raw) }
+                .getOrNull()
+                ?.let(CloneSensorKeyCodec::normalize)
+                ?.let(::add)
+            runCatching { SensorIdentity.resolveRoomStorageSensorId(raw) }
+                .getOrNull()
+                ?.let(CloneSensorKeyCodec::normalize)
+                ?.let(::add)
+        }
+    }
+
+    @JvmStatic
+    fun markCloneSensor(sensorId: String?, transportCode: Int) {
+        val key = CloneSensorKeyCodec.normalize(sensorId) ?: return
+        val transport = CloneTransport.fromCode(transportCode)
+        synchronized(lock) {
+            val preferences = prefs() ?: return
+            val current = CloneSensorKeyCodec.decode(preferences.getString(KEY_SENSOR_IDS, null))
+            val effectiveTransport = if (transport == CloneTransport.UNKNOWN) {
+                current[key] ?: CloneTransport.UNKNOWN
+            } else {
+                transport
+            }
+            if (current[key] == effectiveTransport) return
+            preferences.edit()
+                .putString(KEY_SENSOR_IDS, CloneSensorKeyCodec.encode(current + (key to effectiveTransport)))
+                .apply()
+        }
+    }
+
+    @JvmStatic
+    fun markLocalSensor(sensorId: String?) {
+        val localKeys = candidateKeys(sensorId)
+        if (localKeys.isEmpty()) return
+        synchronized(lock) {
+            val preferences = prefs() ?: return
+            val current = CloneSensorKeyCodec.decode(preferences.getString(KEY_SENSOR_IDS, null))
+            val updated = current.filterKeys { it !in localKeys }
+            if (updated == current) return
+            preferences.edit()
+                .putString(KEY_SENSOR_IDS, CloneSensorKeyCodec.encode(updated))
+                .apply()
+        }
+    }
+
+    @JvmStatic
+    fun isCloneSensor(sensorId: String?): Boolean {
+        return transportForSensor(sensorId) != null
+    }
+
+    @JvmStatic
+    fun transportForSensor(sensorId: String?): CloneTransport? {
+        val requested = candidateKeys(sensorId)
+        if (requested.isEmpty()) return null
+        val stored = CloneSensorKeyCodec.decode(prefs()?.getString(KEY_SENSOR_IDS, null))
+        return requested.asSequence().mapNotNull(stored::get).firstOrNull()
+    }
+}

--- a/Common/src/main/java/tk/glucodata/GlucoseReadingSource.kt
+++ b/Common/src/main/java/tk/glucodata/GlucoseReadingSource.kt
@@ -1,0 +1,26 @@
+package tk.glucodata
+
+/** Stable database values describing how a glucose row reached this phone. */
+object GlucoseReadingSource {
+    const val SENSOR = "sensor"
+    const val NIGHTSCOUT = "nightscout"
+    const val API = "api"
+    const val MQ_FOLLOWER = "mq_follower"
+    const val IMPORT = "import"
+    const val CLONE = "clone"
+    const val CLONE_LOCAL_ICE = "clone_local_ice"
+    const val CLONE_TURN = "clone_turn"
+
+    fun forCloneTransport(transport: CloneTransport?): String = when (transport) {
+        CloneTransport.LOCAL_ICE -> CLONE_LOCAL_ICE
+        CloneTransport.TURN -> CLONE_TURN
+        CloneTransport.UNKNOWN, null -> CLONE
+    }
+
+    fun cloneTransport(source: String?): CloneTransport? = when (source) {
+        CLONE_LOCAL_ICE -> CloneTransport.LOCAL_ICE
+        CLONE_TURN -> CloneTransport.TURN
+        CLONE -> CloneTransport.UNKNOWN
+        else -> null
+    }
+}

--- a/Common/src/main/java/tk/glucodata/HistorySourceProvenance.kt
+++ b/Common/src/main/java/tk/glucodata/HistorySourceProvenance.kt
@@ -2,11 +2,8 @@ package tk.glucodata
 
 /** Keeps a row's known origin stable when overlap syncs revisit the same timestamp. */
 object HistorySourceProvenance {
-    fun stableSource(existing: String?, incoming: String): String = when {
-        existing == null -> incoming
-        existing == GlucoseReadingSource.SENSOR && incoming != GlucoseReadingSource.SENSOR -> incoming
-        else -> existing
-    }
+    fun stableSource(existing: String?, incoming: String): String =
+        existing?.takeIf { it.isNotBlank() } ?: incoming
 
     fun stableFirstStoredAt(existing: Long?, incoming: Long): Long = when {
         existing != null && existing > 0L -> existing

--- a/Common/src/main/java/tk/glucodata/HistorySourceProvenance.kt
+++ b/Common/src/main/java/tk/glucodata/HistorySourceProvenance.kt
@@ -1,0 +1,10 @@
+package tk.glucodata
+
+/** Keeps a row's known origin stable when overlap syncs revisit the same timestamp. */
+object HistorySourceProvenance {
+    fun stableSource(existing: String?, incoming: String): String = when {
+        existing == null -> incoming
+        existing == GlucoseReadingSource.SENSOR && incoming != GlucoseReadingSource.SENSOR -> incoming
+        else -> existing
+    }
+}

--- a/Common/src/main/java/tk/glucodata/HistorySourceProvenance.kt
+++ b/Common/src/main/java/tk/glucodata/HistorySourceProvenance.kt
@@ -7,4 +7,10 @@ object HistorySourceProvenance {
         existing == GlucoseReadingSource.SENSOR && incoming != GlucoseReadingSource.SENSOR -> incoming
         else -> existing
     }
+
+    fun stableFirstStoredAt(existing: Long?, incoming: Long): Long = when {
+        existing != null && existing > 0L -> existing
+        incoming > 0L -> incoming
+        else -> System.currentTimeMillis()
+    }
 }

--- a/Common/src/main/java/tk/glucodata/HistorySyncAccess.kt
+++ b/Common/src/main/java/tk/glucodata/HistorySyncAccess.kt
@@ -58,6 +58,19 @@ object HistorySyncAccess {
             )
         }.getOrNull()
     }
+    private val storeReadingWithSourceMethod by lazy {
+        runCatching {
+            repositoryHolder?.getMethod(
+                "storeReadingWithSourceAsync",
+                Long::class.javaPrimitiveType,
+                Float::class.javaPrimitiveType,
+                Float::class.javaPrimitiveType,
+                Float::class.javaPrimitiveType,
+                String::class.java,
+                String::class.java
+            )
+        }.getOrNull()
+    }
     private val storeHistoryBatchMethod by lazy {
         runCatching {
             repositoryHolder?.getMethod(
@@ -77,6 +90,18 @@ object HistorySyncAccess {
                 LongArray::class.java,
                 FloatArray::class.java,
                 FloatArray::class.java
+            )
+        }.getOrNull()
+    }
+    private val storeHistoryBatchWithSourceBlockingMethod by lazy {
+        runCatching {
+            repositoryHolder?.getMethod(
+                "storeHistoryBatchWithSourceBlocking",
+                String::class.java,
+                LongArray::class.java,
+                FloatArray::class.java,
+                FloatArray::class.java,
+                String::class.java
             )
         }.getOrNull()
     }
@@ -255,6 +280,37 @@ object HistorySyncAccess {
     }
 
     @JvmStatic
+    fun storeCurrentReadingWithSourceAsync(
+        timestamp: Long,
+        valueMgdl: Float,
+        rawValueMgdl: Float,
+        rate: Float,
+        sensorSerial: String?,
+        source: String
+    ) {
+        if (timestamp <= 0L || sensorSerial.isNullOrBlank()) return
+        val method = storeReadingWithSourceMethod
+        if (method == null) {
+            Log.w(TAG, "source-aware current storage unavailable; using sensor default for $sensorSerial")
+            storeCurrentReadingAsync(timestamp, valueMgdl, rawValueMgdl, rate, sensorSerial)
+            return
+        }
+        runCatching {
+            method.invoke(
+                null,
+                timestamp,
+                valueMgdl,
+                rawValueMgdl,
+                rate,
+                sensorSerial,
+                source,
+            )
+        }.onFailure {
+            Log.w(TAG, "source-aware current storage failed for serial=$sensorSerial timestamp=$timestamp", it)
+        }
+    }
+
+    @JvmStatic
     fun storeSensorHistoryBatchAsync(
         sensorSerial: String?,
         timestamps: LongArray,
@@ -313,6 +369,35 @@ object HistorySyncAccess {
                 "storeSensorHistoryBatchBlocking failed for serial=$sensorSerial size=${timestamps.size}",
                 it
             )
+        }.getOrDefault(false)
+    }
+
+    @JvmStatic
+    fun storeSensorHistoryBatchWithSourceBlocking(
+        sensorSerial: String?,
+        timestamps: LongArray,
+        valuesMgdl: FloatArray,
+        rawValuesMgdl: FloatArray,
+        source: String
+    ): Boolean {
+        if (sensorSerial.isNullOrBlank()) return false
+        if (timestamps.isEmpty()) return true
+        val method = storeHistoryBatchWithSourceBlockingMethod
+        if (method == null) {
+            Log.w(TAG, "source-aware history storage unavailable; using sensor default for $sensorSerial")
+            return storeSensorHistoryBatchBlocking(sensorSerial, timestamps, valuesMgdl, rawValuesMgdl)
+        }
+        return runCatching {
+            method.invoke(
+                null,
+                sensorSerial,
+                timestamps,
+                valuesMgdl,
+                rawValuesMgdl,
+                source,
+            ) as? Boolean ?: false
+        }.onFailure {
+            Log.w(TAG, "source-aware history storage failed for serial=$sensorSerial size=${timestamps.size}", it)
         }.getOrDefault(false)
     }
 

--- a/Common/src/main/java/tk/glucodata/HistorySyncAccess.kt
+++ b/Common/src/main/java/tk/glucodata/HistorySyncAccess.kt
@@ -110,6 +110,12 @@ object HistorySyncAccess {
         }.getOrNull() ?: DEFAULT_AIDEX_SOURCE
     }
 
+    /** Called only by the native mirror receiver before it imports remote sensor files. */
+    @JvmStatic
+    fun markCloneSensor(serial: String?, transportCode: Int) {
+        CloneSensorRegistry.markCloneSensor(serial, transportCode)
+    }
+
     @JvmStatic
     @JvmOverloads
     fun syncSensorFromNative(serial: String?, forceFull: Boolean = false) {

--- a/Common/src/main/java/tk/glucodata/SuperGattCallback.java
+++ b/Common/src/main/java/tk/glucodata/SuperGattCallback.java
@@ -810,6 +810,7 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
                     Log.i(LOG_ID, "RAW mode during warmup: using raw=" + glucoseToUse + " mgdl=" + mgdlToUse);
                 }
 
+                CloneSensorRegistry.markLocalSensor(SerialNumber);
                 markLocalReadingAccepted(timmsec);
                 dowithglucose(SerialNumber, mgdlToUse, glucoseToUse, rate, alarm, timmsec, sensorstartmsec, showtime, sensorgen);
                 charcha[0] = timmsec;
@@ -888,6 +889,7 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
                 mgdlToUse = (int) Math.round(glucoseToUse * (Applic.unit == 1 ? mgdLmult : 1.0f));
             }
 
+            CloneSensorRegistry.markLocalSensor(SerialNumber);
             markLocalReadingAccepted(timmsec);
             dowithglucose(SerialNumber, mgdlToUse, glucoseToUse, rate, alarm, timmsec, sensorstartmsec, showtime,
                     sensorgen);

--- a/Common/src/main/java/tk/glucodata/drivers/VirtualGlucoseSensorBridge.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/VirtualGlucoseSensorBridge.kt
@@ -2,6 +2,7 @@ package tk.glucodata.drivers
 
 import java.util.Locale
 import tk.glucodata.Applic
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.HistorySyncAccess
 import tk.glucodata.Log
 import tk.glucodata.SuperGattCallback
@@ -41,6 +42,7 @@ object VirtualGlucoseSensorBridge {
         logLabel: String = "virtual",
         backfill: Boolean = true,
         nearDuplicateWindowMs: Long = 0L,
+        source: String = GlucoseReadingSource.SENSOR,
     ): Int {
         if (sensorSerial.isBlank() || readings.isEmpty()) return 0
         val nowMs = System.currentTimeMillis()
@@ -89,7 +91,14 @@ object VirtualGlucoseSensorBridge {
             values[index] = reading.storageGlucoseMgdl
             rawValues[index] = reading.rawMgdl.takeIf { it.isFinite() && it > 0f } ?: Float.NaN
         }
-        if (!HistorySyncAccess.storeSensorHistoryBatchBlocking(sensorSerial, timestamps, values, rawValues)) {
+        if (!HistorySyncAccess.storeSensorHistoryBatchWithSourceBlocking(
+                sensorSerial,
+                timestamps,
+                values,
+                rawValues,
+                source,
+            )
+        ) {
             return 0
         }
         Log.i(
@@ -151,6 +160,7 @@ object VirtualGlucoseSensorBridge {
         reading: Reading,
         sensorGen: Int,
         logLabel: String = "virtual",
+        source: String = GlucoseReadingSource.SENSOR,
     ) {
         if (sensorSerial.isBlank()) return
         if (!isUsableCurrentReading(reading, System.currentTimeMillis())) {
@@ -160,12 +170,13 @@ object VirtualGlucoseSensorBridge {
 
         val rawMgdl = reading.rawMgdl.takeIf { it.isFinite() && it > 0f } ?: 0f
         val rate = reading.rate.takeIf { it.isFinite() } ?: 0f
-        HistorySyncAccess.storeCurrentReadingAsync(
+        HistorySyncAccess.storeCurrentReadingWithSourceAsync(
             reading.timestampMs,
             reading.storageGlucoseMgdl,
             rawMgdl,
             rate,
             sensorSerial,
+            source,
         )
 
         val primaryMgdl = reading.primaryGlucoseMgdl

--- a/Common/src/main/java/tk/glucodata/drivers/api/ApiGlucoseSourceManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/api/ApiGlucoseSourceManager.kt
@@ -10,6 +10,7 @@ import java.util.Locale
 import org.json.JSONArray
 import org.json.JSONObject
 import tk.glucodata.Applic
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.Log
 import tk.glucodata.R
 import tk.glucodata.SensorIdentity
@@ -252,6 +253,7 @@ class ApiGlucoseSourceManager(
             sensorSerial = SerialNumber,
             readings = readings,
             logLabel = "API source",
+            source = GlucoseReadingSource.API,
         )
         if (tailMs > 0L) {
             lastImportedHistoryTailMs = tailMs
@@ -280,6 +282,7 @@ class ApiGlucoseSourceManager(
             reading = latest.copy(rate = rate),
             sensorGen = SENSOR_GEN,
             logLabel = "API source",
+            source = GlucoseReadingSource.API,
         )
     }
 

--- a/Common/src/main/java/tk/glucodata/drivers/mq/MQFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/mq/MQFollowerManager.kt
@@ -7,6 +7,7 @@ import android.os.HandlerThread
 import java.util.Locale
 import kotlin.math.abs
 import tk.glucodata.Applic
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.HistorySyncAccess
 import tk.glucodata.Log
 import tk.glucodata.R
@@ -459,6 +460,7 @@ class MQFollowerManager(
                 )
             },
             logLabel = "MQ follower",
+            source = GlucoseReadingSource.MQ_FOLLOWER,
         )
         if (tailMs > 0L) {
             lastImportedHistoryTailMs = tailMs
@@ -504,6 +506,7 @@ class MQFollowerManager(
                 ),
                 sensorGen = MQBleManager.SENSOR_GEN,
                 logLabel = "MQ follower",
+                source = GlucoseReadingSource.MQ_FOLLOWER,
             )
         } else if (previousTimeMs > 0L && latest.timestampMs == previousTimeMs && previousMgdl != latest.glucoseMgdl) {
             UiRefreshBus.requestDataRefresh()

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.json.JSONArray
 import org.json.JSONObject
 import tk.glucodata.Applic
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.HistorySyncAccess
 import tk.glucodata.Log
 import tk.glucodata.R
@@ -426,6 +427,7 @@ class NightscoutFollowerManager(
             sensorSerial = SerialNumber,
             readings = readings,
             logLabel = "Nightscout follower",
+            source = GlucoseReadingSource.NIGHTSCOUT,
         )
         if (tailMs > 0L) {
             lastImportedHistoryTailMs = tailMs
@@ -449,6 +451,7 @@ class NightscoutFollowerManager(
             reading = latest.copy(rate = rate),
             sensorGen = SENSOR_GEN,
             logLabel = "Nightscout follower",
+            source = GlucoseReadingSource.NIGHTSCOUT,
         )
     }
 
@@ -475,6 +478,7 @@ class NightscoutFollowerManager(
                         sensorSerial = SerialNumber,
                         readings = page,
                         logLabel = "Nightscout follower",
+                        source = GlucoseReadingSource.NIGHTSCOUT,
                     )
                     check(imported > 0) {
                         "Nightscout history page could not be stored"

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistry.kt
@@ -227,6 +227,9 @@ object NightscoutFollowerRegistry {
         return left.isNotEmpty() && right.isNotEmpty() && left.equals(right, ignoreCase = true)
     }
 
+    fun isFollowerSensorId(candidate: String?): Boolean =
+        candidate?.trim()?.startsWith(SENSOR_PREFIX, ignoreCase = true) == true
+
     fun applyAuth(connection: HttpURLConnection, secret: String) {
         val trimmed = secret.trim()
         if (trimmed.isEmpty()) return

--- a/Common/src/main/java/tk/glucodata/ui/GlucosePoint.kt
+++ b/Common/src/main/java/tk/glucodata/ui/GlucosePoint.kt
@@ -1,5 +1,6 @@
 package tk.glucodata.ui
 
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.GlucoseUncertainty
 
 /**
@@ -24,6 +25,7 @@ data class GlucosePoint(
     val rawValue: Float = 0f,
     val rate: Float? = null,
     val sensorSerial: String? = null,
+    val source: String = GlucoseReadingSource.SENSOR,
     val uncertainty: GlucoseUncertainty? = null,
     val sealedDisplayValue: Float? = null,
 )

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2689,4 +2689,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Правяраць новыя значэнні</string>
     <string name="nightscout_follow_interval_desc">Як часта падпісчык апытвае сервер. Гэта таксама тое, наколькі старым можа быць значэнне, а значыць і наколькі позна прыйдзе трывога па сачыльным значэнні. У падпісчыка няма свайго сэнсара, які трымаў бы тэлефон абуджаным, таму кожная праверка — гэта абуджэнне.</string>
     <string name="nightscout_follow_interval_doze">Менш за 9 хвілін Android усё роўна можа разводзіць праверкі, пакуль тэлефон бяздзейнічае. Выключэнне Juggluco з аптымізацыі батарэі захоўвае выбраны інтэрвал.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone праз TURN</string>
+    <string name="clone_source_local_ice_description">Clone праз лакальны ICE</string>
 </resources>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2657,4 +2657,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightscout_follow_interval_title">Neue Werte abrufen</string>
     <string name="nightscout_follow_interval_desc">Wie oft der Follower den Server fragt. Das ist zugleich, wie alt ein Wert sein kann, und damit auch, wie spät ein Alarm auf einen gefolgten Wert kommen kann. Ein Follower hat keinen eigenen Sensor, der das Telefon wach hält, also ist jede Abfrage ein Aufwecken.</string>
     <string name="nightscout_follow_interval_doze">Unter 9 Minuten kann Android die Abfragen im Ruhezustand trotzdem weiter auseinanderziehen. Juggluco von der Akku-Optimierung auszunehmen hält das eingestellte Intervall.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone über TURN</string>
+    <string name="clone_source_local_ice_description">Clone über lokales ICE</string>
 </resources>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2624,4 +2624,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Rechercher de nouvelles valeurs</string>
     <string name="nightscout_follow_interval_desc">À quelle fréquence le suiveur interroge le serveur. C\'est aussi l\'âge que peut avoir une valeur, et donc le retard possible d\'une alarme déclenchée sur une valeur suivie. Un suiveur n\'a pas de capteur à lui pour garder le téléphone éveillé, donc chaque interrogation est un réveil.</string>
     <string name="nightscout_follow_interval_doze">En dessous de 9 minutes, Android peut malgré tout espacer les interrogations lorsque le téléphone est inactif. Exclure Juggluco de l\'optimisation de la batterie préserve l\'intervalle choisi.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone via TURN</string>
+    <string name="clone_source_local_ice_description">Clone via ICE local</string>
 </resources>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2608,4 +2608,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Cerca nuovi valori</string>
     <string name="nightscout_follow_interval_desc">Ogni quanto il follower interroga il server. È anche quanto può essere vecchio un valore, e quindi quanto può ritardare un allarme su un valore seguito. Un follower non ha un sensore proprio che tenga sveglio il telefono, quindi ogni controllo è un risveglio.</string>
     <string name="nightscout_follow_interval_doze">Sotto i 9 minuti Android può comunque distanziare i controlli mentre il telefono è inattivo. Escludere Juggluco dall\'ottimizzazione della batteria mantiene l\'intervallo scelto.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone tramite TURN</string>
+    <string name="clone_source_local_ice_description">Clone tramite ICE locale</string>
 </resources>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2725,4 +2725,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="nightscout_follow_interval_title">Шинэ утга шалгах</string>
     <string name="nightscout_follow_interval_desc">Дагагч сервер рүү ямар давтамжтай хандахыг заана. Энэ нь мөн утга хэр хуучин байж болохыг, тиймээс дагасан утган дээр сэрэмжлүүлэг хэр хожуу ирэхийг тодорхойлно. Дагагчид утсыг сэрүүн байлгах өөрийн мэдрэгч байхгүй тул шалгалт бүр нь сэрээх үйлдэл юм.</string>
     <string name="nightscout_follow_interval_doze">9 минутаас бага бол утас сул зогсож байх үед Android шалгалтуудыг улам сунгаж болно. Juggluco-г батерейны оновчлолоос хасвал сонгосон интервал хэвээр үлдэнэ.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">TURN-ээр дамжих Clone</string>
+    <string name="clone_source_local_ice_description">Дотоод ICE-ээр дамжих Clone</string>
 </resources>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2661,4 +2661,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="nightscout_follow_interval_title">Naar nieuwe waarden kijken</string>
     <string name="nightscout_follow_interval_desc">Hoe vaak de volger de server bevraagt. Dat is ook hoe oud een waarde kan zijn, en dus hoe laat een alarm op een gevolgde waarde kan komen. Een volger heeft geen eigen sensor die de telefoon wakker houdt, dus elke controle is een wekmoment.</string>
     <string name="nightscout_follow_interval_doze">Onder 9 minuten kan Android de controles alsnog verder uit elkaar leggen terwijl de telefoon inactief is. Juggluco uitsluiten van batterijoptimalisatie behoudt het gekozen interval.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone via TURN</string>
+    <string name="clone_source_local_ice_description">Clone via lokale ICE</string>
 </resources>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2656,4 +2656,7 @@
     <string name="nightscout_follow_interval_title">Sprawdzanie nowych wartości</string>
     <string name="nightscout_follow_interval_desc">Jak często obserwator odpytuje serwer. To zarazem wiek, jaki może mieć wartość, a więc i opóźnienie alarmu opartego na obserwowanej wartości. Obserwator nie ma własnego sensora, który utrzymywałby telefon wybudzony, więc każde sprawdzenie to wybudzenie.</string>
     <string name="nightscout_follow_interval_doze">Poniżej 9 minut Android i tak może rozsuwać sprawdzenia, gdy telefon jest bezczynny. Wyłączenie Juggluco z optymalizacji baterii zachowuje wybrany odstęp.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone przez TURN</string>
+    <string name="clone_source_local_ice_description">Clone przez lokalne ICE</string>
 </resources>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2619,4 +2619,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Procurar novos valores</string>
     <string name="nightscout_follow_interval_desc">Com que frequência o seguidor pergunta ao servidor. É também a idade que um valor pode ter e, portanto, o atraso possível de um alarme baseado num valor seguido. Um seguidor não tem sensor próprio para manter o telemóvel acordado, por isso cada verificação é um despertar.</string>
     <string name="nightscout_follow_interval_doze">Abaixo de 9 minutos, o Android pode ainda assim afastar as verificações enquanto o telemóvel está inativo. Excluir o Juggluco da otimização da bateria mantém o intervalo escolhido.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone por TURN</string>
+    <string name="clone_source_local_ice_description">Clone por ICE local</string>
 </resources>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2665,4 +2665,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Проверять новые значения</string>
     <string name="nightscout_follow_interval_desc">Как часто подписчик опрашивает сервер. Это же определяет, насколько старым может быть значение, а значит и насколько поздно придёт тревога по отслеживаемому значению. У подписчика нет своего сенсора, который держал бы телефон активным, поэтому каждая проверка — это пробуждение.</string>
     <string name="nightscout_follow_interval_doze">Меньше 9 минут Android всё равно может разносить проверки, пока телефон простаивает. Исключение Juggluco из оптимизации батареи сохраняет выбранный интервал.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone через TURN</string>
+    <string name="clone_source_local_ice_description">Clone через локальный ICE</string>
 </resources>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2810,4 +2810,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="nightscout_follow_interval_title">Hubi qiimayaal cusub</string>
     <string name="nightscout_follow_interval_desc">Inta jeer ee raacuhu weydiiyo server-ka. Waxay sidoo kale tahay sida uu qiime u duugoobi karo, sidaas darteedna sida uu digniin ku salaysan qiime la raacayo u soo daahi karto. Raacuhu ma laha dareeme u gaar ah oo taleefanka soo jeeda ka dhiga, sidaas darteed hubin kastaa waa toosin.</string>
     <string name="nightscout_follow_interval_doze">Ka hooseeya 9 daqiiqo, Android weli wuu kala fogayn karaa hubinnada inta taleefanku shaqo la\'yahay. In Juggluco laga saaro wanaajinta baytariga waxay ilaalinaysaa waqtiga aad dooratay.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone iyada oo loo marayo TURN</string>
+    <string name="clone_source_local_ice_description">Clone iyada oo loo marayo ICE maxalli ah</string>
 </resources>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2618,4 +2618,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Leta efter nya värden</string>
     <string name="nightscout_follow_interval_desc">Hur ofta följaren frågar servern. Det är också hur gammalt ett värde kan vara, och därmed hur sent ett larm på ett följt värde kan komma. En följare har ingen egen sensor som håller telefonen vaken, så varje kontroll är en väckning.</string>
     <string name="nightscout_follow_interval_doze">Under 9 minuter kan Android ändå glesa ut kontrollerna medan telefonen är inaktiv. Att undanta Juggluco från batterioptimering behåller det valda intervallet.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone via TURN</string>
+    <string name="clone_source_local_ice_description">Clone via lokal ICE</string>
 </resources>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2646,4 +2646,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="nightscout_follow_interval_title">Yeni değerleri kontrol et</string>
     <string name="nightscout_follow_interval_desc">Takipçinin sunucuya ne sıklıkla sorduğu. Bu aynı zamanda bir değerin ne kadar eski olabileceği, dolayısıyla takip edilen bir değere dayanan alarmın ne kadar geç gelebileceğidir. Takipçinin telefonu uyanık tutan kendi sensörü yoktur, bu yüzden her kontrol bir uyandırmadır.</string>
     <string name="nightscout_follow_interval_doze">9 dakikanın altında Android, telefon boştayken kontrolleri yine de aralayabilir. Juggluco\'yu pil optimizasyonundan çıkarmak seçilen aralığı korur.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">TURN üzerinden Clone</string>
+    <string name="clone_source_local_ice_description">Yerel ICE üzerinden Clone</string>
 </resources>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2694,4 +2694,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Перевіряти нові значення</string>
     <string name="nightscout_follow_interval_desc">Як часто підписник опитує сервер. Це водночас і те, наскільки старим може бути значення, а отже і наскільки пізно надійде тривога за відстежуваним значенням. Підписник не має власного сенсора, який тримав би телефон активним, тож кожна перевірка — це пробудження.</string>
     <string name="nightscout_follow_interval_doze">Менше 9 хвилин Android усе одно може розсувати перевірки, поки телефон бездіяльний. Виключення Juggluco з оптимізації батареї зберігає вибраний інтервал.</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone через TURN</string>
+    <string name="clone_source_local_ice_description">Clone через локальний ICE</string>
 </resources>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2634,4 +2634,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">检查新数值</string>
     <string name="nightscout_follow_interval_desc">跟随者向服务器询问的频率。它同时决定数值可能有多旧，因此也决定基于跟随数值的警报可能有多晚。跟随者没有自己的传感器让手机保持唤醒，所以每次检查都是一次唤醒。</string>
     <string name="nightscout_follow_interval_doze">低于 9 分钟时，手机闲置期间 Android 仍可能拉长检查间隔。将 Juggluco 排除在电池优化之外可保持所选间隔。</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">通过 TURN 的 Clone</string>
+    <string name="clone_source_local_ice_description">通过本地 ICE 的 Clone</string>
 </resources>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2835,4 +2835,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="anytime_restart_title">Restart sensor?</string>
     <string name="anytime_restart_warning">End the current transmitter session and start a fresh pairing cycle? Existing glucose history will stay in the app.</string>
     <string name="anytime_history_action">History</string>
+    <string name="clone_source_label">Clone</string>
+    <string name="clone_source_turn_description">Clone via TURN</string>
+    <string name="clone_source_local_ice_description">Clone via local ICE</string>
 </resources>

--- a/Common/src/mobile/java/tk/glucodata/data/ExportPackageExporter.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/ExportPackageExporter.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 import tk.glucodata.BuildConfig
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.data.calibration.CalibrationDatabase
 import tk.glucodata.data.calibration.CalibrationEntity
 import tk.glucodata.data.calibration.CalibrationManager
@@ -572,6 +573,7 @@ object ExportPackageExporter {
             .put("rawValueMgDl", rawValue.toDouble())
             .put("calibratedValueMgDl", calibratedMgDl?.toDouble() ?: JSONObject.NULL)
             .put("rate", rate?.toDouble() ?: JSONObject.NULL)
+            .put("source", source)
     }
 
     private fun JournalEntryEntity.toJson(): JSONObject {
@@ -657,7 +659,9 @@ object ExportPackageExporter {
                         sensorSerial = sensorSerial,
                         value = value,
                         rawValue = rawValue,
-                        rate = item.optNullableFloat("rate")
+                        rate = item.optNullableFloat("rate"),
+                        source = item.optString("source", GlucoseReadingSource.SENSOR)
+                            .ifBlank { GlucoseReadingSource.SENSOR },
                     )
                 )
             }

--- a/Common/src/mobile/java/tk/glucodata/data/ExportPackageExporter.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/ExportPackageExporter.kt
@@ -574,6 +574,7 @@ object ExportPackageExporter {
             .put("calibratedValueMgDl", calibratedMgDl?.toDouble() ?: JSONObject.NULL)
             .put("rate", rate?.toDouble() ?: JSONObject.NULL)
             .put("source", source)
+            .put("firstStoredAt", firstStoredAt)
     }
 
     private fun JournalEntryEntity.toJson(): JSONObject {
@@ -662,6 +663,8 @@ object ExportPackageExporter {
                         rate = item.optNullableFloat("rate"),
                         source = item.optString("source", GlucoseReadingSource.SENSOR)
                             .ifBlank { GlucoseReadingSource.SENSOR },
+                        firstStoredAt = item.optLong("firstStoredAt", System.currentTimeMillis())
+                            .takeIf { it > 0L } ?: System.currentTimeMillis(),
                     )
                 )
             }

--- a/Common/src/mobile/java/tk/glucodata/data/ExportPackageExporter.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/ExportPackageExporter.kt
@@ -2,12 +2,14 @@ package tk.glucodata.data
 
 import android.content.Context
 import android.net.Uri
+import androidx.room.withTransaction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 import tk.glucodata.BuildConfig
 import tk.glucodata.GlucoseReadingSource
+import tk.glucodata.HistorySourceProvenance
 import tk.glucodata.data.calibration.CalibrationDatabase
 import tk.glucodata.data.calibration.CalibrationEntity
 import tk.glucodata.data.calibration.CalibrationManager
@@ -24,6 +26,7 @@ import java.util.concurrent.TimeUnit
 object ExportPackageExporter {
     private const val SCHEMA = "tk.glucodata.export-package"
     private const val SCHEMA_VERSION = 1
+    private const val SQLITE_BIND_CHUNK = 900
 
     data class ExportRequest(
         val includeSettings: Boolean,
@@ -427,7 +430,19 @@ object ExportPackageExporter {
         val foods = history.optJSONArray("journalFoods").toFoods()
 
         if (readings.isNotEmpty()) {
-            database.historyDao().insertAll(readings)
+            database.withTransaction {
+                val dao = database.historyDao()
+                val existingByKey = HashMap<Pair<String, Long>, HistoryReading>()
+                readings.groupBy(HistoryReading::sensorSerial).forEach { (serial, rows) ->
+                    rows.map(HistoryReading::timestamp).distinct().chunked(SQLITE_BIND_CHUNK)
+                        .forEach { timestamps ->
+                            dao.getSensorReadingsAtTimestamps(serial, timestamps).forEach { existing ->
+                                existingByKey[serial to existing.timestamp] = existing
+                            }
+                        }
+                }
+                dao.insertAll(preserveImportedHistoryProvenance(readings, existingByKey))
+            }
         }
         if (foods.isNotEmpty()) {
             database.journalDao().insertFoods(foods)
@@ -669,6 +684,20 @@ object ExportPackageExporter {
                 )
             }
         }
+    }
+
+    internal fun preserveImportedHistoryProvenance(
+        incoming: List<HistoryReading>,
+        existingByKey: Map<Pair<String, Long>, HistoryReading>,
+    ): List<HistoryReading> = incoming.map { reading ->
+        val existing = existingByKey[reading.sensorSerial to reading.timestamp]
+        reading.copy(
+            source = HistorySourceProvenance.stableSource(existing?.source, reading.source),
+            firstStoredAt = HistorySourceProvenance.stableFirstStoredAt(
+                existing?.firstStoredAt,
+                reading.firstStoredAt,
+            ),
+        )
     }
 
     private fun JSONArray?.toJournalEntries(): List<JournalEntryEntity> {

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDao.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDao.kt
@@ -38,6 +38,19 @@ interface HistoryDao {
     suspend fun getReadingsSinceForSensors(serials: List<String>, startTime: Long): List<HistoryReading>
 
     @Query("""
+        SELECT * FROM history_readings
+        WHERE sensorSerial = :sensorSerial
+          AND timestamp >= :startTimeInclusive
+          AND timestamp < :endTimeExclusive
+        ORDER BY timestamp ASC
+    """)
+    suspend fun getSensorReadingsInTimeRange(
+        sensorSerial: String,
+        startTimeInclusive: Long,
+        endTimeExclusive: Long
+    ): List<HistoryReading>
+
+    @Query("""
         SELECT timestamp FROM history_readings
         WHERE sensorSerial IN (:serials)
           AND timestamp >= :startTime

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDao.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDao.kt
@@ -50,6 +50,12 @@ interface HistoryDao {
         endTimeExclusive: Long
     ): List<HistoryReading>
 
+    @Query("SELECT * FROM history_readings WHERE sensorSerial = :sensorSerial AND timestamp IN (:timestamps)")
+    suspend fun getSensorReadingsAtTimestamps(
+        sensorSerial: String,
+        timestamps: List<Long>
+    ): List<HistoryReading>
+
     @Query("""
         SELECT timestamp FROM history_readings
         WHERE sensorSerial IN (:serials)

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
@@ -37,6 +37,7 @@ import tk.glucodata.data.journal.JournalPendingDeleteEntity
  *         phone holds at v15 depends on which build it happened to install
  *   v17 — per-journal-entry LibreView delivery timestamp
  *   v18 — per-reading glucose source provenance
+ *   v19 — stable first-arrival ordering for equivalent replicated readings
  */
 @Database(
     entities = [
@@ -49,7 +50,7 @@ import tk.glucodata.data.journal.JournalPendingDeleteEntity
         JournalInsulinPresetEntity::class,
         JournalPendingDeleteEntity::class
     ],
-    version = 18,
+    version = 19,
     exportSchema = false
 )
 abstract class HistoryDatabase : RoomDatabase() {
@@ -447,6 +448,22 @@ abstract class HistoryDatabase : RoomDatabase() {
             }
         }
 
+        /** v18 -> v19: retain stable first-arrival ordering for equivalent replicas. */
+        private val MIGRATION_18_19 = object : Migration(18, 19) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE history_readings " +
+                        "ADD COLUMN firstStoredAt INTEGER NOT NULL DEFAULT 0"
+                )
+                // The table's autoincrement id is the only durable arrival order
+                // available for pre-migration rows. New rows use wall-clock time.
+                db.execSQL(
+                    "UPDATE history_readings SET firstStoredAt = id " +
+                        "WHERE firstStoredAt <= 0"
+                )
+            }
+        }
+
         fun getInstance(context: Context): HistoryDatabase =
             INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
@@ -470,7 +487,8 @@ abstract class HistoryDatabase : RoomDatabase() {
                     MIGRATION_14_15,
                     MIGRATION_15_16,
                     MIGRATION_16_17,
-                    MIGRATION_17_18
+                    MIGRATION_17_18,
+                    MIGRATION_18_19
                 )
                 .build().also { INSTANCE = it }
             }

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
@@ -36,6 +36,7 @@ import tk.glucodata.data.journal.JournalPendingDeleteEntity
  *   v16 — repair step: two branches each shipped a different "v13", so what a
  *         phone holds at v15 depends on which build it happened to install
  *   v17 — per-journal-entry LibreView delivery timestamp
+ *   v18 — per-reading glucose source provenance
  */
 @Database(
     entities = [
@@ -48,7 +49,7 @@ import tk.glucodata.data.journal.JournalPendingDeleteEntity
         JournalInsulinPresetEntity::class,
         JournalPendingDeleteEntity::class
     ],
-    version = 17,
+    version = 18,
     exportSchema = false
 )
 abstract class HistoryDatabase : RoomDatabase() {
@@ -421,6 +422,31 @@ abstract class HistoryDatabase : RoomDatabase() {
             return false
         }
 
+        /** v17 -> v18: persist the source that first delivered each glucose reading. */
+        private val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE history_readings " +
+                        "ADD COLUMN source TEXT NOT NULL DEFAULT 'sensor'"
+                )
+                // These virtual sensor ids are stable and unambiguous, so older
+                // rows can retain their known origin. Existing Clone rows cannot
+                // be reconstructed per entry and deliberately remain "sensor".
+                db.execSQL(
+                    "UPDATE history_readings SET source = 'nightscout' " +
+                        "WHERE UPPER(sensorSerial) LIKE 'NSF-%'"
+                )
+                db.execSQL(
+                    "UPDATE history_readings SET source = 'api' " +
+                        "WHERE UPPER(sensorSerial) LIKE 'API-%'"
+                )
+                db.execSQL(
+                    "UPDATE history_readings SET source = 'mq_follower' " +
+                        "WHERE UPPER(sensorSerial) LIKE 'MQF-%'"
+                )
+            }
+        }
+
         fun getInstance(context: Context): HistoryDatabase =
             INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
@@ -443,7 +469,8 @@ abstract class HistoryDatabase : RoomDatabase() {
                     MIGRATION_13_14,
                     MIGRATION_14_15,
                     MIGRATION_15_16,
-                    MIGRATION_16_17
+                    MIGRATION_16_17,
+                    MIGRATION_17_18
                 )
                 .build().also { INSTANCE = it }
             }

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDisplayMerge.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDisplayMerge.kt
@@ -1,6 +1,7 @@
 package tk.glucodata.data
 
 import tk.glucodata.SensorIdentity
+import kotlin.math.abs
 
 internal object HistoryDisplayMerge {
     private const val SENSOR_MINUTE_BUCKET_MS = 60_000L
@@ -77,7 +78,12 @@ internal object HistoryDisplayMerge {
         }
 
         val coalesced = collapseLogicalSensorBuckets(readings, resolver, logicalResolver)
-        val filtered = applyPreferredOverlapDominance(coalesced, resolver, logicalResolver)
+        // A Nightscout pull and Clone can persist the same physical reading under
+        // different virtual sensors. Pick its first delivery before applying the
+        // currently selected sensor's coverage, otherwise changing receivers
+        // retroactively relabels the entire visible timeline.
+        val stableDeliveries = collapseEquivalentDeliveries(coalesced, resolver)
+        val filtered = applyPreferredOverlapDominance(stableDeliveries, resolver, logicalResolver)
         val merged = ArrayList<HistoryReading>(filtered.size)
         var currentTimestamp = Long.MIN_VALUE
         var currentBest: HistoryReading? = null
@@ -176,6 +182,63 @@ internal object HistoryDisplayMerge {
             byBucket[key] = if (existing == null) reading else choosePreferred(existing, reading, resolver)
         }
         return byBucket.values.sortedBy { it.timestamp }
+    }
+
+    private fun collapseEquivalentDeliveries(
+        readings: List<HistoryReading>,
+        resolver: PreferredMatchResolver,
+    ): List<HistoryReading> {
+        if (readings.size < 2) return readings
+
+        val collapsed = ArrayList<HistoryReading>(readings.size)
+        var start = 0
+        while (start < readings.size) {
+            val timestamp = readings[start].timestamp
+            var end = start + 1
+            while (end < readings.size && readings[end].timestamp == timestamp) end++
+
+            val deliveries = ArrayList<HistoryReading>(end - start)
+            for (index in start until end) {
+                val candidate = readings[index]
+                val equivalentIndex = deliveries.indexOfFirst { sameDeliveredValue(it, candidate) }
+                if (equivalentIndex < 0) {
+                    deliveries.add(candidate)
+                } else {
+                    deliveries[equivalentIndex] = chooseFirstDelivery(
+                        deliveries[equivalentIndex],
+                        candidate,
+                        resolver,
+                    )
+                }
+            }
+            collapsed.addAll(deliveries)
+            start = end
+        }
+        return collapsed
+    }
+
+    private fun sameDeliveredValue(left: HistoryReading, right: HistoryReading): Boolean {
+        val leftValue = left.value.takeIf { it.isFinite() && it > 0f }
+            ?: left.rawValue.takeIf { it.isFinite() && it > 0f }
+        val rightValue = right.value.takeIf { it.isFinite() && it > 0f }
+            ?: right.rawValue.takeIf { it.isFinite() && it > 0f }
+        return leftValue != null && rightValue != null && abs(leftValue - rightValue) <= 0.5f
+    }
+
+    private fun chooseFirstDelivery(
+        current: HistoryReading,
+        candidate: HistoryReading,
+        resolver: PreferredMatchResolver,
+    ): HistoryReading {
+        val currentOrder = current.firstStoredAt.takeIf { it > 0L } ?: current.id
+        val candidateOrder = candidate.firstStoredAt.takeIf { it > 0L } ?: candidate.id
+        if (candidateOrder != currentOrder) {
+            return if (candidateOrder < currentOrder) candidate else current
+        }
+        if (candidate.id != current.id) {
+            return if (candidate.id < current.id) candidate else current
+        }
+        return choosePreferred(current, candidate, resolver)
     }
 
     /**

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDisplayMerge.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDisplayMerge.kt
@@ -1,5 +1,6 @@
 package tk.glucodata.data
 
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.SensorIdentity
 import kotlin.math.abs
 
@@ -7,11 +8,18 @@ internal object HistoryDisplayMerge {
     private const val SENSOR_MINUTE_BUCKET_MS = 60_000L
     private const val OVERLAP_PADDING_MS = 5L * 60L * 1000L
     private const val COVERAGE_SEGMENT_GAP_MS = 15L * 60L * 1000L
+    private const val REPLICA_TIMESTAMP_TOLERANCE_MS = 30_000L
+    private const val REPLICA_VALUE_TOLERANCE_MGDL = 1f
 
 
     private data class LogicalSensorBucket(
         val sensorId: String,
         val bucket: Long
+    )
+
+    private data class StableDeliveryCollapse(
+        val readings: List<HistoryReading>,
+        val winners: Set<HistoryReading>,
     )
 
     private class PreferredMatchResolver(preferredSerial: String?) {
@@ -83,7 +91,12 @@ internal object HistoryDisplayMerge {
         // currently selected sensor's coverage, otherwise changing receivers
         // retroactively relabels the entire visible timeline.
         val stableDeliveries = collapseEquivalentDeliveries(coalesced, resolver)
-        val filtered = applyPreferredOverlapDominance(stableDeliveries, resolver, logicalResolver)
+        val filtered = applyPreferredOverlapDominance(
+            stableDeliveries.readings,
+            resolver,
+            logicalResolver,
+            stableDeliveries.winners,
+        )
         val merged = ArrayList<HistoryReading>(filtered.size)
         var currentTimestamp = Long.MIN_VALUE
         var currentBest: HistoryReading? = null
@@ -187,42 +200,52 @@ internal object HistoryDisplayMerge {
     private fun collapseEquivalentDeliveries(
         readings: List<HistoryReading>,
         resolver: PreferredMatchResolver,
-    ): List<HistoryReading> {
-        if (readings.size < 2) return readings
+    ): StableDeliveryCollapse {
+        if (readings.size < 2) return StableDeliveryCollapse(readings, emptySet())
 
         val collapsed = ArrayList<HistoryReading>(readings.size)
-        var start = 0
-        while (start < readings.size) {
-            val timestamp = readings[start].timestamp
-            var end = start + 1
-            while (end < readings.size && readings[end].timestamp == timestamp) end++
-
-            val deliveries = ArrayList<HistoryReading>(end - start)
-            for (index in start until end) {
-                val candidate = readings[index]
-                val equivalentIndex = deliveries.indexOfFirst { sameDeliveredValue(it, candidate) }
-                if (equivalentIndex < 0) {
-                    deliveries.add(candidate)
-                } else {
-                    deliveries[equivalentIndex] = chooseFirstDelivery(
-                        deliveries[equivalentIndex],
-                        candidate,
-                        resolver,
-                    )
+        val winners = LinkedHashSet<HistoryReading>()
+        for (candidate in readings) {
+            var equivalentIndex = -1
+            for (index in collapsed.lastIndex downTo 0) {
+                val existing = collapsed[index]
+                if (candidate.timestamp - existing.timestamp > REPLICA_TIMESTAMP_TOLERANCE_MS) break
+                if (sameReplicatedDelivery(existing, candidate)) {
+                    equivalentIndex = index
+                    break
                 }
             }
-            collapsed.addAll(deliveries)
-            start = end
+            if (equivalentIndex < 0) {
+                collapsed.add(candidate)
+                continue
+            }
+            val existing = collapsed[equivalentIndex]
+            val winner = chooseFirstDelivery(existing, candidate, resolver)
+            collapsed[equivalentIndex] = winner
+            winners.remove(existing)
+            winners.remove(candidate)
+            winners.add(winner)
         }
-        return collapsed
+        return StableDeliveryCollapse(collapsed.sortedBy(HistoryReading::timestamp), winners)
     }
 
-    private fun sameDeliveredValue(left: HistoryReading, right: HistoryReading): Boolean {
+    private fun sameReplicatedDelivery(left: HistoryReading, right: HistoryReading): Boolean {
+        if (!isNightscoutClonePair(left.source, right.source)) return false
+        if (abs(left.timestamp - right.timestamp) > REPLICA_TIMESTAMP_TOLERANCE_MS) return false
         val leftValue = left.value.takeIf { it.isFinite() && it > 0f }
             ?: left.rawValue.takeIf { it.isFinite() && it > 0f }
         val rightValue = right.value.takeIf { it.isFinite() && it > 0f }
             ?: right.rawValue.takeIf { it.isFinite() && it > 0f }
-        return leftValue != null && rightValue != null && abs(leftValue - rightValue) <= 0.5f
+        return leftValue != null && rightValue != null &&
+            abs(leftValue - rightValue) <= REPLICA_VALUE_TOLERANCE_MGDL
+    }
+
+    private fun isNightscoutClonePair(leftSource: String, rightSource: String): Boolean {
+        val leftNightscout = leftSource == GlucoseReadingSource.NIGHTSCOUT
+        val rightNightscout = rightSource == GlucoseReadingSource.NIGHTSCOUT
+        val leftClone = GlucoseReadingSource.cloneTransport(leftSource) != null
+        val rightClone = GlucoseReadingSource.cloneTransport(rightSource) != null
+        return (leftNightscout && rightClone) || (rightNightscout && leftClone)
     }
 
     private fun chooseFirstDelivery(
@@ -269,7 +292,8 @@ internal object HistoryDisplayMerge {
     private fun applyPreferredOverlapDominance(
         readings: List<HistoryReading>,
         resolver: PreferredMatchResolver,
-        logicalResolver: LogicalSensorResolver
+        logicalResolver: LogicalSensorResolver,
+        stableReplicaWinners: Set<HistoryReading> = emptySet(),
     ): List<HistoryReading> {
         // With no preferred sensor named there is nothing to rank against, and
         // the caller wants the richest reading per timestamp instead — that is
@@ -298,7 +322,7 @@ internal object HistoryDisplayMerge {
 
         val filtered = ArrayList<HistoryReading>(readings.size)
         for (reading in readings) {
-            if (resolver.matches(reading.sensorSerial)) {
+            if (resolver.matches(reading.sensorSerial) || reading in stableReplicaWinners) {
                 filtered.add(reading)
                 continue
             }

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryExporter.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryExporter.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.ui.GlucosePoint
 import tk.glucodata.ui.util.GlucoseFormatter
 import java.io.BufferedReader
@@ -362,7 +363,8 @@ object HistoryExporter {
                         sensorSerial = importSerial,
                         value = reading.valueMgDl,
                         rawValue = reading.rawValueMgDl,
-                        rate = 0f
+                        rate = 0f,
+                        source = GlucoseReadingSource.IMPORT,
                     )
                 }
                 if (readings.isNotEmpty()) {

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryReading.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryReading.kt
@@ -28,5 +28,7 @@ data class HistoryReading(
     val value: Float,             // Calibrated/auto glucose value (mg/dL)
     val rawValue: Float,          // Raw sensor value (mg/dL)
     val rate: Float?,             // Rate of change (nullable - may not always be available)
-    val source: String = GlucoseReadingSource.SENSOR
+    val source: String = GlucoseReadingSource.SENSOR,
+    /** First time this logical row reached Room; preserved across overlap rewrites. */
+    val firstStoredAt: Long = System.currentTimeMillis(),
 )

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryReading.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryReading.kt
@@ -3,6 +3,7 @@ package tk.glucodata.data
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import tk.glucodata.GlucoseReadingSource
 
 /**
  * Room entity for storing glucose readings independently from C++ sensor data.
@@ -26,5 +27,6 @@ data class HistoryReading(
     val sensorSerial: String,     // Sensor short name (e.g. "X-ABCDEF123456", "GS1Sb-XXX")
     val value: Float,             // Calibrated/auto glucose value (mg/dL)
     val rawValue: Float,          // Raw sensor value (mg/dL)
-    val rate: Float?              // Rate of change (nullable - may not always be available)
+    val rate: Float?,             // Rate of change (nullable - may not always be available)
+    val source: String = GlucoseReadingSource.SENSOR
 )

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
@@ -670,11 +670,11 @@ class HistoryRepository(context: Context = Applic.app) {
                 }
                 database.withTransaction {
                     val bucketStart = (timestamp / SENSOR_MINUTE_BUCKET_MS) * SENSOR_MINUTE_BUCKET_MS
-                    val existingSource = dao.getSensorReadingsInTimeRange(
+                    val existing = dao.getSensorReadingsInTimeRange(
                         sensorSerial = serial,
                         startTimeInclusive = bucketStart,
                         endTimeExclusive = bucketStart + SENSOR_MINUTE_BUCKET_MS,
-                    ).firstOrNull { it.timestamp == timestamp }?.source
+                    ).firstOrNull { it.timestamp == timestamp }
                     deleteSensorRowsInBucketRanges(
                         sensorSerial = serial,
                         bucketDurationMs = SENSOR_MINUTE_BUCKET_MS,
@@ -687,7 +687,11 @@ class HistoryRepository(context: Context = Applic.app) {
                     )
                     dao.insert(
                         reading.copy(
-                            source = HistorySourceProvenance.stableSource(existingSource, reading.source)
+                            source = HistorySourceProvenance.stableSource(existing?.source, reading.source),
+                            firstStoredAt = HistorySourceProvenance.stableFirstStoredAt(
+                                existing?.firstStoredAt,
+                                reading.firstStoredAt,
+                            ),
                         )
                     )
                 }
@@ -775,7 +779,28 @@ class HistoryRepository(context: Context = Applic.app) {
                 filteredReadings.maxByOrNull { it.timestamp }?.let { newest ->
                     reportIfFutureTimestamp(newest.sensorSerial, newest.timestamp, writer = "storeReadings")
                 }
-                dao.insertAll(filteredReadings)
+                database.withTransaction {
+                    val existingByKey = HashMap<Pair<String, Long>, HistoryReading>()
+                    filteredReadings.groupBy(HistoryReading::sensorSerial).forEach { (serial, rows) ->
+                        rows.map(HistoryReading::timestamp).distinct().chunked(DELETED_TIMESTAMP_QUERY_CHUNK)
+                            .forEach { timestamps ->
+                                dao.getSensorReadingsAtTimestamps(serial, timestamps).forEach { existing ->
+                                    existingByKey[serial to existing.timestamp] = existing
+                                }
+                            }
+                    }
+                    val readingsWithStableProvenance = filteredReadings.map { incoming ->
+                        val existing = existingByKey[incoming.sensorSerial to incoming.timestamp]
+                        incoming.copy(
+                            source = HistorySourceProvenance.stableSource(existing?.source, incoming.source),
+                            firstStoredAt = HistorySourceProvenance.stableFirstStoredAt(
+                                existing?.firstStoredAt,
+                                incoming.firstStoredAt,
+                            ),
+                        )
+                    }
+                    dao.insertAll(readingsWithStableProvenance)
+                }
                 BatteryTrace.bump("room.history.insert_batch", logEvery = 20L, detail = "size=${filteredReadings.size}")
                 // Only log small batches (likely genuine new data, not re-syncs)
                 if (filteredReadings.size <= 10) {
@@ -823,7 +848,7 @@ class HistoryRepository(context: Context = Applic.app) {
                     bucketDurationMs = bucketDurationMs,
                 ) ?: return@withContext false
                 database.withTransaction {
-                    val existingSources = HashMap<Long, String>()
+                    val existingProvenance = HashMap<Long, HistoryReading>()
                     for (range in plan.bucketRanges) {
                         val startTimeInclusive = range.firstBucketId * bucketDurationMs
                         val endTimeExclusive = (range.lastBucketId + 1L) * bucketDurationMs
@@ -831,14 +856,19 @@ class HistoryRepository(context: Context = Applic.app) {
                             sensorSerial = sensorSerial,
                             startTimeInclusive = startTimeInclusive,
                             endTimeExclusive = endTimeExclusive,
-                        ).forEach { existing -> existingSources[existing.timestamp] = existing.source }
+                        ).forEach { existing -> existingProvenance[existing.timestamp] = existing }
                     }
                     val readingsWithStableSources = collapsedReadings.map { incoming ->
+                        val existing = existingProvenance[incoming.timestamp]
                         incoming.copy(
                             source = HistorySourceProvenance.stableSource(
-                                existingSources[incoming.timestamp],
+                                existing?.source,
                                 incoming.source,
-                            )
+                            ),
+                            firstStoredAt = HistorySourceProvenance.stableFirstStoredAt(
+                                existing?.firstStoredAt,
+                                incoming.firstStoredAt,
+                            ),
                         )
                     }
                     deleteSensorRowsInBucketRanges(

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryRepository.kt
@@ -12,6 +12,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.CoroutineScope
 import tk.glucodata.Applic
 import tk.glucodata.BatteryTrace
+import tk.glucodata.CloneSensorRegistry
+import tk.glucodata.GlucoseReadingSource
+import tk.glucodata.HistorySourceProvenance
 import tk.glucodata.Natives
 import tk.glucodata.SensorIdentity
 import tk.glucodata.UiRefreshBus
@@ -482,11 +485,40 @@ class HistoryRepository(context: Context = Applic.app) {
         }
 
         @JvmStatic
+        fun storeReadingWithSourceAsync(
+            timestamp: Long,
+            value: Float,
+            rawValue: Float,
+            rate: Float,
+            sensorSerial: String,
+            source: String
+        ) {
+            kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
+                HistoryRepository().storeReading(timestamp, value, rawValue, rate, sensorSerial, source)
+            }
+        }
+
+        @JvmStatic
         fun storeHistoryBatchAsync(
             sensorSerial: String,
             timestamps: LongArray,
             values: FloatArray,
             rawValues: FloatArray
+        ) = storeHistoryBatchWithSourceAsync(
+            sensorSerial,
+            timestamps,
+            values,
+            rawValues,
+            GlucoseReadingSource.SENSOR,
+        )
+
+        @JvmStatic
+        fun storeHistoryBatchWithSourceAsync(
+            sensorSerial: String,
+            timestamps: LongArray,
+            values: FloatArray,
+            rawValues: FloatArray,
+            source: String
         ) {
             val roomSerial = SensorIdentity.resolveRoomStorageSensorId(sensorSerial) ?: sensorSerial
             if (roomSerial.isBlank()) return
@@ -513,7 +545,8 @@ class HistoryRepository(context: Context = Applic.app) {
                         sensorSerial = roomSerial,
                         value = if (value.isFinite()) value else 0f,
                         rawValue = if (rawValue.isFinite()) rawValue else 0f,
-                        rate = null
+                        rate = null,
+                        source = source,
                     )
                 )
             }
@@ -529,6 +562,22 @@ class HistoryRepository(context: Context = Applic.app) {
             timestamps: LongArray,
             values: FloatArray,
             rawValues: FloatArray
+        ): Boolean = storeHistoryBatchWithSourceBlocking(
+            sensorSerial,
+            timestamps,
+            values,
+            rawValues,
+            GlucoseReadingSource.SENSOR,
+        )
+
+        @Keep
+        @JvmStatic
+        fun storeHistoryBatchWithSourceBlocking(
+            sensorSerial: String,
+            timestamps: LongArray,
+            values: FloatArray,
+            rawValues: FloatArray,
+            source: String
         ): Boolean {
             val roomSerial = SensorIdentity.resolveRoomStorageSensorId(sensorSerial) ?: sensorSerial
             if (roomSerial.isBlank()) return false
@@ -557,7 +606,8 @@ class HistoryRepository(context: Context = Applic.app) {
                                 sensorSerial = roomSerial,
                                 value = if (value.isFinite()) value else 0f,
                                 rawValue = if (rawValue.isFinite()) rawValue else 0f,
-                                rate = null
+                                rate = null,
+                                source = source,
                             )
                         )
                     }
@@ -583,7 +633,14 @@ class HistoryRepository(context: Context = Applic.app) {
      * Values should be in mg/dL (will be converted on display).
      * Uses main sensor serial if none specified.
      */
-    suspend fun storeReading(timestamp: Long, value: Float, rawValue: Float, rate: Float, sensorSerial: String? = null) {
+    suspend fun storeReading(
+        timestamp: Long,
+        value: Float,
+        rawValue: Float,
+        rate: Float,
+        sensorSerial: String? = null,
+        source: String = GlucoseReadingSource.SENSOR,
+    ) {
         // Don't store invalid readings
         if (value <= 0 && rawValue <= 0) return
         
@@ -601,7 +658,8 @@ class HistoryRepository(context: Context = Applic.app) {
             sensorSerial = serial,
             value = value,
             rawValue = rawValue,
-            rate = rate
+            rate = rate,
+            source = source,
         )
         reportIfFutureTimestamp(serial, timestamp, writer = "storeReading")
         withContext(Dispatchers.IO) {
@@ -611,6 +669,12 @@ class HistoryRepository(context: Context = Applic.app) {
                     return@withContext
                 }
                 database.withTransaction {
+                    val bucketStart = (timestamp / SENSOR_MINUTE_BUCKET_MS) * SENSOR_MINUTE_BUCKET_MS
+                    val existingSource = dao.getSensorReadingsInTimeRange(
+                        sensorSerial = serial,
+                        startTimeInclusive = bucketStart,
+                        endTimeExclusive = bucketStart + SENSOR_MINUTE_BUCKET_MS,
+                    ).firstOrNull { it.timestamp == timestamp }?.source
                     deleteSensorRowsInBucketRanges(
                         sensorSerial = serial,
                         bucketDurationMs = SENSOR_MINUTE_BUCKET_MS,
@@ -621,7 +685,11 @@ class HistoryRepository(context: Context = Applic.app) {
                             )
                         )
                     )
-                    dao.insert(reading)
+                    dao.insert(
+                        reading.copy(
+                            source = HistorySourceProvenance.stableSource(existingSource, reading.source)
+                        )
+                    )
                 }
                 recordDisplayValueForStoredReading(
                     sensorSerial = serial,
@@ -755,12 +823,30 @@ class HistoryRepository(context: Context = Applic.app) {
                     bucketDurationMs = bucketDurationMs,
                 ) ?: return@withContext false
                 database.withTransaction {
+                    val existingSources = HashMap<Long, String>()
+                    for (range in plan.bucketRanges) {
+                        val startTimeInclusive = range.firstBucketId * bucketDurationMs
+                        val endTimeExclusive = (range.lastBucketId + 1L) * bucketDurationMs
+                        dao.getSensorReadingsInTimeRange(
+                            sensorSerial = sensorSerial,
+                            startTimeInclusive = startTimeInclusive,
+                            endTimeExclusive = endTimeExclusive,
+                        ).forEach { existing -> existingSources[existing.timestamp] = existing.source }
+                    }
+                    val readingsWithStableSources = collapsedReadings.map { incoming ->
+                        incoming.copy(
+                            source = HistorySourceProvenance.stableSource(
+                                existingSources[incoming.timestamp],
+                                incoming.source,
+                            )
+                        )
+                    }
                     deleteSensorRowsInBucketRanges(
                         sensorSerial = sensorSerial,
                         bucketDurationMs = bucketDurationMs,
                         bucketRanges = plan.bucketRanges
                     )
-                    dao.insertAll(collapsedReadings)
+                    dao.insertAll(readingsWithStableSources)
                 }
                 BatteryTrace.bump(
                     "room.history.replace_bucket_batch",
@@ -1061,7 +1147,8 @@ class HistoryRepository(context: Context = Applic.app) {
                     timestamp = reading.timestamp,
                     rawValue = reading.rawValue,
                     rate = reading.rate,
-                    sensorSerial = reading.sensorSerial
+                    sensorSerial = reading.sensorSerial,
+                    source = reading.source,
                 )
             }
         }.flowOn(Dispatchers.IO)
@@ -1107,7 +1194,8 @@ class HistoryRepository(context: Context = Applic.app) {
                     timestamp = it.timestamp,
                     rawValue = it.rawValue,
                     rate = it.rate,
-                    sensorSerial = it.sensorSerial
+                    sensorSerial = it.sensorSerial,
+                    source = it.source,
                 )
             }
         }.flowOn(Dispatchers.IO)
@@ -1276,7 +1364,8 @@ class HistoryRepository(context: Context = Applic.app) {
                     timestamp = it.timestamp,
                     rawValue = it.rawValue,
                     rate = it.rate,
-                    sensorSerial = it.sensorSerial
+                    sensorSerial = it.sensorSerial,
+                    source = it.source,
                 )
             }
         }.flowOn(Dispatchers.IO)
@@ -1458,6 +1547,7 @@ class HistoryRepository(context: Context = Applic.app) {
                 rawValue = reading.rawValue,
                 rate = reading.rate,
                 sensorSerial = reading.sensorSerial,
+                source = reading.source,
                 uncertainty = uncertainty[uncertaintyKey(reading)]?.toGlucoseUncertainty(),
                 sealedDisplayValue = if (!freezeEnabled) {
                     null
@@ -1465,7 +1555,7 @@ class HistoryRepository(context: Context = Applic.app) {
                     display[displayKey(reading.sensorSerial, reading.timestamp)]
                         ?.takeIf { it.isUsable && it.isSealedAt(nowMs) }
                         ?.displayMgdl
-                }
+                },
             )
         }
     }
@@ -1546,9 +1636,10 @@ class HistoryRepository(context: Context = Applic.app) {
             rawValue = reading.rawValue,
             rate = reading.rate,
             sensorSerial = reading.sensorSerial,
+            source = reading.source,
             sealedDisplayValue = display[displayKey(reading.sensorSerial, reading.timestamp)]
                 ?.takeIf { it.isUsable && it.isSealedAt(nowMs) }
-                ?.displayMgdl
+                ?.displayMgdl,
         )
     }
 
@@ -1657,6 +1748,13 @@ class HistoryRepository(context: Context = Applic.app) {
     private suspend fun backfillSensor(serial: String, requestedStartTimeMs: Long): Boolean {
         try {
             val roomSerial = SensorIdentity.resolveRoomStorageSensorId(serial) ?: serial
+            val readingSource = if (CloneSensorRegistry.isCloneSensor(roomSerial)) {
+                GlucoseReadingSource.forCloneTransport(
+                    CloneSensorRegistry.transportForSensor(roomSerial)
+                )
+            } else {
+                GlucoseReadingSource.SENSOR
+            }
             val startSec = resolveNativeBackfillStartSec(serial, requestedStartTimeMs)
             val rawHistory = loadNativeHistory(serial, startSec)
             if (rawHistory == null) {
@@ -1684,7 +1782,8 @@ class HistoryRepository(context: Context = Applic.app) {
                         sensorSerial = roomSerial,
                         value = value,
                         rawValue = rawValue,
-                        rate = 0f  // Rate not available from history
+                        rate = 0f, // Rate not available from history
+                        source = readingSource,
                     ))
                     if (readings.size >= NATIVE_BACKFILL_INSERT_CHUNK) {
                         storedCount += insertBackfillChunk(serial, readings)

--- a/Common/src/mobile/java/tk/glucodata/data/HistorySync.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistorySync.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import tk.glucodata.Applic
 import tk.glucodata.BatteryTrace
+import tk.glucodata.CloneSensorRegistry
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.Natives
 import tk.glucodata.SensorIdentity
 import tk.glucodata.UiRefreshBus
@@ -349,6 +351,9 @@ object HistorySync {
         }
 
         val roomSerial = SensorIdentity.resolveRoomStorageSensorId(serial) ?: serial
+        val readingSource = GlucoseReadingSource.forCloneTransport(
+            CloneSensorRegistry.transportForSensor(serial)
+        ).takeIf { CloneSensorRegistry.isCloneSensor(serial) } ?: GlucoseReadingSource.SENSOR
         val readings = ArrayList<HistoryReading>(NATIVE_SYNC_INSERT_CHUNK)
         var parsedCount = 0
         var storedAny = false
@@ -372,7 +377,8 @@ object HistorySync {
                         sensorSerial = roomSerial,
                         value = value,
                         rawValue = rawValue,
-                        rate = null
+                        rate = null,
+                        source = readingSource,
                     )
                 )
                 parsedCount++

--- a/Common/src/mobile/java/tk/glucodata/ui/CloneSourceMark.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/CloneSourceMark.kt
@@ -1,0 +1,59 @@
+package tk.glucodata.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Hub
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import tk.glucodata.CloneTransport
+import tk.glucodata.R
+
+@Composable
+fun CloneSourceMark(
+    transport: CloneTransport?,
+    showLabel: Boolean,
+    tint: Color,
+    modifier: Modifier = Modifier,
+    iconSize: Dp = 14.dp,
+    textStyle: TextStyle = TextStyle.Default,
+) {
+    val description = stringResource(
+        when (transport) {
+            CloneTransport.TURN -> R.string.clone_source_turn_description
+            CloneTransport.LOCAL_ICE -> R.string.clone_source_local_ice_description
+            CloneTransport.UNKNOWN, null -> R.string.clone_source_label
+        }
+    )
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = if (transport == CloneTransport.TURN) Icons.Default.Hub else Icons.Default.SwapHoriz,
+            contentDescription = description,
+            tint = tint,
+            modifier = Modifier.size(iconSize),
+        )
+        if (showLabel) {
+            Spacer(modifier = Modifier.width(5.dp))
+            Text(
+                text = stringResource(R.string.clone_source_label),
+                style = textStyle,
+                color = tint,
+                maxLines = 1,
+            )
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -358,6 +358,9 @@ fun DashboardCombinedHeader(
             ?.takeIf { it.isNotBlank() }
             ?: sensorName
     }
+    val cloneTransport = remember(refreshRevision, sensorName) {
+        tk.glucodata.CloneSensorRegistry.transportForSensor(sensorName)
+    }
     val resolvedDataState = dataState ?: remember(
         resolvedCurrentSnapshot?.timeMillis,
         latestPoint?.timestamp,
@@ -907,14 +910,23 @@ fun DashboardCombinedHeader(
                     // 1. Sensor Name (Top Label)
                     if (sensorDisplayName.isNotEmpty()) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = sensorDisplayName,
-                                style = MaterialTheme.typography.labelMedium, // M3 Standard
-                                color = sensorContentColor.copy(alpha = 0.7f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f, fill = false) // Allow shrinking for dots
-                            )
+                            if (cloneTransport != null) {
+                                CloneSourceMark(
+                                    transport = cloneTransport,
+                                    showLabel = true,
+                                    tint = sensorContentColor.copy(alpha = 0.7f),
+                                    textStyle = MaterialTheme.typography.labelMedium,
+                                )
+                            } else {
+                                Text(
+                                    text = sensorDisplayName,
+                                    style = MaterialTheme.typography.labelMedium, // M3 Standard
+                                    color = sensorContentColor.copy(alpha = 0.7f),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f, fill = false) // Allow shrinking for dots
+                                )
+                            }
                             
                             // Active Indicators (Dots) - Right of Name
                             // Hidden if only 1 active sensor

--- a/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -271,6 +272,8 @@ fun ReadingRow(
             val timeWeight = if (isActive) FontWeight.Bold else FontWeight.Normal
             val readingSensorId = point.sensorSerial?.takeIf { it.isNotBlank() } ?: sensorId
             val cloneTransport = tk.glucodata.CloneSensorRegistry.transportForSensor(readingSensorId)
+            val isNightscoutReading =
+                tk.glucodata.drivers.nightscout.NightscoutFollowerRegistry.isFollowerSensorId(readingSensorId)
             val isRawModeRR = viewMode == 1 || viewMode == 3
             val calibrationSensorId = sensorId?.takeIf { it.isNotBlank() }
             // Recorded value if this reading has one, otherwise the projection —
@@ -328,6 +331,14 @@ fun ReadingRow(
                             showLabel = false,
                             tint = timeColor,
                             iconSize = 13.dp,
+                        )
+                    } else if (isNightscoutReading) {
+                        Spacer(modifier = Modifier.width(5.dp))
+                        Icon(
+                            imageVector = Icons.Default.CloudDownload,
+                            contentDescription = stringResource(R.string.journal_source_nightscout),
+                            tint = timeColor,
+                            modifier = Modifier.size(13.dp),
                         )
                     }
                 }

--- a/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
@@ -269,6 +269,8 @@ fun ReadingRow(
             val timeStyle = MaterialTheme.typography.bodySmall
             val timeColor = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
             val timeWeight = if (isActive) FontWeight.Bold else FontWeight.Normal
+            val readingSensorId = point.sensorSerial?.takeIf { it.isNotBlank() } ?: sensorId
+            val cloneTransport = tk.glucodata.CloneSensorRegistry.transportForSensor(readingSensorId)
             val isRawModeRR = viewMode == 1 || viewMode == 3
             val calibrationSensorId = sensorId?.takeIf { it.isNotBlank() }
             // Recorded value if this reading has one, otherwise the projection —
@@ -306,6 +308,30 @@ fun ReadingRow(
             // chips: keep it tight against the main value (not floating in a
             // wide right-aligned slot) and give it the primary identity tint.
             val primaryTrendColor = if (isMultiSensor) primaryColor.copy(alpha = 0.7f) else tertiaryColor
+
+            @Composable
+            fun ReadingTime() {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = java.text.SimpleDateFormat(
+                            "HH:mm",
+                            java.util.Locale.getDefault()
+                        ).format(java.util.Date(point.timestamp)),
+                        style = timeStyle,
+                        fontWeight = timeWeight,
+                        color = timeColor
+                    )
+                    if (cloneTransport != null) {
+                        Spacer(modifier = Modifier.width(5.dp))
+                        CloneSourceMark(
+                            transport = cloneTransport,
+                            showLabel = false,
+                            tint = timeColor,
+                            iconSize = 13.dp,
+                        )
+                    }
+                }
+            }
 
             @Composable
             fun ReadingValueContent(modifier: Modifier = Modifier) {
@@ -511,15 +537,7 @@ fun ReadingRow(
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        text = java.text.SimpleDateFormat(
-                            "HH:mm",
-                            java.util.Locale.getDefault()
-                        ).format(java.util.Date(point.timestamp)),
-                        style = timeStyle,
-                        fontWeight = timeWeight,
-                        color = timeColor
-                    )
+                    ReadingTime()
 
                     if (showLeadingAction) {
                         Box(
@@ -563,15 +581,7 @@ fun ReadingRow(
                             ),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Text(
-                            text = java.text.SimpleDateFormat(
-                                "HH:mm",
-                                java.util.Locale.getDefault()
-                            ).format(java.util.Date(point.timestamp)),
-                            style = timeStyle,
-                            fontWeight = timeWeight,
-                            color = timeColor
-                        )
+                        ReadingTime()
 
                         if (showLeadingAction) {
                             Box(

--- a/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.graphics.ColorUtils
 import kotlinx.coroutines.delay
 import tk.glucodata.R
+import tk.glucodata.GlucoseReadingSource
 import tk.glucodata.SensorIdentity
 import tk.glucodata.data.journal.JournalEntry
 import tk.glucodata.data.journal.JournalFood
@@ -270,10 +271,8 @@ fun ReadingRow(
             val timeStyle = MaterialTheme.typography.bodySmall
             val timeColor = if (isActive) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
             val timeWeight = if (isActive) FontWeight.Bold else FontWeight.Normal
-            val readingSensorId = point.sensorSerial?.takeIf { it.isNotBlank() } ?: sensorId
-            val cloneTransport = tk.glucodata.CloneSensorRegistry.transportForSensor(readingSensorId)
-            val isNightscoutReading =
-                tk.glucodata.drivers.nightscout.NightscoutFollowerRegistry.isFollowerSensorId(readingSensorId)
+            val cloneTransport = GlucoseReadingSource.cloneTransport(point.source)
+            val isNightscoutSource = point.source == GlucoseReadingSource.NIGHTSCOUT
             val isRawModeRR = viewMode == 1 || viewMode == 3
             val calibrationSensorId = sensorId?.takeIf { it.isNotBlank() }
             // Recorded value if this reading has one, otherwise the projection —
@@ -332,7 +331,7 @@ fun ReadingRow(
                             tint = timeColor,
                             iconSize = 13.dp,
                         )
-                    } else if (isNightscoutReading) {
+                    } else if (isNightscoutSource) {
                         Spacer(modifier = Modifier.width(5.dp))
                         Icon(
                             imageVector = Icons.Default.CloudDownload,

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -1724,22 +1724,33 @@ fun SensorCard(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        SensorModelBadge(
-                            badge = badge,
-                            vendor = sensor.vendor,
-                            color = sensorTint,
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        SensorIdentityControl(
-                            name = displayName,
-                            selected = sensor.isSelectedForDisplay,
-                            selectable = canToggleEnabled,
-                            color = sensorTint,
-                            onToggle = { viewModel.toggleDisplaySelection(sensor.serial) },
-                            onPickColor = { showColorSheet = true },
-                            modifier = Modifier.weight(1f),
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
+                        if (sensor.isCloneSource) {
+                            CloneSourceMark(
+                                transport = tk.glucodata.CloneSensorRegistry.transportForSensor(sensor.serial),
+                                showLabel = true,
+                                tint = MaterialTheme.colorScheme.onSurface,
+                                iconSize = 18.dp,
+                                textStyle = MaterialTheme.typography.titleLarge,
+                                modifier = Modifier.weight(1f),
+                            )
+                        } else {
+                            SensorModelBadge(
+                                badge = badge,
+                                vendor = sensor.vendor,
+                                color = sensorTint,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            SensorIdentityControl(
+                                name = displayName,
+                                selected = sensor.isSelectedForDisplay,
+                                selectable = canToggleEnabled,
+                                color = sensorTint,
+                                onToggle = { viewModel.toggleDisplaySelection(sensor.serial) },
+                                onPickColor = { showColorSheet = true },
+                                modifier = Modifier.weight(1f),
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
 
                         if (isHandedOff) {
                             IconButton(

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/SensorViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/SensorViewModel.kt
@@ -103,6 +103,7 @@ data class SensorInfo(
     val isSelectedForDisplay: Boolean = false,
     val assignedColorArgb: Int = SensorVisuals.colorArgb(serial),
     val handoffUiState: SensorHandoffUiState = SensorHandoffUiState.NONE,
+    val isCloneSource: Boolean = false,
 ) {
     /** Get the assigned color for this sensor */
     val color: Color get() = Color(assignedColorArgb)
@@ -158,7 +159,10 @@ class SensorViewModel : ViewModel() {
 
     private fun normalizePublishedSensor(sensor: SensorInfo): SensorInfo {
         val resolved = SensorIdentity.resolveAppSensorId(sensor.serial) ?: sensor.serial
-        return if (resolved == sensor.serial) sensor else sensor.copy(serial = resolved)
+        return sensor.copy(
+            serial = resolved,
+            isCloneSource = tk.glucodata.CloneSensorRegistry.isCloneSensor(resolved),
+        )
     }
 
     private fun sensorPriority(sensor: SensorInfo): Int {

--- a/Common/src/test/java/tk/glucodata/CloneSensorKeyCodecTests.kt
+++ b/Common/src/test/java/tk/glucodata/CloneSensorKeyCodecTests.kt
@@ -1,0 +1,37 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CloneSensorKeyCodecTests {
+    @Test
+    fun normalizesSensorIdsForStableMatching() {
+        assertEquals("ABC-123", CloneSensorKeyCodec.normalize("  abc-123 "))
+        assertNull(CloneSensorKeyCodec.normalize("  "))
+    }
+
+    @Test
+    fun encodingIsDistinctAndDeterministic() {
+        assertEquals(
+            "ABC|1\nXYZ|2",
+            CloneSensorKeyCodec.encode(
+                linkedMapOf(
+                    " xyz " to CloneTransport.TURN,
+                    "ABC" to CloneTransport.LOCAL_ICE,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun decodingIgnoresBlankLinesAndAcceptsLegacyUnknownEntries() {
+        assertEquals(
+            mapOf(
+                "ABC" to CloneTransport.UNKNOWN,
+                "XYZ" to CloneTransport.TURN,
+            ),
+            CloneSensorKeyCodec.decode("abc\n\n XYZ|2 \n")
+        )
+    }
+}

--- a/Common/src/test/java/tk/glucodata/GlucoseReadingSourceTests.kt
+++ b/Common/src/test/java/tk/glucodata/GlucoseReadingSourceTests.kt
@@ -1,0 +1,25 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GlucoseReadingSourceTests {
+    @Test
+    fun cloneTransportRoundTripsThroughStableDatabaseValue() {
+        CloneTransport.entries.forEach { transport ->
+            assertEquals(
+                transport,
+                GlucoseReadingSource.cloneTransport(
+                    GlucoseReadingSource.forCloneTransport(transport)
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun nonCloneSourcesDoNotPretendToHaveAnIceRoute() {
+        assertNull(GlucoseReadingSource.cloneTransport(GlucoseReadingSource.NIGHTSCOUT))
+        assertNull(GlucoseReadingSource.cloneTransport(GlucoseReadingSource.SENSOR))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/HistorySourceProvenanceTests.kt
+++ b/Common/src/test/java/tk/glucodata/HistorySourceProvenanceTests.kt
@@ -24,9 +24,9 @@ class HistorySourceProvenanceTests {
     }
 
     @Test
-    fun aNewKnownSourceCanReplaceTheLegacySensorDefault() {
+    fun aLaterRemoteImportCannotRelabelAnEstablishedSensorRow() {
         assertEquals(
-            GlucoseReadingSource.NIGHTSCOUT,
+            GlucoseReadingSource.SENSOR,
             HistorySourceProvenance.stableSource(
                 GlucoseReadingSource.SENSOR,
                 GlucoseReadingSource.NIGHTSCOUT,

--- a/Common/src/test/java/tk/glucodata/HistorySourceProvenanceTests.kt
+++ b/Common/src/test/java/tk/glucodata/HistorySourceProvenanceTests.kt
@@ -33,4 +33,16 @@ class HistorySourceProvenanceTests {
             ),
         )
     }
+
+    @Test
+    fun firstStoredTimeSurvivesOverlapRewrites() {
+        assertEquals(
+            123L,
+            HistorySourceProvenance.stableFirstStoredAt(123L, 999L),
+        )
+        assertEquals(
+            999L,
+            HistorySourceProvenance.stableFirstStoredAt(null, 999L),
+        )
+    }
 }

--- a/Common/src/test/java/tk/glucodata/HistorySourceProvenanceTests.kt
+++ b/Common/src/test/java/tk/glucodata/HistorySourceProvenanceTests.kt
@@ -1,0 +1,36 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HistorySourceProvenanceTests {
+    @Test
+    fun newRowsUseTheirIncomingSource() {
+        assertEquals(
+            GlucoseReadingSource.CLONE_TURN,
+            HistorySourceProvenance.stableSource(null, GlucoseReadingSource.CLONE_TURN),
+        )
+    }
+
+    @Test
+    fun knownSourceSurvivesAnOverlapRescan() {
+        assertEquals(
+            GlucoseReadingSource.CLONE_TURN,
+            HistorySourceProvenance.stableSource(
+                GlucoseReadingSource.CLONE_TURN,
+                GlucoseReadingSource.CLONE_LOCAL_ICE,
+            ),
+        )
+    }
+
+    @Test
+    fun aNewKnownSourceCanReplaceTheLegacySensorDefault() {
+        assertEquals(
+            GlucoseReadingSource.NIGHTSCOUT,
+            HistorySourceProvenance.stableSource(
+                GlucoseReadingSource.SENSOR,
+                GlucoseReadingSource.NIGHTSCOUT,
+            ),
+        )
+    }
+}

--- a/Common/src/test/java/tk/glucodata/data/ExportPackageProvenanceTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/ExportPackageProvenanceTests.kt
@@ -1,0 +1,41 @@
+package tk.glucodata.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import tk.glucodata.GlucoseReadingSource
+
+class ExportPackageProvenanceTests {
+    @Test
+    fun overlappingRestoreKeepsTheLocallyStoredProvenance() {
+        val existing = reading(
+            id = 7,
+            source = GlucoseReadingSource.CLONE_LOCAL_ICE,
+            firstStoredAt = 1_000L,
+        )
+        val backup = reading(
+            id = 0,
+            source = GlucoseReadingSource.NIGHTSCOUT,
+            firstStoredAt = 9_000L,
+        )
+
+        val restored = ExportPackageExporter.preserveImportedHistoryProvenance(
+            incoming = listOf(backup),
+            existingByKey = mapOf((existing.sensorSerial to existing.timestamp) to existing),
+        ).single()
+
+        assertEquals(GlucoseReadingSource.CLONE_LOCAL_ICE, restored.source)
+        assertEquals(1_000L, restored.firstStoredAt)
+        assertEquals(backup.value, restored.value)
+    }
+
+    private fun reading(id: Long, source: String, firstStoredAt: Long) = HistoryReading(
+        id = id,
+        timestamp = 123_000L,
+        sensorSerial = "TEST-SENSOR",
+        value = 112f,
+        rawValue = 111f,
+        rate = null,
+        source = source,
+        firstStoredAt = firstStoredAt,
+    )
+}

--- a/Common/src/test/java/tk/glucodata/data/HistoryDisplayMergeTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/HistoryDisplayMergeTests.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertSame
 import org.junit.Test
+import tk.glucodata.GlucoseReadingSource
 
 class HistoryDisplayMergeTests {
     private companion object {
@@ -196,19 +197,87 @@ class HistoryDisplayMergeTests {
         )
     }
 
+    @Test
+    fun mergeReadings_keepsFirstDeliveryWhenNightscoutBecomesPreferred() {
+        val clone = reading(
+            id = 20,
+            timestamp = 5 * HOUR_MS,
+            sensorSerial = "physical-sensor",
+            value = 112f,
+            rawValue = 111f,
+            source = GlucoseReadingSource.CLONE_TURN,
+            firstStoredAt = 1_000L,
+        )
+        val nightscout = reading(
+            id = 21,
+            timestamp = 5 * HOUR_MS,
+            sensorSerial = "NSF-TEST",
+            value = 112f,
+            rawValue = 112f,
+            source = GlucoseReadingSource.NIGHTSCOUT,
+            firstStoredAt = 2_000L,
+        )
+
+        val clonePreferred = HistoryDisplayMerge.mergeReadings(
+            listOf(clone, nightscout),
+            preferredSerial = "physical-sensor",
+        )
+        val nightscoutPreferred = HistoryDisplayMerge.mergeReadings(
+            listOf(clone, nightscout),
+            preferredSerial = "NSF-TEST",
+        )
+
+        assertEquals(clone, clonePreferred.single())
+        assertEquals(clone, nightscoutPreferred.single())
+        assertEquals(GlucoseReadingSource.CLONE_TURN, nightscoutPreferred.single().source)
+    }
+
+    @Test
+    fun mergeReadings_keepsDistinctSameTimestampValuesUnderPreferredRules() {
+        val clone = reading(
+            id = 30,
+            timestamp = 6 * HOUR_MS,
+            sensorSerial = "physical-sensor",
+            value = 112f,
+            rawValue = 111f,
+            source = GlucoseReadingSource.CLONE_LOCAL_ICE,
+            firstStoredAt = 1_000L,
+        )
+        val nightscout = reading(
+            id = 31,
+            timestamp = 6 * HOUR_MS,
+            sensorSerial = "NSF-TEST",
+            value = 118f,
+            rawValue = 118f,
+            source = GlucoseReadingSource.NIGHTSCOUT,
+            firstStoredAt = 2_000L,
+        )
+
+        val merged = HistoryDisplayMerge.mergeReadings(
+            listOf(clone, nightscout),
+            preferredSerial = "NSF-TEST",
+        )
+
+        assertEquals(nightscout, merged.single())
+    }
+
     private fun reading(
         id: Long,
         timestamp: Long,
         sensorSerial: String,
         value: Float,
-        rawValue: Float
+        rawValue: Float,
+        source: String = GlucoseReadingSource.SENSOR,
+        firstStoredAt: Long = id,
     ) = HistoryReading(
         id = id,
         timestamp = timestamp,
         sensorSerial = sensorSerial,
         value = value,
         rawValue = rawValue,
-        rate = null
+        rate = null,
+        source = source,
+        firstStoredAt = firstStoredAt,
     )
 
     /**

--- a/Common/src/test/java/tk/glucodata/data/HistoryDisplayMergeTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/HistoryDisplayMergeTests.kt
@@ -233,7 +233,7 @@ class HistoryDisplayMergeTests {
     }
 
     @Test
-    fun mergeReadings_keepsDistinctSameTimestampValuesUnderPreferredRules() {
+    fun mergeReadings_selectsThePreferredCopyWhenReplicatedValuesDisagree() {
         val clone = reading(
             id = 30,
             timestamp = 6 * HOUR_MS,
@@ -259,6 +259,98 @@ class HistoryDisplayMergeTests {
         )
 
         assertEquals(nightscout, merged.single())
+    }
+
+    @Test
+    fun mergeReadings_keepsAReplicaWinnerAcrossSmallTimestampSkew() {
+        val clone = reading(
+            id = 40,
+            timestamp = 7 * HOUR_MS,
+            sensorSerial = "physical-sensor",
+            value = 121f,
+            rawValue = 120f,
+            source = GlucoseReadingSource.CLONE_LOCAL_ICE,
+            firstStoredAt = 1_000L,
+        )
+        val nightscout = reading(
+            id = 41,
+            timestamp = 7 * HOUR_MS + 20_000L,
+            sensorSerial = "NSF-TEST",
+            value = 122f,
+            rawValue = 122f,
+            source = GlucoseReadingSource.NIGHTSCOUT,
+            firstStoredAt = 2_000L,
+        )
+
+        assertEquals(
+            clone,
+            HistoryDisplayMerge.mergeReadings(listOf(clone, nightscout), "physical-sensor").single(),
+        )
+        assertEquals(
+            clone,
+            HistoryDisplayMerge.mergeReadings(listOf(clone, nightscout), "NSF-TEST").single(),
+        )
+    }
+
+    @Test
+    fun mergeReadings_doesNotCollapseTwoIndependentPhysicalSensors() {
+        val first = reading(
+            id = 50,
+            timestamp = 8 * HOUR_MS,
+            sensorSerial = "physical-a",
+            value = 133f,
+            rawValue = 132f,
+            firstStoredAt = 1_000L,
+        )
+        val second = reading(
+            id = 51,
+            timestamp = 8 * HOUR_MS,
+            sensorSerial = "physical-b",
+            value = 133f,
+            rawValue = 132f,
+            firstStoredAt = 2_000L,
+        )
+
+        assertEquals(
+            first,
+            HistoryDisplayMerge.mergeReadings(listOf(first, second), "physical-a").single(),
+        )
+        assertEquals(
+            second,
+            HistoryDisplayMerge.mergeReadings(listOf(first, second), "physical-b").single(),
+        )
+    }
+
+    @Test
+    fun mergeReadings_keepsMultiRowReplicaProvenanceUnderEitherPreference() {
+        val cloneFirst = reading(
+            id = 60,
+            timestamp = 9 * HOUR_MS,
+            sensorSerial = "physical-sensor",
+            value = 140f,
+            rawValue = 139f,
+            source = GlucoseReadingSource.CLONE_TURN,
+            firstStoredAt = 1_000L,
+        )
+        val nightscoutFirst = reading(
+            id = 61,
+            timestamp = 9 * HOUR_MS + 5 * MINUTE_MS,
+            sensorSerial = "NSF-TEST",
+            value = 145f,
+            rawValue = 145f,
+            source = GlucoseReadingSource.NIGHTSCOUT,
+            firstStoredAt = 2_000L,
+        )
+        val copies = listOf(
+            cloneFirst,
+            reading(62, cloneFirst.timestamp, "NSF-TEST", 140f, 140f, GlucoseReadingSource.NIGHTSCOUT, 3_000L),
+            nightscoutFirst,
+            reading(63, nightscoutFirst.timestamp, "physical-sensor", 145f, 144f, GlucoseReadingSource.CLONE_TURN, 4_000L),
+        ).sortedBy(HistoryReading::timestamp)
+
+        val expected = listOf(cloneFirst, nightscoutFirst)
+        assertEquals(expected, HistoryDisplayMerge.mergeReadings(copies, "physical-sensor"))
+        assertEquals(expected, HistoryDisplayMerge.mergeReadings(copies, "NSF-TEST"))
     }
 
     private fun reading(

--- a/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistryTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/nightscout/NightscoutFollowerRegistryTests.kt
@@ -17,6 +17,14 @@ import java.net.URL
  */
 class NightscoutFollowerRegistryTests {
 
+    @Test
+    fun followerSensorIdentityRecognizesPersistedHistoryRows() {
+        assertTrue(NightscoutFollowerRegistry.isFollowerSensorId("NSF-EXAMPLE123"))
+        assertTrue(NightscoutFollowerRegistry.isFollowerSensorId(" nsf-example123 "))
+        assertFalse(NightscoutFollowerRegistry.isFollowerSensorId("LOCAL-EXAMPLE123"))
+        assertFalse(NightscoutFollowerRegistry.isFollowerSensorId(null))
+    }
+
     private fun applyAuthToMock(secret: String): Map<String, String> {
         val headers = mutableMapOf<String, String>()
         val connection = object : HttpURLConnection(URL("https://example.com")) {


### PR DESCRIPTION
Glucose history previously inferred its source from whichever sensor was selected when the UI rendered. That made old readings appear to change source after a receiver switch, and overlap between Clone and Nightscout could replace the apparent origin of an existing row. This PR stores provenance with each history row and uses that stored value whenever the reading is displayed.

This is the smaller provenance layer required by PR #248. It does not introduce ICE, TURN, or Clone connection management.

## Stored provenance

- Store the source and first local arrival time with every Room history row through additive migrations.
- Record Nightscout follower, Clone, API, message-queue follower, and import sources at ingestion.
- Record the selected Clone route for each new reading, so Local ICE and TURN entries remain distinguishable in history.
- Keep the stored source stable when another receiver revisits the same reading or the preferred sensor changes.
- Preserve both fields through history export, import, package restore, and overlapping restore into an existing database.
- Use synthetic sensor identifiers throughout the tests.

The icon on a history row describes how that row first reached this installation. It is not a live connection indicator. A later route change therefore affects new readings without relabeling existing history.

## Replica overlap

Nightscout and Clone copies are treated as the same delivery only when their timestamps are within 30 seconds and their glucose values differ by no more than 1 mg/dL. First local arrival decides which copy is displayed. Independent physical sensors remain separate, including readings that happen to share a timestamp.

This keeps a brief Nightscout and Clone overlap usable during receiver changes without making the history source flicker or change retroactively.

## Verification

- Current-head focused suite: 25 tests passed across history merge behavior, source persistence, export and restore, and database safety.
- Generated Room schema checked for the non-null `source` and `firstStoredAt` columns and the complete migration chain.
- An in-memory SQLite upgrade from version 16 through versions 17 and 18 preserved existing rows and backfilled the new fields without destructive fallback.
- Real-device testing covered Nightscout and Clone overlap, receiver switches, application restarts, and Local ICE to TURN transitions. Existing glucose rows retained their stored source while new rows followed the active receiver and route.

A dedicated Android `MigrationTestHelper` test has not been added. The migration was checked against Room's generated implementation, an in-memory SQLite upgrade, and repeated on-device upgrades.
