### PR TITLE
Fix color wheel hue alignment

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/components/ExpressiveHueWheelPicker.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/components/ExpressiveHueWheelPicker.kt
@@ -14,12 +14,22 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.hypot
 import kotlin.math.sin
+
+internal const val HUE_WHEEL_START_ANGLE_DEGREES = -90f
+
+internal fun hueForWheelVector(dx: Float, dy: Float): Float {
+    val angle = Math.toDegrees(atan2(dy.toDouble(), dx.toDouble())).toFloat()
+    return (angle + 450f) % 360f
+}
+
+internal fun wheelAngleForHue(hue: Float): Float = hue + HUE_WHEEL_START_ANGLE_DEGREES
 
 @Composable
 fun ExpressiveHueWheelPicker(
@@ -30,13 +40,13 @@ fun ExpressiveHueWheelPicker(
 ) {
     val sweepColors = remember {
         listOf(
-            Color(0xFFFF1744),
-            Color(0xFFFF9100),
-            Color(0xFFFFEA00),
-            Color(0xFF00E676),
-            Color(0xFF00B0FF),
-            Color(0xFF651FFF),
-            Color(0xFFFF1744)
+            Color.Red,
+            Color.Yellow,
+            Color.Green,
+            Color.Cyan,
+            Color.Blue,
+            Color.Magenta,
+            Color.Red
         )
     }
     val handleHaloColor = MaterialTheme.colorScheme.surface
@@ -52,10 +62,7 @@ fun ExpressiveHueWheelPicker(
                     val dx = offset.x - size.width / 2f
                     val dy = offset.y - size.height / 2f
                     if (hypot(dx, dy) < minOf(size.width, size.height) * 0.28f) return
-                    val angle = Math.toDegrees(
-                        atan2(dy.toDouble(), dx.toDouble())
-                    ).toFloat()
-                    onHueChange((angle + 450f) % 360f)
+                    onHueChange(hueForWheelVector(dx, dy))
                 }
                 detectTapGestures(onTap = ::updateHue)
             }
@@ -67,22 +74,22 @@ fun ExpressiveHueWheelPicker(
                     if (hypot(dx, dy) < minOf(size.width, size.height) * 0.28f) {
                         return@detectDragGestures
                     }
-                    val angle = Math.toDegrees(
-                        atan2(dy.toDouble(), dx.toDouble())
-                    ).toFloat()
-                    onHueChange((angle + 450f) % 360f)
+                    onHueChange(hueForWheelVector(dx, dy))
                 }
             }
     ) {
         val ringWidth = 22.dp.toPx()
         val radius = (size.minDimension / 2f) - ringWidth
-        drawCircle(
-            brush = Brush.sweepGradient(sweepColors),
-            radius = radius,
-            style = Stroke(width = ringWidth, cap = StrokeCap.Round)
-        )
+        // Compose sweep gradients start at 3 o'clock. HSV hue 0 starts at 12 o'clock here.
+        rotate(HUE_WHEEL_START_ANGLE_DEGREES) {
+            drawCircle(
+                brush = Brush.sweepGradient(sweepColors),
+                radius = radius,
+                style = Stroke(width = ringWidth, cap = StrokeCap.Round)
+            )
+        }
 
-        val angleRadians = Math.toRadians((hue - 90f).toDouble())
+        val angleRadians = Math.toRadians(wheelAngleForHue(hue).toDouble())
         val handleCenter = Offset(
             x = center.x + (cos(angleRadians) * radius).toFloat(),
             y = center.y + (sin(angleRadians) * radius).toFloat()

--- a/Common/src/test/java/tk/glucodata/ui/components/ExpressiveHueWheelPickerTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/components/ExpressiveHueWheelPickerTests.kt
@@ -1,0 +1,20 @@
+package tk.glucodata.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ExpressiveHueWheelPickerTests {
+    @Test
+    fun cardinalPositionsFollowHsvHueOrderClockwiseFromTop() {
+        assertEquals(0f, hueForWheelVector(dx = 0f, dy = -1f), 0.001f)
+        assertEquals(90f, hueForWheelVector(dx = 1f, dy = 0f), 0.001f)
+        assertEquals(180f, hueForWheelVector(dx = 0f, dy = 1f), 0.001f)
+        assertEquals(270f, hueForWheelVector(dx = -1f, dy = 0f), 0.001f)
+    }
+
+    @Test
+    fun hueZeroAndSweepStartAtTopOfWheel() {
+        assertEquals(HUE_WHEEL_START_ANGLE_DEGREES, wheelAngleForHue(0f), 0.001f)
+        assertEquals(-90f, HUE_WHEEL_START_ANGLE_DEGREES, 0.001f)
+    }
+}


### PR DESCRIPTION
## Summary

Compose sweep gradients start at 3 o’clock, but the picker maps hue 0 to 12 o’clock. This left the handle and selected color on a different part of the wheel.

- rotate the sweep gradient so its origin matches the picker coordinates
- use HSV color stops so the ring represents the selected hue
- add tests for the four cardinal positions and gradient origin

## Testing

- ./gradlew :Common:testMobileReleaseUnitTest --rerun-tasks on local-build: 2,320 tests passed
- verified on device