### PR TITLE
Add entrypoint to connect google health in settings

### DIFF
--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -220,6 +220,8 @@
     <string name="broadcast_computed_trend_desc">Use the app’s trend instead of the sensor’s</string>
     <string name="xdrip_compatible_title">xDrip broadcast</string>
     <string name="xdrip_compatible_desc">AAPS compatible</string>
+    <string name="health_connect_title">Health Connect</string>
+    <string name="health_connect_desc">Send glucose readings to Health Connect for compatible health apps</string>
     <string name="sensorpermission">Sensors permission</string>
  <string name="sensorpermissionmessage">needed to display heart rate. Set it in Device Settings, Apps, Permissions, Juggluco</string>
  <string name="floatglucose">Floating glucose</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
@@ -5,6 +5,7 @@ package tk.glucodata.ui
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -63,6 +64,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tk.glucodata.BuildConfig
 import tk.glucodata.DataSmoothing
+import tk.glucodata.HealthConnection
+import tk.glucodata.MainActivity
 import tk.glucodata.Natives
 import tk.glucodata.OutboundApiSettings
 import tk.glucodata.R
@@ -128,6 +131,7 @@ fun ExpressiveSettingsScreen(
     val journalEnabled by viewModel.journalEnabled.collectAsState()
     val predictiveSimulationEnabled by viewModel.predictiveSimulationEnabled.collectAsState()
     val alertsMasterEnabled by viewModel.alertsMasterEnabled.collectAsState()
+    var healthConnectEnabled by rememberSaveable { mutableStateOf(Natives.gethealthConnect()) }
     val viewMode by viewModel.viewMode.collectAsState()
     val sensorName by viewModel.sensorName.collectAsState()
     val isRawCalibrationMode = viewMode == 1 || viewMode == 3
@@ -416,6 +420,27 @@ fun ExpressiveSettingsScreen(
                         iconTint = exchangeColor,
                         position = CardPosition.MIDDLE,
                         onCheckedChange = { viewModel.setBroadcastComputedTrend(it) }
+                    )
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    SettingsSwitchItem(
+                        title = stringResource(R.string.health_connect_title),
+                        subtitle = stringResource(R.string.health_connect_desc),
+                        checked = healthConnectEnabled,
+                        icon = Icons.Default.HealthAndSafety,
+                        iconTint = exchangeColor,
+                        position = CardPosition.MIDDLE,
+                        onCheckedChange = { enabled ->
+                            Natives.sethealthConnect(enabled)
+                            healthConnectEnabled = enabled
+                            if (enabled) {
+                                MainActivity.tryHealth = 5
+                                (context.findActivity() as? MainActivity)?.let(HealthConnection::init)
+                            } else {
+                                MainActivity.tryHealth = 0
+                                HealthConnection.stop()
+                            }
+                        }
                     )
                 }
                 SettingsItem(


### PR DESCRIPTION
Google health connect is already implemented (coming from the original Juggluco repo), but there isn't an entry point in settings to enable health connect.

This PR adds the entry point, and now you can export glucose data to Google Health from this app.

Screenshot:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/0317dc02-1fc9-41f6-afef-9cd04d86e6e3" />

Fixes #278 
