### PR TITLE
Add opt-in delta matching for hero and notification arrows

### DIFF
--- a/Common/src/main/java/tk/glucodata/GlucoseDelta.java
+++ b/Common/src/main/java/tk/glucodata/GlucoseDelta.java
@@ -20,15 +20,14 @@ import java.util.Locale;
 
 /**
  * The "Δ" readout: measured change over a configurable interval (1 or 5
- * minutes), in display units. Unlike the trend arrow (an estimate over a
- * window) this is a raw measurement, an independent number to sanity-check
- * the arrow's angle and color against. Five minutes rather than one: adjacent
- * readings repeat on plain sensor noise, so a one-minute delta shows "0" next
- * to a visibly climbing chart — GDH exposes the same 1-vs-5-minute choice for
- * the same reason. The interval is a global setting; the same value drives the
- * readout and the FALLING_FAST / RISING_FAST delta alarms.
+ * minutes), in display units. Five minutes rather than one: adjacent readings
+ * repeat on plain sensor noise, so a one-minute delta shows "0" next to a visibly
+ * climbing chart — GDH exposes the same 1-vs-5-minute choice for the same reason.
+ * The interval is a global setting; the same value drives the readout and the
+ * FALLING_FAST / RISING_FAST delta alarms.
  */
 public final class GlucoseDelta {
+    private static final float MGDL_PER_MMOL = 18.0182f;
     public static final int DEFAULT_INTERVAL_MINUTES = 5;
     public static final long WINDOW_MILLIS = 5L * 60L * 1000L;
     // Callers walk back to a point at least this much older than the newest
@@ -72,6 +71,14 @@ public final class GlucoseDelta {
     /** Convenience wrapper for the default 5-minute interval. */
     public static float fiveMinuteDelta(long newMillis, float newValue, long prevMillis, float prevValue) {
         return delta(newMillis, newValue, prevMillis, prevValue, DEFAULT_INTERVAL_MINUTES);
+    }
+
+    /** Converts a displayed delta back to the mg/dL-per-minute rate an arrow consumes. */
+    public static float rateMgdlPerMinute(float delta, boolean isMmol, int intervalMinutes) {
+        if (!Float.isFinite(delta))
+            return Float.NaN;
+        final float rate = delta / sanitizeIntervalMinutes(intervalMinutes);
+        return isMmol ? rate * MGDL_PER_MMOL : rate;
     }
 
     /**

--- a/Common/src/main/java/tk/glucodata/GlucoseDelta.java
+++ b/Common/src/main/java/tk/glucodata/GlucoseDelta.java
@@ -24,10 +24,14 @@ import java.util.Locale;
  * repeat on plain sensor noise, so a one-minute delta shows "0" next to a visibly
  * climbing chart — GDH exposes the same 1-vs-5-minute choice for the same reason.
  * The interval is a global setting; the same value drives the readout and the
- * FALLING_FAST / RISING_FAST delta alarms.
+ * FALLING_FAST / RISING_FAST delta alarms. The readout is independent of the
+ * smoother trend regression by default; users can instead match visible dashboard
+ * and notification arrows to this interval.
  */
 public final class GlucoseDelta {
     private static final float MGDL_PER_MMOL = 18.0182f;
+    public static final String MATCH_ARROW_TO_DISPLAYED_DELTA_KEY = "match_arrow_to_displayed_delta";
+    public static final boolean DEFAULT_MATCH_ARROW_TO_DISPLAYED_DELTA = false;
     public static final int DEFAULT_INTERVAL_MINUTES = 5;
     public static final long WINDOW_MILLIS = 5L * 60L * 1000L;
     // Callers walk back to a point at least this much older than the newest

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -3477,6 +3477,9 @@ public class Notify {
         boolean showIob = prefs.getBoolean("notification_show_iob", false);
         boolean showCob = prefs.getBoolean("notification_show_cob", false);
         boolean showDelta = prefs.getBoolean("notification_show_delta", false);
+        boolean matchArrowToDisplayedDelta = prefs.getBoolean(
+                GlucoseDelta.MATCH_ARROW_TO_DISPLAYED_DELTA_KEY,
+                GlucoseDelta.DEFAULT_MATCH_ARROW_TO_DISPLAYED_DELTA);
         int deltaIntervalMinutes = prefs.getInt("delta_interval_minutes", GlucoseDelta.DEFAULT_INTERVAL_MINUTES);
         boolean iobCobRiskColored = prefs.getBoolean("notification_iob_cob_risk_colored", false);
         boolean arrowForecastColored = prefs.getBoolean("glucose_arrow_forecast_colors_enabled", false);
@@ -3502,8 +3505,8 @@ public class Notify {
         // the peer values and look like it belongs to the last peer.
         boolean inlineMultiArrows = showArrow && !peerValueItems.isEmpty();
 
-        // A visible Δ and its arrow state one movement. Derive both from the same pair;
-        // without a usable or enabled Δ, keep the steadier regression rate.
+        // Keep the delta as an independent readout unless the user chooses to match the
+        // arrow to it. Without a usable delta, keep the steadier regression rate.
         String deltaText = "";
         if (showDelta && nativePoints.size() >= 2) {
             final GlucosePoint newest = nativePoints.get(nativePoints.size() - 1);
@@ -3522,7 +3525,7 @@ public class Notify {
             final float displayedDelta = previous == null ? Float.NaN : GlucoseDelta.delta(
                     newest.timestamp, newestValue, previous.timestamp, previousValue, deltaIntervalMinutes);
             deltaText = GlucoseDelta.format(displayedDelta, isMmol);
-            if (!deltaText.isEmpty())
+            if (matchArrowToDisplayedDelta && !deltaText.isEmpty())
                 rate = GlucoseDelta.rateMgdlPerMinute(displayedDelta, isMmol, deltaIntervalMinutes);
             if (doLog)
                 Log.i(LOG_ID, "notification delta=" + deltaText

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -3502,6 +3502,34 @@ public class Notify {
         // the peer values and look like it belongs to the last peer.
         boolean inlineMultiArrows = showArrow && !peerValueItems.isEmpty();
 
+        // A visible Δ and its arrow state one movement. Derive both from the same pair;
+        // without a usable or enabled Δ, keep the steadier regression rate.
+        String deltaText = "";
+        if (showDelta && nativePoints.size() >= 2) {
+            final GlucosePoint newest = nativePoints.get(nativePoints.size() - 1);
+            final float newestValue = (isRawMode && newest.rawValue > 0f) ? newest.rawValue : newest.value;
+            GlucosePoint previous = null;
+            for (int i = nativePoints.size() - 2; i >= 0; i--) {
+                final GlucosePoint p = nativePoints.get(i);
+                final float value = (isRawMode && p.rawValue > 0f) ? p.rawValue : p.value;
+                if (value > 0.1f && newest.timestamp - p.timestamp >= GlucoseDelta.minGapMillis(deltaIntervalMinutes)) {
+                    previous = p;
+                    break;
+                }
+            }
+            final float previousValue = previous == null ? Float.NaN
+                    : (isRawMode && previous.rawValue > 0f) ? previous.rawValue : previous.value;
+            final float displayedDelta = previous == null ? Float.NaN : GlucoseDelta.delta(
+                    newest.timestamp, newestValue, previous.timestamp, previousValue, deltaIntervalMinutes);
+            deltaText = GlucoseDelta.format(displayedDelta, isMmol);
+            if (!deltaText.isEmpty())
+                rate = GlucoseDelta.rateMgdlPerMinute(displayedDelta, isMmol, deltaIntervalMinutes);
+            if (doLog)
+                Log.i(LOG_ID, "notification delta=" + deltaText
+                        + " points=" + nativePoints.size()
+                        + " gap=" + (previous == null ? -1L : (newest.timestamp - previous.timestamp)));
+        }
+
         // Arrow color: optionally driven by the 30-minute linear forecast
         // (value color says where you are, arrow color where you're heading).
         // Gated on data age: during a reconnect gap the trend window only
@@ -3586,38 +3614,11 @@ public class Notify {
                         ? iobLine
                         : new android.text.SpannableStringBuilder(iobLine).append(" · ").append(sensorStatusText);
         }
-        // The "Δ" readout: measured change over the last ~5 minutes — a raw
-        // number to sanity-check the estimated arrow against. Leftmost, right
-        // next to the arrow. Walks back to the first point old enough for the
-        // window; the tail can hold near-duplicates (persisted vs live
-        // timestamp of the same reading), so never take blind indices.
-        if (showDelta && nativePoints.size() >= 2) {
-            final GlucosePoint newest = nativePoints.get(nativePoints.size() - 1);
-            final float newestValue = (isRawMode && newest.rawValue > 0f) ? newest.rawValue : newest.value;
-            GlucosePoint previous = null;
-            for (int i = nativePoints.size() - 2; i >= 0; i--) {
-                final GlucosePoint p = nativePoints.get(i);
-                final float value = (isRawMode && p.rawValue > 0f) ? p.rawValue : p.value;
-                if (value > 0.1f && newest.timestamp - p.timestamp >= GlucoseDelta.minGapMillis(deltaIntervalMinutes)) {
-                    previous = p;
-                    break;
-                }
-            }
-            final float previousValue = previous == null ? Float.NaN
-                    : (isRawMode && previous.rawValue > 0f) ? previous.rawValue : previous.value;
-            final String deltaText = previous == null ? "" : GlucoseDelta.format(
-                    GlucoseDelta.delta(newest.timestamp, newestValue, previous.timestamp, previousValue, deltaIntervalMinutes),
-                    isMmol);
-            if (doLog)
-                Log.i(LOG_ID, "notification delta=" + deltaText
-                        + " points=" + nativePoints.size()
-                        + " gap=" + (previous == null ? -1L : (newest.timestamp - previous.timestamp)));
-            if (!deltaText.isEmpty()) {
-                newStatusText = (newStatusText == null || newStatusText.length() == 0)
-                        ? "Δ " + deltaText
-                        : new android.text.SpannableStringBuilder("Δ ").append(deltaText)
-                                .append(" · ").append(newStatusText);
-            }
+        if (!deltaText.isEmpty()) {
+            newStatusText = (newStatusText == null || newStatusText.length() == 0)
+                    ? "Δ " + deltaText
+                    : new android.text.SpannableStringBuilder("Δ ").append(deltaText)
+                            .append(" · ").append(newStatusText);
         }
 
         // Apply Style to Status Text too

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2136,6 +2136,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="broadcast_computed_trend_title">Перадаваць трэнд праграмы</string>
     <string name="broadcast_computed_trend_desc">Выкарыстоўваць трэнд праграмы замест трэнду датчыка</string>
     <string name="dashboard_show_delta_desc">Вымеранае змяненне ў дэльта-інтэрвале пад стрэлкай трэнду</string>
+    <string name="match_arrow_to_displayed_delta_title">Супастаўляць стрэлкі з дэльтай</string>
+    <string name="match_arrow_to_displayed_delta_desc">Калі паказваецца дэльта, выкарыстоўваць той жа інтэрвал для стрэлак на панэлі і ў апавяшчэнні</string>
     <string name="dashboard_show_delta_title">Дэльта (Δ) на прыборнай панэлі</string>
     <string name="delta_alarm_interval_follow">Счытванне Like Δ (у цяперашні час мін. %1$d)</string>
     <string name="delta_alarm_interval_label">Дэльтавае акно</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1717,6 +1717,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="notification_show_delta_desc">Gemessene Änderung über das Delta-Intervall, neben dem Pfeil</string>
     <string name="dashboard_show_delta_title">Delta (Δ) auf dem Dashboard</string>
     <string name="dashboard_show_delta_desc">Gemessene Änderung über das Delta-Intervall, unter dem Trendpfeil</string>
+    <string name="match_arrow_to_displayed_delta_title">Pfeile an Delta anpassen</string>
+    <string name="match_arrow_to_displayed_delta_desc">Wenn ein Delta angezeigt wird, dasselbe Intervall für die Pfeile auf dem Dashboard und in der Benachrichtigung verwenden</string>
     <string name="dashboard_rows_show_delta_title">Delta in der Messwertliste</string>
     <string name="dashboard_rows_show_delta_desc">Änderung neben jedem Messwert anzeigen, im Dashboard und in der Historie</string>
     <string name="delta_interval_title">Delta-Intervall (Δ)</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2075,6 +2075,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="broadcast_computed_trend_title">Diffuser la tendance de l’application</string>
     <string name="broadcast_computed_trend_desc">Utiliser la tendance de l’application plutôt que celle du capteur</string>
     <string name="dashboard_show_delta_desc">Changement mesuré sur l\'intervalle delta, sous la flèche de tendance</string>
+    <string name="match_arrow_to_displayed_delta_title">Faire correspondre les flèches au delta</string>
+    <string name="match_arrow_to_displayed_delta_desc">Lorsqu’un delta est affiché, utiliser le même intervalle pour les flèches du tableau de bord et de la notification</string>
     <string name="dashboard_show_delta_title">Delta (Δ) sur le tableau de bord</string>
     <string name="delta_alarm_interval_follow">Comme lecture Δ (actuellement %1$d min)</string>
     <string name="delta_alarm_interval_label">Fenêtre Delta</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2059,6 +2059,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="broadcast_computed_trend_title">Trasmetti trend app</string>
     <string name="broadcast_computed_trend_desc">Usa il trend dell\'app invece di quello del sensore</string>
     <string name="dashboard_show_delta_desc">Variazione misurata nell\'intervallo delta, sotto la freccia di tendenza</string>
+    <string name="match_arrow_to_displayed_delta_title">Abbina le frecce al delta</string>
+    <string name="match_arrow_to_displayed_delta_desc">Quando viene mostrato un delta, usa lo stesso intervallo per le frecce del cruscotto e della notifica</string>
     <string name="dashboard_show_delta_title">Delta (Δ) sul cruscotto</string>
     <string name="delta_alarm_interval_follow">Come la lettura Δ (attualmente %1$d min)</string>
     <string name="delta_alarm_interval_label">Finestra Delta</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2198,6 +2198,8 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="broadcast_computed_trend_title">Аппын трендийг дамжуулах</string>
     <string name="broadcast_computed_trend_desc">Мэдрэгчийн оронд аппын трендийг ашиглах</string>
     <string name="dashboard_show_delta_desc">Тренд сумны доор дельта интервал дээрх хэмжсэн өөрчлөлт</string>
+    <string name="match_arrow_to_displayed_delta_title">Сумыг дельтатай тааруулах</string>
+    <string name="match_arrow_to_displayed_delta_desc">Дельта харагдах үед хяналтын самбар болон мэдэгдлийн суманд ижил интервалыг ашиглана</string>
     <string name="dashboard_show_delta_title">Хяналтын самбар дээрх Delta (Δ).</string>
     <string name="delta_alarm_interval_follow">Δ унших дуртай (одоогоор %1$d мин)</string>
     <string name="delta_alarm_interval_label">Дельта цонх</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2111,6 +2111,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="broadcast_computed_trend_title">Apptrend uitzenden</string>
     <string name="broadcast_computed_trend_desc">Gebruik de apptrend in plaats van de sensortrend</string>
     <string name="dashboard_show_delta_desc">Gemeten verandering over het delta-interval, onder de trendpijl</string>
+    <string name="match_arrow_to_displayed_delta_title">Pijlen afstemmen op delta</string>
+    <string name="match_arrow_to_displayed_delta_desc">Als een delta wordt getoond, hetzelfde interval gebruiken voor de pijlen op het dashboard en in de melding</string>
     <string name="dashboard_show_delta_title">Delta (Δ) op het dashboard</string>
     <string name="delta_alarm_interval_follow">Zoals Δ uitlezing (momenteel %1$d min)</string>
     <string name="delta_alarm_interval_label">Delta-venster</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2103,6 +2103,8 @@
     <string name="broadcast_computed_trend_title">Wysyłaj trend aplikacji</string>
     <string name="broadcast_computed_trend_desc">Używaj trendu aplikacji zamiast trendu czujnika</string>
     <string name="dashboard_show_delta_desc">Zmierzona zmiana w przedziale delta, poniżej strzałki trendu</string>
+    <string name="match_arrow_to_displayed_delta_title">Dopasuj strzałki do delty</string>
+    <string name="match_arrow_to_displayed_delta_desc">Gdy delta jest widoczna, użyj tego samego przedziału dla strzałek na pulpicie i w powiadomieniu</string>
     <string name="dashboard_show_delta_title">Delta (Δ) na desce rozdzielczej</string>
     <string name="delta_alarm_interval_follow">Podobnie jak odczyt Δ (obecnie %1$d min)</string>
     <string name="delta_alarm_interval_label">Okno delty</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2070,6 +2070,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="broadcast_computed_trend_title">Transmitir tendência do app</string>
     <string name="broadcast_computed_trend_desc">Use a tendência do app em vez da tendência do sensor</string>
     <string name="dashboard_show_delta_desc">Mudança medida ao longo do intervalo delta, abaixo da seta de tendência</string>
+    <string name="match_arrow_to_displayed_delta_title">Corresponder setas ao delta</string>
+    <string name="match_arrow_to_displayed_delta_desc">Quando um delta for mostrado, usar o mesmo intervalo para as setas do painel e da notificação</string>
     <string name="dashboard_show_delta_title">Delta (Δ) no painel</string>
     <string name="delta_alarm_interval_follow">Como leitura Δ (atualmente %1$d min)</string>
     <string name="delta_alarm_interval_label">Janela Delta</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2124,6 +2124,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="broadcast_computed_trend_title">Передавать тренд приложения</string>
     <string name="broadcast_computed_trend_desc">Использовать тренд приложения вместо тренда датчика</string>
     <string name="dashboard_show_delta_desc">Измеренное изменение в интервале дельта, ниже стрелки тренда.</string>
+    <string name="match_arrow_to_displayed_delta_title">Сопоставлять стрелки с дельтой</string>
+    <string name="match_arrow_to_displayed_delta_desc">Когда показана дельта, использовать тот же интервал для стрелок на панели и в уведомлении</string>
     <string name="dashboard_show_delta_title">Дельта (Δ) на приборной панели</string>
     <string name="delta_alarm_interval_follow">Аналогично показанию Δ (в настоящее время %1$d мин)</string>
     <string name="delta_alarm_interval_label">Окно Дельта</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2286,6 +2286,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="broadcast_computed_trend_title">Gudbi jihada app-ka</string>
     <string name="broadcast_computed_trend_desc">Isticmaal jihada app-ka halkii tan dareemaha</string>
     <string name="dashboard_show_delta_desc">Isbeddel lagu cabbiray inta u dhexaysa delta, ka hooseeya fallaadha isbeddelka</string>
+    <string name="match_arrow_to_displayed_delta_title">Fallaadhaha ku waafaji delta</string>
+    <string name="match_arrow_to_displayed_delta_desc">Marka delta la muujiyo, u isticmaal isla muddada fallaadhaha dashboard-ka iyo ogeysiiska</string>
     <string name="dashboard_show_delta_title">Delta (Δ) ee dashboard-ka</string>
     <string name="delta_alarm_interval_follow">Sida akhrinta Δ (hadda %1$d daq)</string>
     <string name="delta_alarm_interval_label">Daaqadda Delta</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2068,6 +2068,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="broadcast_computed_trend_title">Sänd appens trend</string>
     <string name="broadcast_computed_trend_desc">Använd appens trend i stället för sensorns</string>
     <string name="dashboard_show_delta_desc">Uppmätt förändring över deltaintervallet, under trendpilen</string>
+    <string name="match_arrow_to_displayed_delta_title">Matcha pilar med delta</string>
+    <string name="match_arrow_to_displayed_delta_desc">När ett delta visas, använd samma intervall för pilarna på instrumentpanelen och i aviseringen</string>
     <string name="dashboard_show_delta_title">Delta (Δ) på instrumentbrädan</string>
     <string name="delta_alarm_interval_follow">Som Δ-avläsning (för närvarande %1$d min)</string>
     <string name="delta_alarm_interval_label">Delta fönster</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2096,6 +2096,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="broadcast_computed_trend_title">Uygulama eğilimini yayınla</string>
     <string name="broadcast_computed_trend_desc">Sensör eğilimi yerine uygulama eğilimini kullan</string>
     <string name="dashboard_show_delta_desc">Trend okunun altındaki delta aralığında ölçülen değişiklik</string>
+    <string name="match_arrow_to_displayed_delta_title">Okları delta ile eşleştir</string>
+    <string name="match_arrow_to_displayed_delta_desc">Delta gösterildiğinde pano ve bildirim okları için aynı aralığı kullan</string>
     <string name="dashboard_show_delta_title">Gösterge tablosundaki Delta (Δ)</string>
     <string name="delta_alarm_interval_follow">Δ okuması gibi (şu anda %1$d dk)</string>
     <string name="delta_alarm_interval_label">Delta penceresi</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2141,6 +2141,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="broadcast_computed_trend_title">Передавати тренд застосунку</string>
     <string name="broadcast_computed_trend_desc">Використовувати тренд застосунку замість тренду датчика</string>
     <string name="dashboard_show_delta_desc">Виміряна зміна протягом дельта-інтервалу, під стрілкою тенденції</string>
+    <string name="match_arrow_to_displayed_delta_title">Узгоджувати стрілки з дельтою</string>
+    <string name="match_arrow_to_displayed_delta_desc">Коли показано дельту, використовувати той самий інтервал для стрілок на панелі та в сповіщенні</string>
     <string name="dashboard_show_delta_title">Дельта (Δ) на панелі приладів</string>
     <string name="delta_alarm_interval_follow">Зчитування Like Δ (наразі %1$d min)</string>
     <string name="delta_alarm_interval_label">Дельта вікно</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2084,6 +2084,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="broadcast_computed_trend_title">广播应用趋势</string>
     <string name="broadcast_computed_trend_desc">使用应用趋势代替传感器趋势</string>
     <string name="dashboard_show_delta_desc">趋势箭头下方的 Delta 间隔内测得的变化</string>
+    <string name="match_arrow_to_displayed_delta_title">使箭头与 Delta 一致</string>
+    <string name="match_arrow_to_displayed_delta_desc">显示 Delta 时，仪表板和通知箭头使用相同的时间间隔</string>
     <string name="dashboard_show_delta_title">仪表板上的 Delta (Δ)</string>
     <string name="delta_alarm_interval_follow">类似于 Δ 读数（当前为 %1$d 分钟）</string>
     <string name="delta_alarm_interval_label">德尔塔窗</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2145,6 +2145,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_show_delta_minutes_desc">Show %1$d-minute change beside the trend arrow</string>
     <string name="dashboard_show_delta_title">Dashboard delta</string>
     <string name="dashboard_show_delta_desc">Show measured change below the trend arrow</string>
+    <string name="match_arrow_to_displayed_delta_title">Match arrows to delta</string>
+    <string name="match_arrow_to_displayed_delta_desc">When a delta is shown, use the same interval for the dashboard and notification arrows</string>
     <string name="dashboard_rows_show_delta_title">Reading-list delta</string>
     <string name="dashboard_rows_show_delta_desc">Show measured change beside each reading, on the dashboard and in the history</string>
     <string name="delta_interval_title">Delta (Δ) interval</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChartPipeline.kt
@@ -322,7 +322,10 @@ internal fun readingDeltas(
         )
         val text = tk.glucodata.GlucoseDelta.format(delta, isMmol).takeIf { it.isNotEmpty() }
             ?: return@map null
-        ReadingDelta(text, perMinuteMgdl(delta, isMmol, deltaIntervalMinutes))
+        ReadingDelta(
+            text,
+            tk.glucodata.GlucoseDelta.rateMgdlPerMinute(delta, isMmol, deltaIntervalMinutes)
+        )
     }
 }
 
@@ -411,14 +414,4 @@ internal class RowDeltaIndex(
         /** The bucket of the rows no sensor owns; a string no serial can be. */
         const val SHARED = "\u0000shared"
     }
-}
-
-/**
- * The delta is a change over the configured window, in the unit on screen; an arrow turns by
- * mg/dL per minute. Same movement, said the way the arrow reads it.
- */
-private fun perMinuteMgdl(delta: Float, isMmol: Boolean, deltaIntervalMinutes: Int): Float {
-    val minutes = tk.glucodata.GlucoseDelta.sanitizeIntervalMinutes(deltaIntervalMinutes)
-    val perMinute = delta / minutes
-    return if (isMmol) perMinute * tk.glucodata.ui.util.GlucoseFormatter.MGDL_PER_MMOL else perMinute
 }

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -244,6 +244,7 @@ fun DashboardCombinedHeader(
     valueRangeColorsEnabled: Boolean = false,
     arrowForecastColorsEnabled: Boolean = false,
     showDelta: Boolean = false,
+    matchArrowToDisplayedDelta: Boolean = tk.glucodata.GlucoseDelta.DEFAULT_MATCH_ARROW_TO_DISPLAYED_DELTA,
     deltaIntervalMinutes: Int = tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES,
     peerReadings: List<tk.glucodata.ui.viewmodel.DashboardViewModel.PeerCurrentReading> = emptyList(),
     onPeerReadingClick: (String) -> Unit = {},
@@ -280,8 +281,8 @@ fun DashboardCombinedHeader(
             tk.glucodata.logic.TrendEngine.TrendResult(tk.glucodata.logic.TrendEngine.TrendState.Unknown, 0f, 0f, 0f, 0f)
         }
     }
-    // When the hero states a Δ below its arrow, both describe that same movement. Without
-    // the number, the arrow keeps the steadier regression over the trend engine's window.
+    // The delta remains an independent readout unless the user asks the arrow to use the
+    // same interval. Without a usable delta, the steadier regression always remains.
     val heroDelta = if (showDelta) {
         remember(history, isMmol, deltaIntervalMinutes) {
             history.lastOrNull()?.let { newest ->
@@ -293,8 +294,12 @@ fun DashboardCombinedHeader(
         null
     }
     val heroDeltaText = heroDelta?.text
-    val trendResult = remember(regressedTrendResult, heroDelta) {
-        trendResultForDisplayedDelta(regressedTrendResult, heroDelta?.rateMgdlPerMinute)
+    val trendResult = remember(regressedTrendResult, heroDelta, matchArrowToDisplayedDelta) {
+        trendResultForDisplayedDelta(
+            regressedTrendResult,
+            heroDelta?.rateMgdlPerMinute,
+            useDisplayedDelta = matchArrowToDisplayedDelta,
+        )
     }
     val adaptiveMetrics = rememberAdaptiveWindowMetrics()
     val isLandscape = adaptiveMetrics.isLandscape

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardComponents.kt
@@ -264,7 +264,7 @@ fun DashboardCombinedHeader(
     val sensorContentColor = if (isExpiring) MaterialTheme.colorScheme.onTertiaryContainer else MaterialTheme.colorScheme.onPrimaryContainer
 
     // Advanced Trend
-    val trendResult = remember(history, latestPoint, currentSnapshot) {
+    val regressedTrendResult = remember(history, latestPoint, currentSnapshot) {
         if (history.isNotEmpty()) {
              // Map Kotlin UI points to Native Java points for shared TrendEngine
              val nativeList = history.map { tk.glucodata.GlucosePoint(it.timestamp, it.value, it.rawValue) }
@@ -280,18 +280,21 @@ fun DashboardCombinedHeader(
             tk.glucodata.logic.TrendEngine.TrendResult(tk.glucodata.logic.TrendEngine.TrendState.Unknown, 0f, 0f, 0f, 0f)
         }
     }
-    // "Δ" readout: the measured change over the last ~5 minutes — a raw
-    // number to sanity-check the estimated arrow against. Same computation as
-    // the per-row deltas in the readings list, anchored at the newest point.
-    val heroDeltaText = if (showDelta) {
+    // When the hero states a Δ below its arrow, both describe that same movement. Without
+    // the number, the arrow keeps the steadier regression over the trend engine's window.
+    val heroDelta = if (showDelta) {
         remember(history, isMmol, deltaIntervalMinutes) {
             history.lastOrNull()?.let { newest ->
-                readingDeltaTexts(listOf(newest.timestamp), history, isMmol, deltaIntervalMinutes)
+                readingDeltas(listOf(newest.timestamp), history, isMmol, deltaIntervalMinutes)
                     .first()
             }
         }
     } else {
         null
+    }
+    val heroDeltaText = heroDelta?.text
+    val trendResult = remember(regressedTrendResult, heroDelta) {
+        trendResultForDisplayedDelta(regressedTrendResult, heroDelta?.rateMgdlPerMinute)
     }
     val adaptiveMetrics = rememberAdaptiveWindowMetrics()
     val isLandscape = adaptiveMetrics.isLandscape

--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardScreen.kt
@@ -357,6 +357,7 @@ fun DashboardScreen(
     val appChartRangeColorsEnabled by viewModel.glucoseAppChartRangeColorsEnabled.collectAsState()
     val dashboardShowDelta by viewModel.dashboardShowDelta.collectAsState()
     val dashboardRowsShowDelta by viewModel.dashboardRowsShowDelta.collectAsState()
+    val matchArrowToDisplayedDelta by viewModel.matchArrowToDisplayedDelta.collectAsState()
     val deltaIntervalMinutes by viewModel.deltaIntervalMinutes.collectAsState()
     val journalDoseCalculatorEnabled by viewModel.journalDoseCalculatorEnabled.collectAsState()
     val journalFoodMacrosEnabled by viewModel.journalFoodMacrosEnabled.collectAsState()
@@ -1364,6 +1365,7 @@ fun DashboardScreen(
                             veryHighThreshold = veryHighThreshold,
                             valueRangeColorsEnabled = glucoseRangeColorsDisplayEnabled,
                             showDelta = dashboardShowDelta,
+                            matchArrowToDisplayedDelta = matchArrowToDisplayedDelta,
                             deltaIntervalMinutes = deltaIntervalMinutes,
                             arrowForecastColorsEnabled = glucoseArrowForecastEnabled,
                             onHeroClick = {
@@ -1635,6 +1637,7 @@ fun DashboardScreen(
                             veryHighThreshold = veryHighThreshold,
                             valueRangeColorsEnabled = glucoseRangeColorsDisplayEnabled,
                             showDelta = dashboardShowDelta,
+                            matchArrowToDisplayedDelta = matchArrowToDisplayedDelta,
                             deltaIntervalMinutes = deltaIntervalMinutes,
                             arrowForecastColorsEnabled = glucoseArrowForecastEnabled,
                             onHeroClick = {

--- a/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
@@ -351,6 +351,7 @@ fun DisplayAndColorSettingsScreen(
     val appChartRangeColorsEnabled by viewModel.glucoseAppChartRangeColorsEnabled.collectAsState()
     val dashboardDeltaEnabled by viewModel.dashboardShowDelta.collectAsState()
     val dashboardRowsDeltaEnabled by viewModel.dashboardRowsShowDelta.collectAsState()
+    val matchArrowToDisplayedDelta by viewModel.matchArrowToDisplayedDelta.collectAsState()
     val previewWindowMode by viewModel.previewWindowMode.collectAsState()
     var showPreviewWindowDialog by rememberSaveable { mutableStateOf(false) }
     val previewWindowLabel = when (previewWindowMode) {
@@ -425,6 +426,13 @@ fun DisplayAndColorSettingsScreen(
                 subtitle = stringResource(R.string.dashboard_show_delta_desc),
                 checked = dashboardDeltaEnabled,
                 onCheckedChange = { viewModel.setDashboardShowDelta(it) },
+                position = CardPosition.MIDDLE
+            )
+            SettingsSwitchItem(
+                title = stringResource(R.string.match_arrow_to_displayed_delta_title),
+                subtitle = stringResource(R.string.match_arrow_to_displayed_delta_desc),
+                checked = matchArrowToDisplayedDelta,
+                onCheckedChange = { viewModel.setMatchArrowToDisplayedDelta(it) },
                 position = CardPosition.MIDDLE
             )
             SettingsSwitchItem(

--- a/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
@@ -899,7 +899,9 @@ fun JournalTimelineRow(
 internal fun trendResultForDisplayedDelta(
     regressed: tk.glucodata.logic.TrendEngine.TrendResult,
     deltaRateMgdlPerMinute: Float?,
+    useDisplayedDelta: Boolean = true,
 ): tk.glucodata.logic.TrendEngine.TrendResult {
+    if (!useDisplayedDelta) return regressed
     val rate = deltaRateMgdlPerMinute?.takeIf { it.isFinite() } ?: return regressed
     return regressed.copy(state = tk.glucodata.logic.TrendEngine.stateFor(rate), velocity = rate)
 }

--- a/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ReadingRow.kt
@@ -227,7 +227,7 @@ fun ReadingRow(
     // than the longer regression, which answers a different question and can point the other
     // way during a reversal — Δ −5 beside an arrow up is the app contradicting itself.
     val trendResult = remember(regressed, deltaRateMgdlPerMinute) {
-        rowTrendResult(regressed, deltaRateMgdlPerMinute)
+        trendResultForDisplayedDelta(regressed, deltaRateMgdlPerMinute)
     }
 
     Surface(
@@ -891,12 +891,12 @@ fun JournalTimelineRow(
 }
 
 /**
- * The arrow's own reading of a row: the movement the Δ beside it states when there is one,
- * the regression otherwise. Only the velocity and the state it maps to are replaced; how
+ * The movement stated by an arrow with a visible Δ: the Δ's rate when there is one, the
+ * regression otherwise. Only the velocity and the state it maps to are replaced; how
  * confident and how noisy the neighbourhood is are properties of the data, not of which
- * window was measured.
+ * window was measured. Shared by the hero and reading rows so both pairings stay coherent.
  */
-internal fun rowTrendResult(
+internal fun trendResultForDisplayedDelta(
     regressed: tk.glucodata.logic.TrendEngine.TrendResult,
     deltaRateMgdlPerMinute: Float?,
 ): tk.glucodata.logic.TrendEngine.TrendResult {

--- a/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/viewmodel/DashboardViewModel.kt
@@ -336,6 +336,9 @@ class DashboardViewModel(
     private val _dashboardRowsShowDelta = MutableStateFlow(false)
     val dashboardRowsShowDelta = _dashboardRowsShowDelta.asStateFlow()
 
+    private val _matchArrowToDisplayedDelta = MutableStateFlow(tk.glucodata.GlucoseDelta.DEFAULT_MATCH_ARROW_TO_DISPLAYED_DELTA)
+    val matchArrowToDisplayedDelta = _matchArrowToDisplayedDelta.asStateFlow()
+
     private val _deltaIntervalMinutes = MutableStateFlow(tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES)
     val deltaIntervalMinutes = _deltaIntervalMinutes.asStateFlow()
 
@@ -637,6 +640,10 @@ class DashboardViewModel(
         _glucoseAppChartRangeColorsEnabled.value = prefs.getBoolean(APP_CHART_RANGE_COLORS_KEY, false)
         _dashboardShowDelta.value = prefs.getBoolean(DASHBOARD_SHOW_DELTA_KEY, false)
         _dashboardRowsShowDelta.value = prefs.getBoolean(DASHBOARD_ROWS_SHOW_DELTA_KEY, false)
+        _matchArrowToDisplayedDelta.value = prefs.getBoolean(
+            tk.glucodata.GlucoseDelta.MATCH_ARROW_TO_DISPLAYED_DELTA_KEY,
+            tk.glucodata.GlucoseDelta.DEFAULT_MATCH_ARROW_TO_DISPLAYED_DELTA
+        )
         _deltaIntervalMinutes.value = tk.glucodata.GlucoseDelta.sanitizeIntervalMinutes(
             prefs.getInt(DELTA_INTERVAL_KEY, tk.glucodata.GlucoseDelta.DEFAULT_INTERVAL_MINUTES)
         )
@@ -1440,6 +1447,14 @@ class DashboardViewModel(
         val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
         prefs.edit().putBoolean(DASHBOARD_ROWS_SHOW_DELTA_KEY, enabled).apply()
         _dashboardRowsShowDelta.value = enabled
+    }
+
+    fun setMatchArrowToDisplayedDelta(enabled: Boolean) {
+        val context = tk.glucodata.Applic.app
+        val prefs = context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(tk.glucodata.GlucoseDelta.MATCH_ARROW_TO_DISPLAYED_DELTA_KEY, enabled).apply()
+        _matchArrowToDisplayedDelta.value = enabled
+        refreshNotificationPredictionSurfaces(context)
     }
 
     /**

--- a/Common/src/test/java/tk/glucodata/GlucoseDeltaTests.kt
+++ b/Common/src/test/java/tk/glucodata/GlucoseDeltaTests.kt
@@ -1,6 +1,7 @@
 package tk.glucodata
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.Locale
@@ -8,6 +9,11 @@ import java.util.Locale
 class GlucoseDeltaTests {
 
     private val t0 = 1_700_000_000_000L
+
+    @Test
+    fun arrowMatchingDefaultsOff() {
+        assertFalse(GlucoseDelta.DEFAULT_MATCH_ARROW_TO_DISPLAYED_DELTA)
+    }
 
     @Test
     fun fiveMinutePairGivesRawChange() {

--- a/Common/src/test/java/tk/glucodata/GlucoseDeltaTests.kt
+++ b/Common/src/test/java/tk/glucodata/GlucoseDeltaTests.kt
@@ -77,6 +77,13 @@ class GlucoseDeltaTests {
     }
 
     @Test
+    fun displayedDeltaConvertsToTheArrowRate() {
+        assertEquals(1.22f, GlucoseDelta.rateMgdlPerMinute(6.1f, false, 5), 0.001f)
+        assertEquals(3.60364f, GlucoseDelta.rateMgdlPerMinute(0.2f, true, 1), 0.001f)
+        assertTrue(GlucoseDelta.rateMgdlPerMinute(Float.NaN, false, 5).isNaN())
+    }
+
+    @Test
     fun formatsMgdlCompactlyWithSign() {
         withLocale(Locale.US) {
             assertEquals("+2", GlucoseDelta.format(2f, false))

--- a/Common/src/test/java/tk/glucodata/ui/ReadingRowArrowBasisTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/ReadingRowArrowBasisTests.kt
@@ -69,10 +69,27 @@ class ReadingRowArrowBasisTests {
         ).single()!!
 
         assertEquals("+6.1", delta.text)
-        val shown = trendResultForDisplayedDelta(regressed(velocity = -2.4f), delta.rateMgdlPerMinute)
+        val shown = trendResultForDisplayedDelta(
+            regressed(velocity = -2.4f),
+            delta.rateMgdlPerMinute,
+            useDisplayedDelta = true,
+        )
 
         assertEquals(1.22f, shown.velocity, 0.001f)
         assertEquals(TrendEngine.TrendState.SingleUp, shown.state)
+    }
+
+    @Test
+    fun theHeroKeepsItsRegressionWhenArrowMatchingIsOff() {
+        val falling = regressed(velocity = -2.4f)
+
+        val shown = trendResultForDisplayedDelta(
+            falling,
+            deltaRateMgdlPerMinute = 1.22f,
+            useDisplayedDelta = false,
+        )
+
+        assertSame(falling, shown)
     }
 
     @Test

--- a/Common/src/test/java/tk/glucodata/ui/ReadingRowArrowBasisTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/ReadingRowArrowBasisTests.kt
@@ -42,7 +42,7 @@ class ReadingRowArrowBasisTests {
         assertEquals(-21f / 5f, delta.rateMgdlPerMinute, 0.001f)
 
         val climbing = regressed(velocity = 2.4f)
-        val shown = rowTrendResult(climbing, delta.rateMgdlPerMinute)
+        val shown = trendResultForDisplayedDelta(climbing, delta.rateMgdlPerMinute)
 
         assertTrue("the arrow may not point up beside a fall", shown.velocity < 0f)
         assertEquals(TrendEngine.TrendState.DoubleDown, shown.state)
@@ -53,8 +53,26 @@ class ReadingRowArrowBasisTests {
     fun withoutADeltaTheRegressionIsKept() {
         val climbing = regressed(velocity = 2.4f)
 
-        assertSame(climbing, rowTrendResult(climbing, null))
-        assertSame(climbing, rowTrendResult(climbing, Float.NaN))
+        assertSame(climbing, trendResultForDisplayedDelta(climbing, null))
+        assertSame(climbing, trendResultForDisplayedDelta(climbing, Float.NaN))
+    }
+
+    /** The reported field case: the hero regresses down while its displayed Δ is positive. */
+    @Test
+    fun theHeroArrowFollowsItsDisplayedPositiveDelta() {
+        val points = history(5L to 207.9f, 0L to 214f)
+        val delta = readingDeltas(
+            listOf(nowMillis),
+            points,
+            isMmol = false,
+            deltaIntervalMinutes = 5,
+        ).single()!!
+
+        assertEquals("+6.1", delta.text)
+        val shown = trendResultForDisplayedDelta(regressed(velocity = -2.4f), delta.rateMgdlPerMinute)
+
+        assertEquals(1.22f, shown.velocity, 0.001f)
+        assertEquals(TrendEngine.TrendState.SingleUp, shown.state)
     }
 
     @Test


### PR DESCRIPTION
PR #222 made reading-row arrows follow the delta shown beside them, while deliberately keeping the dashboard hero on the longer regression. The hero also shows a delta, and glucose notifications can pair those two timescales as well, so an arrow and its adjacent number can still point in opposite directions during a sharp reversal. Changing this unconditionally would remove the steadier behavior that #222 kept.

This PR adds a single Display setting named Match arrows to delta. It is off by default. When enabled, the dashboard hero and glucose notifications derive their arrow from the displayed delta. When disabled, or when no usable delta is available, they keep the existing regression result. Reading rows continue to follow their visible delta regardless of this setting.

### Changes

- Adds the setting and saves it in the existing preferences path.
- Applies the option to the dashboard hero and glucose notifications.
- Adds the setting text to every maintained locale.
- Covers the default, enabled, disabled, and missing-delta paths with unit tests.

### Verification

- ./gradlew :Common:testMobileReleaseUnitTest
- Device verification confirmed on September 6, 2026.

