### PR TITLE
Keep Journal rows while observation is paused

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
@@ -437,7 +437,9 @@ class DashboardViewModel(
     private fun stopJournalEntriesObservation() {
         journalEntriesJob?.cancel()
         journalEntriesJob = null
-        _journalEntries.value = emptyList()
+        // The enabled state controls visibility at the UI boundary. Keep the
+        // last Room emission while observation is paused so a receiver or
+        // sensor-mode refresh cannot masquerade as an empty database.
     }
 
     private fun ensureJournalPresetsObserved() {

--- a/Common/src/test/java/tk/glucodata/ui/JournalObservationSafetyTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/JournalObservationSafetyTests.kt
@@ -1,0 +1,34 @@
+package tk.glucodata.ui
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JournalObservationSafetyTests {
+    private fun repoRoot(): File {
+        var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        while (dir != null) {
+            if (File(dir, "Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt").isFile) {
+                return dir
+            }
+            dir = dir.parentFile
+        }
+        throw AssertionError("DashboardViewModel source not found")
+    }
+
+    @Test
+    fun stoppingTheObserverDoesNotPresentAnEmptyDatabase() {
+        val source = File(
+            repoRoot(),
+            "Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt",
+        ).readText()
+        val start = source.indexOf("private fun stopJournalEntriesObservation()")
+        val end = source.indexOf("private fun ensureJournalPresetsObserved()", start)
+        assertTrue("journal observer stop function not found", start >= 0 && end > start)
+        val function = source.substring(start, end)
+
+        assertTrue(function.contains("journalEntriesJob?.cancel()"))
+        assertFalse(function.contains("_journalEntries.value = emptyList()"))
+    }
+}


### PR DESCRIPTION
Clone and Nightscout transitions can temporarily stop the Journal's Room observer. The stop path currently publishes an empty list before removing the observer, so the UI looks as if the Journal was deleted until observation starts again even though the rows are still in the database.

This change stops the observer without replacing its last emission. Visibility still follows the Journal enabled state, while receiver and sensor-mode transitions can no longer clear the displayed rows as a side effect.

No Journal rows or historical glucose data are modified.

## Verification

- Added a regression guard for the observer stop path
- Included in `./gradlew :Common:testMobileReleaseUnitTest`: 2,364 tests, 0 failures
- `git diff --check`
