### PR TITLE
Mute ordinary high alerts whenever their arrow points down

### DIFF
--- a/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertConfig.kt
@@ -127,9 +127,10 @@ data class AlertConfig(
     // covers the projected overshoot x this factor. 0 = off. Never applied to
     // PRE_LOW - insulin makes a predicted low MORE likely.
     val iobCoverageFactor: Float? = null,
-    // PERSISTENT_HIGH only: suppress while the value falls at least this fast
-    // (mg/dl per minute, magnitude). The alert exists to say "your correction
-    // was not enough"; a steep fall is direct proof it was. 0 = off.
+    // PERSISTENT_HIGH: suppress while the value falls at least this fast
+    // (mg/dl per minute, magnitude). HIGH uses any positive value only as the
+    // opt-in marker for suppressing while its displayed arrow points down.
+    // 0/null = off.
     val fallRateSuppress: Float? = null,
 
     // Delta-counter settings (FALLING_FAST / RISING_FAST): GDH-style robust rate-of-change alarm.
@@ -284,40 +285,17 @@ object AlertDefaults {
     const val THRESHOLD_REARM_MARGIN_MGDL = 10f
     const val THRESHOLD_REARM_MARGIN_MMOL = 0.6f
 
-    // PERSISTENT_HIGH: silent while falling at least this fast (mg/dl/min).
     /**
-     * One scale for both high alerts, in whole arrows, because that is the only precision the
-     * number behind it has: it is a regression over the last ten to twenty minutes, not a
-     * measurement of this minute. The steps are this app's own vocabulary, the same ones it
-     * tells other apps through ExchangeTrend: one is a 45 degree fall, two is falling, three
-     * is falling fast.
-     *
-     * PERSISTENT_HIGH's default is the first of them. It used to be half, which this app draws
-     * as level, so the change makes it suppress less and alarm more.
+     * PERSISTENT_HIGH's adjustable fall threshold. It has already waited out a duration, so a
+     * configurable minimum is useful here; ordinary HIGH instead follows its visible arrow.
      */
     const val FALL_RATE_SUPPRESS_MGDL_PER_MIN = 1.0f
 
-    /** The step the scale moves in, so the slider and the floor cannot drift apart. */
+    /** The step the PERSISTENT_HIGH slider moves in. */
     const val FALL_RATE_STEP_MGDL_PER_MIN = 1.0f
 
-    /** The furthest the scale goes: a fall this app calls fast. */
+    /** The furthest the PERSISTENT_HIGH scale goes: a fall this app calls fast. */
     const val FALL_RATE_MAX_MGDL_PER_MIN = 3.0f
-
-    /**
-     * HIGH's bar, and it is a different question. That alert fires the moment the line is
-     * crossed and is the one somebody relies on to hear about a high at all, so silencing it
-     * needs a fall this app would actually call a fall. Its own vocabulary: TrendArrowAngle
-     * draws anything under 0.5 as level, and ExchangeTrend, which is what it tells other
-     * apps, does not say "falling" until 2.0 and "falling fast" until 3.0. Two is a real
-     * downward arrow, around 120 mg/dl an hour.
-     */
-    const val HIGH_FALL_RATE_MGDL_PER_MIN = 2.0f
-
-    /**
-     * And nothing quieter than this may silence a high, whatever is stored: one is where this
-     * app stops calling the movement level. A setting below it is treated as this.
-     */
-    const val HIGH_FALL_RATE_FLOOR_MGDL_PER_MIN = 1.0f
 
     // PRE_HIGH IOB coverage: suppress when remaining insulin effect covers the
     // full projected overshoot (factor 1.0). Conservative: only a complete
@@ -365,9 +343,9 @@ object AlertDefaults {
                 // Off unless asked for. The same rule as PERSISTENT_HIGH, but this is the
                 // alarm somebody relies on to hear about a high at all, and it is on by
                 // default: switching it to conditional under everybody who upgrades is not
-                // a decision to make on their behalf. The slider turns it on, and the
-                // magnitude it lands on is the flat-arrow boundary, so a drift the app draws
-                // as level does not silence anything unless that is what was asked for.
+                // a decision to make on their behalf. The toggle turns it on; once enabled,
+                // the displayed arrow is the contract, so a flat arrow never silences it and
+                // a downward arrow always does.
                 fallRateSuppress = null,
                 defaultSnoozeMinutes = 30
             )

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRepository.kt
@@ -91,7 +91,8 @@ object AlertRepository {
         return prefs.getFloat(key, 0f).takeIf { it.isFinite() }?.coerceAtLeast(0f) ?: default
     }
 
-    // PERSISTENT_HIGH only: fall-rate suppression (mg/dl/min). 0 = off.
+    // HIGH: positive = opt in to down-arrow suppression. PERSISTENT_HIGH: configured
+    // fall-rate magnitude (mg/dl/min). 0 = off for either type.
     private fun keyFallRateSuppress(type: AlertType) = "alert_${type.id}_fallRateSuppress"
 
     private fun readFallRateSuppress(type: AlertType, default: Float?): Float? {

--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -229,8 +229,8 @@ object AlertRuntimeManager {
             ?: return AlertRuntimeEvaluation()
         val condition = activeConditions[type] ?: return AlertRuntimeEvaluation()
 
-        // Coming down fast enough that the alert's own sentence is being disproved as it is
-        // read. It waits rather than resolves: the episode stays open, so a dismissal and
+        // The opted-in alert would be shown beside a downward arrow, contradicting its own
+        // sentence. It waits rather than resolves: the episode stays open, so a dismissal and
         // whatever was queued on it survive, and the moment the fall stops it can speak
         // without waiting out a fresh episode. Anything already repeating stops now.
         if (type == AlertType.HIGH &&

--- a/Common/src/main/java/tk/glucodata/alerts/FallSuppressionPolicy.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/FallSuppressionPolicy.kt
@@ -1,9 +1,11 @@
 package tk.glucodata.alerts
 
+import tk.glucodata.TrendArrowAngle
+
 /**
  * Suppression rule for the high alerts that are about a value not coming down:
  * PERSISTENT_HIGH, which says "your correction was not enough", and HIGH, which says
- * "you are high". A steep fall is the direct proof that the correction is working, so
+ * "you are high". A visible fall is the direct proof that the correction is working, so
  * firing during one announces the opposite of what the curve shows (field cases:
  * "persistent high" at 226 mg/dl under a double down arrow, and a plain "high" arriving
  * while the value dropped eighteen in a minute).
@@ -14,28 +16,28 @@ package tk.glucodata.alerts
  * Deliberately rate-based, no insulin arithmetic: unlike the PRE_HIGH
  * coverage check ([ForecastIobCoverage]), which reasons about a PREDICTION,
  * the observed direction suffices here - the falling value already proves the
- * insulin is working. With IOB active and the value FALLING the alert stays
- * silent; with IOB active and the value STAGNANT above threshold it still
- * fires - that is exactly what it is for.
+ * correction is working. With the value FALLING the opted-in alert stays
+ * silent; with the value STAGNANT above threshold it still fires.
  */
 internal object FallSuppressionPolicy {
 
     /**
-     * True while the value falls at least as fast as the configured magnitude
-     * (mg/dl per minute; the rate estimate is unit-independent). 0 or unset
-     * limit disables the suppression - regression to today's behaviour.
-     */
-    /**
-     * The same rule for HIGH, with two differences that matter for the alert somebody relies
-     * on to hear about a high at all: it is off unless a limit was set, and no limit quieter
-     * than [AlertDefaults.HIGH_FALL_RATE_FLOOR_MGDL_PER_MIN] counts, so a value merely
-     * drifting can never take this alarm away.
+     * HIGH is off unless a positive value was saved, preserving the alarm for users who never
+     * opted in. Once enabled, its boundary is the renderer's own boundary: if the rate paints
+     * a downward arrow on the alarm screen, HIGH stays quiet. Treat the stored positive value
+     * as the opt-in marker so existing non-zero settings acquire the promised semantics without
+     * a preference migration.
      */
     fun highFallingSuppresses(rate: Float, fallRateSuppress: Float?): Boolean {
-        val asked = fallRateSuppress?.takeIf { it.isFinite() && it > 0f } ?: return false
-        return fallingSuppresses(rate, asked.coerceAtLeast(AlertDefaults.HIGH_FALL_RATE_FLOOR_MGDL_PER_MIN))
+        fallRateSuppress?.takeIf { it.isFinite() && it > 0f } ?: return false
+        return TrendArrowAngle.rotationDegrees(rate) > 0f
     }
 
+    /**
+     * PERSISTENT_HIGH is quiet while the value falls at least as fast as the configured
+     * magnitude (mg/dl per minute; the rate estimate is unit-independent). 0 disables it;
+     * unset uses that alert's default.
+     */
     fun fallingSuppresses(rate: Float, fallRateSuppress: Float?): Boolean {
         val limit = fallRateSuppress ?: AlertDefaults.FALL_RATE_SUPPRESS_MGDL_PER_MIN
         if (!limit.isFinite() || limit <= 0f) {

--- a/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/alerts/AlertSettingsScreen.kt
@@ -1161,15 +1161,32 @@ private fun AlertSettingsExpanded(
                     )
                 }
 
-                // === Falling-value suppression ===
-                // These alerts say the value is not coming down; a steep fall proves it is.
-                // Slider in tenths of mg/dl per minute; 0 = off. VERY_HIGH is not among them:
-                // there the number itself is the problem.
-                if (config.type == AlertType.PERSISTENT_HIGH || config.type == AlertType.HIGH) {
-                    // One scale for both, in whole arrows: that is all the precision the
-                    // number behind it has, and it is the app's own vocabulary for what an
-                    // arrow means. Each step names itself, so the setting can be read
-                    // without knowing what a rate in mg/dL per minute looks like.
+                // HIGH follows the exact arrow shown on its alarm screen. A saved positive
+                // value from the former slider counts as enabled, so existing opt-ins do not
+                // need a preference migration.
+                if (config.type == AlertType.HIGH) {
+                    ClickableToggleRow(
+                        icon = Icons.AutoMirrored.Filled.TrendingDown,
+                        title = stringResource(R.string.persistent_high_fall_suppress_label),
+                        checked = (config.fallRateSuppress ?: 0f) > 0f,
+                        onCheckedChange = { enabled ->
+                            onConfigChange(
+                                config.copy(
+                                    fallRateSuppress = if (enabled) {
+                                        AlertDefaults.FALL_RATE_SUPPRESS_MGDL_PER_MIN
+                                    } else {
+                                        null
+                                    }
+                                )
+                            )
+                        }
+                    )
+                }
+
+                // PERSISTENT_HIGH has already waited out a duration and keeps its adjustable
+                // fall threshold. VERY_HIGH is excluded because there the number itself is
+                // the problem, whichever way it is moving.
+                if (config.type == AlertType.PERSISTENT_HIGH) {
                     DurationSlider(
                         label = stringResource(R.string.persistent_high_fall_suppress_label),
                         value = (((config.fallRateSuppress ?: 0f) * 10f) + 0.5f).toInt(),

--- a/Common/src/test/java/tk/glucodata/alerts/FallSuppressionPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/FallSuppressionPolicyTests.kt
@@ -3,6 +3,7 @@ package tk.glucodata.alerts
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import tk.glucodata.TrendArrowAngle
 
 /**
  * PERSISTENT_HIGH suppression while a correction visibly works. Field case:
@@ -49,46 +50,38 @@ class FallSuppressionPolicyTests {
         assertFalse(FallSuppressionPolicy.fallingSuppresses(rate = Float.NaN, fallRateSuppress = 0.5f))
     }
 
-    /**
-     * HIGH is the alarm somebody relies on to hear about a high at all, and it fires the
-     * moment the line is crossed, so silencing it takes a fall this app would call a fall.
-     * Its own vocabulary: under 0.5 is drawn level, and it does not tell other apps
-     * "falling" until 2.0.
-     */
     @Test
-    fun aHighIsOnlySilencedByAFallThisAppWouldCallOne() {
-        val asked = AlertDefaults.HIGH_FALL_RATE_MGDL_PER_MIN
+    fun enabledHighSuppressionExactlyMatchesTheDrawnDownArrow() {
+        val enabled = AlertDefaults.FALL_RATE_SUPPRESS_MGDL_PER_MIN
+        val rates = listOf(-5f, -2f, -1.9f, -1f, -0.51f, -0.5f, -0.49f, 0f, 0.51f, 2f, Float.NaN)
 
-        assertTrue(FallSuppressionPolicy.highFallingSuppresses(rate = -2.5f, fallRateSuppress = asked))
-        assertTrue(FallSuppressionPolicy.highFallingSuppresses(rate = -2.0f, fallRateSuppress = asked))
-        // A value coming down thirty an hour is not the correction plainly working.
-        assertFalse(FallSuppressionPolicy.highFallingSuppresses(rate = -0.5f, fallRateSuppress = asked))
-        assertFalse(FallSuppressionPolicy.highFallingSuppresses(rate = -1.9f, fallRateSuppress = asked))
+        rates.forEach { rate ->
+            val arrowPointsDown = TrendArrowAngle.rotationDegrees(rate) > 0f
+            assertTrue(
+                "rate=$rate arrowPointsDown=$arrowPointsDown",
+                FallSuppressionPolicy.highFallingSuppresses(rate, enabled) == arrowPointsDown
+            )
+        }
     }
 
-    /** Nothing quieter than the floor counts, whatever is stored or edited into the file. */
+    /** Every former non-zero slider choice was an opt-in and now gets the same arrow rule. */
     @Test
-    fun aStoredLimitBelowTheFloorDoesNotSilenceAHigh() {
-        assertFalse(FallSuppressionPolicy.highFallingSuppresses(rate = -0.6f, fallRateSuppress = 0.2f))
-        assertFalse(FallSuppressionPolicy.highFallingSuppresses(rate = -0.9f, fallRateSuppress = 0.5f))
-        // At the floor it does, since that is where this app stops calling the movement level.
-        assertTrue(
-            FallSuppressionPolicy.highFallingSuppresses(
-                rate = -1.0f,
-                fallRateSuppress = AlertDefaults.HIGH_FALL_RATE_FLOOR_MGDL_PER_MIN
-            )
-        )
+    fun anExistingPositiveHighSettingRemainsEnabled() {
+        assertTrue(FallSuppressionPolicy.highFallingSuppresses(rate = -0.6f, fallRateSuppress = 0.2f))
+        assertTrue(FallSuppressionPolicy.highFallingSuppresses(rate = -0.6f, fallRateSuppress = 1.0f))
+        assertTrue(FallSuppressionPolicy.highFallingSuppresses(rate = -0.6f, fallRateSuppress = 3.0f))
     }
 
     /** Off unless asked for: no limit means the alarm somebody has today, unchanged. */
     @Test
     fun aHighWithNoLimitSetIsNeverSilenced() {
+        assertTrue(AlertDefaults.defaultConfig(AlertType.HIGH, isMmol = true).fallRateSuppress == null)
         assertFalse(FallSuppressionPolicy.highFallingSuppresses(rate = -5.0f, fallRateSuppress = null))
         assertFalse(FallSuppressionPolicy.highFallingSuppresses(rate = -5.0f, fallRateSuppress = 0f))
         assertFalse(
             FallSuppressionPolicy.highFallingSuppresses(
                 rate = Float.NaN,
-                fallRateSuppress = AlertDefaults.HIGH_FALL_RATE_MGDL_PER_MIN
+                fallRateSuppress = AlertDefaults.FALL_RATE_SUPPRESS_MGDL_PER_MIN
             )
         )
     }


### PR DESCRIPTION
The existing "Mute while falling" setting for the ordinary High alert did not match the alarm screen. It stored a rate threshold, so a High alert could still open full screen while the same fired rate drew a downward arrow. This change makes the opt-in setting follow the screen's arrow instead.

## Changes

- Treat any existing positive High fall-suppression value as enabled and suppress High whenever the production arrow renderer points down.
- Replace the High rate slider with an on/off toggle while keeping the adjustable threshold for Persistent high.
- Keep suppression off by default for users who never opted in. Existing nonzero values remain enabled without a preference migration.

## Verification

- `./gradlew :Common:testMobileReleaseUnitTest`
- `./gradlew :Common:testMobileReleaseUnitTest --tests tk.glucodata.alerts.FallSuppressionPolicyTests --rerun-tasks` on the local integration branch
- Device verification confirmed on September 6, 2026.

