### PR TITLE
Persist recent BLE error history

### DIFF
--- a/Common/src/main/java/tk/glucodata/BleErrorHistory.kt
+++ b/Common/src/main/java/tk/glucodata/BleErrorHistory.kt
@@ -1,0 +1,141 @@
+package tk.glucodata
+
+import android.content.Context
+import java.util.Base64
+import java.util.Locale
+
+data class BleErrorEvent(
+    val sensorId: String,
+    val status: String,
+    val atMs: Long,
+)
+
+internal const val BLE_ERROR_CARD_WINDOW_MS = 60L * 60L * 1_000L
+internal const val BLE_ERROR_RETENTION_MS = 30L * 24L * 60L * 60L * 1_000L
+internal const val BLE_ERROR_MAX_PER_SENSOR = 20
+internal const val BLE_ERROR_MAX_TOTAL = 100
+
+/**
+ * Keep diagnostics useful without letting a sensor that repeatedly reconnects grow storage
+ * forever. Results are newest-first so callers can use the first matching event as the latest.
+ */
+internal fun retainBleErrorEvents(
+    events: List<BleErrorEvent>,
+    nowMs: Long,
+    maxPerSensor: Int = BLE_ERROR_MAX_PER_SENSOR,
+    maxTotal: Int = BLE_ERROR_MAX_TOTAL,
+    retentionMs: Long = BLE_ERROR_RETENTION_MS,
+): List<BleErrorEvent> {
+    if (maxPerSensor <= 0 || maxTotal <= 0) return emptyList()
+    val oldestAllowed = nowMs - retentionMs
+    val counts = HashMap<String, Int>()
+    return events.asSequence()
+        .filter { event ->
+            event.atMs > 0L &&
+                event.atMs >= oldestAllowed &&
+                event.sensorId.isNotBlank() &&
+                event.status.isNotBlank()
+        }
+        .sortedByDescending(BleErrorEvent::atMs)
+        .filter { event ->
+            val key = event.sensorId.trim().uppercase(Locale.ROOT)
+            val count = counts[key] ?: 0
+            if (count >= maxPerSensor) {
+                false
+            } else {
+                counts[key] = count + 1
+                true
+            }
+        }
+        .take(maxTotal)
+        .toList()
+}
+
+internal fun encodeBleErrorEvents(events: List<BleErrorEvent>): String =
+    events.joinToString("\n") { event ->
+        val encoder = Base64.getUrlEncoder().withoutPadding()
+        listOf(
+            event.atMs.toString(),
+            encoder.encodeToString(event.sensorId.toByteArray(Charsets.UTF_8)),
+            encoder.encodeToString(event.status.toByteArray(Charsets.UTF_8)),
+        ).joinToString("\t")
+    }
+
+internal fun decodeBleErrorEvents(encoded: String): List<BleErrorEvent> {
+    if (encoded.isBlank()) return emptyList()
+    val decoder = Base64.getUrlDecoder()
+    return encoded.lineSequence().mapNotNull { line ->
+        runCatching {
+            val parts = line.split('\t')
+            if (parts.size != 3) return@runCatching null
+            BleErrorEvent(
+                sensorId = String(decoder.decode(parts[1]), Charsets.UTF_8),
+                status = String(decoder.decode(parts[2]), Charsets.UTF_8),
+                atMs = parts[0].toLong(),
+            )
+        }.getOrNull()
+    }.toList()
+}
+
+/** Durable, bounded diagnostics for BLE failures. This is independent of trace recording. */
+object BleErrorHistory {
+    private const val PREFS_NAME = "ble_error_history"
+    private const val KEY_EVENTS = "events_v1"
+    private val lock = Any()
+
+    @JvmStatic
+    fun record(sensorId: String?, status: String?, atMs: Long = System.currentTimeMillis()) {
+        val validSensorId = sensorId?.trim()?.takeIf { SensorIdentity.isUsableSensorId(it) } ?: return
+        val validStatus = status?.trim()?.takeIf { it.isNotEmpty() } ?: return
+        val context = Applic.app ?: return
+        synchronized(lock) {
+            val retained = retainBleErrorEvents(
+                listOf(BleErrorEvent(validSensorId, validStatus, atMs)) + load(context),
+                nowMs = System.currentTimeMillis(),
+            )
+            save(context, retained)
+        }
+    }
+
+    @JvmStatic
+    fun latest(sensorId: String?): BleErrorEvent? {
+        if (sensorId.isNullOrBlank()) return null
+        return events().firstOrNull { SensorIdentity.matches(it.sensorId, sensorId) }
+    }
+
+    @JvmStatic
+    fun events(): List<BleErrorEvent> {
+        val context = Applic.app ?: return emptyList()
+        synchronized(lock) {
+            val loaded = load(context)
+            val retained = retainBleErrorEvents(loaded, System.currentTimeMillis())
+            if (retained != loaded) save(context, retained)
+            return retained
+        }
+    }
+
+    @JvmStatic
+    fun clear() {
+        val context = Applic.app ?: return
+        synchronized(lock) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .remove(KEY_EVENTS)
+                .apply()
+        }
+    }
+
+    private fun load(context: Context): List<BleErrorEvent> =
+        decodeBleErrorEvents(
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getString(KEY_EVENTS, null)
+                .orEmpty(),
+        )
+
+    private fun save(context: Context, events: List<BleErrorEvent>) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_EVENTS, encodeBleErrorEvents(events))
+            .apply()
+    }
+}

--- a/Common/src/main/java/tk/glucodata/SensorBluetooth.java
+++ b/Common/src/main/java/tk/glucodata/SensorBluetooth.java
@@ -1185,6 +1185,11 @@ public class SensorBluetooth {
                 && gatt.charcha[0] > gatt.constatchange[1];
     }
 
+    /** Wall-clock time of the last connection failure recorded for the sensor. */
+    public static long connectionStatusChangedAt(SuperGattCallback gatt) {
+        return gatt == null ? 0L : gatt.constatchange[1];
+    }
+
     // --- KOTLIN SENSORS (AiDex) SUPPORT ---
     public static void addAiDexSensor(Context context, String name, String address) {
         if (context == null || name == null || name.trim().isEmpty() || address == null || address.trim().isEmpty()) {

--- a/Common/src/main/java/tk/glucodata/SuperGattCallback.java
+++ b/Common/src/main/java/tk/glucodata/SuperGattCallback.java
@@ -198,6 +198,7 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
                 ;
                 constatstatusstr = "Loss of signal";
                 constatchange[1] = now;
+                BleErrorHistory.record(SerialNumber, constatstatusstr, now);
                 final var thegatt = mBluetoothGatt;
                 if (thegatt != null) {
                     thegatt.disconnect();
@@ -213,6 +214,9 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
 
     void setConStatus(int status) {
         constatstatusstr = "Status=" + status;
+        if (status != BluetoothGatt.GATT_SUCCESS) {
+            BleErrorHistory.record(SerialNumber, constatstatusstr, System.currentTimeMillis());
+        }
     }
 
     void shouldreconnect(long now) {

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -518,6 +518,7 @@
     <string name="debug_logs_title">Журналы адладкі</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">Гісторыя памылак BLE</string>
     <string name="log_enabled_waiting">Журнал уключаны. Чаканне запісаў...</string>
     <string name="log_unchecked">Журнал выключаны. Уключыце для пачатку.</string>
     <string name="error_reading_file">"Памылка чытання файла: "</string>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -766,6 +766,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Апошняя памылка BLE</string>
     <string name="libre_setup_done">Гатова</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Наладзьце эксперыментальныя паводзіны сканавання Libre 3 перад спалучэннем.</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -451,6 +451,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="clear">Löschen</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">BLE-Fehlerverlauf</string>
     <string name="log_enabled_waiting">Protokoll aktiviert. Warte auf Einträge...</string>
     <string name="log_unchecked">Protokoll deaktiviert. Aktivieren zum Starten.</string>
     <string name="error_reading_file">"Fehler beim Lesen der Datei: "</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -868,6 +868,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="keep_auto_calibration">Autokalibrierungsdaten behalten</string>
     <string name="keep_data">Sensorinfo behalten</string>
     <string name="last_ble_status">Letzter BLE-Status</string>
+    <string name="last_ble_error">Letzter BLE-Fehler</string>
     <string name="libre_setup_done">Fertig</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Experimentelles Scan-Verhalten für Libre 3 vor dem Koppeln anpassen.</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -328,6 +328,7 @@
     <string name="clear">Effacer</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">Historique des erreurs BLE</string>
     <string name="log_enabled_waiting">Journal activé. En attente d\'entrées...</string>
     <string name="log_unchecked">Journal désactivé. Activer pour commencer.</string>
     <string name="error_reading_file">"Erreur de lecture du fichier : "</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -740,6 +740,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Dernière erreur BLE</string>
     <string name="libre_setup_done">Terminé</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Ajustez le comportement expérimental du scan Libre 3 avant l\'appairage.</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -238,6 +238,7 @@
     <string name="clear">Cancella</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">Cronologia errori BLE</string>
     <string name="log_enabled_waiting">Log abilitato. In attesa di voci...</string>
     <string name="log_unchecked">Log disabilitato. Abilita per iniziare.</string>
     <string name="error_reading_file">"Errore lettura file: "</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -684,6 +684,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Ultimo errore BLE</string>
     <string name="libre_setup_done">Fatto</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Regola il comportamento sperimentale della scansione Libre 3 prima dell\'associazione.</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -483,6 +483,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="clear">Цэвэрлэх</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">BLE алдааны түүх</string>
     <string name="log_enabled_waiting">Лог идэвхжсэн. Бичилтүүдийг хүлээж байна...</string>
     <string name="log_unchecked">Лог сонгогдоогүй. Эхлүүлэхийн тулд идэвхжүүлнэ үү.</string>
     <string name="error_reading_file">"Файлыг уншихад алдаа гарлаа: "</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -611,6 +611,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="enabled_status">Идэвхжсэн</string>
     <string name="disabled_status">Идэвхгүй болгосон</string>
     <string name="last_ble_status">Сүүлчийн BLE төлөв</string>
+    <string name="last_ble_error">Сүүлийн BLE алдаа</string>
     <string name="sensor_address">Хаяг</string>
     <string name="sensor_started">Эхэлсэн</string>
     <string name="sensor_ends_officially">Албан ёсоор дуусах</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -443,6 +443,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="clear">Wissen</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">BLE-foutgeschiedenis</string>
     <string name="log_enabled_waiting">Log ingeschakeld. Wachten op items...</string>
     <string name="log_unchecked">Log uitgeschakeld. Inschakelen om te starten.</string>
     <string name="error_reading_file">"Fout bij lezen bestand: "</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -839,6 +839,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="keep_auto_calibration">Keep auto-calibration data</string>
     <string name="keep_data">Keep sensor info</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Laatste BLE-fout</string>
     <string name="libre_setup_done">Klaar</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Pas experimenteel Libre 3-scangedrag aan voordat je koppelt.</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -439,6 +439,7 @@
     <string name="clear">Wyczyść</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">Historia błędów BLE</string>
     <string name="log_enabled_waiting">Log włączony. Oczekiwanie...</string>
     <string name="log_unchecked">Log wyłączony. Włącz, aby rozpocząć.</string>
     <string name="error_reading_file">"Błąd odczytu pliku: "</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -828,6 +828,7 @@
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Ostatni: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Ostatni błąd BLE</string>
     <string name="libre_setup_done">Gotowe</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Dostosuj eksperymentalne zachowanie skanowania Libre 3 przed parowaniem.</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -263,6 +263,7 @@
     <string name="clear">Limpar</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">Histórico de erros BLE</string>
     <string name="log_enabled_waiting">Log ativado. Aguardando entradas...</string>
     <string name="log_unchecked">Log desativado. Ative para iniciar.</string>
     <string name="error_reading_file">"Erro ao ler arquivo: "</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -706,6 +706,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Último erro de BLE</string>
     <string name="libre_setup_done">Concluído</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Ajuste o comportamento experimental da leitura do Libre 3 antes do emparelhamento.</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -359,6 +359,7 @@
     <string name="clear">Очистить</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">История ошибок BLE</string>
     <string name="log_enabled_waiting">Лог включен. Ожидание записей...</string>
     <string name="log_unchecked">Лог выключен. Включите для начала.</string>
     <string name="error_reading_file">"Ошибка чтения файла: "</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -493,6 +493,7 @@
     <string name="enabled_status">Включен</string>
     <string name="disabled_status">Отключен</string>
     <string name="last_ble_status">Статус BLE</string>
+    <string name="last_ble_error">Последняя ошибка BLE</string>
     <string name="sensor_address">Адрес</string>
     <string name="sensor_started">Запущен</string>
     <string name="sensor_ends_officially">Офиц. окончание</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -509,6 +509,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="clear">Cad</string>
     <string name="trace_log">Raad raac.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">Taariikhda khaladaadka BLE</string>
     <string name="log_enabled_waiting">Log waa la furay Sugaya soo gelida...</string>
     <string name="log_unchecked">Log aan la hubin Awood in aad bilowdo</string>
     <string name="error_reading_file">"Cilaad akhriska faylka:"</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -653,6 +653,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="enabled_status">Hawl gal</string>
     <string name="disabled_status">Dansan</string>
     <string name="last_ble_status">Heerka BLE ee u dambeeyay</string>
+    <string name="last_ble_error">Ciladdii BLE ee u dambeysay</string>
     <string name="sensor_address">Cinwaanka</string>
     <string name="sensor_started">bilaabay</string>
     <string name="sensor_ends_officially">Si Rasmi Ah U Dhamaatay</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -364,6 +364,7 @@
     <string name="clear">Rensa</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">BLE-felhistorik</string>
     <string name="log_enabled_waiting">Logg aktiverad. Väntar på poster...</string>
     <string name="log_unchecked">Logg inaktiverad. Aktivera för att starta.</string>
     <string name="error_reading_file">"Fel vid läsning av fil: "</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -771,6 +771,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Senaste BLE-felet</string>
     <string name="libre_setup_done">Klart</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Justera det experimentella Libre 3-skanningsbeteendet innan parkoppling.</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -416,6 +416,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="clear">Temizle</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">BLE hata geçmişi</string>
     <string name="log_enabled_waiting">Günlük etkin. Girişler bekleniyor...</string>
     <string name="log_unchecked">Günlük devre dışı. Başlatmak için etkinleştirin.</string>
     <string name="error_reading_file">"Dosya okuma hatası: "</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -809,6 +809,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Son BLE hatası</string>
     <string name="libre_setup_done">Bitti</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Eşleştirmeden önce deneysel Libre 3 tarama davranışını ayarlayın.</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -376,6 +376,7 @@
     <string name="clear">Очистити</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">Історія помилок BLE</string>
     <string name="log_enabled_waiting">Журнал увімкнено. Очікування записів...</string>
     <string name="log_unchecked">Журнал вимкнено. Увімкніть для початку.</string>
     <string name="error_reading_file">"Помилка читання файлу: "</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -783,6 +783,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Остання помилка BLE</string>
     <string name="libre_setup_done">Готово</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Налаштуйте експериментальну поведінку сканування Libre 3 перед сполученням.</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -371,6 +371,7 @@
     <string name="clear">清除</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">BLE 错误历史</string>
     <string name="log_enabled_waiting">日志已启用。等待条目...</string>
     <string name="log_unchecked">日志未选中。启用以开始。</string>
     <string name="error_reading_file">"读取文件错误： "</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -783,6 +783,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="keep_data">Keep sensor info</string>
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">上次 BLE 错误</string>
     <string name="libre_setup_done">完成</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">在配对前调整 Libre 3 的实验性扫描行为。</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -512,6 +512,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="clear">Clear</string>
     <string name="trace_log">Trace.log</string>
     <string name="logcat">Logcat</string>
+    <string name="ble_error_history">BLE error history</string>
     <string name="log_enabled_waiting">Log enabled. Waiting for entries...</string>
     <string name="log_unchecked">Log unchecked. Enable to start.</string>
     <string name="error_reading_file">"Error reading file: "</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -675,6 +675,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="enabled_status">Enabled</string>
     <string name="disabled_status">Disabled</string>
     <string name="last_ble_status">Last BLE status</string>
+    <string name="last_ble_error">Last BLE error</string>
     <string name="sensor_address">Address</string>
     <string name="sensor_started">Started</string>
     <string name="sensor_ends_officially">Ends Officially</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/DebugLogExport.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DebugLogExport.kt
@@ -1,0 +1,38 @@
+package tk.glucodata.ui
+
+import java.io.File
+import java.io.OutputStream
+
+/**
+ * Export payloads stay split by storage type: trace and logcat are streamed from disk, while the
+ * deliberately bounded BLE history can remain an in-memory string.
+ */
+internal sealed class DebugLogExportSource {
+    abstract fun isEmpty(): Boolean
+    abstract fun copyTo(output: OutputStream)
+
+    class FileContent(private val file: File) : DebugLogExportSource() {
+        override fun isEmpty(): Boolean = !file.exists() || file.length() == 0L
+
+        override fun copyTo(output: OutputStream) {
+            file.inputStream().buffered().use { input -> input.copyTo(output) }
+        }
+    }
+
+    class TextContent(private val text: String) : DebugLogExportSource() {
+        override fun isEmpty(): Boolean = text.isEmpty()
+
+        override fun copyTo(output: OutputStream) {
+            output.write(text.toByteArray(Charsets.UTF_8))
+        }
+    }
+}
+
+internal fun writeDebugLogReport(
+    output: OutputStream,
+    header: String,
+    source: DebugLogExportSource,
+) {
+    output.write(header.toByteArray(Charsets.UTF_8))
+    source.copyTo(output)
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/DebugSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DebugSettingsScreen.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tk.glucodata.BuildConfig
+import tk.glucodata.BleErrorHistory
 import tk.glucodata.Natives
 import tk.glucodata.R
 import tk.glucodata.ui.components.MasterSwitchCard
@@ -63,18 +64,25 @@ import java.util.Date
 import java.util.Locale
 
 enum class LogType {
-    TRACE, LOGCAT
+    TRACE, LOGCAT, BLE_ERRORS
 }
 
 private const val LOG_TAIL_BYTES = 50L * 1024L
 private const val PREF_HOWTO_DISMISSED = "debug_howto_dismissed"
 
-private fun LogType.fileName(): String =
-    if (this == LogType.TRACE) "logs/trace.log" else "logs/logcat.txt"
+private fun LogType.fileName(): String? = when (this) {
+    LogType.TRACE -> "logs/trace.log"
+    LogType.LOGCAT -> "logs/logcat.txt"
+    LogType.BLE_ERRORS -> null
+}
 
 private fun LogType.exportName(): String {
     val stamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
-    return if (this == LogType.TRACE) "juggluco-trace-$stamp.log" else "juggluco-logcat-$stamp.txt"
+    return when (this) {
+        LogType.TRACE -> "juggluco-trace-$stamp.log"
+        LogType.LOGCAT -> "juggluco-logcat-$stamp.txt"
+        LogType.BLE_ERRORS -> "juggluco-ble-errors-$stamp.txt"
+    }
 }
 
 /** Snapshot of what is currently on disk, so the poll loop can skip untouched files. */
@@ -107,6 +115,20 @@ private fun readLog(file: File, truncationNotice: String): LogSnapshot {
     } catch (e: Exception) {
         LogSnapshot(lines = listOf("${e.message}"), bytes = size, stamp = stamp)
     }
+}
+
+private fun readBleErrorHistory(): LogSnapshot {
+    val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ", Locale.US)
+    val events = BleErrorHistory.events()
+    val lines = events.asReversed().map { event ->
+        "${formatter.format(Date(event.atMs))} sensor=${event.sensorId} status=${event.status}"
+    }
+    val bytes = lines.sumOf { it.toByteArray().size + 1 }.toLong()
+    return LogSnapshot(
+        lines = lines,
+        bytes = bytes,
+        stamp = events.firstOrNull()?.atMs ?: 0L,
+    )
 }
 
 /** Short, non-identifying preamble so a shared log says which build it came from. */
@@ -144,20 +166,35 @@ fun DebugSettingsScreen(navController: NavController) {
     val chooserTitle = stringResource(R.string.debug_share_chooser)
     val savingError = stringResource(R.string.error_saving_file)
 
-    fun currentFile(): File = File(context.filesDir, logType.fileName())
+    fun currentFile(): File? = logType.fileName()?.let { File(context.filesDir, it) }
+
+    fun currentText(): String = if (logType == LogType.BLE_ERRORS) {
+        readBleErrorHistory().lines
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString("\n", postfix = "\n")
+            .orEmpty()
+    } else {
+        currentFile()?.takeIf(File::exists)?.readText().orEmpty()
+    }
 
     LaunchedEffect(logType) {
-        isRecording = if (logType == LogType.TRACE) Natives.islogging() else Natives.islogcat()
+        isRecording = when (logType) {
+            LogType.TRACE -> Natives.islogging()
+            LogType.LOGCAT -> Natives.islogcat()
+            LogType.BLE_ERRORS -> false
+        }
         loading = true
         var lastStamp = -1L
         var lastBytes = -1L
         while (isActive) {
             val next = withContext(Dispatchers.IO) {
                 val file = currentFile()
-                if (file.exists() && file.lastModified() == lastStamp && file.length() == lastBytes) {
+                if (logType == LogType.BLE_ERRORS) {
+                    readBleErrorHistory()
+                } else if (file != null && file.exists() && file.lastModified() == lastStamp && file.length() == lastBytes) {
                     null
                 } else {
-                    readLog(file, truncationNotice)
+                    file?.let { readLog(it, truncationNotice) } ?: LogSnapshot()
                 }
             }
             if (next != null) {
@@ -178,10 +215,9 @@ fun DebugSettingsScreen(navController: NavController) {
         scope.launch {
             val error = withContext(Dispatchers.IO) {
                 runCatching {
-                    val source = currentFile()
                     context.contentResolver.openOutputStream(uri)?.use { output ->
                         output.write(reportHeader().toByteArray())
-                        source.inputStream().use { it.copyTo(output) }
+                        output.write(currentText().toByteArray())
                     }
                 }.exceptionOrNull()
             }
@@ -193,8 +229,8 @@ fun DebugSettingsScreen(navController: NavController) {
         scope.launch {
             val result = withContext(Dispatchers.IO) {
                 runCatching {
-                    val source = currentFile()
-                    if (!source.exists() || source.length() == 0L) return@runCatching null
+                    val contents = currentText()
+                    if (contents.isEmpty()) return@runCatching null
                     val outDir = File(context.cacheDir, "exports").apply { mkdirs() }
                     // Each staged copy is as large as the log itself. Drop earlier ones so
                     // repeated shares don't quietly park tens of MB in the cache.
@@ -203,7 +239,7 @@ fun DebugSettingsScreen(navController: NavController) {
                     val staged = File(outDir, logType.exportName())
                     staged.outputStream().use { output ->
                         output.write(reportHeader().toByteArray())
-                        source.inputStream().use { it.copyTo(output) }
+                        output.write(contents.toByteArray())
                     }
                     FileProvider.getUriForFile(
                         context,
@@ -251,7 +287,11 @@ fun DebugSettingsScreen(navController: NavController) {
                         )
                     }
                     IconButton(onClick = {
-                        if (logType == LogType.TRACE) Natives.zeroLog() else Natives.zeroLogcat()
+                        when (logType) {
+                            LogType.TRACE -> Natives.zeroLog()
+                            LogType.LOGCAT -> Natives.zeroLogcat()
+                            LogType.BLE_ERRORS -> BleErrorHistory.clear()
+                        }
                         snapshot = LogSnapshot()
                     }) {
                         Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.clear))
@@ -276,29 +316,32 @@ fun DebugSettingsScreen(navController: NavController) {
                 )
             }
 
-            MasterSwitchCard(
-                title = stringResource(R.string.debug_record_title),
-                subtitle = stringResource(
-                    if (isRecording) R.string.debug_record_on else R.string.debug_record_off
-                ),
-                checked = isRecording,
-                icon = Icons.Default.BugReport,
-                onCheckedChange = { enabled ->
-                    isRecording = enabled
-                    if (logType == LogType.TRACE) {
-                        Natives.dolog(enabled)
-                        // Java-side guards mirror the native switch — refresh or they stay
-                        // short-circuited and the trace comes back empty.
-                        tk.glucodata.Log.refreshDoLog()
-                    } else {
-                        Natives.dologcat(enabled)
+            AnimatedVisibility(visible = logType != LogType.BLE_ERRORS) {
+                MasterSwitchCard(
+                    title = stringResource(R.string.debug_record_title),
+                    subtitle = stringResource(
+                        if (isRecording) R.string.debug_record_on else R.string.debug_record_off
+                    ),
+                    checked = isRecording,
+                    icon = Icons.Default.BugReport,
+                    onCheckedChange = { enabled ->
+                        isRecording = enabled
+                        if (logType == LogType.TRACE) {
+                            Natives.dolog(enabled)
+                            // Java-side guards mirror the native switch — refresh or they stay
+                            // short-circuited and the trace comes back empty.
+                            tk.glucodata.Log.refreshDoLog()
+                        } else {
+                            Natives.dologcat(enabled)
+                        }
                     }
-                }
-            )
+                )
+            }
 
             val logTypeLabels = mapOf(
                 LogType.TRACE to stringResource(R.string.trace_log),
-                LogType.LOGCAT to stringResource(R.string.logcat)
+                LogType.LOGCAT to stringResource(R.string.logcat),
+                LogType.BLE_ERRORS to stringResource(R.string.ble_error_history),
             )
             ConnectedButtonGroup(
                 options = LogType.entries,

--- a/Common/src/mobile/java/tk/glucodata/ui/DebugSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DebugSettingsScreen.kt
@@ -59,6 +59,7 @@ import tk.glucodata.R
 import tk.glucodata.ui.components.MasterSwitchCard
 import tk.glucodata.ui.util.ConnectedButtonGroup
 import java.io.File
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -131,6 +132,12 @@ private fun readBleErrorHistory(): LogSnapshot {
     )
 }
 
+private fun bleErrorHistoryText(): String =
+    readBleErrorHistory().lines
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString("\n", postfix = "\n")
+        .orEmpty()
+
 /** Short, non-identifying preamble so a shared log says which build it came from. */
 private fun reportHeader(): String = buildString {
     append("# Juggluco ").append(BuildConfig.VERSION_NAME).append('\n')
@@ -168,13 +175,14 @@ fun DebugSettingsScreen(navController: NavController) {
 
     fun currentFile(): File? = logType.fileName()?.let { File(context.filesDir, it) }
 
-    fun currentText(): String = if (logType == LogType.BLE_ERRORS) {
-        readBleErrorHistory().lines
-            .takeIf { it.isNotEmpty() }
-            ?.joinToString("\n", postfix = "\n")
-            .orEmpty()
-    } else {
-        currentFile()?.takeIf(File::exists)?.readText().orEmpty()
+    fun exportSource(type: LogType): DebugLogExportSource? {
+        val source = when (type) {
+            LogType.TRACE, LogType.LOGCAT -> DebugLogExportSource.FileContent(
+                File(context.filesDir, requireNotNull(type.fileName()))
+            )
+            LogType.BLE_ERRORS -> DebugLogExportSource.TextContent(bleErrorHistoryText())
+        }
+        return source.takeUnless(DebugLogExportSource::isEmpty)
     }
 
     LaunchedEffect(logType) {
@@ -212,45 +220,79 @@ fun DebugSettingsScreen(navController: NavController) {
         ActivityResultContracts.CreateDocument("text/plain")
     ) { uri ->
         uri ?: return@rememberLauncherForActivityResult
+        val selectedType = logType
         scope.launch {
+            var empty = false
             val error = withContext(Dispatchers.IO) {
-                runCatching {
-                    context.contentResolver.openOutputStream(uri)?.use { output ->
-                        output.write(reportHeader().toByteArray())
-                        output.write(currentText().toByteArray())
+                val source = exportSource(selectedType)
+                if (source == null) {
+                    empty = true
+                    null
+                } else {
+                    var destinationOpened = false
+                    runCatching {
+                        val output = context.contentResolver.openOutputStream(uri, "wt")
+                            ?: throw IOException("Could not open export destination")
+                        destinationOpened = true
+                        output.use {
+                            writeDebugLogReport(it, reportHeader(), source)
+                        }
+                    }.exceptionOrNull().also {
+                        if (it != null && destinationOpened) {
+                            // ACTION_CREATE_DOCUMENT has already created the destination. Do not
+                            // leave a header-only or otherwise partial file behind after failure.
+                            runCatching { context.contentResolver.delete(uri, null, null) }
+                        }
                     }
-                }.exceptionOrNull()
+                }
             }
-            if (error != null) snackbarHost.showSnackbar(savingError + error.message)
+            when {
+                empty -> snackbarHost.showSnackbar(nothingToShare)
+                error != null -> snackbarHost.showSnackbar(savingError + error.message)
+            }
         }
     }
 
     fun shareLog() {
+        val selectedType = logType
         scope.launch {
+            var empty = false
             val result = withContext(Dispatchers.IO) {
+                var staged: File? = null
                 runCatching {
-                    val contents = currentText()
-                    if (contents.isEmpty()) return@runCatching null
+                    val source = exportSource(selectedType)
+                    if (source == null) {
+                        empty = true
+                        return@runCatching null
+                    }
                     val outDir = File(context.cacheDir, "exports").apply { mkdirs() }
                     // Each staged copy is as large as the log itself. Drop earlier ones so
                     // repeated shares don't quietly park tens of MB in the cache.
                     outDir.listFiles { f -> f.name.startsWith("juggluco-") }
                         ?.forEach { it.delete() }
-                    val staged = File(outDir, logType.exportName())
-                    staged.outputStream().use { output ->
-                        output.write(reportHeader().toByteArray())
-                        output.write(contents.toByteArray())
+                    val stagedFile = File(outDir, selectedType.exportName())
+                    staged = stagedFile
+                    stagedFile.outputStream().use { output ->
+                        writeDebugLogReport(output, reportHeader(), source)
                     }
                     FileProvider.getUriForFile(
                         context,
                         "${context.packageName}.fileprovider",
-                        staged
+                        stagedFile
                     )
+                }.onFailure {
+                    // A failed staged copy must not masquerade as a valid shareable trace.
+                    staged?.delete()
                 }
+            }
+            val error = result.exceptionOrNull()
+            if (error != null) {
+                snackbarHost.showSnackbar(savingError + error.message)
+                return@launch
             }
             val uri = result.getOrNull()
             if (uri == null) {
-                snackbarHost.showSnackbar(nothingToShare)
+                if (empty) snackbarHost.showSnackbar(nothingToShare)
                 return@launch
             }
             runCatching {

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -2,6 +2,7 @@
 
 package tk.glucodata.ui
 
+import android.text.format.DateUtils
 import androidx.compose.foundation.background
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
@@ -133,6 +134,14 @@ private fun nextSensorReadingAgeDelay(nowMillis: Long, readingMillis: Long): Lon
 
 private fun formatSibionicsSensitivity(value: Float): String =
     String.format(Locale.getDefault(), "%.2f", value)
+
+internal fun bleErrorEventTimeForDisplay(eventAtMs: Long, nowMs: Long): Long? =
+    eventAtMs.takeIf { it > 0L }?.coerceAtMost(nowMs)
+
+internal fun bleErrorValue(status: String, relativeAge: CharSequence?): String {
+    val age = relativeAge?.toString()?.trim().orEmpty()
+    return if (age.isEmpty()) status else "$status · $age"
+}
 
 @Composable
 private fun SensorCurrentValueChip(
@@ -1496,7 +1505,25 @@ fun SensorCard(
                     if (sensor.connectionStatus.isNotEmpty() &&
                         !sensor.connectionStatus.equals(connectedStatus, ignoreCase = true)
                     ) {
-                        DataRow(stringResource(R.string.last_ble_status), sensor.connectionStatus)
+                        val errorEventAt = bleErrorEventTimeForDisplay(sensor.connectionStatusAtMs, now)
+                        val rowLabel = if (errorEventAt != null) {
+                            stringResource(R.string.last_ble_error)
+                        } else {
+                            stringResource(R.string.last_ble_status)
+                        }
+                        val rowValue = if (errorEventAt != null) {
+                            bleErrorValue(
+                                sensor.connectionStatus,
+                                DateUtils.getRelativeTimeSpanString(
+                                    errorEventAt,
+                                    now,
+                                    DateUtils.MINUTE_IN_MILLIS,
+                                ),
+                            )
+                        } else {
+                            sensor.connectionStatus
+                        }
+                        DataRow(rowLabel, rowValue)
                     }
                     DataRow(stringResource(R.string.sensor_address), sensor.deviceAddress)
                     

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.draw.alpha
 
 import androidx.compose.material.icons.filled.AccessTime
 import tk.glucodata.CurrentDisplaySource
+import tk.glucodata.BLE_ERROR_CARD_WINDOW_MS
 import tk.glucodata.Notify
 import tk.glucodata.R
 import tk.glucodata.SensorHandoffUiState
@@ -69,6 +70,7 @@ import tk.glucodata.ui.components.SettingsItem
 import tk.glucodata.ui.components.SettingsSwitchItem
 import tk.glucodata.ui.components.StableModalBottomSheet
 import kotlin.math.abs
+import kotlin.math.min
 import kotlin.math.roundToInt
 import java.util.Locale
 
@@ -135,8 +137,11 @@ private fun nextSensorReadingAgeDelay(nowMillis: Long, readingMillis: Long): Lon
 private fun formatSibionicsSensitivity(value: Float): String =
     String.format(Locale.getDefault(), "%.2f", value)
 
-internal fun bleErrorEventTimeForDisplay(eventAtMs: Long, nowMs: Long): Long? =
-    eventAtMs.takeIf { it > 0L }?.coerceAtMost(nowMs)
+internal fun bleErrorEventTimeForDisplay(eventAtMs: Long, nowMs: Long): Long? {
+    if (eventAtMs <= 0L) return null
+    val clamped = eventAtMs.coerceAtMost(nowMs)
+    return clamped.takeIf { nowMs - it <= BLE_ERROR_CARD_WINDOW_MS }
+}
 
 internal fun bleErrorValue(status: String, relativeAge: CharSequence?): String {
     val age = relativeAge?.toString()?.trim().orEmpty()
@@ -1195,6 +1200,18 @@ fun SensorCard(
     // Visual Feedback: Darken card when disconnected/paused
     val containerColor = if (isStreaming) MaterialTheme.colorScheme.surfaceContainerHigh else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
     val contentAlpha = if (isStreaming) 1f else 0.9f
+    var bleErrorNow by remember(sensor.connectionStatusAtMs) {
+        mutableLongStateOf(System.currentTimeMillis())
+    }
+    LaunchedEffect(sensor.connectionStatusAtMs) {
+        while (sensor.connectionStatusAtMs > 0L) {
+            bleErrorNow = System.currentTimeMillis()
+            val remaining = BLE_ERROR_CARD_WINDOW_MS -
+                (bleErrorNow - sensor.connectionStatusAtMs).coerceAtLeast(0L)
+            if (remaining < 0L) break
+            delay(min(60_000L, remaining + 1L).coerceAtLeast(1_000L))
+        }
+    }
 
 
     Card(
@@ -1502,28 +1519,33 @@ fun SensorCard(
                     }
 
                     val connectedStatus = stringResource(R.string.status_connected)
-                    if (sensor.connectionStatus.isNotEmpty() &&
+                    val errorEventAt = bleErrorEventTimeForDisplay(
+                        sensor.connectionStatusAtMs,
+                        bleErrorNow,
+                    )
+                    if (errorEventAt != null &&
+                        sensor.connectionStatus.isNotEmpty() &&
                         !sensor.connectionStatus.equals(connectedStatus, ignoreCase = true)
                     ) {
-                        val errorEventAt = bleErrorEventTimeForDisplay(sensor.connectionStatusAtMs, now)
-                        val rowLabel = if (errorEventAt != null) {
-                            stringResource(R.string.last_ble_error)
-                        } else {
-                            stringResource(R.string.last_ble_status)
-                        }
-                        val rowValue = if (errorEventAt != null) {
+                        DataRow(
+                            stringResource(R.string.last_ble_error),
                             bleErrorValue(
                                 sensor.connectionStatus,
                                 DateUtils.getRelativeTimeSpanString(
                                     errorEventAt,
-                                    now,
+                                    bleErrorNow,
                                     DateUtils.MINUTE_IN_MILLIS,
                                 ),
-                            )
-                        } else {
-                            sensor.connectionStatus
-                        }
-                        DataRow(rowLabel, rowValue)
+                            ),
+                        )
+                    } else if (sensor.connectionStatusAtMs <= 0L &&
+                        sensor.connectionStatus.isNotEmpty() &&
+                        !sensor.connectionStatus.equals(connectedStatus, ignoreCase = true)
+                    ) {
+                        // Managed drivers can publish a current diagnostic status without an
+                        // event timestamp. Keep that live status; only timestamped history ages
+                        // off after the one-hour card window.
+                        DataRow(stringResource(R.string.last_ble_status), sensor.connectionStatus)
                     }
                     DataRow(stringResource(R.string.sensor_address), sensor.deviceAddress)
                     

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/SensorViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/SensorViewModel.kt
@@ -47,6 +47,7 @@ data class SensorInfo(
     val displayName: String,
     val deviceAddress: String,
     val connectionStatus: String,
+    val connectionStatusAtMs: Long = 0L,
     val starttime: String,
     val streaming: Boolean,
     val rssi: Int,
@@ -513,7 +514,7 @@ class SensorViewModel : ViewModel() {
                         // when the link recovers, so any of those strings can stick
                         // around while readings flow. A reading newer than the event
                         // proves recovery: the recorded status is then history and
-                        // only shown in the "Last BLE status" detail row.
+                        // only shown in the timestamped "Last BLE error" detail row.
                         val bleStatusOutdated = SensorBluetooth.connectionStatusOutdated(gatt)
 
                         fun mapBleStatus(status: String): String = when {
@@ -565,6 +566,7 @@ class SensorViewModel : ViewModel() {
                                 bleStatusOutdated && bleStatus.isNotEmpty() -> mapBleStatus(bleStatus)
                                 else -> ""
                             },
+                            connectionStatusAtMs = SensorBluetooth.connectionStatusChangedAt(gatt),
                             starttime = if (startMs > 0) tk.glucodata.bluediag.datestr(startMs) else "",
                             streaming = warmupStatus == null && isActivelyReceiving,
                             rssi = gatt.readrssi,

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/SensorViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/SensorViewModel.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import tk.glucodata.Applic
+import tk.glucodata.BleErrorEvent
+import tk.glucodata.BleErrorHistory
 import tk.glucodata.MultiSensorSelection
 import tk.glucodata.SensorBluetooth
 import tk.glucodata.SensorIdentity
@@ -454,6 +456,7 @@ class SensorViewModel : ViewModel() {
             // Legacy sensors not in activeSensors() are finished — exclude them from the UI.
             // AiDex sensors (X- prefix) are managed via SharedPreferences, not activeSensors().
             val activeSet = activeSensors?.toHashSet() ?: HashSet()
+            val persistedBleErrors = BleErrorHistory.events()
 
             val sensorList = gatts.mapNotNull { gatt ->
                 try {
@@ -554,6 +557,25 @@ class SensorViewModel : ViewModel() {
                         val sensorSerial = SensorIdentity.resolveAppSensorId(gatt.SerialNumber)
                             ?: gatt.SerialNumber
                             ?: "Unknown"
+                        val isGattFailure = bleStatus.startsWith("Status=") &&
+                            bleStatus.removePrefix("Status=").toIntOrNull()?.let { it != 0 } != false
+                        val liveError = when {
+                            isGattFailure ||
+                                (bleStatusOutdated && bleStatus.isNotEmpty() &&
+                                    !bleStatus.startsWith("Status=")) -> BleErrorEvent(
+                                sensorId = sensorSerial,
+                                status = bleStatus,
+                                atMs = SensorBluetooth.connectionStatusChangedAt(gatt),
+                            )
+                            else -> null
+                        }
+                        // A newly constructed callback has no memory of the previous process.
+                        // Once readings are flowing again, restore its latest retained failure so
+                        // the one-hour card window survives an app or APK restart.
+                        val displayedError = liveError
+                            ?: persistedBleErrors.firstOrNull {
+                                SensorIdentity.matches(it.sensorId, sensorSerial)
+                            }.takeIf { isActivelyReceiving }
                         val currentViewMode = nativeViewMode
                         val isActiveSensor = activeSensorSerial != null && SensorIdentity.matches(sensorSerial, activeSensorSerial)
     
@@ -561,12 +583,8 @@ class SensorViewModel : ViewModel() {
                             serial = sensorSerial,
                             displayName = try { gatt.mygetDeviceName() } catch (_: Throwable) { sensorSerial },
                             deviceAddress = gatt.mActiveDeviceAddress ?: "Unknown",
-                            connectionStatus = when {
-                                bleStatus.startsWith("Status=") -> mapBleStatus(bleStatus)
-                                bleStatusOutdated && bleStatus.isNotEmpty() -> mapBleStatus(bleStatus)
-                                else -> ""
-                            },
-                            connectionStatusAtMs = SensorBluetooth.connectionStatusChangedAt(gatt),
+                            connectionStatus = displayedError?.status?.let(::mapBleStatus).orEmpty(),
+                            connectionStatusAtMs = displayedError?.atMs ?: 0L,
                             starttime = if (startMs > 0) tk.glucodata.bluediag.datestr(startMs) else "",
                             streaming = warmupStatus == null && isActivelyReceiving,
                             rssi = gatt.readrssi,

--- a/Common/src/testMobile/java/tk/glucodata/BleErrorHistoryTests.kt
+++ b/Common/src/testMobile/java/tk/glucodata/BleErrorHistoryTests.kt
@@ -9,7 +9,7 @@ class BleErrorHistoryTests {
     @Test
     fun `serialized history reloads without losing sensor status or timestamp`() {
         val expected = listOf(
-            BleErrorEvent("XX0PMEN0HA5", "Status=147", 12_345L),
+            BleErrorEvent("TEST-SENSOR-001", "Status=147", 12_345L),
             BleErrorEvent("sensor with spaces", "Loss of signal", 12_000L),
         )
 

--- a/Common/src/testMobile/java/tk/glucodata/BleErrorHistoryTests.kt
+++ b/Common/src/testMobile/java/tk/glucodata/BleErrorHistoryTests.kt
@@ -1,0 +1,67 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BleErrorHistoryTests {
+
+    @Test
+    fun `serialized history reloads without losing sensor status or timestamp`() {
+        val expected = listOf(
+            BleErrorEvent("XX0PMEN0HA5", "Status=147", 12_345L),
+            BleErrorEvent("sensor with spaces", "Loss of signal", 12_000L),
+        )
+
+        assertEquals(expected, decodeBleErrorEvents(encodeBleErrorEvents(expected)))
+    }
+
+    @Test
+    fun `malformed persisted rows do not hide valid events`() {
+        val valid = encodeBleErrorEvents(listOf(BleErrorEvent("sensor", "Status=133", 9_000L)))
+
+        assertEquals(
+            listOf(BleErrorEvent("sensor", "Status=133", 9_000L)),
+            decodeBleErrorEvents("broken\n$valid\n9001\t%%%\t%%%"),
+        )
+    }
+
+    @Test
+    fun `retention is bounded per sensor and globally`() {
+        val now = 1_000_000L
+        val events = buildList {
+            repeat(30) { index -> add(BleErrorEvent("sensor-a", "Status=$index", now - index)) }
+            repeat(30) { index -> add(BleErrorEvent("sensor-b", "Status=$index", now - 100 - index)) }
+        }
+
+        val retained = retainBleErrorEvents(
+            events = events,
+            nowMs = now,
+            maxPerSensor = 20,
+            maxTotal = 25,
+            retentionMs = 10_000L,
+        )
+
+        assertEquals(25, retained.size)
+        assertEquals(20, retained.count { it.sensorId == "sensor-a" })
+        assertEquals(5, retained.count { it.sensorId == "sensor-b" })
+        assertEquals(retained.sortedByDescending { it.atMs }, retained)
+    }
+
+    @Test
+    fun `events beyond retention are removed`() {
+        val now = 100_000L
+        val retained = retainBleErrorEvents(
+            events = listOf(
+                BleErrorEvent("sensor", "old", 89_999L),
+                BleErrorEvent("sensor", "boundary", 90_000L),
+                BleErrorEvent("sensor", "recent", 99_000L),
+            ),
+            nowMs = now,
+            retentionMs = 10_000L,
+        )
+
+        assertEquals(listOf("recent", "boundary"), retained.map { it.status })
+        assertTrue(retained.none { it.status == "old" })
+    }
+}

--- a/Common/src/testMobile/java/tk/glucodata/ui/BleErrorDetailTests.kt
+++ b/Common/src/testMobile/java/tk/glucodata/ui/BleErrorDetailTests.kt
@@ -3,6 +3,7 @@ package tk.glucodata.ui
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import tk.glucodata.BLE_ERROR_CARD_WINDOW_MS
 
 class BleErrorDetailTests {
 
@@ -14,6 +15,21 @@ class BleErrorDetailTests {
     @Test
     fun `future event time caused by a clock change is clamped to now`() {
         assertEquals(2_000L, bleErrorEventTimeForDisplay(eventAtMs = 3_000L, nowMs = 2_000L))
+    }
+
+    @Test
+    fun `error at the one hour boundary remains visible`() {
+        val now = 10_000_000L
+        assertEquals(
+            now - BLE_ERROR_CARD_WINDOW_MS,
+            bleErrorEventTimeForDisplay(now - BLE_ERROR_CARD_WINDOW_MS, now),
+        )
+    }
+
+    @Test
+    fun `error older than one hour leaves the sensor card`() {
+        val now = 10_000_000L
+        assertNull(bleErrorEventTimeForDisplay(now - BLE_ERROR_CARD_WINDOW_MS - 1L, now))
     }
 
     @Test

--- a/Common/src/testMobile/java/tk/glucodata/ui/BleErrorDetailTests.kt
+++ b/Common/src/testMobile/java/tk/glucodata/ui/BleErrorDetailTests.kt
@@ -1,0 +1,23 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BleErrorDetailTests {
+
+    @Test
+    fun `missing event time keeps the status as a non-historical detail`() {
+        assertNull(bleErrorEventTimeForDisplay(eventAtMs = 0L, nowMs = 2_000L))
+    }
+
+    @Test
+    fun `future event time caused by a clock change is clamped to now`() {
+        assertEquals(2_000L, bleErrorEventTimeForDisplay(eventAtMs = 3_000L, nowMs = 2_000L))
+    }
+
+    @Test
+    fun `historical error includes its localized relative age`() {
+        assertEquals("Disconnected (147) · 1 day ago", bleErrorValue("Disconnected (147)", "1 day ago"))
+    }
+}

--- a/Common/src/testMobile/java/tk/glucodata/ui/DebugLogExportTests.kt
+++ b/Common/src/testMobile/java/tk/glucodata/ui/DebugLogExportTests.kt
@@ -1,0 +1,57 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+class DebugLogExportTests {
+
+    @Test
+    fun `file backed log is copied after the report header`() {
+        val sourceFile = File.createTempFile("juggluco-debug-export", ".log")
+        try {
+            val payload = ByteArray(256 * 1024) { index -> (index % 251).toByte() }
+            sourceFile.outputStream().use { it.write(payload) }
+            val output = ByteArrayOutputStream()
+
+            writeDebugLogReport(
+                output = output,
+                header = "# test build\n\n",
+                source = DebugLogExportSource.FileContent(sourceFile),
+            )
+
+            assertArrayEquals("# test build\n\n".toByteArray() + payload, output.toByteArray())
+        } finally {
+            sourceFile.delete()
+        }
+    }
+
+    @Test
+    fun `bounded text log is copied after the report header`() {
+        val output = ByteArrayOutputStream()
+
+        writeDebugLogReport(
+            output = output,
+            header = "# test build\n\n",
+            source = DebugLogExportSource.TextContent("BLE error\n"),
+        )
+
+        assertArrayEquals("# test build\n\nBLE error\n".toByteArray(), output.toByteArray())
+    }
+
+    @Test
+    fun `missing and empty file sources are rejected before export`() {
+        val missing = File("/path/that/does/not/exist/juggluco-trace.log")
+        val empty = File.createTempFile("juggluco-empty-export", ".log")
+        try {
+            assertTrue(DebugLogExportSource.FileContent(missing).isEmpty())
+            assertTrue(DebugLogExportSource.FileContent(empty).isEmpty())
+            assertFalse(DebugLogExportSource.TextContent("one line\n").isEmpty())
+        } finally {
+            empty.delete()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Rename the sensor-card detail to "Last BLE error" and show its relative age.
- Keep the row for one hour, then remove it from the sensor card while retaining the event for diagnostics.
- Persist non-success GATT statuses and signal-loss events across process and APK restarts.
- Add a BLE error history tab to Debug Logs with clear, save, and share support.
- Limit storage to 30 days, 20 entries per sensor, and 100 entries overall.

History begins with events recorded by a build that contains this change. Earlier in-memory events cannot be recovered.

## Testing

- `./gradlew :Common:testMobileReleaseUnitTest`
- `./gradlew :Common:testMobileReleaseUnitTest --tests tk.glucodata.BleErrorHistoryTests --tests tk.glucodata.ui.BleErrorDetailTests --rerun-tasks`
