### PR TITLE
Translate the Anytime setup wizard into every locale

### DIFF
--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -572,6 +572,14 @@
     <string name="icanhealth_sensor_picker_desc">Налада Bluetooth</string>
     <string name="mq_sensor_picker_desc">Спалучэнне Bluetooth</string>
     <string name="anytime_sensor_picker_desc">Спалучэнне Bluetooth</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Падключыце трансмітар Anytime або Yuwell CT3 CGM праз Bluetooth</string>
+    <string name="anytime_setup_title">Наладка Anytime / Yuwell</string>
+    <string name="anytime_searching_sensors">Пошук трансмітараў Anytime / Yuwell…</string>
+    <string name="anytime_no_sensors_hint">Трымайце трансмітар побач і пераканайцеся, што ён уключаны.</string>
+    <string name="anytime_detected_label">%1$s · сямʼя Anytime CT3</string>
+    <string name="anytime_selectable_unrecognized">%1$s · паказана, бо ўключана \"Паказаць усе прылады\"</string>
+    <string name="anytime_connecting_to">Спалучэнне з %1$s…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">Скан. QR-код</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -669,6 +669,14 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="icanhealth_sensor_picker_desc">Bluetooth-Setup</string>
     <string name="mq_sensor_picker_desc">Bluetooth-Kopplung</string>
     <string name="anytime_sensor_picker_desc">Bluetooth-Kopplung</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Einen Anytime- oder Yuwell-CT3-CGM-Transmitter über Bluetooth koppeln</string>
+    <string name="anytime_setup_title">Anytime-/Yuwell-Einrichtung</string>
+    <string name="anytime_searching_sensors">Suche nach Anytime-/Yuwell-Transmittern…</string>
+    <string name="anytime_no_sensors_hint">Halte den Transmitter in der Nähe und stelle sicher, dass er eingeschaltet ist.</string>
+    <string name="anytime_detected_label">%1$s · Anytime-CT3-Familie</string>
+    <string name="anytime_selectable_unrecognized">%1$s · angezeigt, weil \"Alle Geräte anzeigen\" aktiv ist</string>
+    <string name="anytime_connecting_to">%1$s wird gekoppelt…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">QR-Code scannen</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -529,6 +529,14 @@
     <string name="icanhealth_sensor_picker_desc">Configuration Bluetooth</string>
     <string name="mq_sensor_picker_desc">Appairage Bluetooth</string>
     <string name="anytime_sensor_picker_desc">Appairage Bluetooth</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Associer un transmetteur MCG Anytime ou Yuwell CT3 via Bluetooth</string>
+    <string name="anytime_setup_title">Configuration Anytime / Yuwell</string>
+    <string name="anytime_searching_sensors">Recherche de transmetteurs Anytime / Yuwell…</string>
+    <string name="anytime_no_sensors_hint">Gardez le transmetteur à proximité et assurez-vous qu\'il est allumé.</string>
+    <string name="anytime_detected_label">%1$s · famille Anytime CT3</string>
+    <string name="anytime_selectable_unrecognized">%1$s · affiché car \"Voir tous les appareils\" est activé</string>
+    <string name="anytime_connecting_to">Association de %1$s…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">Scanner le code QR</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -455,6 +455,14 @@
     <string name="icanhealth_sensor_picker_desc">Configurazione Bluetooth</string>
     <string name="mq_sensor_picker_desc">Associazione Bluetooth</string>
     <string name="anytime_sensor_picker_desc">Associazione Bluetooth</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Associa un trasmettitore CGM Anytime o Yuwell CT3 via Bluetooth</string>
+    <string name="anytime_setup_title">Configurazione Anytime / Yuwell</string>
+    <string name="anytime_searching_sensors">Ricerca di trasmettitori Anytime / Yuwell…</string>
+    <string name="anytime_no_sensors_hint">Tieni il trasmettitore vicino e assicurati che sia acceso.</string>
+    <string name="anytime_detected_label">%1$s · famiglia Anytime CT3</string>
+    <string name="anytime_selectable_unrecognized">%1$s · mostrato perché \"Vedi tutti i dispositivi\" è attivo</string>
+    <string name="anytime_connecting_to">Associazione di %1$s…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">Scansiona codice QR</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -670,6 +670,14 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="icanhealth_sensor_picker_desc">Bluetooth-instelling</string>
     <string name="mq_sensor_picker_desc">Bluetooth-koppeling</string>
     <string name="anytime_sensor_picker_desc">Bluetooth-koppeling</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Een Anytime- of Yuwell-CT3-CGM-zender koppelen via Bluetooth</string>
+    <string name="anytime_setup_title">Anytime / Yuwell instellen</string>
+    <string name="anytime_searching_sensors">Zoeken naar Anytime-/Yuwell-zenders…</string>
+    <string name="anytime_no_sensors_hint">Houd de zender dichtbij en zorg dat hij aanstaat.</string>
+    <string name="anytime_detected_label">%1$s · Anytime CT3-familie</string>
+    <string name="anytime_selectable_unrecognized">%1$s · getoond omdat \"Alle apparaten bekijken\" aanstaat</string>
+    <string name="anytime_connecting_to">%1$s koppelen…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">Scan QR-code</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -657,6 +657,14 @@
     <string name="icanhealth_sensor_picker_desc">Konfiguracja Bluetooth</string>
     <string name="mq_sensor_picker_desc">Parowanie Bluetooth</string>
     <string name="anytime_sensor_picker_desc">Parowanie Bluetooth</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Sparuj nadajnik CGM Anytime lub Yuwell CT3 przez Bluetooth</string>
+    <string name="anytime_setup_title">Konfiguracja Anytime / Yuwell</string>
+    <string name="anytime_searching_sensors">Szukanie nadajników Anytime / Yuwell…</string>
+    <string name="anytime_no_sensors_hint">Trzymaj nadajnik blisko i upewnij się, że jest włączony.</string>
+    <string name="anytime_detected_label">%1$s · rodzina Anytime CT3</string>
+    <string name="anytime_selectable_unrecognized">%1$s · pokazano, bo opcja \"Zobacz wszystkie urządzenia\" jest włączona</string>
+    <string name="anytime_connecting_to">Parowanie %1$s…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">Skanuj kod QR</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -482,6 +482,14 @@
     <string name="icanhealth_sensor_picker_desc">Configuração Bluetooth</string>
     <string name="mq_sensor_picker_desc">Emparelhamento Bluetooth</string>
     <string name="anytime_sensor_picker_desc">Emparelhamento Bluetooth</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Emparelhar um transmissor MCG Anytime ou Yuwell CT3 por Bluetooth</string>
+    <string name="anytime_setup_title">Configuração Anytime / Yuwell</string>
+    <string name="anytime_searching_sensors">A procurar transmissores Anytime / Yuwell…</string>
+    <string name="anytime_no_sensors_hint">Mantenha o transmissor por perto e certifique-se de que está ligado.</string>
+    <string name="anytime_detected_label">%1$s · família Anytime CT3</string>
+    <string name="anytime_selectable_unrecognized">%1$s · mostrado porque \"Ver todos os dispositivos\" está ativo</string>
+    <string name="anytime_connecting_to">A emparelhar %1$s…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">Digitalizar QR</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -679,6 +679,14 @@
     <string name="icanhealth_sensor_picker_desc">Настройка Bluetooth</string>
     <string name="mq_sensor_picker_desc">Сопряжение Bluetooth</string>
     <string name="anytime_sensor_picker_desc">Сопряжение Bluetooth</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Подключите трансмиттер Anytime или Yuwell CT3 CGM через Bluetooth</string>
+    <string name="anytime_setup_title">Настройка Anytime / Yuwell</string>
+    <string name="anytime_searching_sensors">Поиск трансмиттеров Anytime / Yuwell…</string>
+    <string name="anytime_no_sensors_hint">Держите трансмиттер рядом и убедитесь, что он включён.</string>
+    <string name="anytime_detected_label">%1$s · семейство Anytime CT3</string>
+    <string name="anytime_selectable_unrecognized">%1$s · показано, потому что включено \"Показать все устройства\"</string>
+    <string name="anytime_connecting_to">Сопряжение с %1$s…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">Сканировать QR-код</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -582,6 +582,14 @@
     <string name="icanhealth_sensor_picker_desc">Bluetooth-inställning</string>
     <string name="mq_sensor_picker_desc">Bluetooth-parkoppling</string>
     <string name="anytime_sensor_picker_desc">Bluetooth-parkoppling</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Para en Anytime- eller Yuwell-CT3-CGM-sändare via Bluetooth</string>
+    <string name="anytime_setup_title">Anytime-/Yuwell-inställning</string>
+    <string name="anytime_searching_sensors">Söker efter Anytime-/Yuwell-sändare…</string>
+    <string name="anytime_no_sensors_hint">Håll sändaren nära och se till att den är påslagen.</string>
+    <string name="anytime_detected_label">%1$s · Anytime CT3-familjen</string>
+    <string name="anytime_selectable_unrecognized">%1$s · visas eftersom \"Se alla enheter\" är på</string>
+    <string name="anytime_connecting_to">Parkopplar %1$s…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">Skanna QR-kod</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -634,6 +634,14 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="icanhealth_sensor_picker_desc">Bluetooth kurulumu</string>
     <string name="mq_sensor_picker_desc">Bluetooth eşleştirme</string>
     <string name="anytime_sensor_picker_desc">Bluetooth eşleştirme</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Anytime veya Yuwell CT3 CGM vericisini Bluetooth ile eşleştirin</string>
+    <string name="anytime_setup_title">Anytime / Yuwell Kurulumu</string>
+    <string name="anytime_searching_sensors">Anytime / Yuwell vericileri aranıyor…</string>
+    <string name="anytime_no_sensors_hint">Vericiyi yakında tutun ve açık olduğundan emin olun.</string>
+    <string name="anytime_detected_label">%1$s · Anytime CT3 ailesi</string>
+    <string name="anytime_selectable_unrecognized">%1$s · \"Tüm cihazları gör\" açık olduğu için gösteriliyor</string>
+    <string name="anytime_connecting_to">%1$s eşleştiriliyor…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">QR Kodu tara</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -594,6 +594,14 @@
     <string name="icanhealth_sensor_picker_desc">Налаштування Bluetooth</string>
     <string name="mq_sensor_picker_desc">Сполучення Bluetooth</string>
     <string name="anytime_sensor_picker_desc">Сполучення Bluetooth</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">Підключіть передавач Anytime або Yuwell CT3 CGM через Bluetooth</string>
+    <string name="anytime_setup_title">Налаштування Anytime / Yuwell</string>
+    <string name="anytime_searching_sensors">Пошук передавачів Anytime / Yuwell…</string>
+    <string name="anytime_no_sensors_hint">Тримайте передавач поруч і переконайтеся, що він увімкнений.</string>
+    <string name="anytime_detected_label">%1$s · родина Anytime CT3</string>
+    <string name="anytime_selectable_unrecognized">%1$s · показано, бо ввімкнено \"Показати всі пристрої\"</string>
+    <string name="anytime_connecting_to">Сполучення з %1$s…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">Скан. QR-код</string>
     <string name="libre_sensor">Libre 2/3</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -594,6 +594,14 @@
     <string name="icanhealth_sensor_picker_desc">蓝牙设置</string>
     <string name="mq_sensor_picker_desc">蓝牙配对</string>
     <string name="anytime_sensor_picker_desc">蓝牙配对</string>
+    <string name="anytime_sensor">Anytime / Yuwell 4 / 4H / 5</string>
+    <string name="anytime_sensor_desc">通过蓝牙配对 Anytime 或 Yuwell CT3 CGM 发射器</string>
+    <string name="anytime_setup_title">Anytime / Yuwell 设置</string>
+    <string name="anytime_searching_sensors">正在搜索 Anytime / Yuwell 发射器…</string>
+    <string name="anytime_no_sensors_hint">请将发射器放在附近，并确保已开机。</string>
+    <string name="anytime_detected_label">%1$s · Anytime CT3 系列</string>
+    <string name="anytime_selectable_unrecognized">%1$s · 因已开启“查看所有设备”而显示</string>
+    <string name="anytime_connecting_to">正在配对 %1$s…</string>
     <string name="sibionics_sensor">Sibionics</string>
     <string name="sibionics_sensor_desc">扫描二维码</string>
     <string name="libre_sensor">Libre 2/3</string>


### PR DESCRIPTION
The eight strings the Anytime/Yuwell pairing wizard shows — its title, the search and hint lines, the detected and unrecognized-device labels, and the pairing progress — existed only in English, Mongolian and Somali. A German or Russian user setting up an Anytime transmitter read the whole flow in English.

Adds them to `be de fr it nl pl pt ru sv tr uk zh`. Product names stay as they ship. The quoted toggle in `anytime_selectable_unrecognized` uses each locale's own wording for `see_all_devices`, so the label names the switch the way that switch is actually labelled.

Verified: every file still parses, no duplicate keys, format arguments match English in all 96 strings, and `:Common:assembleMobileDebug` is green.

Predates #261 — these were missing since the wizard landed. The wider gap is separate: 156 keys are untranslated in at least one locale across the whole file.