### PR TITLE
AOD: opt the lock-screen overlay out of automatic dark conversion

### DIFF
--- a/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
+++ b/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
@@ -289,6 +289,13 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
             val inflater = LayoutInflater.from(this)
             overlayView = inflater.inflate(R.layout.aod_overlay, null)
             overlayView?.setBackgroundColor(android.graphics.Color.TRANSPARENT)
+            // The overlay always draws a light-on-transparent palette, so an
+            // automatic dark conversion (platform force-dark, or a vendor
+            // "expanded dark mode") only inverts the value into black on the
+            // always-on display. Opt the whole hierarchy out of it.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                overlayView?.isForceDarkAllowed = false
+            }
             
             params = WindowManager.LayoutParams(
                 WindowManager.LayoutParams.MATCH_PARENT,

--- a/Common/src/main/res/layout/aod_overlay.xml
+++ b/Common/src/main/res/layout/aod_overlay.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/aod_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:forceDarkAllowed="false"
+    tools:targetApi="q"
     android:orientation="vertical"
     android:padding="0dp"
     android:gravity="center_horizontal">


### PR DESCRIPTION
Fixes #271.

The AOD overlay always draws its own light-on-transparent palette — `NotificationChartDrawer.getGlucoseColor()` returns white unconditionally when the context is `AODOverlayService`. On a device running a vendor "expanded dark mode" (and under the platform's own force-dark), the overlay window gets dark-converted anyway, so the white glucose value is rendered black and is unreadable on the always-on display.

Set `forceDarkAllowed=false` on the overlay root so nothing re-tints a hierarchy that is already drawn for a dark background:

- `Common/src/main/res/layout/aod_overlay.xml` — `android:forceDarkAllowed="false"` on `aod_root`.
- `Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt` — `isForceDarkAllowed = false` on the inflated view (API 29+ guard, minSdk is 26), covering the case where the view is built outside the layout's inflation path.

No behaviour change on devices that were not force-darkening the overlay.

Verified: `./gradlew :Common:testMobileDebugUnitTest` green.