### PR TITLE
Suppress forecast low for flat or rising arrows and sufficient COB

### DIFF
--- a/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/AlertRuntimeManager.kt
@@ -32,6 +32,7 @@ object AlertRuntimeManager {
     private var persistentHighStartedAtMs: Long = 0L
     private var lastLoggedExpiryEndMs: Long = Long.MIN_VALUE
     private var warnedForecastRateUntrusted = false
+    private var preLowSuppressionReason: String? = null
     private var preHighIobSuppressed = false
     private var preHighCoverageSkipLogged: String? = null
     private val standardEpisodes = AlertEpisodeState<AlertType>()
@@ -214,9 +215,12 @@ object AlertRuntimeManager {
         val glucoseValue = currentGlucoseValueLocked() ?: return AlertRuntimeEvaluation()
         val rate = currentRateLocked()
         val configs = standardGlucoseAlertTypes.associateWith { AlertRepository.loadConfig(it) }
-        val activeConditions = suppressIobCoveredPreHigh(
-            resolveActiveStandardGlucoseAlerts(glucoseValue, rate, configs),
-            configs
+        val activeConditions = suppressPreLow(
+            suppressIobCoveredPreHigh(
+                resolveActiveStandardGlucoseAlerts(glucoseValue, rate, configs),
+                configs
+            ),
+            rate
         )
         val activeTypes = activeConditions.keys
         val transition = standardEpisodes.update(activeTypes)
@@ -294,6 +298,38 @@ object AlertRuntimeManager {
             wasConditionActive = standardEpisodes::isActive,
             forecastRateTrusted = forecastRateTrusted
         )
+    }
+
+    private fun suppressPreLow(
+        conditions: Map<AlertType, StandardGlucoseAlertCondition>,
+        rate: Float
+    ): Map<AlertType, StandardGlucoseAlertCondition> {
+        preLowSuppressionReason = null
+        val condition = conditions[AlertType.PRE_LOW] ?: return conditions
+        if (!ForecastLowSuppression.hasDownwardArrow(rate)) {
+            preLowSuppressionReason = "forecast-low-not-falling"
+            return conditions - AlertType.PRE_LOW
+        }
+        val covered = try {
+            val nowMs = System.currentTimeMillis()
+            val cobGrams = tk.glucodata.JournalIobAccess.snapshot(nowMs)?.getOrNull(2) ?: Float.NaN
+            val prefs = Applic.app.getSharedPreferences(
+                "tk.glucodata_preferences", android.content.Context.MODE_PRIVATE
+            )
+            val profile = tk.glucodata.data.prediction.PredictionModelProfileStore.parametersAt(prefs, nowMs)
+            ForecastLowSuppression.cobCoversLow(
+                condition.evaluatedValue, condition.threshold, Applic.unit == 1,
+                cobGrams, profile.carbRatioGramsPerUnit, profile.insulinSensitivityMgDlPerUnit
+            )
+        } catch (t: Throwable) {
+            Log.stack(LOG_ID, "suppressPreLow", t)
+            false
+        }
+        if (covered) {
+            preLowSuppressionReason = "forecast-cob-covered"
+            return conditions - AlertType.PRE_LOW
+        }
+        return conditions
     }
 
     /**
@@ -390,6 +426,9 @@ object AlertRuntimeManager {
     ): String {
         if (type != AlertType.PRE_LOW && type != AlertType.PRE_HIGH) {
             return "standard-condition-cleared"
+        }
+        if (type == AlertType.PRE_LOW) {
+            preLowSuppressionReason?.let { return it }
         }
         if (type == AlertType.PRE_HIGH && preHighIobSuppressed) {
             return "forecast-iob-covered"

--- a/Common/src/main/java/tk/glucodata/alerts/ForecastLowSuppression.kt
+++ b/Common/src/main/java/tk/glucodata/alerts/ForecastLowSuppression.kt
@@ -1,0 +1,36 @@
+package tk.glucodata.alerts
+
+import tk.glucodata.TrendArrowAngle
+
+/** Delivery gates for PRE_LOW only; measured LOW and VERY_LOW remain independent. */
+internal object ForecastLowSuppression {
+    fun hasDownwardArrow(rate: Float): Boolean = TrendArrowAngle.rotationDegrees(rate) > 0f
+
+    /**
+     * Remaining COB can potentially fill the forecast's shortfall. Use the same
+     * carb ratio and sensitivity as the prediction profile. This estimates total
+     * remaining effect, not a guarantee of absorption within the forecast horizon.
+     * It changes alert eligibility, never the underlying trend projection.
+     */
+    fun cobCoversLow(
+        projectedValue: Float,
+        threshold: Float,
+        isMmol: Boolean,
+        cobGrams: Float,
+        carbRatioGramsPerUnit: Float,
+        insulinSensitivityMgdlPerUnit: Float
+    ): Boolean {
+        if (!cobGrams.isFinite() || cobGrams <= 0f ||
+            !carbRatioGramsPerUnit.isFinite() || carbRatioGramsPerUnit <= 0f ||
+            !insulinSensitivityMgdlPerUnit.isFinite() || insulinSensitivityMgdlPerUnit <= 0f ||
+            !projectedValue.isFinite() || !threshold.isFinite() || threshold <= 0f
+        ) return false
+
+        // An active episode can outlive its projected crossing. Positive COB
+        // also covers a zero shortfall; absent COB does not grant suppression.
+        val shortfallMgdl = (threshold.toDouble() - projectedValue).coerceAtLeast(0.0) *
+            (if (isMmol) 18.0182 else 1.0)
+        val remainingRiseMgdl = cobGrams.toDouble() / carbRatioGramsPerUnit * insulinSensitivityMgdlPerUnit
+        return remainingRiseMgdl >= shortfallMgdl
+    }
+}

--- a/Common/src/test/java/tk/glucodata/alerts/ForecastLowSuppressionTests.kt
+++ b/Common/src/test/java/tk/glucodata/alerts/ForecastLowSuppressionTests.kt
@@ -1,0 +1,73 @@
+package tk.glucodata.alerts
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ForecastLowSuppressionTests {
+    @Test
+    fun flatAndRisingArrowsBlockEvenWithoutCarbs() {
+        for (rate in listOf(-0.5f, -0.2f, -0.0f, 0f, 0.5f, 1f, 3f)) {
+            assertFalse("rate=$rate", ForecastLowSuppression.hasDownwardArrow(rate))
+        }
+    }
+
+    @Test
+    fun everyDownwardArrowPassesTheDirectionGate() {
+        for (rate in listOf(-0.5001f, -0.75f, -1f, -2f, -10f)) {
+            assertTrue("rate=$rate", ForecastLowSuppression.hasDownwardArrow(rate))
+        }
+    }
+
+    @Test
+    fun unavailableArrowDoesNotPermitForecastLow() {
+        for (rate in listOf(Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY)) {
+            assertFalse(ForecastLowSuppression.hasDownwardArrow(rate))
+        }
+    }
+
+    @Test
+    fun absentOrInsufficientCarbsDoNotCoverTheLow() {
+        // A 20 mg/dL shortfall needs 4 g at 10 g/U and 50 mg/dL/U.
+        for (cob in listOf(Float.NaN, Float.POSITIVE_INFINITY, -1f, 0f, 3.99f)) {
+            assertFalse("COB=$cob", covered(cob))
+        }
+    }
+
+    @Test
+    fun exactOrGreaterCoverageSuppressesTheForecast() {
+        assertTrue(covered(4f))
+        assertTrue(covered(10f))
+    }
+
+    @Test
+    fun coverageUsesTheConfiguredCarbRatioAndSensitivity() {
+        assertFalse(ForecastLowSuppression.cobCoversLow(50f, 70f, false, 4f, 20f, 50f))
+        assertTrue(ForecastLowSuppression.cobCoversLow(50f, 70f, false, 4f, 20f, 100f))
+    }
+
+    @Test
+    fun mmolShortfallIsConvertedBeforeComparingCarbEffect() {
+        assertFalse(ForecastLowSuppression.cobCoversLow(3f, 4f, true, 3.6f, 10f, 50f))
+        assertTrue(ForecastLowSuppression.cobCoversLow(3f, 4f, true, 3.61f, 10f, 50f))
+    }
+
+    @Test
+    fun invalidProfileOrForecastDoesNotClaimCoverage() {
+        for (invalid in listOf(Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, 0f, -1f)) {
+            assertFalse(ForecastLowSuppression.cobCoversLow(50f, 70f, false, 10f, invalid, 50f))
+            assertFalse(ForecastLowSuppression.cobCoversLow(50f, 70f, false, 10f, 10f, invalid))
+            assertFalse(ForecastLowSuppression.cobCoversLow(50f, invalid, false, 10f, 10f, 50f))
+        }
+        assertFalse(ForecastLowSuppression.cobCoversLow(Float.NaN, 70f, false, 10f, 10f, 50f))
+    }
+
+    @Test
+    fun recoveredProjectionInAnOpenEpisodeStillRequiresPositiveCob() {
+        assertTrue(ForecastLowSuppression.cobCoversLow(75f, 70f, false, 1f, 10f, 50f))
+        assertFalse(ForecastLowSuppression.cobCoversLow(75f, 70f, false, 0f, 10f, 50f))
+    }
+
+    private fun covered(cob: Float) =
+        ForecastLowSuppression.cobCoversLow(50f, 70f, false, cob, 10f, 50f)
+}


### PR DESCRIPTION
Forecast low can remain active after the trend arrow has flattened or turned upward, including when no carbs are on board. It also lacks a check for carbs that could cover the predicted shortfall. This change requires a downward arrow and suppresses the forecast warning when remaining COB could bring the projected value back to its low threshold.

- Use the displayed arrow's direction boundary, including its flat range. This applies even with no COB.
- Estimate COB's potential remaining glucose effect from the current prediction profile's carb ratio and insulin sensitivity. Missing or insufficient COB does not suppress a downward forecast.
- Clear suppressed forecast-low episodes through the existing lifecycle, cancelling pending retries. Measured Low and Very low alerts keep their existing behavior.

The COB comparison uses total remaining effect; it does not predict absorption timing within the forecast horizon or change the trend projection.

Verification: `./gradlew :Common:testMobileReleaseUnitTest` passed all 2,091 tests with zero failures, errors or skips on this branch. Nine new tests cover arrow boundaries, absent and insufficient COB, exact coverage, profile values, mmol conversion and invalid inputs. Device verification is pending.
