### PR TITLE
Stop Ottai dropping live records to a per-frame layout guess

### DIFF
--- a/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
+++ b/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
@@ -402,72 +402,64 @@ public class NotificationChartDrawer {
             float lineAlpha,
             float thresholdAlpha) {
         int size = Math.min(timestamps.size(), values.size());
-        if (size < 2) {
+        if (size < 1) {
             return;
         }
 
         long previousTimestamp = 0L;
         float previousValue = 0f;
         boolean hasPrevious = false;
+        // Whether the point currently held in previous* ever got a line drawn to or from it.
+        // A reading with no neighbour close enough to join strokes nothing, so it is drawn as
+        // a dot instead of vanishing — the same rule ChartLineRun applies on the Compose side,
+        // and the nvgCircle the native renderer draws for a one-point run.
+        boolean previousConnected = false;
 
         for (int index = 0; index < size; index++) {
             float currentValue = values.get(index);
             long currentTimestamp = timestamps.get(index);
             boolean valid = Float.isFinite(currentValue) && currentValue > 0.1f;
             if (!valid) {
+                if (hasPrevious && !previousConnected) {
+                    drawIsolatedPoint(canvas, linePaint, previousTimestamp, previousValue, startTime, duration,
+                            chartLeft, chartBottom, chartWidth, chartHeight, minY, yRange, targetLow, targetHigh,
+                            veryLowThreshold, veryHighThreshold, isMmol, inRangeColor, useThresholdColors,
+                            thresholdTintColor, lineAlpha, thresholdAlpha);
+                }
                 hasPrevious = false;
+                previousConnected = false;
                 continue;
             }
 
-            if (hasPrevious) {
+            // A hole in the data has to look like a hole. Without this the line was drawn
+            // straight across however long the sensor had been silent, so a dropout the
+            // dashboard broke on read as an unremarkable stretch of glucose in the
+            // notification, the widget and the AOD overlay. Same constant as the Compose
+            // chart's ChartGap, so the two cannot drift apart again.
+            boolean joins = hasPrevious && joinsAcross(previousTimestamp, currentTimestamp);
+            if (hasPrevious && !joins) {
+                if (!previousConnected) {
+                    drawIsolatedPoint(canvas, linePaint, previousTimestamp, previousValue, startTime, duration,
+                            chartLeft, chartBottom, chartWidth, chartHeight, minY, yRange, targetLow, targetHigh,
+                            veryLowThreshold, veryHighThreshold, isMmol, inRangeColor, useThresholdColors,
+                            thresholdTintColor, lineAlpha, thresholdAlpha);
+                }
+                hasPrevious = false;
+                previousConnected = false;
+            }
+
+            if (joins) {
                 float startX = chartLeft + ((previousTimestamp - startTime) / (float) duration) * chartWidth;
                 float startY = chartBottom - ((previousValue - minY) / yRange) * chartHeight;
                 float endX = chartLeft + ((currentTimestamp - startTime) / (float) duration) * chartWidth;
                 float endY = chartBottom - ((currentValue - minY) / yRange) * chartHeight;
                 if (useThresholdColors) {
-                    int startColor;
-                    int endColor;
-                    if (lineAlpha < 1f || thresholdAlpha < 1f || thresholdTintColor != 0) {
-                        startColor = resolvePrimaryPointColor(
-                                previousValue,
-                                targetLow,
-                                targetHigh,
-                                veryLowThreshold,
-                                veryHighThreshold,
-                                inRangeColor,
-                                thresholdTintColor,
-                                isMmol,
-                                lineAlpha,
-                                thresholdAlpha);
-                        endColor = resolvePrimaryPointColor(
-                                currentValue,
-                                targetLow,
-                                targetHigh,
-                                veryLowThreshold,
-                                veryHighThreshold,
-                                inRangeColor,
-                                thresholdTintColor,
-                                isMmol,
-                                lineAlpha,
-                                thresholdAlpha);
-                    } else {
-                        startColor = resolveThresholdPointColor(
-                                previousValue,
-                                targetLow,
-                                targetHigh,
-                                veryLowThreshold,
-                                veryHighThreshold,
-                                inRangeColor,
-                                isMmol);
-                        endColor = resolveThresholdPointColor(
-                                currentValue,
-                                targetLow,
-                                targetHigh,
-                                veryLowThreshold,
-                                veryHighThreshold,
-                                inRangeColor,
-                                isMmol);
-                    }
+                    int startColor = pointColor(previousValue, targetLow, targetHigh, veryLowThreshold,
+                            veryHighThreshold, isMmol, inRangeColor, true, thresholdTintColor,
+                            lineAlpha, thresholdAlpha);
+                    int endColor = pointColor(currentValue, targetLow, targetHigh, veryLowThreshold,
+                            veryHighThreshold, isMmol, inRangeColor, true, thresholdTintColor,
+                            lineAlpha, thresholdAlpha);
                     if (startColor == endColor) {
                         linePaint.setShader(null);
                         linePaint.setColor(startColor);
@@ -491,8 +483,107 @@ public class NotificationChartDrawer {
 
             previousTimestamp = currentTimestamp;
             previousValue = currentValue;
+            previousConnected = joins;
             hasPrevious = true;
         }
+
+        if (hasPrevious && !previousConnected) {
+            drawIsolatedPoint(canvas, linePaint, previousTimestamp, previousValue, startTime, duration,
+                    chartLeft, chartBottom, chartWidth, chartHeight, minY, yRange, targetLow, targetHigh,
+                    veryLowThreshold, veryHighThreshold, isMmol, inRangeColor, useThresholdColors,
+                    thresholdTintColor, lineAlpha, thresholdAlpha);
+        }
+    }
+
+    /**
+     * Whether two consecutive readings are close enough in time for the line to join them.
+     *
+     * The same rule, from the same constant, that the Compose charts apply through
+     * ui.ChartGap — so a hole reads as a hole on every surface, and the two cannot drift.
+     */
+    static boolean joinsAcross(long previousTimestamp, long currentTimestamp) {
+        return (currentTimestamp - previousTimestamp) <= GlucoseChartGap.THRESHOLD_MS;
+    }
+
+    /** The colour one reading contributes to the line, matching the series' colouring mode. */
+    private static int pointColor(
+            float value,
+            float targetLow,
+            float targetHigh,
+            float veryLowThreshold,
+            float veryHighThreshold,
+            boolean isMmol,
+            int inRangeColor,
+            boolean useThresholdColors,
+            int thresholdTintColor,
+            float lineAlpha,
+            float thresholdAlpha) {
+        if (!useThresholdColors) {
+            return lineAlpha < 1f ? withAlpha(inRangeColor, lineAlpha) : inRangeColor;
+        }
+        if (lineAlpha < 1f || thresholdAlpha < 1f || thresholdTintColor != 0) {
+            return resolvePrimaryPointColor(
+                    value,
+                    targetLow,
+                    targetHigh,
+                    veryLowThreshold,
+                    veryHighThreshold,
+                    inRangeColor,
+                    thresholdTintColor,
+                    isMmol,
+                    lineAlpha,
+                    thresholdAlpha);
+        }
+        return resolveThresholdPointColor(
+                value,
+                targetLow,
+                targetHigh,
+                veryLowThreshold,
+                veryHighThreshold,
+                inRangeColor,
+                isMmol);
+    }
+
+    /**
+     * A reading with no neighbour close enough to connect to, drawn as a dot.
+     *
+     * Adding the gap rule above without this would have swapped one wrong picture for
+     * another: a reading either side of a long silence would simply stop being drawn.
+     */
+    private static void drawIsolatedPoint(
+            Canvas canvas,
+            Paint linePaint,
+            long timestamp,
+            float value,
+            long startTime,
+            long duration,
+            float chartLeft,
+            float chartBottom,
+            float chartWidth,
+            float chartHeight,
+            float minY,
+            float yRange,
+            float targetLow,
+            float targetHigh,
+            float veryLowThreshold,
+            float veryHighThreshold,
+            boolean isMmol,
+            int inRangeColor,
+            boolean useThresholdColors,
+            int thresholdTintColor,
+            float lineAlpha,
+            float thresholdAlpha) {
+        float x = chartLeft + ((timestamp - startTime) / (float) duration) * chartWidth;
+        float y = chartBottom - ((value - minY) / yRange) * chartHeight;
+        linePaint.setShader(null);
+        linePaint.setColor(pointColor(value, targetLow, targetHigh, veryLowThreshold, veryHighThreshold,
+                isMmol, inRangeColor, useThresholdColors, thresholdTintColor, lineAlpha, thresholdAlpha));
+        // The line paint strokes; a stroked circle of this radius would draw a ring around
+        // nothing. Fill for the dot and hand the paint back as it was found.
+        Paint.Style style = linePaint.getStyle();
+        linePaint.setStyle(Paint.Style.FILL);
+        canvas.drawCircle(x, y, linePaint.getStrokeWidth() / 2f, linePaint);
+        linePaint.setStyle(style);
     }
 
     private static void drawNotificationSourceSeries(

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -120,6 +120,10 @@ class OttaiBleManager(
         // flood the ledger. Both rules only ever widen a window — coverage is never traded away.
         private const val HISTORY_GAP_COALESCE_RECORDS = 5
         private const val MAX_HISTORY_GAP_RANGES = 8
+        // Widest hole the live path will ledger on its own. Anything larger is not a dropout
+        // during a live session, it is a store that needs the initial reconciliation, and
+        // enqueueing it here would spend the ledger's bounded attempts on the wrong problem.
+        private const val MAX_LIVE_GAP_RECORDS = 240
         private const val HISTORY_HOLE_MAX_ATTEMPTS = 5
         private const val HISTORY_HOLE_RETRY_DELAY_MS = 5_000L
         private const val MAX_LIVE_POLL_INTERVAL_MS = 60_000L
@@ -335,6 +339,35 @@ class OttaiBleManager(
          * index stays inside some returned window. Hitting [maxRanges] costs redundant records,
          * never coverage.
          */
+        /**
+         * The records a live sample says are missing, or null when nothing is.
+         *
+         * A live frame that lands on `liveDataNo` when the app holds `previousDataNo` is the
+         * sensor telling us, without being asked, that everything between them is gone from
+         * our side. That is a bounded, self-describing hole and the ledger exists to carry
+         * exactly this kind — but before this the only route to the ledger ran through
+         * requestRoomBackfillAfterLive, whose one-shot latches for the whole connection. On a
+         * 2026-08-30 trace the latch closed at 02:10 and the link then stayed up 11.5 hours,
+         * so a hole that opened at 12:10 was never re-requested at all.
+         *
+         * Bounded twice over: [ceiling] rejects a jump to a dataNo the sensor cannot have
+         * reached, and [maxRecords] refuses a span too large to be a live-path hole — that is
+         * the initial reconciliation's job, not this one's.
+         */
+        internal fun liveGapRange(
+            previousDataNo: Int,
+            liveDataNo: Int,
+            ceiling: Int = Int.MAX_VALUE,
+            maxRecords: Int = MAX_LIVE_GAP_RECORDS,
+        ): MissingRange? {
+            // A first-ever sample has nothing to be missing behind it, and a live dataNo past
+            // the ceiling is not a position the sensor can be in.
+            if (previousDataNo < 0 || liveDataNo <= 0 || liveDataNo > ceiling) return null
+            val missing = liveDataNo - previousDataNo - 1
+            if (missing <= 0 || missing > maxRecords) return null
+            return MissingRange(previousDataNo + 1, liveDataNo)
+        }
+
         internal fun missingRanges(
             present: BooleanArray,
             coalesceGap: Int = HISTORY_GAP_COALESCE_RECORDS,
@@ -2985,6 +3018,7 @@ class OttaiBleManager(
                 // independent backstop so the two don't both issue (which would wipe and restart
                 // the in-flight chunk chain via clearPendingHistoryRange).
                 handler.removeCallbacks(initialHistoryRunnable)
+                ledgerLiveGap(previousForHistory, liveDataNo)
                 val backfill = requestRoomBackfillAfterLive(liveDataNo, previousForHistory)
                 if (!backfill.issued && !backfill.diffOwnsRecovery && !roomBackfillChecked) {
                     val missingBeforeLive = liveDataNo - previousForHistory - 1
@@ -4349,6 +4383,21 @@ class OttaiBleManager(
     // Requested-but-undelivered windows. Added at request time for detected gaps, trimmed only
     // when their data actually arrives, retired by the cross-session attempt cap. Survives
     // disconnects and app restarts via OttaiRegistry (per-sensor pref).
+
+    /**
+     * Put a hole the live path just revealed on the ledger, whatever the one-shot thinks.
+     *
+     * [roomBackfillChecked] guards the *initial* whole-history reconciliation, which is
+     * expensive and belongs once per connection. A hole that opens mid-session is a different
+     * and bounded thing, and gating it behind that latch is why a 16-minute dropout on a link
+     * that never dropped stayed missing for the remaining eleven hours of the session.
+     */
+    private fun ledgerLiveGap(previousDataNo: Int, liveDataNo: Int) {
+        val gap = liveGapRange(previousDataNo, liveDataNo, dataNoCeiling(live = true)) ?: return
+        Log.i(TAG, "live gap ledgered ${gap.start}..<${gap.endExclusive} previous=$previousDataNo live=$liveDataNo")
+        addHistoryHole(gap.start, gap.endExclusive)
+        scheduleHoleRetry()
+    }
 
     private fun addHistoryHole(start: Int, endExclusive: Int) {
         if (endExclusive <= start || start < 0) return

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -774,6 +774,13 @@ class OttaiBleManager(
     @Volatile private var livePollIntervalMs = 60_000L
     @Volatile private var lastHistoryRequestAtMs = 0L
     @Volatile private var roomBackfillChecked = false
+    // The sensor's BLE record layout (8 or 9), 0 until a payload big enough to prove one has
+    // been seen. A minute live notify is 24 bytes — one 9-byte record plus padding, which is
+    // also two 8-byte records — so it cannot tell the layouts apart and must not be allowed to
+    // choose. See OttaiParser.decisiveRecordSize.
+    @Volatile private var learnedRecordSize = 0
+    // One log line per run of payloads whose own inference disagrees with the held layout.
+    @Volatile private var recordSizeDisagreementLogged = false
     @Volatile private var initialHistoryAttempt = 0
     @Volatile private var pendingHistoryReason: String? = null
     @Volatile private var pendingHistoryNextStart = 0
@@ -1033,6 +1040,7 @@ class OttaiBleManager(
         authKeys = materials.authKeys
         activatedMaxActiveMs = OttaiRegistry.loadAcceptedMaxActive(context, id)
         lastDataNo = OttaiRegistry.loadLastDataNo(context, id)
+        learnedRecordSize = OttaiRegistry.loadRecordSize(context, id)
         synchronized(historyHolesLock) {
             historyHoles.clear()
             OttaiRegistry.loadHistoryHoles(context, id).forEach { (s, e, attempts) ->
@@ -2848,6 +2856,47 @@ class OttaiBleManager(
     private fun appString(resId: Int, fallback: String, vararg args: Any): String =
         runCatching { Applic.app?.getString(resId, *args) }.getOrNull() ?: fallback
 
+    /** The learned layout to frame with, or null while nothing has proved one. */
+    private fun heldRecordSize(): Int? = learnedRecordSize.takeIf { it > 0 }
+
+    /**
+     * Adopt the record layout when a payload is big enough to prove it, and say so when a
+     * payload would have chosen differently.
+     *
+     * The diagnostic is the point of the second half: the 2026-08-30 trace could show that
+     * 112 live frames framed as 8-byte and lost their sample, but not *why* the inference
+     * flipped, because the payloads are encrypted and only the record count reaches the log.
+     * Printing the evidence counts on disagreement makes the next trace answer that directly.
+     * Logged once per run of disagreement so a persistently odd sensor cannot flood the log.
+     */
+    private fun learnRecordSize(payload: ByteArray) {
+        val id = SerialNumber ?: return
+        val decisive = OttaiParser.decisiveRecordSize(payload, materials.deviceVersion)
+        if (decisive != null) {
+            recordSizeDisagreementLogged = false
+            if (decisive != learnedRecordSize) {
+                val previous = learnedRecordSize
+                learnedRecordSize = decisive
+                Applic.app?.let { OttaiRegistry.saveRecordSize(it, id, decisive) }
+                Log.i(TAG, "record size learned=$decisive previous=$previous len=${payload.size}")
+            }
+            return
+        }
+        val held = learnedRecordSize.takeIf { it > 0 } ?: return
+        val wouldChoose = OttaiParser.chooseRecordSize(payload, materials.deviceVersion)
+        if (wouldChoose == held) {
+            recordSizeDisagreementLogged = false
+            return
+        }
+        if (recordSizeDisagreementLogged) return
+        recordSizeDisagreementLogged = true
+        val (nine, eight) = OttaiParser.recordSizeEvidence(payload)
+        Log.i(
+            TAG,
+            "record size held=$held payloadWould=$wouldChoose nine=$nine eight=$eight len=${payload.size}",
+        )
+    }
+
     private fun handleGlucosePayload(cipher: ByteArray, live: Boolean, source: String) {
         if (sessionKeyHex.isBlank()) { Log.w(TAG, "payload before session key"); return }
         if (live && commandStatus >= 4) {
@@ -2864,7 +2913,8 @@ class OttaiBleManager(
             Log.w(TAG, "$kind $source decrypt failed len=${cipher.size} blockMod=${cipher.size % 16}")
             return
         }
-        val records = OttaiParser.frameRecords(payload, materials.deviceVersion)
+        learnRecordSize(payload)
+        val records = OttaiParser.frameRecords(payload, materials.deviceVersion, heldRecordSize())
         if (records.isEmpty()) {
             Log.w(TAG, "$kind $source no records payloadLen=${payload.size} hex=${OttaiCrypto.bytesToHex(payload).take(160)}")
             if (live) {
@@ -2966,7 +3016,7 @@ class OttaiBleManager(
             Log.w(TAG, "ended live $source decrypt failed len=${cipher.size}")
             return
         }
-        val latest = OttaiParser.frameRecords(payload, materials.deviceVersion)
+        val latest = OttaiParser.frameRecords(payload, materials.deviceVersion, heldRecordSize())
             .map(OttaiParser::parseRecord)
             .maxByOrNull { it.dataNo }
         if (latest == null) {

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiConstants.kt
@@ -370,6 +370,9 @@ object OttaiConstants {
     const val PREF_RETAIN_TIME_PREFIX = "ottai_retain_time_"      // retainTime ms (destruction value)
     const val PREF_DEVICE_VERSION_PREFIX = "ottai_device_version_"
     const val PREF_LAST_DATA_NO_PREFIX = "ottai_last_datano_"
+    // BLE record layout (8 or 9) once a payload big enough to prove it has been seen. Held
+    // per sensor so a short live notify, which cannot tell the two apart, never re-decides it.
+    const val PREF_RECORD_SIZE_PREFIX = "ottai_record_size_"
     // Requested-but-undelivered history windows: "start:endExclusive:attempts" joined by ';'.
     const val PREF_HISTORY_HOLES_PREFIX = "ottai_history_holes_"
     const val PREF_DEVICE_ID_PREFIX = "ottai_device_id_"

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiParser.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiParser.kt
@@ -20,6 +20,11 @@
 //   [10..11] temperature*100 LE16  -> /100.0
 //
 // Live mode parses only the LAST record; history parses all records.
+//
+// The record size is NOT re-decided per payload once the driver has learned it. A
+// minute live notify is header + one 9-byte record + padding, which is also a valid
+// length for two 8-byte records, and one record is not enough evidence to tell them
+// apart. See chooseRecordSize/decisiveRecordSize.
 
 package tk.glucodata.drivers.ottai
 
@@ -68,12 +73,69 @@ object OttaiParser {
      * is still valid, while the mis-aligned layout loses because it decodes an impossible
      * current/temperature (e.g. 505 °C).
      * 9-byte: current[0:2], temp[7:9]; 8-byte: current[4:6], temp[6:8].
+     *
+     * The inference is only as good as the payload it is given, and a minute live notify is
+     * not good enough. It carries header(8) + one 9-byte record + seven pad bytes — 24 bytes,
+     * which is equally a header plus two 8-byte records. One record cannot outvote two, and
+     * the tie below falls to 8. A 2026-08-30 trace of an E1.1.4(V1.7.S2530.1) sensor caught
+     * this happening on 112 of 702 live frames: each time, record[1] was assembled out of the
+     * padding (`runtime=0 raw=0`), the live path's records.last() landed on it, it was
+     * rejected, and the real sample in record[0] went unexamined. Fourteen consecutive
+     * minutes were lost that way while the sensor was connected and talking.
+     *
+     * So [learned] wins over the guess: once [decisiveRecordSize] has settled the layout from
+     * a payload that could actually settle it, a short frame consumes that answer rather than
+     * voting again. The version string still outranks both — a confirmed family is not a
+     * guess at all.
      */
-    internal fun chooseRecordSize(payload: ByteArray, deviceVersion: String): Int {
+    internal fun chooseRecordSize(
+        payload: ByteArray,
+        deviceVersion: String,
+        learned: Int? = null,
+    ): Int {
         confirmedRecordSize(deviceVersion)?.let { return it }
-        val nine = vendorValidCount(payload, BLE_RECORD_SIZE_E12, curLo = 0, tempLo = 7)
-        val eight = vendorValidCount(payload, BLE_RECORD_SIZE, curLo = 4, tempLo = 6)
+        learned?.takeIf { it == BLE_RECORD_SIZE || it == BLE_RECORD_SIZE_E12 }?.let { return it }
+        val (nine, eight) = recordSizeEvidence(payload)
         return if (nine > eight) BLE_RECORD_SIZE_E12 else BLE_RECORD_SIZE
+    }
+
+    /**
+     * Vendor-valid record counts for a payload read as 9-byte and as 8-byte, in that order.
+     *
+     * Exposed so the decision, the "is this decisive" test and the driver's diagnostics all
+     * read one computation instead of three that could drift.
+     */
+    internal fun recordSizeEvidence(payload: ByteArray): Pair<Int, Int> = Pair(
+        vendorValidCount(payload, BLE_RECORD_SIZE_E12, curLo = 0, tempLo = 7),
+        vendorValidCount(payload, BLE_RECORD_SIZE, curLo = 4, tempLo = 6),
+    )
+
+    /**
+     * Records the winning layout needs before its margin means anything. Two candidate
+     * records — all a 24-byte live notify can offer — is noise; a history page or a polled
+     * live read carries nine or more.
+     */
+    private const val MIN_DECISIVE_RECORDS = 3
+
+    /** How far ahead the winner must be. One record of daylight can be padding luck. */
+    private const val DECISIVE_MARGIN = 2
+
+    /**
+     * The layout this payload can prove, or null when it cannot prove one.
+     *
+     * A confirmed version string proves it without looking at content. Otherwise the winner
+     * must have at least [MIN_DECISIVE_RECORDS] vendor-valid records and lead by
+     * [DECISIVE_MARGIN], which a minute live notify can never do and a history page or a
+     * nine-record live read always does.
+     */
+    internal fun decisiveRecordSize(payload: ByteArray, deviceVersion: String): Int? {
+        confirmedRecordSize(deviceVersion)?.let { return it }
+        val (nine, eight) = recordSizeEvidence(payload)
+        return when {
+            nine >= MIN_DECISIVE_RECORDS && nine - eight >= DECISIVE_MARGIN -> BLE_RECORD_SIZE_E12
+            eight >= MIN_DECISIVE_RECORDS && eight - nine >= DECISIVE_MARGIN -> BLE_RECORD_SIZE
+            else -> null
+        }
     }
 
     /** E major.minor -> record size, only for families still unambiguous on hardware. */
@@ -123,10 +185,14 @@ object OttaiParser {
      * (`{0,0} || LE16(frontDataNo+idx) || record8`). Trailing partial bytes are
      * ignored. Returns empty if there is no record region.
      */
-    fun frameRecords(payload: ByteArray, deviceVersion: String = ""): List<ByteArray> {
+    fun frameRecords(
+        payload: ByteArray,
+        deviceVersion: String = "",
+        learned: Int? = null,
+    ): List<ByteArray> {
         if (payload.size <= HEADER_SIZE) return emptyList()
         val front = frontDataNo(payload)
-        val bleSize = chooseRecordSize(payload, deviceVersion)
+        val bleSize = chooseRecordSize(payload, deviceVersion, learned)
         val nineByte = bleSize == BLE_RECORD_SIZE_E12
         val bodyLen = payload.size - HEADER_SIZE
         val count = bodyLen / bleSize

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiRegistry.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiRegistry.kt
@@ -597,6 +597,19 @@ object OttaiRegistry {
     }
 
     /**
+     * The sensor's learned BLE record layout, 0 when nothing has proved one yet.
+     *
+     * Persisted rather than kept per connection so the layout is right from the very first
+     * frame of the next session too — otherwise every reconnect spends its opening live
+     * notifies guessing, and a wrong guess silently drops those minutes.
+     */
+    @JvmStatic fun loadRecordSize(c: Context, id: String): Int =
+        prefs(c).getInt(OttaiConstants.PREF_RECORD_SIZE_PREFIX + OttaiConstants.canonicalSensorId(id), 0)
+    @JvmStatic fun saveRecordSize(c: Context, id: String, size: Int) {
+        prefs(c).edit().putInt(OttaiConstants.PREF_RECORD_SIZE_PREFIX + OttaiConstants.canonicalSensorId(id), size).apply()
+    }
+
+    /**
      * Hole ledger: requested-but-undelivered history windows, serialized by the driver as
      * "start:endExclusive:attempts" entries joined by ';'. Persisted so a disconnect or app
      * restart cannot turn a missed window into a permanent history gap.

--- a/Common/src/mobile/java/tk/glucodata/data/HistoryDisplayMerge.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/HistoryDisplayMerge.kt
@@ -4,7 +4,23 @@ import tk.glucodata.SensorIdentity
 
 internal object HistoryDisplayMerge {
     private const val SENSOR_MINUTE_BUCKET_MS = 60_000L
-    private const val OVERLAP_PADDING_MS = 5L * 60L * 1000L
+    /**
+     * How far past its own rows a sensor keeps ownership of a stretch.
+     *
+     * This is the chart's own gap rule, not a number of its own, and that is the whole point.
+     * The chart connects two readings up to [tk.glucodata.GlucoseChartGap.THRESHOLD_MS] apart;
+     * a hole narrower than that is not drawn as a hole. While this padding was five minutes,
+     * every dropout between ten and seventeen minutes fell in the space between the two rules:
+     * the merge handed the middle of it to a lower-ranked sensor, and the chart — which breaks
+     * the line on a sensor change — drew a line it was about to bridge as two holes with a
+     * fragment between them, at another sensor's calibration.
+     *
+     * A 2026-08-30 trace has it exactly: sixteen minutes missing from the live sensor, filled
+     * by a third sensor reading half a mmol lower, rendered as an outage that was not one.
+     *
+     * So another sensor may only own what the chart would genuinely draw broken.
+     */
+    private const val OVERLAP_PADDING_MS = tk.glucodata.GlucoseChartGap.THRESHOLD_MS
     private const val COVERAGE_SEGMENT_GAP_MS = 15L * 60L * 1000L
 
 
@@ -202,6 +218,14 @@ internal object HistoryDisplayMerge {
      * Rows no sensor owns keep their own rule: they are not a sensor competing
      * for a stretch, they are filler, and they are dropped only where the
      * preferred sensor already has that minute.
+     *
+     * That fixed the case where two sensors alternate minute by minute. The case it left
+     * is the one where they do not: a single sensor cleanly owns the middle of a short
+     * hole in the higher-ranked sensor's stream. The result is not a row of fragments but
+     * one of them — and it was still wrong, because a hole that narrow is not a hole at
+     * all as far as the chart is concerned. See [OVERLAP_PADDING_MS]: ownership now
+     * reaches exactly as far as the chart would bridge, so a lower-ranked sensor gets a
+     * stretch only when leaving it empty would genuinely read as missing data.
      */
     private fun applyPreferredOverlapDominance(
         readings: List<HistoryReading>,

--- a/Common/src/test/java/tk/glucodata/NotificationChartGapTests.kt
+++ b/Common/src/test/java/tk/glucodata/NotificationChartGapTests.kt
@@ -1,0 +1,40 @@
+package tk.glucodata
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The notification chart drew a straight line across however long the sensor had been silent:
+ * drawSeries walked the list and joined consecutive points with no reference to elapsed time.
+ * On a 2026-08-30 trace that turned fourteen missing minutes into an unremarkable stretch of
+ * rising glucose, while the dashboard — reading the same rows — broke the line.
+ *
+ * It now uses the chart's own constant, so a hole reads as a hole on every surface.
+ */
+class NotificationChartGapTests {
+    private companion object {
+        const val MINUTE_MS = 60L * 1000L
+    }
+
+    @Test
+    fun adjacentHistorySlotsStillConnect() {
+        // 15-minute Libre history plus write drift is what the threshold is derived from;
+        // joining those is the behaviour the rule must not break.
+        assertTrue(NotificationChartDrawer.joinsAcross(0L, 15 * MINUTE_MS))
+        assertTrue(NotificationChartDrawer.joinsAcross(0L, 16 * MINUTE_MS))
+        assertTrue(NotificationChartDrawer.joinsAcross(0L, GlucoseChartGap.THRESHOLD_MS))
+    }
+
+    @Test
+    fun aGenuineHoleBreaksTheLine() {
+        assertFalse(NotificationChartDrawer.joinsAcross(0L, GlucoseChartGap.THRESHOLD_MS + 1))
+        assertFalse(NotificationChartDrawer.joinsAcross(0L, 30 * MINUTE_MS))
+    }
+
+    @Test
+    fun theRuleIsTheChartsOwnConstant() {
+        // Not a second opinion about the same question — the same number the Compose charts use.
+        assertTrue(GlucoseChartGap.THRESHOLD_MS == 17 * MINUTE_MS)
+    }
+}

--- a/Common/src/test/java/tk/glucodata/data/HistoryDisplayMergeTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/HistoryDisplayMergeTests.kt
@@ -3,6 +3,7 @@ package tk.glucodata.data
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class HistoryDisplayMergeTests {
@@ -194,6 +195,67 @@ class HistoryDisplayMergeTests {
             ),
             merged.map { it.sensorSerial }
         )
+    }
+
+    /**
+     * The 2026-08-30 shape: the live sensor drops sixteen minutes on a link that never went
+     * down, a second sensor streams straight through the hole half a mmol lower, and the
+     * chart's gap rule would have bridged sixteen minutes without comment. Handing the middle
+     * of it to the other sensor turned one invisible dropout into two visible holes with a
+     * fragment between them.
+     */
+    @Test
+    fun mergeReadings_doesNotLetAnotherSensorFillAGapTheChartWouldBridge() {
+        val readings = ArrayList<HistoryReading>()
+        var id = 1L
+        // Preferred sensor: a reading a minute, with 12:11..12:25 missing.
+        for (minute in 0..10) {
+            readings += reading(id++, minute * MINUTE_MS, "sensor-live", 100f, 95f)
+        }
+        for (minute in 26..40) {
+            readings += reading(id++, minute * MINUTE_MS, "sensor-live", 105f, 100f)
+        }
+        // Another sensor streaming throughout, reading lower.
+        for (minute in 0..40) {
+            readings += reading(id++, minute * MINUTE_MS + 30_000L, "sensor-other", 80f, 76f)
+        }
+
+        val merged = HistoryDisplayMerge.mergeReadings(
+            readings = readings.sortedBy { it.timestamp },
+            preferredSerial = "sensor-live"
+        )
+
+        assertEquals(emptyList<String>(), merged.map { it.sensorSerial }.filter { it != "sensor-live" })
+    }
+
+    /**
+     * The other half of the same rule: a hole the chart *would* draw as a hole is exactly where
+     * another sensor's data is worth having. Suppressing it there would trade one wrong picture
+     * for another.
+     */
+    @Test
+    fun mergeReadings_stillLetsAnotherSensorOwnAGenuineOutage() {
+        val readings = ArrayList<HistoryReading>()
+        var id = 1L
+        for (minute in 0..10) {
+            readings += reading(id++, minute * MINUTE_MS, "sensor-live", 100f, 95f)
+        }
+        for (minute in 55..70) {
+            readings += reading(id++, minute * MINUTE_MS, "sensor-live", 105f, 100f)
+        }
+        for (minute in 0..70) {
+            readings += reading(id++, minute * MINUTE_MS + 30_000L, "sensor-other", 80f, 76f)
+        }
+
+        val merged = HistoryDisplayMerge.mergeReadings(
+            readings = readings.sortedBy { it.timestamp },
+            preferredSerial = "sensor-live"
+        )
+
+        val filler = merged.filter { it.sensorSerial == "sensor-other" }
+        assertNotEquals(emptyList<HistoryReading>(), filler)
+        // Only the middle of the outage — the edges stay with the sensor that owns them.
+        assertTrue(filler.all { it.timestamp > 27 * MINUTE_MS && it.timestamp < 38 * MINUTE_MS })
     }
 
     private fun reading(

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiLiveGapLedgerTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiLiveGapLedgerTests.kt
@@ -1,0 +1,52 @@
+package tk.glucodata.drivers.ottai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * A live sample that lands past the record the app holds has told us, unasked, that the
+ * records in between are missing. That is a bounded hole and the ledger is built for it — but
+ * the only route to the ledger used to run through the connection-lifetime backfill one-shot.
+ *
+ * On the 2026-08-30 trace the one-shot latched at 02:10, the link then stayed up for eleven and
+ * a half hours, and the hole that opened at 12:10 was consequently never re-requested: the
+ * sensor was connected and streaming the whole time, and the chart still showed an outage.
+ */
+class OttaiLiveGapLedgerTests {
+
+    @Test
+    fun consecutiveRecordsAreNotAGap() {
+        assertNull(OttaiBleManager.liveGapRange(previousDataNo = 9744, liveDataNo = 9745))
+    }
+
+    @Test
+    fun theTraceGapIsLedgeredExactly() {
+        // 12:10:38 stored 9744; the next stored record was 9760 at 12:26:37.
+        assertEquals(
+            OttaiBleManager.MissingRange(9745, 9760),
+            OttaiBleManager.liveGapRange(previousDataNo = 9744, liveDataNo = 9760),
+        )
+    }
+
+    @Test
+    fun aJumpPastTheCeilingIsNotLedgered() {
+        // The ceiling is the app's answer to "the sensor cannot be there yet". A dataNo beyond
+        // it is a corrupt frame, and enqueueing its span would ask for records that don't exist.
+        assertNull(
+            OttaiBleManager.liveGapRange(previousDataNo = 9744, liveDataNo = 20_000, ceiling = 9_800)
+        )
+    }
+
+    @Test
+    fun aSpanTooWideForTheLivePathIsLeftToTheReconciliation() {
+        // A whole-store hole is the initial backfill's problem. Spending the ledger's bounded
+        // attempts on it would starve the real dropouts it exists to repair.
+        assertNull(OttaiBleManager.liveGapRange(previousDataNo = 100, liveDataNo = 9_000))
+    }
+
+    @Test
+    fun aFirstEverSampleHasNothingBehindIt() {
+        assertNull(OttaiBleManager.liveGapRange(previousDataNo = -1, liveDataNo = 9760))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiParserTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiParserTests.kt
@@ -3,6 +3,7 @@ package tk.glucodata.drivers.ottai
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -197,6 +198,101 @@ class OttaiParserTests {
         assertEquals(OttaiParser.BLE_RECORD_SIZE_E12, OttaiParser.chooseRecordSize(payload, "E9.9.9(V3.1.ZZ0000.0)"))
         // Including a bare V1.7 with no E-number: ambiguous by name, decided by the data.
         assertEquals(OttaiParser.BLE_RECORD_SIZE_E12, OttaiParser.chooseRecordSize(payload, "V1.7.SH2542.1"))
+    }
+
+    /**
+     * The same CN V3 live frame, but with the seven padding bytes carrying leftover data
+     * instead of zeros. Read as two 8-byte records, the second one now falls entirely inside
+     * that padding and passes the vendor gate by accident — so the 8-byte reading ties the
+     * 9-byte one and the tie-break hands it the frame. This is the 2026-08-30 field failure:
+     * 112 of 702 live notifies framed as 8-byte, the padding record was rejected
+     * (`runtime=0 raw=0`), and the real sample went unexamined, costing fourteen consecutive
+     * minutes of a connected sensor.
+     */
+    @Test
+    fun chooseRecordSize_shortLiveNotifyCannotOutvoteALearnedLayout() {
+        val payload = hex("000000007600ffff1f3c34e115ba47c50b" + "000000401fac0d")
+
+        // Left to itself the frame gets it wrong — one record cannot outvote two.
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE,
+            OttaiParser.chooseRecordSize(payload, "E1.1.4(V1.7.S2530.1)"),
+        )
+
+        // Given the layout a real page already proved, it does not get a vote.
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE_E12,
+            OttaiParser.chooseRecordSize(
+                payload,
+                "E1.1.4(V1.7.S2530.1)",
+                learned = OttaiParser.BLE_RECORD_SIZE_E12,
+            ),
+        )
+
+        val records = OttaiParser.frameRecords(
+            payload,
+            "E1.1.4(V1.7.S2530.1)",
+            learned = OttaiParser.BLE_RECORD_SIZE_E12,
+        )
+        assertEquals(1, records.size)
+        val r = OttaiParser.parseRecord(records.single())
+        assertEquals(118, r.dataNo)
+        assertEquals(15391, r.rawCurrent)
+        assertEquals(30.13, r.temperatureC, 1e-9)
+    }
+
+    @Test
+    fun decisiveRecordSize_isNullForALiveNotify() {
+        // Two candidate records is not evidence, whichever way the padding happens to fall.
+        val tied = hex("000000007600ffff1f3c34e115ba47c50b" + "000000401fac0d")
+        val zeroPadded = hex("000000007600ffff1f3c34e115ba47c50b" + "00".repeat(7))
+        assertNull(OttaiParser.decisiveRecordSize(tied, "E1.1.4(V1.7.S2530.1)"))
+        assertNull(OttaiParser.decisiveRecordSize(zeroPadded, "E1.1.4(V1.7.S2530.1)"))
+    }
+
+    @Test
+    fun decisiveRecordSize_readsAPageThatCanActuallyDecide() {
+        // A polled live read: 96 bytes, nine 9-byte records. Nine valid against three.
+        val nineByteRead = ByteArray(96).also { p ->
+            for (i in 0 until 9) {
+                val src = 8 + i * 9
+                p[src] = 0x20; p[src + 1] = 0x1F              // current = 7968 LE
+                p[src + 6] = 0x47                             // voltage
+                p[src + 7] = 0xAC.toByte(); p[src + 8] = 0x0D // temp = 35.00 C LE
+            }
+        }
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE_E12,
+            OttaiParser.decisiveRecordSize(nineByteRead, "E1.1.4(V1.7.S2530.1)"),
+        )
+
+        // The Syai history page under the SAME version string decides the other way.
+        val eightBytePage = ByteArray(168).also { p ->
+            for (i in 0 until 20) {
+                val src = 8 + i * 8
+                p[src] = 5
+                p[src + 4] = 0x0C; p[src + 5] = 0x1E              // current = 7692 LE
+                p[src + 6] = 0xA4.toByte(); p[src + 7] = 0x0C     // temp = 32.36 C LE
+            }
+        }
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE,
+            OttaiParser.decisiveRecordSize(eightBytePage, "E1.1.4(V1.7.S2530.1)"),
+        )
+    }
+
+    @Test
+    fun decisiveRecordSize_trustsAConfirmedVersionString() {
+        // A confirmed family is not a guess, so even a one-record frame settles it.
+        val payload = hex("00000000814cffff1f3c34e115ba47c50b" + "00".repeat(15))
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE_E12,
+            OttaiParser.decisiveRecordSize(payload, "E1.2.3(V1.7.SH2542.1)"),
+        )
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE,
+            OttaiParser.decisiveRecordSize(payload, "V1.5.S2428.1"),
+        )
     }
 
     @Test


### PR DESCRIPTION
## What changed

- `OttaiParser` learns the BLE record width once, from a payload that can prove it (a confirmed version string, or a page where the winning layout holds at least 3 vendor-valid records and leads by 2), and `OttaiBleManager` persists it per sensor. Short frames use that answer instead of re-inferring.
- `OttaiBleManager` puts a gap revealed by a live sample straight onto the history hole ledger, bounded by the dataNo ceiling and by a maximum width.
- `HistoryDisplayMerge` keys its overlap padding off `GlucoseChartGap.THRESHOLD_MS` instead of its own 5-minute constant.
- `NotificationChartDrawer.drawSeries` applies the same gap threshold, and draws an unconnected reading as a dot.
- Added unit tests for all four.

## Why

A 2026-08-30 trace shows a 16-minute hole in the Ottai line on the dashboard, with a fragment of another sensor inside it, while the notification chart of the same minutes looks unbroken. The sensor was connected throughout and sent a live notify every minute.

**Record width.** `chooseRecordSize` re-inferred 8- vs 9-byte from every payload. A minute live notify is 24 bytes — header(8) + one 9-byte record + seven pad — which is also a header plus two 8-byte records. One candidate record cannot outvote two, so the tie fell to 8-byte. Record[1] was then assembled out of the padding, arrived as `runtime=0 raw=0` and was rejected, while the real sample in record[0] went unexamined because the live path reads only `records.last()`. This happened on 112 of 702 live frames in one 11.5-hour session, including 14 consecutive minutes.

The live path still reads only the last record. Walking every record is not safe while a wrong width is possible: a mis-decoded record[0] passes the validity gate as plausible glucose (the 505 °C case the `chooseRecordSize` KDoc describes). The current bug loses data; that change would invent it. With the width latched the frame has one record.

**Hole recovery.** `roomBackfillChecked` guards the initial whole-history reconciliation and latches once per connection. Every route to the hole ledger sits behind it, so nothing could re-request a hole opened later. On this trace the latch closed at 02:10 and the link stayed up 11.5 hours; the 15 lost records were never asked for again.

**Chart.** The hole is 16 minutes, under the chart's 17-minute `GlucoseChartGap.THRESHOLD_MS`, so the line would have bridged it. `HistoryDisplayMerge` used a 5-minute padding to decide ownership, which handed the uncovered middle to a third sensor reading about 0.5 mmol/L lower; `GlucosePointSegments` then broke the line at each sensor change. One bridgeable gap rendered as two holes and an orphan fragment.

**Notification.** `drawSeries` had no gap rule and joined consecutive points however far apart, so it drew a straight line across the missing 14 minutes. Adding the threshold alone would have hidden isolated readings, since a one-point run strokes nothing, hence the dot — matching `ChartLineRun` on the Compose side.

None of this is a regression: the affected code was identical on `main`, and `records.last()` dates to the "Ottai v4" commit.

## Verification

- `./gradlew :Common:testMobileDebugUnitTest` — passes on a clean build of this branch from `main`.
- `git diff --check`

New tests: `OttaiParserTests` (a padded live notify loses the stateless inference but cannot outvote a learned width; `decisiveRecordSize` is null for a live notify and reads both a 9-record live page and the 20-record Syai page correctly under the same version string), `OttaiLiveGapLedgerTests`, `HistoryDisplayMergeTests` (16-minute gap not filled, 45-minute outage still filled), `NotificationChartGapTests`.

Not yet exercised on a device: the mid-session ledger path. The trace proves the ledger was unreachable, not that the new route drains. To check, force a ~20-minute hole while staying connected and confirm `live gap ledgered` is followed by a `requestHistoryRange` with no reconnect between them.

## Follow-up

The remaining differences between the dashboard and notification charts are in query scope, not drawing: the notification asks for one sensor's serials, the dashboard for every sensor's rows. That is deliberate and is left alone here.