### PR TITLE
Stop shipping x86 and x86_64

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -50,13 +50,18 @@ android {
     }
 
     defaultConfig {
+        // Ship ARM only. x86 and x86_64 are emulator and ChromeOS territory; on a phone app
+        // they were half the native payload for hardware nobody wears a sensor next to.
+        // armeabi-v7a stays: minSdk is 26, and 32-bit ARM handsets of that vintage are
+        // exactly what people leave plugged in as a dedicated CGM receiver.
+        //
         // Build for one architecture when asked: -PjugglucoAbi=arm64-v8a. A phone needs one
-        // of the four, and the other three are most of the download. Unset, nothing changes
-        // and the APK stays universal, which is what a release has to be.
-        if (project.hasProperty('jugglucoAbi')) {
-            ndk {
-                abiFilters(*project.property('jugglucoAbi').split(',').collect { it.trim() })
-            }
+        // of the two, and the other is most of what is left. The property replaces this list
+        // rather than narrowing it, so -PjugglucoAbi=x86_64 still builds an emulator APK.
+        ndk {
+            abiFilters(*(project.hasProperty('jugglucoAbi')
+                    ? project.property('jugglucoAbi').split(',').collect { it.trim() }
+                    : ['arm64-v8a', 'armeabi-v7a']))
         }
 
         applicationId = "tk.glucodata.ng"


### PR DESCRIPTION
Release APKs carried four ABIs. This drops `x86` and `x86_64`, leaving `arm64-v8a` + `armeabi-v7a`.

**Why these two go:** x86/x86_64 are emulator and ChromeOS territory. For an app whose whole job is talking to a sensor on someone's arm, they are native payload for hardware nobody runs it on.

**Why armeabi-v7a stays:** `minSdk` is 26, so Android 8-era hardware is supported deliberately, and some of that hardware is 32-bit ARM. An old handset left plugged in as a dedicated CGM receiver is an entirely ordinary way to run this app — a worse population to cut off than most.

`-PjugglucoAbi=` keeps working, and now *replaces* the default list instead of narrowing it, so `-PjugglucoAbi=x86_64` still produces an emulator APK when someone wants one.

Verified with `:Common:assembleMobileDebug --dry-run`: the default configures CMake for `arm64-v8a` and `armeabi-v7a` only; with `-PjugglucoAbi=x86_64` it configures `x86_64` only.

The x86 prebuilt `.so` files under `src/main/jniLibs` and `src/libre3/jniLibs` are left in the tree — `abiFilters` keeps them out of the APK, and deleting binaries is a separate call.