### PR TITLE
AOD: lock-screen toggle, wallpaper-aware palette, and force-dark opt-out

### DIFF
--- a/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
+++ b/Common/src/main/java/tk/glucodata/NotificationChartDrawer.java
@@ -883,9 +883,22 @@ public class NotificationChartDrawer {
         return isDark ? Color.WHITE : Color.BLACK;
     }
 
+    /**
+     * Whether the AOD overlay currently draws light-on-dark. Always true over an ambient
+     * (black) panel; the service lowers it when the overlay is shown on an interactive
+     * lock screen whose wallpaper asks for dark text. Every AOD drawing routine reads the
+     * palette through {@link #useLightOnTransparentPalette}, so value, arrow, chart and
+     * grid all flip together.
+     */
+    private static volatile boolean sAodUsesLightPalette = true;
+
+    public static void setAodUsesLightPalette(boolean light) {
+        sAodUsesLightPalette = light;
+    }
+
     private static boolean useLightOnTransparentPalette(Context context) {
         if (context != null && AOD_OVERLAY_SERVICE_NAME.equals(context.getClass().getName())) {
-            return true;
+            return sAodUsesLightPalette;
         }
         int uiMode = context.getResources().getConfiguration().uiMode
                 & android.content.res.Configuration.UI_MODE_NIGHT_MASK;

--- a/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
+++ b/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
@@ -9,6 +9,7 @@ import android.graphics.PixelFormat
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.PowerManager
 import android.os.SystemClock
 import android.hardware.Sensor
 import android.hardware.SensorEvent
@@ -122,10 +123,9 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
                 Intent.ACTION_TIME_TICK -> refreshPeriodic("aod.overlay.refresh.tick")
                 Intent.ACTION_SCREEN_OFF -> {
                     isScreenOn = false
-                    updateVisibility()
+                    showOverlay()
                 }
                 Intent.ACTION_SCREEN_ON -> {
-                    isScreenOn = true
                     // Immediately check keyguard state - faster than waiting for USER_PRESENT
                     checkAndUpdateLockState()
                     // Also schedule quick rechecks to catch unlock faster
@@ -170,6 +170,9 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
         val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as android.app.KeyguardManager
         return keyguardManager.isDeviceLocked || keyguardManager.isKeyguardLocked
     }
+
+    private fun resolveScreenOn(): Boolean =
+        (getSystemService(Context.POWER_SERVICE) as PowerManager).isInteractive
 
     private fun checkAndUpdateLockState() {
         isLocked = resolveDeviceLocked()
@@ -225,6 +228,7 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
             }
         }
         
+        isScreenOn = resolveScreenOn()
         isLocked = resolveDeviceLocked()
         updateVisibility()
     }
@@ -234,12 +238,10 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
     }
 
     private fun updateVisibility() {
-        // Timeout-driven AOD can arrive before the full keyguard UI is considered "showing".
-        // Keep the historical screen-off behavior so ambient mode still appears, and rely on
-        // the unlock/window-state path to hide again as soon as the user returns to an app.
-        val shouldShow = isLocked || !isScreenOn
-        
-        if (shouldShow) {
+        // SCREEN_ON can also be sent while entering ambient mode on some devices.
+        // isInteractive distinguishes that non-interactive AOD state from the lock screen.
+        isScreenOn = resolveScreenOn()
+        if (!isScreenOn) {
             showOverlay()
         } else {
             hideOverlay()

--- a/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
+++ b/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
@@ -291,6 +291,13 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
             val inflater = LayoutInflater.from(this)
             overlayView = inflater.inflate(R.layout.aod_overlay, null)
             overlayView?.setBackgroundColor(android.graphics.Color.TRANSPARENT)
+            // The overlay always draws a light-on-transparent palette, so an
+            // automatic dark conversion (platform force-dark, or a vendor
+            // "expanded dark mode") only inverts the value into black on the
+            // always-on display. Opt the whole hierarchy out of it.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                overlayView?.isForceDarkAllowed = false
+            }
             
             params = WindowManager.LayoutParams(
                 WindowManager.LayoutParams.MATCH_PARENT,

--- a/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
+++ b/Common/src/main/java/tk/glucodata/accessibility/AODOverlayService.kt
@@ -1,6 +1,8 @@
 package tk.glucodata.accessibility
 
 import android.accessibilityservice.AccessibilityService
+import android.app.WallpaperManager
+import android.app.WallpaperColors
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -50,6 +52,9 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
         /** Two periodic drivers feed one refresh; anything sooner than this is the other one. */
         private const val PERIODIC_MIN_INTERVAL_MS = 30_000L
         const val ACTION_IMMEDIATE_REFRESH = "tk.glucodata.action.AOD_IMMEDIATE_REFRESH"
+        /** Whether the overlay is also shown while the screen is on and locked. */
+        const val PREF_SHOW_ON_LOCKSCREEN = "aod_show_on_lockscreen"
+        const val DEFAULT_SHOW_ON_LOCKSCREEN = true
 
         /**
          * A slow ellipse for burn-in, in dp. Consecutive entries always differ, so every
@@ -237,15 +242,48 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
         // View creation is handled by showOverlay() when needed.
     }
 
+    private fun showOnLockscreen(): Boolean =
+        getSharedPreferences("tk.glucodata_preferences", Context.MODE_PRIVATE)
+            .getBoolean(PREF_SHOW_ON_LOCKSCREEN, DEFAULT_SHOW_ON_LOCKSCREEN)
+
     private fun updateVisibility() {
         // SCREEN_ON can also be sent while entering ambient mode on some devices.
         // isInteractive distinguishes that non-interactive AOD state from the lock screen.
         isScreenOn = resolveScreenOn()
-        if (!isScreenOn) {
+        // Ambient mode always shows. The interactive lock screen is opt-out, because the
+        // overlay sits on top of the keyguard's own notification UI there.
+        val shouldShow = !isScreenOn || (isLocked && showOnLockscreen())
+        if (shouldShow) {
             showOverlay()
         } else {
             hideOverlay()
         }
+    }
+
+    /**
+     * The palette the overlay draws with. Ambient mode is black, so it is always light there.
+     * On the interactive lock screen the overlay sits on the wallpaper instead, so it asks
+     * Android what that wallpaper wants — the same signal that decides the keyguard clock.
+     */
+    private fun resolveUsesLightPalette(): Boolean {
+        if (!isScreenOn) return true
+        var supportsDarkText: Boolean? = null
+        var primaryColor: Int? = null
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            try {
+                val colors = (getSystemService(Context.WALLPAPER_SERVICE) as? WallpaperManager)
+                    ?.getWallpaperColors(WallpaperManager.FLAG_LOCK)
+                if (colors != null) {
+                    primaryColor = colors.primaryColor.toArgb()
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        supportsDarkText =
+                            (colors.colorHints and WallpaperColors.HINT_SUPPORTS_DARK_TEXT) != 0
+                    }
+                }
+            } catch (e: Exception) {
+            }
+        }
+        return AodPalette.usesLightPalette(isScreenOn, supportsDarkText, primaryColor)
     }
     
 
@@ -465,6 +503,7 @@ class AODOverlayService : AccessibilityService(), SensorEventListener {
 
     private fun updateOverlayContent() {
         val view = overlayView ?: return
+        NotificationChartDrawer.setAodUsesLightPalette(resolveUsesLightPalette())
 
         // 1. Fetch Data
         val endT = System.currentTimeMillis()

--- a/Common/src/main/java/tk/glucodata/accessibility/AodPalette.kt
+++ b/Common/src/main/java/tk/glucodata/accessibility/AodPalette.kt
@@ -1,0 +1,51 @@
+package tk.glucodata.accessibility
+
+/**
+ * Decides whether the AOD overlay draws its light-on-dark palette.
+ *
+ * Over a genuinely-off ambient panel the answer is always "light": the screen is black.
+ * On an interactive lock screen the overlay sits on the wallpaper instead, so it follows
+ * the same signal the system clock does — Android's own recommendation for that wallpaper,
+ * exposed as [android.app.WallpaperColors.HINT_SUPPORTS_DARK_TEXT]. Devices that predate
+ * the hint (API < 31) only give us the wallpaper's primary colour, so we fall back to its
+ * luminance.
+ *
+ * Kept free of Android types so the decision itself is unit-testable.
+ */
+object AodPalette {
+    /** Below this the wallpaper is dark enough to keep the light palette. */
+    private const val DARK_TEXT_LUMINANCE_THRESHOLD = 0.5f
+
+    /**
+     * @param screenInteractive false while the panel is in ambient mode.
+     * @param supportsDarkText the wallpaper's own hint, or null when the platform doesn't report one.
+     * @param primaryColor the lock wallpaper's primary colour, or null when unavailable.
+     */
+    @JvmStatic
+    fun usesLightPalette(
+        screenInteractive: Boolean,
+        supportsDarkText: Boolean?,
+        primaryColor: Int?,
+    ): Boolean {
+        if (!screenInteractive) return true
+        if (supportsDarkText != null) return !supportsDarkText
+        if (primaryColor != null) return relativeLuminance(primaryColor) < DARK_TEXT_LUMINANCE_THRESHOLD
+        // No wallpaper signal at all: white on an unknown background is the safer miss,
+        // because it stays legible over the dark scrim the keyguard draws behind its own text.
+        return true
+    }
+
+    /** WCAG relative luminance of an opaque ARGB colour, 0f (black) to 1f (white). */
+    @JvmStatic
+    fun relativeLuminance(color: Int): Float {
+        val r = channel((color shr 16) and 0xFF)
+        val g = channel((color shr 8) and 0xFF)
+        val b = channel(color and 0xFF)
+        return 0.2126f * r + 0.7152f * g + 0.0722f * b
+    }
+
+    private fun channel(value: Int): Float {
+        val c = value / 255f
+        return if (c < 0.03928f) c / 12.92f else Math.pow(((c + 0.055f) / 1.055f).toDouble(), 2.4).toFloat()
+    }
+}

--- a/Common/src/main/res/layout/aod_overlay.xml
+++ b/Common/src/main/res/layout/aod_overlay.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/aod_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:forceDarkAllowed="false"
+    tools:targetApi="q"
     android:orientation="vertical"
     android:padding="0dp"
     android:gravity="center_horizontal">

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1754,6 +1754,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_settings_subtitle">Наладзьце шторку апавяшчэнняў</string>
     <string name="lock_screen_aod">Экран блакіроўкі (AOD)</string>
     <string name="aod_settings_title">Налады AOD</string>
+    <string name="aod_show_on_lockscreen">Паказваць на экране блакіроўкі</string>
+    <string name="aod_show_on_lockscreen_desc">Паказваць таксама, калі экран уключаны і заблакаваны</string>
     <string name="customize_always_on_display">Наладзьце заўсёды ўключаны экран</string>
     <string name="enable_overlay_service">Уключыць службу накладання</string>
     <string name="accessibility_service_enabled">Служба спецыяльных магчымасцяў уключана</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1805,6 +1805,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="notification_settings_subtitle">Benachrichtigungsleiste anpassen</string>
     <string name="lock_screen_aod">Sperrbildschirm (AOD)</string>
     <string name="aod_settings_title">AOD-Einstellungen</string>
+    <string name="aod_show_on_lockscreen">Auf dem Sperrbildschirm anzeigen</string>
+    <string name="aod_show_on_lockscreen_desc">Auch anzeigen, wenn der Bildschirm an und gesperrt ist</string>
     <string name="customize_always_on_display">Always-on-Display anpassen</string>
     <string name="enable_overlay_service">Overlay-Dienst aktivieren</string>
     <string name="accessibility_service_enabled">Bedienungshilfen-Dienst aktiviert</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1686,6 +1686,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_settings_subtitle">Personnaliser le panneau de notifications</string>
     <string name="lock_screen_aod">Écran de verrouillage (AOD)</string>
     <string name="aod_settings_title">Paramètres AOD</string>
+    <string name="aod_show_on_lockscreen">Afficher sur l’écran de verrouillage</string>
+    <string name="aod_show_on_lockscreen_desc">Afficher aussi lorsque l’écran est allumé et verrouillé</string>
     <string name="customize_always_on_display">Personnaliser l\'affichage permanent</string>
     <string name="enable_overlay_service">Activer le service de superposition</string>
     <string name="accessibility_service_enabled">Service d\'accessibilité activé</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1670,6 +1670,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_settings_subtitle">Personalizza l\'area notifiche</string>
     <string name="lock_screen_aod">Schermata di blocco (AOD)</string>
     <string name="aod_settings_title">Impostazioni AOD</string>
+    <string name="aod_show_on_lockscreen">Mostra nella schermata di blocco</string>
+    <string name="aod_show_on_lockscreen_desc">Mostra anche quando lo schermo è acceso e bloccato</string>
     <string name="customize_always_on_display">Personalizza always-on display</string>
     <string name="enable_overlay_service">Abilita servizio overlay</string>
     <string name="accessibility_service_enabled">Servizio di accessibilità attivo</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1701,6 +1701,8 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="notification_settings_subtitle">Customize notification shade</string>
     <string name="lock_screen_aod">Lock screen (AOD)</string>
     <string name="aod_settings_title">AOD settings</string>
+    <string name="aod_show_on_lockscreen">Түгжээтэй дэлгэцэд харуулах</string>
+    <string name="aod_show_on_lockscreen_desc">Дэлгэц асаалттай бөгөөд түгжээтэй үед бас харуулах</string>
     <string name="customize_always_on_display">Customize always-on display</string>
     <string name="enable_overlay_service">Enable overlay service</string>
     <string name="accessibility_service_enabled">Accessibility service enabled</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1723,6 +1723,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="notification_settings_subtitle">Notificatiepaneel aanpassen</string>
     <string name="lock_screen_aod">Vergrendelscherm (AOD)</string>
     <string name="aod_settings_title">AOD-instellingen</string>
+    <string name="aod_show_on_lockscreen">Op het vergrendelscherm tonen</string>
+    <string name="aod_show_on_lockscreen_desc">Ook tonen als het scherm aan en vergrendeld is</string>
     <string name="customize_always_on_display">Always-on-display aanpassen</string>
     <string name="enable_overlay_service">Overlayservice inschakelen</string>
     <string name="accessibility_service_enabled">Toegankelijkheidsservice ingeschakeld</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1715,6 +1715,8 @@
     <string name="notification_settings_subtitle">Dostosuj panel powiadomień</string>
     <string name="lock_screen_aod">Ekran blokady (AOD)</string>
     <string name="aod_settings_title">Ustawienia AOD</string>
+    <string name="aod_show_on_lockscreen">Pokazuj na ekranie blokady</string>
+    <string name="aod_show_on_lockscreen_desc">Pokazuj także, gdy ekran jest włączony i zablokowany</string>
     <string name="customize_always_on_display">Dostosuj always-on display</string>
     <string name="enable_overlay_service">Włącz usługę nakładki</string>
     <string name="accessibility_service_enabled">Usługa ułatwień dostępu włączona</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1681,6 +1681,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_settings_subtitle">Personalize a bandeja de notificações</string>
     <string name="lock_screen_aod">Tela de bloqueio (AOD)</string>
     <string name="aod_settings_title">Configurações de AOD</string>
+    <string name="aod_show_on_lockscreen">Mostrar no ecrã de bloqueio</string>
+    <string name="aod_show_on_lockscreen_desc">Mostrar também quando o ecrã está ligado e bloqueado</string>
     <string name="customize_always_on_display">Personalize a tela sempre ativa</string>
     <string name="enable_overlay_service">Ativar serviço de sobreposição</string>
     <string name="accessibility_service_enabled">Serviço de acessibilidade ativado</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1727,6 +1727,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_settings_subtitle">Настройте шторку уведомлений</string>
     <string name="lock_screen_aod">Экран блокировки (AOD)</string>
     <string name="aod_settings_title">Настройки AOD</string>
+    <string name="aod_show_on_lockscreen">Показывать на экране блокировки</string>
+    <string name="aod_show_on_lockscreen_desc">Показывать также, когда экран включён и заблокирован</string>
     <string name="customize_always_on_display">Настройте постоянно включенный экран</string>
     <string name="enable_overlay_service">Включить службу наложения</string>
     <string name="accessibility_service_enabled">Служба специальных возможностей включена</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1996,6 +1996,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="notification_settings_subtitle">Habbee hadh wargelinta</string>
     <string name="lock_screen_aod">Shaashadda quful (AOD)</string>
     <string name="aod_settings_title">Dejinta AOD</string>
+    <string name="aod_show_on_lockscreen">Ku muuji shaashadda quful</string>
+    <string name="aod_show_on_lockscreen_desc">Sidoo kale muuji marka shaashadda ay shidan tahay oo qufulan</string>
     <string name="customize_always_on_display">Habee had iyo jeer-muuqaalka</string>
     <string name="enable_overlay_service">Daar adeega dulsaar</string>
     <string name="accessibility_service_enabled">Adeegga gelitaanka waa la furay</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1680,6 +1680,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_settings_subtitle">Anpassa aviseringspanelen</string>
     <string name="lock_screen_aod">Låsskärm (AOD)</string>
     <string name="aod_settings_title">AOD-inställningar</string>
+    <string name="aod_show_on_lockscreen">Visa på låsskärmen</string>
+    <string name="aod_show_on_lockscreen_desc">Visa även när skärmen är på och låst</string>
     <string name="customize_always_on_display">Anpassa alltid-på-skärmen</string>
     <string name="enable_overlay_service">Aktivera överlagringstjänst</string>
     <string name="accessibility_service_enabled">Tillgänglighetstjänst aktiverad</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1708,6 +1708,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="notification_settings_subtitle">Bildirim panelini özelleştir</string>
     <string name="lock_screen_aod">Kilit ekranı (AOD)</string>
     <string name="aod_settings_title">AOD ayarları</string>
+    <string name="aod_show_on_lockscreen">Kilit ekranında göster</string>
+    <string name="aod_show_on_lockscreen_desc">Ekran açık ve kilitliyken de göster</string>
     <string name="customize_always_on_display">Her zaman açık ekranı özelleştir</string>
     <string name="enable_overlay_service">Yer paylaşımı hizmetini etkinleştir</string>
     <string name="accessibility_service_enabled">Erişilebilirlik hizmeti etkin</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1759,6 +1759,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_settings_subtitle">Налаштуйте панель сповіщень</string>
     <string name="lock_screen_aod">Екран блокування (AOD)</string>
     <string name="aod_settings_title">Налаштування AOD</string>
+    <string name="aod_show_on_lockscreen">Показувати на екрані блокування</string>
+    <string name="aod_show_on_lockscreen_desc">Показувати також, коли екран увімкнено та заблоковано</string>
     <string name="customize_always_on_display">Налаштуйте постійно ввімкнений екран</string>
     <string name="enable_overlay_service">Увімкнути службу накладання</string>
     <string name="accessibility_service_enabled">Службу доступності увімкнено</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1696,6 +1696,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="notification_settings_subtitle">自定义通知栏</string>
     <string name="lock_screen_aod">锁屏（AOD）</string>
     <string name="aod_settings_title">AOD 设置</string>
+    <string name="aod_show_on_lockscreen">在锁定屏幕上显示</string>
+    <string name="aod_show_on_lockscreen_desc">屏幕点亮且已锁定时也显示</string>
     <string name="customize_always_on_display">自定义息屏显示</string>
     <string name="enable_overlay_service">启用覆盖层服务</string>
     <string name="accessibility_service_enabled">无障碍服务已启用</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2255,6 +2255,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="display_readouts_section">Dashboard readouts</string>
     <string name="lock_screen_aod">Lock screen (AOD)</string>
     <string name="aod_settings_title">AOD settings</string>
+    <string name="aod_show_on_lockscreen">Show on the lock screen</string>
+    <string name="aod_show_on_lockscreen_desc">Also show while the screen is on and locked</string>
     <string name="customize_always_on_display">Customize always-on display</string>
     <string name="enable_overlay_service">Enable overlay service</string>
     <string name="accessibility_service_enabled">Accessibility service enabled</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DisplaySettingsScreens.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CropSquare
 import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.SettingsAccessibility
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
@@ -69,6 +70,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.navigation.NavController
 import tk.glucodata.R
+import tk.glucodata.accessibility.AODOverlayService
 import tk.glucodata.data.settings.FloatingSettingsRepository
 import tk.glucodata.ui.components.CardPosition
 import tk.glucodata.ui.components.MasterSwitchCard
@@ -723,6 +725,14 @@ fun AodSettingsScreen(navController: NavController) {
     var alignment by rememberSaveable { mutableStateOf(prefs.getString("aod_alignment", "CENTER") ?: "CENTER") }
     var fontSource by rememberSaveable { mutableStateOf(prefs.getString("aod_font_source", "APP") ?: "APP") }
     var fontWeight by rememberSaveable { mutableIntStateOf(prefs.getInt("aod_font_weight", 400)) }
+    var showOnLockscreen by rememberSaveable {
+        mutableStateOf(
+            prefs.getBoolean(
+                AODOverlayService.PREF_SHOW_ON_LOCKSCREEN,
+                AODOverlayService.DEFAULT_SHOW_ON_LOCKSCREEN
+            )
+        )
+    }
 
     fun save() {
         prefs.edit()
@@ -737,6 +747,7 @@ fun AodSettingsScreen(navController: NavController) {
             .putString("aod_alignment", alignment)
             .putString("aod_font_source", fontSource)
             .putInt("aod_font_weight", fontWeight)
+            .putBoolean(AODOverlayService.PREF_SHOW_ON_LOCKSCREEN, showOnLockscreen)
             .apply()
     }
 
@@ -760,6 +771,23 @@ fun AodSettingsScreen(navController: NavController) {
                 context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
             },
             icon = Icons.Default.SettingsAccessibility,
+            modifier = Modifier.padding(horizontal = legacySettingsHorizontalPadding)
+        )
+
+        Spacer(Modifier.height(8.dp))
+        SettingsSwitchItem(
+            title = stringResource(R.string.aod_show_on_lockscreen),
+            subtitle = stringResource(R.string.aod_show_on_lockscreen_desc),
+            checked = showOnLockscreen,
+            onCheckedChange = {
+                showOnLockscreen = it
+                save()
+                context.sendBroadcast(
+                    Intent(AODOverlayService.ACTION_IMMEDIATE_REFRESH).setPackage(context.packageName)
+                )
+            },
+            icon = Icons.Default.Lock,
+            position = CardPosition.SINGLE,
             modifier = Modifier.padding(horizontal = legacySettingsHorizontalPadding)
         )
 

--- a/Common/src/test/java/tk/glucodata/AodPaletteTests.kt
+++ b/Common/src/test/java/tk/glucodata/AodPaletteTests.kt
@@ -1,0 +1,62 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tk.glucodata.accessibility.AodPalette
+
+class AodPaletteTests {
+
+    @Test
+    fun ambientPanelAlwaysDrawsLight() {
+        // The panel is black in ambient mode, so no wallpaper signal may override it.
+        assertTrue(AodPalette.usesLightPalette(false, supportsDarkText = true, primaryColor = 0xFFFFFFFF.toInt()))
+        assertTrue(AodPalette.usesLightPalette(false, supportsDarkText = null, primaryColor = null))
+    }
+
+    @Test
+    fun lockscreenFollowsTheWallpaperHint() {
+        // HINT_SUPPORTS_DARK_TEXT means the wallpaper wants dark foreground, so we stop drawing light.
+        assertEquals(false, AodPalette.usesLightPalette(true, supportsDarkText = true, primaryColor = null))
+        assertEquals(true, AodPalette.usesLightPalette(true, supportsDarkText = false, primaryColor = null))
+    }
+
+    @Test
+    fun theHintWinsOverTheWallpaperColour() {
+        // A dark primary colour must not override an explicit dark-text recommendation.
+        assertEquals(
+            false,
+            AodPalette.usesLightPalette(true, supportsDarkText = true, primaryColor = 0xFF101010.toInt())
+        )
+    }
+
+    @Test
+    fun withoutAHintTheWallpaperLuminanceDecides() {
+        // Pre-31 devices report no hint, so fall back to the wallpaper's primary colour.
+        assertEquals(
+            false,
+            AodPalette.usesLightPalette(true, supportsDarkText = null, primaryColor = 0xFFF2F2F2.toInt())
+        )
+        assertEquals(
+            true,
+            AodPalette.usesLightPalette(true, supportsDarkText = null, primaryColor = 0xFF1A1A1A.toInt())
+        )
+    }
+
+    @Test
+    fun noWallpaperSignalKeepsTheLightPalette() {
+        assertTrue(AodPalette.usesLightPalette(true, supportsDarkText = null, primaryColor = null))
+    }
+
+    @Test
+    fun luminanceSpansBlackToWhite() {
+        assertEquals(0f, AodPalette.relativeLuminance(0xFF000000.toInt()), 0.001f)
+        assertEquals(1f, AodPalette.relativeLuminance(0xFFFFFFFF.toInt()), 0.001f)
+        // Alpha must not leak into the calculation.
+        assertEquals(
+            AodPalette.relativeLuminance(0xFF808080.toInt()),
+            AodPalette.relativeLuminance(0x00808080),
+            0.001f
+        )
+    }
+}


### PR DESCRIPTION
Supersedes #284 and #286 — both are included here as their original commits, so this can land as one change.

### What's in it

**1. Only ambient mode is unconditional (#286, by @premnirmal)**
`ACTION_SCREEN_ON` is also delivered while entering ambient mode on some devices, so `isLocked` was never a reliable way to tell the two apart. `PowerManager.isInteractive` is, and the overlay now attaches immediately on screen-off.

**2. The lock screen becomes a setting, not a behaviour**
Hiding the overlay whenever the screen is interactive also removes the lock-screen readout for people who rely on it. New switch in AOD settings, **Show on the lock screen**, defaulting to on so nobody loses it without asking. Turning it off gives exactly #286's behaviour — ambient only, no overlap with the keyguard's notification UI.

**3. It now looks right on the lock screen in any wallpaper**
The reason it looked wrong there is that the overlay was drawing its ambient palette on top of a wallpaper. On the interactive lock screen it now follows the same signal the keyguard clock follows — `WallpaperManager.getWallpaperColors(FLAG_LOCK)` and its `HINT_SUPPORTS_DARK_TEXT` recommendation — falling back to the wallpaper's primary luminance below API 31, where the hint doesn't exist. Ambient mode stays white regardless, because the panel is black.

Every AOD drawing routine already reads its palette through `NotificationChartDrawer.useLightOnTransparentPalette()`, so value, arrow, chart and grid flip together from the single flag the service sets before each draw.

**4. Force-dark opt-out (#284), fixes #271**
`forceDarkAllowed=false` on the overlay root, in the layout and on the inflated view (API 29+ guard). The overlay picks its own palette now, so nothing else should be re-tinting it — that's what was turning the white value black under vendor "expanded dark" modes.

### Notes

- The decision logic lives in `AodPalette`, free of Android types, with tests for the ambient override, the wallpaper hint, the pre-31 luminance fallback and the no-signal case.
- New strings are translated into all 15 locales.
- `./gradlew :Common:testMobileDebugUnitTest` green; the 6 new `AodPaletteTests` run and pass.
- Not verified on a device — in particular the wallpaper-hint path on a real light lock-screen wallpaper is untested by me.