### PR TITLE
Let journal marker drags pan the dashboard chart

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DashboardChart.kt
@@ -87,6 +87,7 @@ import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -117,6 +118,8 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.input.pointer.util.addPointerInputChange
@@ -126,6 +129,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
@@ -1688,6 +1695,7 @@ fun InteractiveGlucoseChart(
         }
     }
 
+    val activeJournalMarkerPointers = remember { mutableSetOf<PointerId>() }
 
 
 
@@ -1722,6 +1730,7 @@ fun InteractiveGlucoseChart(
                             // FIX: Use requireUnconsumed = true (default) to respect z-order.
                             // This prevents the chart from hijacking touches meant for the floating buttons.
                             val down = awaitFirstDown()
+                            val startedOnJournalMarker = down.id in activeJournalMarkerPointers
                             val gestureStartTime = System.currentTimeMillis()
                             lastInteractionTimestamp = gestureStartTime
                             cancelAutoScroll()
@@ -1845,7 +1854,8 @@ fun InteractiveGlucoseChart(
                             // 1. Previous gesture was a tap (not a scroll)
                             // 2. Short duration since then (<300ms)
                             // 3. Close spatial proximity (<100px)
-                            val isDoubleTapStart = gestureStartTime >= suppressDoubleTapUntil &&
+                            val isDoubleTapStart = !startedOnJournalMarker &&
+                                    gestureStartTime >= suppressDoubleTapUntil &&
                                     lastGestureWasTap &&
                                     (gestureStartTime - lastTapTime < 300) &&
                                     (down.position - lastTapPos).getDistance() < 100.dp.toPx()
@@ -1907,7 +1917,9 @@ fun InteractiveGlucoseChart(
                             var yGestureStartMax = 0f
                             var yGestureAdjustsMax = false
                             var lastPointerCount = 1
-                            val longPressJob = if (onTimelineTap != null && !isDoubleTapStart) {
+                            val longPressJob = if (
+                                onTimelineTap != null && !isDoubleTapStart && !startedOnJournalMarker
+                            ) {
                                 coroutineScope.launch {
                                     kotlinx.coroutines.delay(viewConfiguration.longPressTimeoutMillis.toLong())
                                     if (!longPressTriggered && totalDragDistance < viewConfiguration.touchSlop) {
@@ -1925,7 +1937,9 @@ fun InteractiveGlucoseChart(
                             }
 
                             // Only allow scrubbing if purely single tap start (not double tap sequence)
-                            isScrubbing = if (pointAtTouch != null && !isOneFingerZoom) {
+                            isScrubbing = if (
+                                !startedOnJournalMarker && pointAtTouch != null && !isOneFingerZoom
+                            ) {
                                 val timeDiff = timeAtTouch - pointAtTouch.timestamp
                                 if (timeDiff > 15 * 60 * 1000) false else {
                                     // When calibration is on and is primary, use calibrated value for touch target
@@ -2095,7 +2109,8 @@ fun InteractiveGlucoseChart(
                             }
 
                             // ON UP
-                            val wasTap = totalDragDistance < viewConfiguration.touchSlop
+                            val wasTap = !startedOnJournalMarker &&
+                                totalDragDistance < viewConfiguration.touchSlop
                             longPressJob?.cancel()
                             lastGestureWasTap = wasTap && !isOneFingerZoom && !isScrubbing && !longPressTriggered
 
@@ -3624,6 +3639,7 @@ fun InteractiveGlucoseChart(
                 }
                 JournalMarkerChip(
                     marker = marker,
+                    activePointerIds = activeJournalMarkerPointers,
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .zIndex(1.5f)
@@ -4780,13 +4796,13 @@ fun InteractiveGlucoseChart(
 @Composable
 private fun JournalMarkerChip(
     marker: JournalChartMarker,
+    activePointerIds: MutableSet<PointerId>,
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
     val tint = Color(marker.accentColor)
     Surface(
-        modifier = modifier,
-        onClick = onClick,
+        modifier = modifier.journalMarkerInput(activePointerIds, onClick),
         shape = RoundedCornerShape(14.dp),
         color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.92f),
         border = BorderStroke(1.dp, tint.copy(alpha = 0.18f)),
@@ -4820,6 +4836,53 @@ private fun JournalMarkerChip(
         }
     }
 }
+
+private fun Modifier.journalMarkerInput(
+    activePointerIds: MutableSet<PointerId>,
+    activateMarker: () -> Unit
+): Modifier = this
+    .minimumInteractiveComponentSize()
+    .semantics(mergeDescendants = true) {
+        role = Role.Button
+        onClick(action = {
+            activateMarker()
+            true
+        })
+    }
+    .pointerInput(activePointerIds, activateMarker) {
+        awaitEachGesture {
+            val down = awaitFirstDown(
+                requireUnconsumed = false,
+                pass = PointerEventPass.Initial
+            )
+            val gate = JournalMarkerGestureGate(viewConfiguration.touchSlop)
+            activePointerIds.add(down.id)
+            try {
+                while (true) {
+                    val event = awaitPointerEvent(PointerEventPass.Main)
+                    val change = event.changes.firstOrNull { it.id == down.id }
+                    if (change == null) {
+                        gate.cancel()
+                        break
+                    }
+                    gate.observe(
+                        displacementX = change.position.x - down.position.x,
+                        displacementY = change.position.y - down.position.y,
+                        pointerCount = event.changes.size
+                    )
+                    if (!change.pressed) {
+                        if (gate.shouldClick(change.changedToUp())) {
+                            change.consume()
+                            activateMarker()
+                        }
+                        break
+                    }
+                }
+            } finally {
+                activePointerIds.remove(down.id)
+            }
+        }
+    }
 
 /**
  * Countdown next to the clock glyph on the active-insulin chip. Rendered as "2 h 40 min"

--- a/Common/src/mobile/java/tk/glucodata/ui/JournalMarkerGestureGate.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/JournalMarkerGestureGate.kt
@@ -1,0 +1,25 @@
+package tk.glucodata.ui
+
+/** Keeps a journal marker tap distinct from a chart drag that starts on the marker. */
+internal class JournalMarkerGestureGate(private val touchSlop: Float) {
+    private var tapCandidate = touchSlop.isFinite() && touchSlop >= 0f
+
+    fun observe(displacementX: Float, displacementY: Float, pointerCount: Int) {
+        if (!tapCandidate) return
+        if (pointerCount != 1 || !displacementX.isFinite() || !displacementY.isFinite()) {
+            tapCandidate = false
+            return
+        }
+
+        val distanceSquared = displacementX * displacementX + displacementY * displacementY
+        if (distanceSquared >= touchSlop * touchSlop) {
+            tapCandidate = false
+        }
+    }
+
+    fun cancel() {
+        tapCandidate = false
+    }
+
+    fun shouldClick(released: Boolean): Boolean = released && tapCandidate
+}

--- a/Common/src/test/java/tk/glucodata/ui/JournalMarkerGestureGateTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/JournalMarkerGestureGateTests.kt
@@ -1,0 +1,55 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JournalMarkerGestureGateTests {
+
+    @Test
+    fun stationaryReleaseClicksTheMarker() {
+        val gate = JournalMarkerGestureGate(touchSlop = 10f)
+        gate.observe(displacementX = 0f, displacementY = 0f, pointerCount = 1)
+
+        assertTrue(gate.shouldClick(released = true))
+    }
+
+    @Test
+    fun movementBelowTouchSlopStillClicksTheMarker() {
+        val gate = JournalMarkerGestureGate(touchSlop = 10f)
+        gate.observe(displacementX = 6f, displacementY = 7f, pointerCount = 1)
+
+        assertTrue(gate.shouldClick(released = true))
+    }
+
+    @Test
+    fun horizontalDragHandsTheGestureToTheChart() {
+        val gate = JournalMarkerGestureGate(touchSlop = 10f)
+        gate.observe(displacementX = 10f, displacementY = 0f, pointerCount = 1)
+
+        assertFalse(gate.shouldClick(released = true))
+    }
+
+    @Test
+    fun verticalDragDoesNotClickTheMarker() {
+        val gate = JournalMarkerGestureGate(touchSlop = 10f)
+        gate.observe(displacementX = 0f, displacementY = 12f, pointerCount = 1)
+
+        assertFalse(gate.shouldClick(released = true))
+    }
+
+    @Test
+    fun secondPointerCancelsTheMarkerClick() {
+        val gate = JournalMarkerGestureGate(touchSlop = 10f)
+        gate.observe(displacementX = 0f, displacementY = 0f, pointerCount = 2)
+
+        assertFalse(gate.shouldClick(released = true))
+    }
+
+    @Test
+    fun canceledGestureDoesNotClickTheMarker() {
+        val gate = JournalMarkerGestureGate(touchSlop = 10f)
+
+        assertFalse(gate.shouldClick(released = false))
+    }
+}


### PR DESCRIPTION
Journal markers currently use an interactive `Surface`, which consumes the initial pointer down before the Dashboard chart's gesture handler sees it. A horizontal drag that starts on a marker therefore cannot pan the chart, even though tapping the marker works.

This change gives journal markers their own tap classifier without consuming the start of the gesture. Motion past Android's touch slop remains available to the chart, while a stationary release still opens the journal entry. The chart also suppresses glucose scrubbing, long press, double tap, and graph tap selection when the gesture began on a journal marker.

## Changes

- Track journal marker pointer IDs during Compose's initial event pass so the parent chart can recognize marker-originated gestures.
- Keep marker drags available to the chart's existing pan and axis handling.
- Preserve marker tap semantics and the platform minimum interactive size.
- Add focused tests for stationary taps, movement below touch slop, horizontal and vertical drags, multi-touch, and cancellation.

## Verification

- `./gradlew :Common:testMobileReleaseUnitTest --rerun-tasks`
- 2,011 tests, zero failures, errors, or skips
- No APK assembled

Physical pointer dispatch should still be checked on a device because the unit tests cover the tap-versus-drag classifier rather than Compose event delivery itself.
