### PR TITLE
Preserve history database when a migration is missing

### DIFF
--- a/Common/src/main/java/tk/glucodata/MainActivity.java
+++ b/Common/src/main/java/tk/glucodata/MainActivity.java
@@ -496,6 +496,10 @@ public class MainActivity extends AppCompatActivity implements NfcAdapter.Reader
             }
             return;
         }
+        if (!Specific.historyDatabaseCompatible(this)) {
+            showHistoryDatabaseIncompatible();
+            return;
+        }
         DisplayMetrics metrics = this.getResources().getDisplayMetrics();
         screenheight = metrics.heightPixels;
         screenwidth = metrics.widthPixels;
@@ -527,6 +531,17 @@ public class MainActivity extends AppCompatActivity implements NfcAdapter.Reader
             Log.i(LOG_ID, "onCreate end");
         }
         ;
+    }
+
+    private void showHistoryDatabaseIncompatible() {
+        AlertDialog dialog = new AlertDialog.Builder(this)
+                .setTitle(R.string.history_database_incompatible_title)
+                .setMessage(R.string.history_database_incompatible_message)
+                .setPositiveButton(R.string.ok, (ignoredDialog, ignoredButton) -> finishAndRemoveTask())
+                .setCancelable(false)
+                .create();
+        dialog.setCanceledOnTouchOutside(false);
+        dialog.show();
     }
 
     static boolean composeUIActive;

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -135,6 +135,8 @@
  <string name="name">Імя:</string>
  <string name="carbperunit">Вугляводы/адзінка:</string>
  <string name="database">База дадзеных</string>
+ <string name="history_database_incompatible_title">Несумяшчальная база даных гісторыі</string>
+ <string name="history_database_incompatible_message">Гэта зборка не можа адкрыць існуючую базу даных гісторыі, таму што яе версія або схема несумяшчальная. Вашы даныя не былі выдалены. Усталюйце зборку, якая стварыла базу даных, або навейшую сумяшчальную зборку, затым перазапусціце праграму.</string>
  <string name="search">Пошук</string>
  <string name="trace">След</string>
  <string name="unknown">Невядомы</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -132,6 +132,8 @@
   <string name="name">Name:</string>
   <string name="carbperunit">Kohlenhydrate/Einheit:</string>
   <string name="database">Datenbank</string>
+  <string name="history_database_incompatible_title">Inkompatible Verlaufsdatenbank</string>
+  <string name="history_database_incompatible_message">Dieser Build kann die vorhandene Verlaufsdatenbank nicht öffnen, weil ihre Version oder ihr Schema inkompatibel ist. Ihre Daten wurden nicht gelöscht. Installieren Sie den Build, der die Datenbank erstellt hat, oder einen neueren kompatiblen Build, und starten Sie die App anschließend neu.</string>
   <string name="search">Suchen</string>
   <string name="trace">Trace</string>
   <string name="unknown">Unbekannt</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -135,6 +135,8 @@
 <string name="name">Nom:</string>
 <string name="carbperunit">Glucides/unité:</string>
 <string name="database">Base de données</string>
+<string name="history_database_incompatible_title">Base de données d’historique incompatible</string>
+<string name="history_database_incompatible_message">Cette version ne peut pas ouvrir la base de données d’historique existante, car sa version ou son schéma est incompatible. Vos données n’ont pas été supprimées. Installez la version qui a créé la base de données, ou une version compatible plus récente, puis redémarrez l’application.</string>
 <string name="search">Chercher</string>
 <string name="trace">Tracer</string>
 <string name="unknown">Inconnu</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -136,6 +136,8 @@
  <string name="name">Nome:</string>
  <string name="carbperunit">Carboidrati/unità:</string>
  <string name="database">Database</string>
+ <string name="history_database_incompatible_title">Database della cronologia incompatibile</string>
+ <string name="history_database_incompatible_message">Questa build non può aprire il database della cronologia esistente perché la versione o lo schema non sono compatibili. I dati non sono stati eliminati. Installa la build che ha creato il database, oppure una build compatibile più recente, quindi riavvia l’app.</string>
  <string name="search">Cerca</string>
  <string name="trace">Traccia</string>
  <string name="unknown">Sconosciuto</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -131,6 +131,8 @@
     <string name="name">Нэр:</string>
     <string name="carbperunit">Нэгж дэх нүүрс ус:</string>
     <string name="database">Өгөгдлийн сан</string>
+    <string name="history_database_incompatible_title">Түүхийн өгөгдлийн сан нийцэхгүй байна</string>
+    <string name="history_database_incompatible_message">Энэ хувилбар одоо байгаа түүхийн өгөгдлийн сангийн хувилбар эсвэл бүтэц нийцэхгүй тул нээж чадахгүй. Таны өгөгдөл устгагдаагүй. Өгөгдлийн санг үүсгэсэн хувилбар эсвэл түүнээс шинэ нийцтэй хувилбарыг суулгаад аппыг дахин эхлүүлнэ үү.</string>
     <string name="search">Хайх</string>
     <string name="trace">Мөрдөх</string>
     <string name="unknown">Тодорхойгүй</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -137,6 +137,8 @@
  <string name="name">Naam:</string>
  <string name="carbperunit">Koolhydraten/eenheid:</string>
  <string name="database">Database</string>
+ <string name="history_database_incompatible_title">Incompatibele geschiedenisdatabase</string>
+ <string name="history_database_incompatible_message">Deze build kan de bestaande geschiedenisdatabase niet openen omdat de versie of het schema niet compatibel is. Uw gegevens zijn niet verwijderd. Installeer de build die de database heeft gemaakt, of een nieuwere compatibele build, en start de app daarna opnieuw.</string>
  <string name="search">Zoeken</string>
  <string name="trace">Trace</string>
  <string name="unknown">Onbekend</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -135,6 +135,8 @@
  <string name="name">Nazwa:</string>
  <string name="carbperunit">Węglowodany/jedn.:</string>
  <string name="database">Baza danych</string>
+ <string name="history_database_incompatible_title">Niezgodna baza danych historii</string>
+ <string name="history_database_incompatible_message">Ta kompilacja nie może otworzyć istniejącej bazy danych historii, ponieważ jej wersja lub schemat są niezgodne. Dane nie zostały usunięte. Zainstaluj kompilację, która utworzyła bazę danych, albo nowszą zgodną kompilację, a następnie uruchom aplikację ponownie.</string>
  <string name="search">Szukaj</string>
  <string name="trace">Ślad</string>
  <string name="unknown">Nieznany</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -136,6 +136,8 @@
 <string name="name">Nome:</string>
 <string name="carbperunit">Carboidratos/unidade:</string>
 <string name="database">Banco de dados</string>
+<string name="history_database_incompatible_title">Banco de dados do histórico incompatível</string>
+<string name="history_database_incompatible_message">Esta compilação não consegue abrir o banco de dados do histórico existente porque a versão ou o esquema é incompatível. Seus dados não foram excluídos. Instale a compilação que criou o banco de dados ou uma compilação compatível mais recente e reinicie o aplicativo.</string>
 <string name="search">Pesquisar</string>
 <string name="trace">Rastrear</string>
 <string name="unknown">Desconhecido</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -40,6 +40,8 @@
     <string name="connectwithsensor">Подключение к датчику</string>
     <string name="darkmode">Темная тема</string>
     <string name="database">База данных</string>
+    <string name="history_database_incompatible_title">Несовместимая база данных истории</string>
+    <string name="history_database_incompatible_message">Эта сборка не может открыть существующую базу данных истории, поскольку её версия или схема несовместима. Ваши данные не были удалены. Установите сборку, которая создала базу данных, или более новую совместимую сборку, затем перезапустите приложение.</string>
     <string name="datapresentuntil">"Данные сохраняются на приемнике до тех пор, пока: "</string>
     <string name="date">К дате</string>
     <string name="day_back">День назад</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -136,6 +136,8 @@
  <string name="name">Magaca:</string>
  <string name="carbperunit">Carbohydrates/cutub:</string>
  <string name="database">Database</string>
+ <string name="history_database_incompatible_title">Kaydka taariikhda lama jaanqaadi karo</string>
+ <string name="history_database_incompatible_message">Noocan ma furi karo kaydka taariikhda ee jira sababtoo ah noociisa ama qaabkiisa lama jaanqaadi karo. Xogtaada lama tirtirin. Ku rakib noocii sameeyay kaydka xogta ama nooc ka cusub oo la jaanqaadi kara, dabadeed dib u bilow abka.</string>
  <string name="search">Raadi</string>
  <string name="trace">Raad raac</string>
  <string name="unknown">Lama garanayo</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -131,6 +131,8 @@
   <string name="name">Namn:</string>
   <string name="carbperunit">Kolhydrater/enhet:</string>
   <string name="database">Databas</string>
+  <string name="history_database_incompatible_title">Inkompatibel historikdatabas</string>
+  <string name="history_database_incompatible_message">Den här versionen kan inte öppna den befintliga historikdatabasen eftersom dess version eller schema inte är kompatibelt. Dina data har inte raderats. Installera versionen som skapade databasen, eller en nyare kompatibel version, och starta sedan om appen.</string>
   <string name="search">Sök</string>
   <string name="trace">Spåra</string>
   <string name="unknown">Okänd</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -135,6 +135,8 @@
  <string name="name">İsim:</string>
  <string name="carbperunit">Karbonhidrat/Birim:</string>
  <string name="database">Veri Tabanı</string>
+ <string name="history_database_incompatible_title">Uyumsuz geçmiş veritabanı</string>
+ <string name="history_database_incompatible_message">Bu derleme, sürümü veya şeması uyumsuz olduğu için mevcut geçmiş veritabanını açamıyor. Verileriniz silinmedi. Veritabanını oluşturan derlemeyi veya daha yeni uyumlu bir derlemeyi yükleyin, ardından uygulamayı yeniden başlatın.</string>
  <string name="search">Ara</string>
  <string name="trace">İzle</string>
  <string name="unknown">Bilinmeyen</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -135,6 +135,8 @@
  <string name="name">Ім\'я:</string>
  <string name="carbperunit">Вуглеводи/одиниця:</string>
  <string name="database">База даних</string>
+ <string name="history_database_incompatible_title">Несумісна база даних історії</string>
+ <string name="history_database_incompatible_message">Ця збірка не може відкрити наявну базу даних історії, оскільки її версія або схема несумісна. Ваші дані не було видалено. Установіть збірку, яка створила базу даних, або новішу сумісну збірку, а потім перезапустіть застосунок.</string>
  <string name="search">Пошук</string>
  <string name="trace">Слід</string>
  <string name="unknown">Невідомий</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -136,6 +136,8 @@
  <string name="name">名称：</string>
  <string name="carbperunit">单位碳水化合物：</string>
  <string name="database">数据库</string>
+ <string name="history_database_incompatible_title">历史数据库不兼容</string>
+ <string name="history_database_incompatible_message">此版本无法打开现有的历史数据库，因为其版本或架构不兼容。您的数据未被删除。请安装创建该数据库的版本或更新的兼容版本，然后重新启动应用。</string>
  <string name="search">搜索</string>
  <string name="trace">追踪</string>
  <string name="unknown">未知</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -136,6 +136,8 @@
  <string name="name">Name:</string>
  <string name="carbperunit">Carbohydrates/unit:</string>
  <string name="database">Database</string>
+ <string name="history_database_incompatible_title">Incompatible history database</string>
+ <string name="history_database_incompatible_message">This build cannot open the existing history database because its version or schema is incompatible. Your data was not deleted. Install the build that created the database, or a newer compatible build, then restart the app.</string>
  <string name="search">Search</string>
  <string name="trace">Trace</string>
  <string name="unknown">Unknown</string>

--- a/Common/src/mobile/java/tk/glucodata/Specific.java
+++ b/Common/src/mobile/java/tk/glucodata/Specific.java
@@ -48,6 +48,10 @@ public class Specific {
 	static void splash(Object act) {
 	}
 
+	static boolean historyDatabaseCompatible(android.content.Context context) {
+		return tk.glucodata.data.HistoryDatabase.isCompatibleAtStartup(context);
+	}
+
 	static void settext(String str) {
 	}
 

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
@@ -271,7 +271,6 @@ abstract class HistoryDatabase : RoomDatabase() {
                     MIGRATION_11_12,
                     MIGRATION_12_13
                 )
-                .fallbackToDestructiveMigration()  // Fallback if migration chain is broken
                 .build().also { INSTANCE = it }
             }
     }

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt
@@ -49,6 +49,8 @@ abstract class HistoryDatabase : RoomDatabase() {
     abstract fun journalDao(): JournalDao
     
     companion object {
+        private const val DATABASE_NAME = "glucose_history.db"
+
         @Volatile
         private var INSTANCE: HistoryDatabase? = null
 
@@ -256,7 +258,7 @@ abstract class HistoryDatabase : RoomDatabase() {
                 INSTANCE ?: Room.databaseBuilder(
                     context.applicationContext,
                     HistoryDatabase::class.java,
-                    "glucose_history.db"
+                    DATABASE_NAME
                 )
                 .addMigrations(
                     MIGRATION_2_3,
@@ -273,5 +275,22 @@ abstract class HistoryDatabase : RoomDatabase() {
                 )
                 .build().also { INSTANCE = it }
             }
+
+        @JvmStatic
+        fun isCompatibleAtStartup(context: Context): Boolean {
+            if (!context.getDatabasePath(DATABASE_NAME).isFile) return true
+
+            return try {
+                getInstance(context).openHelper.writableDatabase
+                true
+            } catch (error: RuntimeException) {
+                android.util.Log.e(
+                    "HistoryDatabase",
+                    "Existing history database is incompatible with this build",
+                    error
+                )
+                false
+            }
+        }
     }
 }

--- a/Common/src/small/java/tk/glucodata/Specific.java
+++ b/Common/src/small/java/tk/glucodata/Specific.java
@@ -31,6 +31,7 @@ import android.widget.TextView;
 public class Specific {
 static void start(Object context) { }
 static    void splash(Object act) { }
+static boolean historyDatabaseCompatible(android.content.Context context) { return true; }
 static void initScreen(Object obj) {}
 static void settext(String str) {}
 static void      rmlayout() {}

--- a/Common/src/test/java/tk/glucodata/data/HistoryDatabaseSafetyTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/HistoryDatabaseSafetyTests.kt
@@ -1,0 +1,35 @@
+package tk.glucodata.data
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class HistoryDatabaseSafetyTests {
+    private fun historyDatabaseSource(): String {
+        var directory: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        while (directory != null) {
+            val repositoryPath = File(
+                directory,
+                "Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt"
+            )
+            if (repositoryPath.isFile) return repositoryPath.readText()
+
+            val modulePath = File(
+                directory,
+                "src/mobile/java/tk/glucodata/data/HistoryDatabase.kt"
+            )
+            if (modulePath.isFile) return modulePath.readText()
+
+            directory = directory.parentFile
+        }
+        error("Could not locate HistoryDatabase.kt")
+    }
+
+    @Test
+    fun historyDatabaseDoesNotUseDestructiveMigrationFallback() {
+        assertFalse(
+            "An incompatible history database must fail to open without deleting stored history",
+            historyDatabaseSource().contains("fallbackToDestructiveMigration")
+        )
+    }
+}

--- a/Common/src/test/java/tk/glucodata/data/HistoryDatabaseSafetyTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/HistoryDatabaseSafetyTests.kt
@@ -2,34 +2,45 @@ package tk.glucodata.data
 
 import java.io.File
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class HistoryDatabaseSafetyTests {
-    private fun historyDatabaseSource(): String {
+    private fun source(relativePath: String): String {
         var directory: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
         while (directory != null) {
-            val repositoryPath = File(
-                directory,
-                "Common/src/mobile/java/tk/glucodata/data/HistoryDatabase.kt"
-            )
+            val repositoryPath = File(directory, "Common/$relativePath")
             if (repositoryPath.isFile) return repositoryPath.readText()
 
-            val modulePath = File(
-                directory,
-                "src/mobile/java/tk/glucodata/data/HistoryDatabase.kt"
-            )
+            val modulePath = File(directory, relativePath)
             if (modulePath.isFile) return modulePath.readText()
 
             directory = directory.parentFile
         }
-        error("Could not locate HistoryDatabase.kt")
+        error("Could not locate $relativePath")
     }
+
+    private fun historyDatabaseSource() =
+        source("src/mobile/java/tk/glucodata/data/HistoryDatabase.kt")
 
     @Test
     fun historyDatabaseDoesNotUseDestructiveMigrationFallback() {
         assertFalse(
             "An incompatible history database must fail to open without deleting stored history",
             historyDatabaseSource().contains("fallbackToDestructiveMigration")
+        )
+    }
+
+    @Test
+    fun startupValidatesAnExistingDatabaseBeforeContinuing() {
+        assertTrue(
+            "The startup probe must force Room to validate the existing database",
+            historyDatabaseSource().contains("openHelper.writableDatabase")
+        )
+        assertTrue(
+            "MainActivity must stop before normal startup when the history database is incompatible",
+            source("src/main/java/tk/glucodata/MainActivity.java")
+                .contains("if (!Specific.historyDatabaseCompatible(this))")
         )
     }
 }

--- a/Common/src/wear/java/tk/glucodata/Specific.java
+++ b/Common/src/wear/java/tk/glucodata/Specific.java
@@ -75,6 +75,9 @@ static void start(Object context) {
 static    void splash(AppCompatActivity act) {
        SplashScreen.installSplashScreen(act);
       }
+static boolean historyDatabaseCompatible(Context context) {
+    return true;
+}
 @SuppressLint("StaticFieldLeak")
 static ViewGroup layout=null;
 @SuppressLint("StaticFieldLeak")


### PR DESCRIPTION
## What changed

- Removed Room's destructive migration fallback from the history database.
- Validated an existing history database before normal mobile startup.
- Added a blocking warning when the installed build cannot open the existing database. The warning states that the data was not deleted and tells the user to install the build that created it, or a newer compatible build.
- Added the warning text to all 15 maintained language resource sets.
- Extended the regression test to cover the startup validation path.

## Why

Developer builds from branches with different Room schemas can leave a valid database without a compatible migration path. The old fallback silently deleted and recreated glucose_history.db, which could erase glucose history and journal data.

The app now fails the open without deleting the file and stops before the dashboard initializes. This keeps the database available for a compatible build or later recovery.

## Verification

- ./gradlew :Common:testMobileReleaseUnitTest --tests tk.glucodata.data.HistoryDatabaseSafetyTests
- ./gradlew :Common:testMobileReleaseUnitTest --tests tk.glucodata.data.HistoryDatabaseSafetyTests :Common:compileWearReleaseJavaWithJavac
- git diff --check

Both Gradle runs completed successfully. Mobile and wear release sources compiled. The warning has not yet been exercised on a device with a deliberately incompatible database.

## Follow-up

Schema-specific idempotent repairs for open feature branches should remain separate and be rebased after those schema changes land.