### PR TITLE
Only show always on display chart/text when screen is off (not interactive) rather than on the lockscreen.

### DIFF
--- a/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
+++ b/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
@@ -9,6 +9,7 @@ import android.graphics.PixelFormat
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.PowerManager
 import android.os.SystemClock
 import android.hardware.Sensor
 import android.hardware.SensorEvent
@@ -122,10 +123,9 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
                 Intent.ACTION_TIME_TICK -> refreshPeriodic("aod.overlay.refresh.tick")
                 Intent.ACTION_SCREEN_OFF -> {
                     isScreenOn = false
-                    updateVisibility()
+                    showOverlay()
                 }
                 Intent.ACTION_SCREEN_ON -> {
-                    isScreenOn = true
                     // Immediately check keyguard state - faster than waiting for USER_PRESENT
                     checkAndUpdateLockState()
                     // Also schedule quick rechecks to catch unlock faster
@@ -170,6 +170,9 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
         val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as android.app.KeyguardManager
         return keyguardManager.isDeviceLocked || keyguardManager.isKeyguardLocked
     }
+
+    private fun resolveScreenOn(): Boolean =
+        (getSystemService(Context.POWER_SERVICE) as PowerManager).isInteractive
 
     private fun checkAndUpdateLockState() {
         isLocked = resolveDeviceLocked()
@@ -225,6 +228,7 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
             }
         }
         
+        isScreenOn = resolveScreenOn()
         isLocked = resolveDeviceLocked()
         updateVisibility()
     }
@@ -234,12 +238,10 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
     }
 
     private fun updateVisibility() {
-        // Timeout-driven AOD can arrive before the full keyguard UI is considered "showing".
-        // Keep the historical screen-off behavior so ambient mode still appears, and rely on
-        // the unlock/window-state path to hide again as soon as the user returns to an app.
-        val shouldShow = isLocked || !isScreenOn
-        
-        if (shouldShow) {
+        // SCREEN_ON can also be sent while entering ambient mode on some devices.
+        // isInteractive distinguishes that non-interactive AOD state from the lock screen.
+        isScreenOn = resolveScreenOn()
+        if (!isScreenOn) {
             showOverlay()
         } else {
             hideOverlay()


### PR DESCRIPTION
The AOD chart and text show even when the screen is on (but is locked). This makes the chart and text interfere with notifcations, for example when you are replying to a notification message with the screen still locked, the chart/text is still visible.
It should only show when the always on display is on (i.e. the screen is not interactive).

Screenshot before this PR (bug):
<img width="200" alt="image" src="https://github.com/user-attachments/assets/fca4bca0-72a6-441d-8e26-229f2a57d567" />

This PR updates the AOD text/chart visibility to only when the screen is off (i.e. always on display is on). This is detected by checking `PowerManager.isInteractive`.

So now the AOD overlay attaches immediately when the screen turns off, and us `PowerManager.isInteractive` to hide it on the active lock screen (when the always on display is not on but the screen is locked).

Screenshot from this PR:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/e4c05aae-1d44-444b-984c-5d497d9cf4d4" />
The text/chart still display when screen is not interactive (AOD on):
<img width="200" alt="image" src="https://github.com/user-attachments/assets/7db8087b-69bc-47b0-b018-5cd8cf25ff9d" />
