### PR TITLE
Read bluetooth poll interval from settings rather than hardcode it to 60s

### DIFF
--- a/Common/src/main/java/tk/glucodata/Libre2GattCallback.java
+++ b/Common/src/main/java/tk/glucodata/Libre2GattCallback.java
@@ -65,6 +65,7 @@ import static tk.glucodata.Natives.processTooth;
 
 public class Libre2GattCallback extends SuperGattCallback {
 	private int conphase = 0;
+	private final Libre2ReadingIntervalGate readingIntervalGate = new Libre2ReadingIntervalGate();
 
        static private final UUID mADCCustomServiceUUID = UUID.fromString("0000fde3-0000-1000-8000-00805f9b34fb");
 	static private final String LOG_ID = "Libre2GattCallback";
@@ -463,7 +464,13 @@ private	void oldonCharacteristicChanged(byte[] value) {
 						if(newpacket!=null) {
 							long res = processTooth(dataptr, newpacket);
 							if(res!=1L) {
-								handleGlucoseResult(res,timmsec);
+								final int glucose = (int) (res & 0xFFFFFFFFL);
+								if(glucose == 0 || readingIntervalGate.shouldPublish(Libre2ReadingInterval.getMinutes())) {
+									handleGlucoseResult(res,timmsec);
+									}
+								else if(doLog) {
+									Log.i(LOG_ID, SerialNumber + " reading suppressed by Libre 2 interval");
+									}
 								}
 							}
 						datatime=timmsec;

--- a/Common/src/main/java/tk/glucodata/Libre2ReadingInterval.kt
+++ b/Common/src/main/java/tk/glucodata/Libre2ReadingInterval.kt
@@ -1,0 +1,59 @@
+package tk.glucodata
+
+import android.content.Context
+
+object Libre2ReadingInterval {
+    const val DEFAULT_MINUTES = 1
+
+    private const val PREFS_NAME = "tk.glucodata_preferences"
+    private const val PREF_KEY = "libre2_reading_interval_minutes"
+    private val allowedMinutes = intArrayOf(1, 2, 5)
+
+    @JvmStatic
+    fun options(): IntArray = allowedMinutes.copyOf()
+
+    @JvmStatic
+    fun sanitize(minutes: Int): Int =
+        if (allowedMinutes.contains(minutes)) minutes else DEFAULT_MINUTES
+
+    @JvmStatic
+    fun getMinutes(): Int {
+        val context = Applic.app ?: return DEFAULT_MINUTES
+        return getMinutes(context)
+    }
+
+    @JvmStatic
+    fun getMinutes(context: Context): Int =
+        sanitize(
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getInt(PREF_KEY, DEFAULT_MINUTES)
+        )
+
+    @JvmStatic
+    fun setMinutes(context: Context, minutes: Int) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putInt(PREF_KEY, sanitize(minutes))
+            .apply()
+    }
+}
+
+internal class Libre2ReadingIntervalGate {
+    private var intervalMinutes = Libre2ReadingInterval.DEFAULT_MINUTES
+    private var readingsToSkip = 0
+
+    @Synchronized
+    fun shouldPublish(configuredMinutes: Int): Boolean {
+        val sanitizedMinutes = Libre2ReadingInterval.sanitize(configuredMinutes)
+        if (sanitizedMinutes != intervalMinutes) {
+            intervalMinutes = sanitizedMinutes
+            readingsToSkip = 0
+        }
+        if (readingsToSkip > 0) {
+            readingsToSkip--
+            return false
+        }
+        readingsToSkip = intervalMinutes - 1
+        return true
+    }
+}

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -805,6 +805,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="turbo_desc">Requests high connection priority</string>
     <string name="autoconnect_title">AutoConnect</string>
     <string name="autoconnect_desc">Uses passive background connection</string>
+    <string name="libre2_interval_title">Libre 2 update interval</string>
+    <string name="libre2_interval_desc">Choose how often Libre 2 readings update alerts and integrations. The sensor still communicates every minute.</string>
+    <string name="libre2_interval_default_option">1 min (default)</string>
     <string name="graph_smoothing_title">Data smoothing</string>
     <string name="graph_smoothing_desc">Smooth chart data and, unless Smooth only graph is enabled, resolved glucose values</string>
     <string name="graph_smoothing_none">Disabled</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExpressiveSettingsScreen.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tk.glucodata.BuildConfig
 import tk.glucodata.DataSmoothing
+import tk.glucodata.Libre2ReadingInterval
 import tk.glucodata.Natives
 import tk.glucodata.OutboundApiSettings
 import tk.glucodata.R
@@ -163,6 +164,7 @@ fun ExpressiveSettingsScreen(
     var showClearHistoryDialog by remember { mutableStateOf(false) }
     var showClearDataDialog by remember { mutableStateOf(false) }
     var showFactoryResetDialog by remember { mutableStateOf(false) }
+    var showLibre2IntervalDialog by remember { mutableStateOf(false) }
     var isClearing by remember { mutableStateOf(false) }
     var showExportDialog by remember { mutableStateOf(false) }
     var pendingSettingsImportUri by remember { mutableStateOf<Uri?>(null) }
@@ -173,6 +175,9 @@ fun ExpressiveSettingsScreen(
     // Advanced settings
     var turbo by remember { mutableStateOf(Natives.getpriority()) }
     var autoConnect by remember { mutableStateOf(Natives.getAndroid13()) }
+    var libre2IntervalMinutes by remember {
+        mutableIntStateOf(Libre2ReadingInterval.getMinutes(context))
+    }
     val handoverPrefs = remember {
         context.getSharedPreferences("tk.glucodata_preferences", android.content.Context.MODE_PRIVATE)
     }
@@ -542,6 +547,15 @@ fun ExpressiveSettingsScreen(
                     position = CardPosition.MIDDLE,
                     onCheckedChange = { SensorBluetooth.setAutoconnect(it); autoConnect = it }
                 )
+                SettingsItem(
+                    title = stringResource(R.string.libre2_interval_title),
+                    subtitle = stringResource(R.string.minutes_short_format, libre2IntervalMinutes),
+                    showArrow = true,
+                    icon = Icons.Default.Schedule,
+                    iconTint = advColor,
+                    position = CardPosition.MIDDLE,
+                    onClick = { showLibre2IntervalDialog = true }
+                )
                 SettingsSwitchItem(
                     title = stringResource(R.string.sensor_handover_title),
                     subtitle = stringResource(R.string.sensor_handover_desc),
@@ -756,6 +770,15 @@ fun ExpressiveSettingsScreen(
         context.findActivity()?.hardRestart() 
     }, { showUnitDialog = false })
     if (showThemeDialog) ThemePickerDialog(themeMode, { onThemeChanged(it); showThemeDialog = false }, { showThemeDialog = false })
+    if (showLibre2IntervalDialog) Libre2IntervalPickerDialog(
+        currentMinutes = libre2IntervalMinutes,
+        onSelect = {
+            Libre2ReadingInterval.setMinutes(context, it)
+            libre2IntervalMinutes = it
+            showLibre2IntervalDialog = false
+        },
+        onDismiss = { showLibre2IntervalDialog = false }
+    )
     if (showSensorHandoverActionDialog) SensorHandoverActionPickerDialog(
         currentAction = sensorHandoverAction,
         onSelect = {
@@ -1824,6 +1847,64 @@ private fun ThemePickerDialog(current: ThemeMode, onSelect: (ThemeMode) -> Unit,
                 }
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Libre2IntervalPickerDialog(
+    currentMinutes: Int,
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    BasicAlertDialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            tonalElevation = 6.dp,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh
+        ) {
+            Column(modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)) {
+                Text(
+                    text = stringResource(R.string.libre2_interval_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                )
+                Text(
+                    text = stringResource(R.string.libre2_interval_desc),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp)
+                )
+                Libre2ReadingInterval.options().forEach { minutes ->
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 56.dp)
+                            .clickable { onSelect(minutes) }
+                            .padding(horizontal = 24.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        RadioButton(selected = currentMinutes == minutes, onClick = null)
+                        Spacer(Modifier.width(16.dp))
+                        Text(
+                            text = if (minutes == Libre2ReadingInterval.DEFAULT_MINUTES) {
+                                stringResource(R.string.libre2_interval_default_option)
+                            } else {
+                                stringResource(R.string.minutes_short_format, minutes)
+                            },
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 8.dp),
                     horizontalArrangement = Arrangement.End
                 ) {
                     TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }


### PR DESCRIPTION
Add a settings option to change the bluetooth polling interval for a libre2 sensor to 1/2/5 minutes. The current default is hardcoded to 1 minute. Increasing to 5 minutes will improve battery usage. Other apps such as https://github.com/nightscout/Trio/ also keep sensor polling at a 5 minute interval.

Screenshots:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/cb450923-5947-432c-8258-31836dc7b376" /><img width="200" alt="image" src="https://github.com/user-attachments/assets/440e584b-2bdb-413d-b7e9-7f66c5a32e9e" />
