### PR TITLE
Restore modal sheet position after keyboard closes

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
 
 /**
  * App-wide modal sheet entry point.
@@ -26,10 +27,11 @@ import androidx.compose.ui.unit.dp
  * dynamically consumes its top inset. That moves the expanded anchor during the gesture and makes
  * the sheet appear to resist or jitter.
  *
- * Short sheets retain their intrinsic height. Once a sheet has measured at the viewport height,
- * it remains viewport-height for the current [contentKey], keeping its expanded anchor stable while
- * nested scrolling continues to work normally. Change [contentKey] when one sheet instance swaps
- * between layouts with fundamentally different intrinsic heights.
+ * Short sheets retain their intrinsic height, including across temporary viewport changes such as
+ * the keyboard opening. A sheet whose content intrinsically needs the whole viewport remains
+ * viewport-height for the current [contentKey], keeping its expanded anchor stable while nested
+ * scrolling continues to work normally. Change [contentKey] when one sheet instance swaps between
+ * layouts with fundamentally different intrinsic heights.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,19 +76,44 @@ internal class StableSheetHeightPolicy {
     var isViewportHeightLocked: Boolean = false
         private set
 
-    fun minimumHeight(maxHeight: Int, hasBoundedHeight: Boolean): Int =
-        if (isViewportHeightLocked && hasBoundedHeight) maxHeight else 0
+    private var decidedForIntrinsicHeight: Int = UNDECIDED
 
-    fun onMeasured(measuredHeight: Int, maxHeight: Int, hasBoundedHeight: Boolean) {
-        if (hasBoundedHeight && measuredHeight >= maxHeight) {
-            isViewportHeightLocked = true
+    /**
+     * Reconsiders the height lock only when the content's intrinsic height changes, not when the
+     * available viewport changes. The latter happens while dragging a full-height sheet and while
+     * the keyboard is visible. A temporary keyboard-sized viewport must not permanently turn an
+     * otherwise short sheet into a full-height one.
+     */
+    fun resolveMinimumHeight(intrinsicHeight: Int, maxHeight: Int, hasBoundedHeight: Boolean): Int {
+        if (!hasBoundedHeight) {
+            isViewportHeightLocked = false
+            decidedForIntrinsicHeight = UNDECIDED
+            return 0
         }
+
+        val undecided = decidedForIntrinsicHeight == UNDECIDED
+        val contentChanged = !undecided &&
+            abs(intrinsicHeight - decidedForIntrinsicHeight) > maxHeight / HYSTERESIS_DIVISOR
+        if (undecided || contentChanged) {
+            isViewportHeightLocked = intrinsicHeight >= maxHeight
+            decidedForIntrinsicHeight = intrinsicHeight
+        }
+        return if (isViewportHeightLocked) maxHeight else 0
+    }
+
+    private companion object {
+        const val UNDECIDED = -1
+        const val HYSTERESIS_DIVISOR = 20
     }
 }
 
 private fun Modifier.stabilizeViewportHeight(policy: StableSheetHeightPolicy): Modifier =
     layout { measurable, constraints ->
-        val minimumHeight = policy.minimumHeight(
+        val intrinsicHeight = runCatching {
+            measurable.maxIntrinsicHeight(constraints.maxWidth)
+        }.getOrDefault(constraints.maxHeight)
+        val minimumHeight = policy.resolveMinimumHeight(
+            intrinsicHeight = intrinsicHeight,
             maxHeight = constraints.maxHeight,
             hasBoundedHeight = constraints.hasBoundedHeight,
         )
@@ -96,11 +123,6 @@ private fun Modifier.stabilizeViewportHeight(policy: StableSheetHeightPolicy): M
             constraints
         }
         val placeable = measurable.measure(measurementConstraints)
-        policy.onMeasured(
-            measuredHeight = placeable.height,
-            maxHeight = constraints.maxHeight,
-            hasBoundedHeight = constraints.hasBoundedHeight,
-        )
 
         layout(placeable.width, placeable.height) {
             placeable.placeRelative(0, 0)

--- a/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/StableModalBottomSheet.kt
@@ -2,6 +2,7 @@ package tk.glucodata.ui.components
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -15,9 +16,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlin.math.abs
 
 /**
  * App-wide modal sheet entry point.
@@ -27,11 +28,11 @@ import kotlin.math.abs
  * dynamically consumes its top inset. That moves the expanded anchor during the gesture and makes
  * the sheet appear to resist or jitter.
  *
- * Short sheets retain their intrinsic height, including across temporary viewport changes such as
- * the keyboard opening. A sheet whose content intrinsically needs the whole viewport remains
- * viewport-height for the current [contentKey], keeping its expanded anchor stable while nested
- * scrolling continues to work normally. Change [contentKey] when one sheet instance swaps between
- * layouts with fundamentally different intrinsic heights.
+ * Short sheets retain their intrinsic height. Once a sheet has measured at the viewport height
+ * without the keyboard visible, it remains viewport-height for the current [contentKey], keeping
+ * its expanded anchor stable while nested scrolling continues to work normally. Change
+ * [contentKey] when one sheet instance swaps between layouts with fundamentally different
+ * intrinsic heights.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,10 +54,12 @@ fun StableModalBottomSheet(
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val heightPolicy = remember(sheetState, contentKey) { StableSheetHeightPolicy() }
+    val density = LocalDensity.current
+    val isImeVisible = WindowInsets.ime.getBottom(density) > 0
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        modifier = modifier.stabilizeViewportHeight(heightPolicy),
+        modifier = modifier.stabilizeViewportHeight(heightPolicy, isImeVisible),
         sheetState = sheetState,
         sheetMaxWidth = sheetMaxWidth,
         sheetGesturesEnabled = sheetGesturesEnabled,
@@ -76,44 +79,31 @@ internal class StableSheetHeightPolicy {
     var isViewportHeightLocked: Boolean = false
         private set
 
-    private var decidedForIntrinsicHeight: Int = UNDECIDED
+    fun minimumHeight(maxHeight: Int, hasBoundedHeight: Boolean): Int =
+        if (isViewportHeightLocked && hasBoundedHeight) maxHeight else 0
 
     /**
-     * Reconsiders the height lock only when the content's intrinsic height changes, not when the
-     * available viewport changes. The latter happens while dragging a full-height sheet and while
-     * the keyboard is visible. A temporary keyboard-sized viewport must not permanently turn an
-     * otherwise short sheet into a full-height one.
+     * A short sheet can fill the reduced viewport while the keyboard is open. Do not mistake that
+     * temporary measurement for content that genuinely needs the full viewport.
      */
-    fun resolveMinimumHeight(intrinsicHeight: Int, maxHeight: Int, hasBoundedHeight: Boolean): Int {
-        if (!hasBoundedHeight) {
-            isViewportHeightLocked = false
-            decidedForIntrinsicHeight = UNDECIDED
-            return 0
+    fun onMeasured(
+        measuredHeight: Int,
+        maxHeight: Int,
+        hasBoundedHeight: Boolean,
+        isImeVisible: Boolean,
+    ) {
+        if (hasBoundedHeight && !isImeVisible && measuredHeight >= maxHeight) {
+            isViewportHeightLocked = true
         }
-
-        val undecided = decidedForIntrinsicHeight == UNDECIDED
-        val contentChanged = !undecided &&
-            abs(intrinsicHeight - decidedForIntrinsicHeight) > maxHeight / HYSTERESIS_DIVISOR
-        if (undecided || contentChanged) {
-            isViewportHeightLocked = intrinsicHeight >= maxHeight
-            decidedForIntrinsicHeight = intrinsicHeight
-        }
-        return if (isViewportHeightLocked) maxHeight else 0
-    }
-
-    private companion object {
-        const val UNDECIDED = -1
-        const val HYSTERESIS_DIVISOR = 20
     }
 }
 
-private fun Modifier.stabilizeViewportHeight(policy: StableSheetHeightPolicy): Modifier =
+private fun Modifier.stabilizeViewportHeight(
+    policy: StableSheetHeightPolicy,
+    isImeVisible: Boolean,
+): Modifier =
     layout { measurable, constraints ->
-        val intrinsicHeight = runCatching {
-            measurable.maxIntrinsicHeight(constraints.maxWidth)
-        }.getOrDefault(constraints.maxHeight)
-        val minimumHeight = policy.resolveMinimumHeight(
-            intrinsicHeight = intrinsicHeight,
+        val minimumHeight = policy.minimumHeight(
             maxHeight = constraints.maxHeight,
             hasBoundedHeight = constraints.hasBoundedHeight,
         )
@@ -123,6 +113,12 @@ private fun Modifier.stabilizeViewportHeight(policy: StableSheetHeightPolicy): M
             constraints
         }
         val placeable = measurable.measure(measurementConstraints)
+        policy.onMeasured(
+            measuredHeight = placeable.height,
+            maxHeight = constraints.maxHeight,
+            hasBoundedHeight = constraints.hasBoundedHeight,
+            isImeVisible = isImeVisible,
+        )
 
         layout(placeable.width, placeable.height) {
             placeable.placeRelative(0, 0)

--- a/Common/src/test/java/tk/glucodata/ui/components/StableSheetHeightPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/components/StableSheetHeightPolicyTests.kt
@@ -10,111 +10,119 @@ class StableSheetHeightPolicyTests {
     fun shortSheetKeepsIntrinsicHeight() {
         val policy = StableSheetHeightPolicy()
 
-        val floor = policy.resolveMinimumHeight(
-            intrinsicHeight = 720,
+        policy.onMeasured(
+            measuredHeight = 720,
             maxHeight = 1000,
             hasBoundedHeight = true,
+            isImeVisible = false,
         )
 
         assertFalse(policy.isViewportHeightLocked)
-        assertEquals(0, floor)
+        assertEquals(0, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
     }
 
     @Test
-    fun contentTallerThanViewportLocksToViewportHeight() {
+    fun viewportHeightSheetLocksForLaterMeasurements() {
         val policy = StableSheetHeightPolicy()
 
-        val floor = policy.resolveMinimumHeight(
-            intrinsicHeight = 1400,
+        policy.onMeasured(
+            measuredHeight = 1000,
             maxHeight = 1000,
             hasBoundedHeight = true,
+            isImeVisible = false,
         )
 
         assertTrue(policy.isViewportHeightLocked)
-        assertEquals(1000, floor)
+        assertEquals(1000, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
     }
 
     @Test
     fun lockedSheetTracksShrinkingViewport() {
         val policy = StableSheetHeightPolicy()
-        policy.resolveMinimumHeight(
-            intrinsicHeight = 1400,
+        policy.onMeasured(
+            measuredHeight = 1000,
             maxHeight = 1000,
             hasBoundedHeight = true,
-        )
-
-        val floor = policy.resolveMinimumHeight(
-            intrinsicHeight = 1400,
-            maxHeight = 720,
-            hasBoundedHeight = true,
+            isImeVisible = false,
         )
 
         assertTrue(policy.isViewportHeightLocked)
-        assertEquals(720, floor)
+        assertEquals(720, policy.minimumHeight(maxHeight = 720, hasBoundedHeight = true))
     }
 
     @Test
     fun keyboardViewportRoundTripDoesNotPinInitiallyShortSheet() {
         val policy = StableSheetHeightPolicy()
 
-        assertEquals(
-            0,
-            policy.resolveMinimumHeight(
-                intrinsicHeight = 720,
-                maxHeight = 1000,
-                hasBoundedHeight = true,
-            ),
+        policy.onMeasured(
+            measuredHeight = 720,
+            maxHeight = 1000,
+            hasBoundedHeight = true,
+            isImeVisible = false,
+        )
+        assertEquals(0, policy.minimumHeight(maxHeight = 600, hasBoundedHeight = true))
+
+        policy.onMeasured(
+            measuredHeight = 600,
+            maxHeight = 600,
+            hasBoundedHeight = true,
+            isImeVisible = true,
         )
         assertEquals(
             0,
-            policy.resolveMinimumHeight(
-                intrinsicHeight = 720,
-                maxHeight = 600,
-                hasBoundedHeight = true,
-            ),
+            policy.minimumHeight(maxHeight = 600, hasBoundedHeight = true),
+        )
+
+        policy.onMeasured(
+            measuredHeight = 720,
+            maxHeight = 1000,
+            hasBoundedHeight = true,
+            isImeVisible = false,
         )
         assertEquals(
             0,
-            policy.resolveMinimumHeight(
-                intrinsicHeight = 720,
-                maxHeight = 1000,
-                hasBoundedHeight = true,
-            ),
+            policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true),
         )
 
         assertFalse(policy.isViewportHeightLocked)
     }
 
     @Test
-    fun substantiallyShorterContentReleasesViewportHeightLock() {
+    fun alreadyLockedSheetStaysLockedWhileKeyboardIsVisible() {
         val policy = StableSheetHeightPolicy()
-        policy.resolveMinimumHeight(
-            intrinsicHeight = 1400,
+        policy.onMeasured(
+            measuredHeight = 1000,
             maxHeight = 1000,
             hasBoundedHeight = true,
+            isImeVisible = false,
         )
 
-        val floor = policy.resolveMinimumHeight(
-            intrinsicHeight = 880,
-            maxHeight = 1000,
+        policy.onMeasured(
+            measuredHeight = 600,
+            maxHeight = 600,
             hasBoundedHeight = true,
+            isImeVisible = true,
         )
 
-        assertFalse(policy.isViewportHeightLocked)
-        assertEquals(0, floor)
+        assertTrue(policy.isViewportHeightLocked)
+        assertEquals(600, policy.minimumHeight(maxHeight = 600, hasBoundedHeight = true))
     }
 
     @Test
     fun unboundedMeasurementDoesNotLockOrInventAHeight() {
         val policy = StableSheetHeightPolicy()
 
-        val floor = policy.resolveMinimumHeight(
-            intrinsicHeight = 1000,
+        policy.onMeasured(
+            measuredHeight = 1000,
             maxHeight = Int.MAX_VALUE,
             hasBoundedHeight = false,
+            isImeVisible = false,
         )
 
         assertFalse(policy.isViewportHeightLocked)
-        assertEquals(0, floor)
+        assertEquals(
+            0,
+            policy.minimumHeight(maxHeight = Int.MAX_VALUE, hasBoundedHeight = false),
+        )
     }
 }

--- a/Common/src/test/java/tk/glucodata/ui/components/StableSheetHeightPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/components/StableSheetHeightPolicyTests.kt
@@ -10,55 +10,111 @@ class StableSheetHeightPolicyTests {
     fun shortSheetKeepsIntrinsicHeight() {
         val policy = StableSheetHeightPolicy()
 
-        policy.onMeasured(measuredHeight = 720, maxHeight = 1000, hasBoundedHeight = true)
+        val floor = policy.resolveMinimumHeight(
+            intrinsicHeight = 720,
+            maxHeight = 1000,
+            hasBoundedHeight = true,
+        )
 
         assertFalse(policy.isViewportHeightLocked)
-        assertEquals(0, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
+        assertEquals(0, floor)
     }
 
     @Test
-    fun viewportHeightSheetLocksForLaterMeasurements() {
+    fun contentTallerThanViewportLocksToViewportHeight() {
         val policy = StableSheetHeightPolicy()
 
-        policy.onMeasured(measuredHeight = 1000, maxHeight = 1000, hasBoundedHeight = true)
+        val floor = policy.resolveMinimumHeight(
+            intrinsicHeight = 1400,
+            maxHeight = 1000,
+            hasBoundedHeight = true,
+        )
 
         assertTrue(policy.isViewportHeightLocked)
-        assertEquals(1000, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
+        assertEquals(1000, floor)
     }
 
     @Test
-    fun lockedSheetTracksAChangedViewportHeight() {
+    fun lockedSheetTracksShrinkingViewport() {
         val policy = StableSheetHeightPolicy()
-        policy.onMeasured(measuredHeight = 1000, maxHeight = 1000, hasBoundedHeight = true)
+        policy.resolveMinimumHeight(
+            intrinsicHeight = 1400,
+            maxHeight = 1000,
+            hasBoundedHeight = true,
+        )
 
-        assertEquals(720, policy.minimumHeight(maxHeight = 720, hasBoundedHeight = true))
-    }
-
-    @Test
-    fun viewportHeightLockDoesNotReleaseWhenContentLaterMeasuresShorter() {
-        val policy = StableSheetHeightPolicy()
-        policy.onMeasured(measuredHeight = 1000, maxHeight = 1000, hasBoundedHeight = true)
-
-        policy.onMeasured(measuredHeight = 960, maxHeight = 1000, hasBoundedHeight = true)
+        val floor = policy.resolveMinimumHeight(
+            intrinsicHeight = 1400,
+            maxHeight = 720,
+            hasBoundedHeight = true,
+        )
 
         assertTrue(policy.isViewportHeightLocked)
-        assertEquals(1000, policy.minimumHeight(maxHeight = 1000, hasBoundedHeight = true))
+        assertEquals(720, floor)
+    }
+
+    @Test
+    fun keyboardViewportRoundTripDoesNotPinInitiallyShortSheet() {
+        val policy = StableSheetHeightPolicy()
+
+        assertEquals(
+            0,
+            policy.resolveMinimumHeight(
+                intrinsicHeight = 720,
+                maxHeight = 1000,
+                hasBoundedHeight = true,
+            ),
+        )
+        assertEquals(
+            0,
+            policy.resolveMinimumHeight(
+                intrinsicHeight = 720,
+                maxHeight = 600,
+                hasBoundedHeight = true,
+            ),
+        )
+        assertEquals(
+            0,
+            policy.resolveMinimumHeight(
+                intrinsicHeight = 720,
+                maxHeight = 1000,
+                hasBoundedHeight = true,
+            ),
+        )
+
+        assertFalse(policy.isViewportHeightLocked)
+    }
+
+    @Test
+    fun substantiallyShorterContentReleasesViewportHeightLock() {
+        val policy = StableSheetHeightPolicy()
+        policy.resolveMinimumHeight(
+            intrinsicHeight = 1400,
+            maxHeight = 1000,
+            hasBoundedHeight = true,
+        )
+
+        val floor = policy.resolveMinimumHeight(
+            intrinsicHeight = 880,
+            maxHeight = 1000,
+            hasBoundedHeight = true,
+        )
+
+        assertFalse(policy.isViewportHeightLocked)
+        assertEquals(0, floor)
     }
 
     @Test
     fun unboundedMeasurementDoesNotLockOrInventAHeight() {
         val policy = StableSheetHeightPolicy()
 
-        policy.onMeasured(
-            measuredHeight = 1000,
+        val floor = policy.resolveMinimumHeight(
+            intrinsicHeight = 1000,
             maxHeight = Int.MAX_VALUE,
             hasBoundedHeight = false,
         )
 
         assertFalse(policy.isViewportHeightLocked)
-        assertEquals(
-            0,
-            policy.minimumHeight(maxHeight = Int.MAX_VALUE, hasBoundedHeight = false),
-        )
+        assertEquals(0, floor)
     }
 }


### PR DESCRIPTION
## Summary

The shared sheet height policy treated a short sheet filling the reduced keyboard viewport as a full-height sheet. That decision persisted after the keyboard closed, so the sheet stayed at the top instead of returning to the bottom.

- Base the stable height decision on the measured sheet height.
- Do not acquire a persistent full-height lock from measurements taken while the keyboard is visible.
- Keep the existing stable lock for sheets that fill the viewport while the keyboard is closed.
- Cover short sheets, full-height sheets, keyboard transitions, and unbounded measurement in policy tests.

## Testing

- `./gradlew :Common:testMobileReleaseUnitTest --rerun-tasks` (1,856 tests, 0 failures)
- Focused `StableSheetHeightPolicyTests` rerun from scratch (6 tests, 0 failures)
- Device test: the insulin entry sheet opens at the bottom, moves above the keyboard while entering a value, and returns to the bottom after the keyboard closes.