### PR TITLE
Show a sensor's connection log on its card, with or without debug logging

### DIFF
--- a/Common/src/main/java/tk/glucodata/Log.java
+++ b/Common/src/main/java/tk/glucodata/Log.java
@@ -103,6 +103,7 @@ private static void log(String type,String one,String two) {
 		}
 	  }
 public static void info(String str) {
+	SensorTraceRing.add(' ',null,str);
 	if(doLog) {
 		if(Applic.Nativesloaded)  {
 			Natives.log(str+'\n');
@@ -141,11 +142,18 @@ public static String stackstring(String mess,Throwable e) {
 
    	}
 public static void e(String one,String two) {
+	SensorTraceRing.add('E',one,two);
 	if(!doLog||!Applic.Nativesloaded)
 		android.util.Log.e(one,two);
 	else
 		log("E",one,two);
 		};
+/**
+ * Not captured into {@link SensorTraceRing}: unlike the tagged calls, this one is the reason
+ * its own message does not exist yet, and capturing would mean running String.format on every
+ * call with logging off. No driver uses it -- they format at the call site and pass the result
+ * to {@link #i} -- so there is nothing here worth that.
+ */
 public static void format(String format, Object... args) {
 	if(doLog) {
 		String form=String.format(usedlocale,format,args);
@@ -169,10 +177,10 @@ public static void annolog(String mess) {
    }
 //s/public static void \([a-z]\).*\(log.*\);/public static void \1(String one,String two) 	{ if(Applic.Nativesloaded) {\2 else android.util.Log.\1(one,two);};/g
 
-public static void d(String one,String two) 	{ if(doLog) {if(Applic.Nativesloaded) {log("D",one,two);} else android.util.Log.d(one,two);}};
-public static void w(String one,String two) 	{ if(doLog) {if(Applic.Nativesloaded) {log("W",one,two);} else android.util.Log.w(one,two);}};
-public static void v(String one,String two) 	{ if(doLog) {if(Applic.Nativesloaded) {log("V",one,two);} else android.util.Log.v(one,two);}};
-public static void i(String one,String two) 	{ if(doLog) {if(Applic.Nativesloaded) {log("I",one,two);} else android.util.Log.i(one,two);}};
+public static void d(String one,String two) 	{ SensorTraceRing.add('D',one,two); if(doLog) {if(Applic.Nativesloaded) {log("D",one,two);} else android.util.Log.d(one,two);}};
+public static void w(String one,String two) 	{ SensorTraceRing.add('W',one,two); if(doLog) {if(Applic.Nativesloaded) {log("W",one,two);} else android.util.Log.w(one,two);}};
+public static void v(String one,String two) 	{ SensorTraceRing.add('V',one,two); if(doLog) {if(Applic.Nativesloaded) {log("V",one,two);} else android.util.Log.v(one,two);}};
+public static void i(String one,String two) 	{ SensorTraceRing.add('I',one,two); if(doLog) {if(Applic.Nativesloaded) {log("I",one,two);} else android.util.Log.i(one,two);}};
 public static void  showbytes(String mess,byte[] ar) {
 	if(doLog)
 		{if(doLog){Natives.showbytes(mess,ar);};}

--- a/Common/src/main/java/tk/glucodata/SensorTraceRing.java
+++ b/Common/src/main/java/tk/glucodata/SensorTraceRing.java
@@ -22,6 +22,14 @@ public final class SensorTraceRing {
 	 */
 	private static final int CAPACITY = 400;
 
+	/**
+	 * Long enough for every line anyone reads -- a full CT5 reading line with its learned scale
+	 * runs about a hundred characters. Without it one driver dumping a payload could pin
+	 * megabytes here for as long as the process lives, which is the whole thing this is
+	 * supposed not to do.
+	 */
+	private static final int MAX_MESSAGE_CHARS = 256;
+
 	private static final Object lock = new Object();
 	private static final long[] times = new long[CAPACITY];
 	private static final char[] levels = new char[CAPACITY];
@@ -55,11 +63,16 @@ public final class SensorTraceRing {
 			return;
 		}
 		final long seconds = System.currentTimeMillis() / 1000L;
+		// Only a line already over the cap pays for a copy, and the copy is the point: it lets
+		// the original be collected instead of held for the next four hundred lines.
+		final String kept = message.length() <= MAX_MESSAGE_CHARS
+				? message
+				: message.substring(0, MAX_MESSAGE_CHARS) + "…";
 		synchronized (lock) {
 			times[next] = seconds;
 			levels[next] = level;
 			tags[next] = tag;
-			messages[next] = message;
+			messages[next] = kept;
 			if (++next == CAPACITY) {
 				next = 0;
 				wrapped = true;

--- a/Common/src/main/java/tk/glucodata/SensorTraceRing.java
+++ b/Common/src/main/java/tk/glucodata/SensorTraceRing.java
@@ -1,0 +1,107 @@
+package tk.glucodata;
+
+/**
+ * The last few hundred log lines, held in memory so the sensor connection log has something
+ * to show when trace.log is switched off.
+ *
+ * <p>The drivers call {@link Log} unguarded and Kotlin string templates are eager, so the
+ * message text is already built on every one of those calls whether or not logging is on --
+ * today it is built and dropped. What this adds is four array stores and an index bump. It
+ * allocates nothing per line, writes nothing to disk, and runs nothing in the background;
+ * the line is only assembled when somebody opens the log and calls {@link #snapshot()}.
+ *
+ * <p>The standing cost is memory: the last {@link #CAPACITY} tag and message strings stay
+ * reachable instead of being collected immediately, which is on the order of a hundred
+ * kilobytes. Losing the buffer when the process dies is the trade for that -- trace.log is
+ * what survives a restart.
+ */
+public final class SensorTraceRing {
+	/**
+	 * Deliberately larger than the 200 lines the log surfaces: these are unfiltered, and one
+	 * sensor's lines are a fraction of what the app logs overall.
+	 */
+	private static final int CAPACITY = 400;
+
+	private static final Object lock = new Object();
+	private static final long[] times = new long[CAPACITY];
+	private static final char[] levels = new char[CAPACITY];
+	private static final String[] tags = new String[CAPACITY];
+	private static final String[] messages = new String[CAPACITY];
+	private static int next = 0;
+	private static boolean wrapped = false;
+
+	/** Resolved once: it cannot change, and a snapshot would otherwise ask per line. */
+	private static final String pid = Integer.toString(android.os.Process.myPid());
+
+	private SensorTraceRing() {
+	}
+
+	/** Drops everything held. For tests, which share one process and one ring. */
+	static void reset() {
+		synchronized (lock) {
+			next = 0;
+			wrapped = false;
+			java.util.Arrays.fill(tags, null);
+			java.util.Arrays.fill(messages, null);
+		}
+	}
+
+	/**
+	 * @param level one of V/D/I/W/E, or a space when the caller logged without one.
+	 * @param tag   the driver tag, or null for an untagged line.
+	 */
+	public static void add(char level, String tag, String message) {
+		if (message == null) {
+			return;
+		}
+		final long seconds = System.currentTimeMillis() / 1000L;
+		synchronized (lock) {
+			times[next] = seconds;
+			levels[next] = level;
+			tags[next] = tag;
+			messages[next] = message;
+			if (++next == CAPACITY) {
+				next = 0;
+				wrapped = true;
+			}
+		}
+	}
+
+	/**
+	 * Oldest first, in trace.log's own line shape -- {@code <epoch seconds> <pid> <level>/<tag>
+	 * <message>} -- so one reader parses both sources.
+	 */
+	public static String[] snapshot() {
+		final long[] whenAt;
+		final char[] levelAt;
+		final String[] tagAt;
+		final String[] messageAt;
+		final int start;
+		final int count;
+		synchronized (lock) {
+			count = wrapped ? CAPACITY : next;
+			if (count == 0) {
+				return new String[0];
+			}
+			start = wrapped ? next : 0;
+			whenAt = times.clone();
+			levelAt = levels.clone();
+			tagAt = tags.clone();
+			messageAt = messages.clone();
+		}
+		final String[] out = new String[count];
+		for (int i = 0; i < count; i++) {
+			final int slot = (start + i) % CAPACITY;
+			final StringBuilder sb = new StringBuilder(64);
+			sb.append(whenAt[slot]).append(' ').append(pid).append(' ');
+			if (levelAt[slot] != ' ' && tagAt[slot] != null) {
+				sb.append(levelAt[slot]).append('/').append(tagAt[slot]).append(' ');
+			} else if (tagAt[slot] != null) {
+				sb.append(tagAt[slot]).append(' ');
+			}
+			sb.append(messageAt[slot]);
+			out[i] = sb.toString();
+		}
+		return out;
+	}
+}

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -167,6 +167,7 @@
  <string name="addsensorenddate">Дадайце дату заканчэння датчыка ў календар</string>
  <string name="enddatesensor">"Дата заканчэння датчыка "</string>
  <string name="open">Адчыніць</string>
+ <string name="copy">Капіраваць</string>
  <string name="share">Падзяліцца</string>
  <string name="withoutsensor">Без сэнсара</string>
  <string name="wronglibrary">Бібліятэка не працуе належным чынам, паспрабуйце іншую</string>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -770,6 +770,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Апошняя памылка BLE</string>
+    <string name="sensor_connection_log">Журнал злучэнняў</string>
     <string name="libre_setup_done">Гатова</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Наладзьце эксперыментальныя паводзіны сканавання Libre 3 перад спалучэннем.</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -164,6 +164,7 @@
   <string name="addsensorenddate">Enddatum des Sensors zur Kalender-App hinzufügen</string>
   <string name="enddatesensor">"Sensor-Enddatum "</string>
   <string name="open">Öffnen</string>
+  <string name="copy">Kopieren</string>
   <string name="share">Teilen</string>
   <string name="withoutsensor">Ohne Sensor</string>
   <string name="wronglibrary">Bibliothek funktioniert nicht richtig, versuche es mit einer anderen</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -872,6 +872,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="keep_data">Sensorinfo behalten</string>
     <string name="last_ble_status">Letzter BLE-Status</string>
     <string name="last_ble_error">Letzter BLE-Fehler</string>
+    <string name="sensor_connection_log">Verbindungsprotokoll</string>
     <string name="libre_setup_done">Fertig</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Experimentelles Scan-Verhalten für Libre 3 vor dem Koppeln anpassen.</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -167,6 +167,7 @@
 <string name="addsensorenddate">Ajouter date de fin de capteur dans le calendrier par l\'appli</string>
 <string name="enddatesensor">"Date de fin du capteur "</string>
 <string name="open">Ouvrir</string>
+<string name="copy">Copier</string>
 <string name="share">Partager</string>
 <string name="withoutsensor">Sans capteur</string>
 <string name="wronglibrary">La librairie ne fonctionne pas correctement, essayez une autre</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -744,6 +744,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Dernière erreur BLE</string>
+    <string name="sensor_connection_log">Journal de connexion</string>
     <string name="libre_setup_done">Terminé</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Ajustez le comportement expérimental du scan Libre 3 avant l\'appairage.</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -688,6 +688,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Ultimo errore BLE</string>
+    <string name="sensor_connection_log">Registro connessione</string>
     <string name="libre_setup_done">Fatto</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Regola il comportamento sperimentale della scansione Libre 3 prima dell\'associazione.</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -161,6 +161,7 @@
 <string name="addsensorenddate">Aggiungi il sensore e aggiungi la data di fine al calendario</string>
 <string name="enddatesensor">"Data di fine sensore "</string>
 <string name="open">Apri</string>
+<string name="copy">Copia</string>
 <string name="share">Condividi</string>
 <string name="withoutsensor">Senza sensore</string>
 <string name="wronglibrary">Libreria non funzionante, prova con un\'altra</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -163,6 +163,7 @@
     <string name="addsensorenddate">Мэдрэгчийн дуусах огноог календарьт нэмэх</string>
     <string name="enddatesensor">"Мэдрэгчийн дуусах огноо "</string>
     <string name="open">Нээх</string>
+    <string name="copy">Хуулах</string>
     <string name="share">Хуваалцах</string>
     <string name="withoutsensor">Мэдрэгчгүй</string>
     <string name="wronglibrary">Library зөв ажиллахгүй байна. Өөрийг туршина уу.</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -615,6 +615,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="disabled_status">Идэвхгүй болгосон</string>
     <string name="last_ble_status">Сүүлчийн BLE төлөв</string>
     <string name="last_ble_error">Сүүлийн BLE алдаа</string>
+    <string name="sensor_connection_log">Холболтын бүртгэл</string>
     <string name="sensor_address">Хаяг</string>
     <string name="sensor_started">Эхэлсэн</string>
     <string name="sensor_ends_officially">Албан ёсоор дуусах</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -169,6 +169,7 @@
  <string name="addsensorenddate">Sensor einddatum toevoegen aan calendar app</string>
  <string name="enddatesensor">"Sensor einddatum "</string>
  <string name="open">Open</string>
+ <string name="copy">Kopiëren</string>
  <string name="share">Delen</string>
  <string name="withoutsensor">Zonder sensor</string>
  <string name="wronglibrary">Library werkt niet goed, probeer een andere</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -843,6 +843,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="keep_data">Keep sensor info</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Laatste BLE-fout</string>
+    <string name="sensor_connection_log">Verbindingslogboek</string>
     <string name="libre_setup_done">Klaar</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Pas experimenteel Libre 3-scangedrag aan voordat je koppelt.</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -832,6 +832,7 @@
     <string name="last">"Ostatni: "</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Ostatni błąd BLE</string>
+    <string name="sensor_connection_log">Dziennik połączenia</string>
     <string name="libre_setup_done">Gotowe</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Dostosuj eksperymentalne zachowanie skanowania Libre 3 przed parowaniem.</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -167,6 +167,7 @@
  <string name="addsensorenddate">Dodaj termin zakończenia działania sensora do kalendarza</string>
  <string name="enddatesensor">&quot;Koniec działania sensora &quot;</string>
  <string name="open">Otwórz</string>
+ <string name="copy">Kopiuj</string>
  <string name="share">Udostępnij</string>
  <string name="withoutsensor">Bez sensora</string>
  <string name="wronglibrary">Biblioteka nie działa prawidłowo, spróbuj innej</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -168,6 +168,7 @@
 <string name="addsensorenddate">Adicionar data de término do sensor à aplicação de calendário</string>
 <string name="enddatesensor">"Sensor de data final "</string>
 <string name="open">Abrir</string>
+<string name="copy">Copiar</string>
 <string name="share">Partilhar</string>
 <string name="withoutsensor">Sem sensor</string>
 <string name="wronglibrary">A biblioteca não está funcionando corretamente, tente outra</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -710,6 +710,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Último erro de BLE</string>
+    <string name="sensor_connection_log">Registo de ligação</string>
     <string name="libre_setup_done">Concluído</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Ajuste o comportamento experimental da leitura do Libre 3 antes do emparelhamento.</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -187,6 +187,7 @@
     <string name="ok">Ок</string>
     <string name="ongoing_description">Текущая программа</string>
     <string name="open">Открыть</string>
+    <string name="copy">Копировать</string>
     <string name="share">Поделиться</string>
     <string name="overlaypermission">Чтобы дать разрешение:</string>
     <string name="parseip">Ошибка при проверке IP-адреса</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -497,6 +497,7 @@
     <string name="disabled_status">Отключен</string>
     <string name="last_ble_status">Статус BLE</string>
     <string name="last_ble_error">Последняя ошибка BLE</string>
+    <string name="sensor_connection_log">Журнал подключений</string>
     <string name="sensor_address">Адрес</string>
     <string name="sensor_started">Запущен</string>
     <string name="sensor_ends_officially">Офиц. окончание</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -657,6 +657,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="disabled_status">Dansan</string>
     <string name="last_ble_status">Heerka BLE ee u dambeeyay</string>
     <string name="last_ble_error">Ciladdii BLE ee u dambeysay</string>
+    <string name="sensor_connection_log">Diiwaanka isku xirka</string>
     <string name="sensor_address">Cinwaanka</string>
     <string name="sensor_started">bilaabay</string>
     <string name="sensor_ends_officially">Si Rasmi Ah U Dhamaatay</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -169,6 +169,7 @@
  <string name="enddatesensor">"Dareenka taariikhda dhamaadka"</string>
  <string name="open">Furan</string>
  <string name="withoutsensor">Dareem la\'aan</string>
+ <string name="copy">Koobi</string>
  <string name="share">Wadaag</string>
  <string name="wronglibrary">Maktabadu si fiican uma shaqaynayso, isku day mid kale</string>
  <string name="installedlibrary">Maktabada la rakibay</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -163,6 +163,7 @@
   <string name="addsensorenddate">Lägg till sensorns slutdatum i kalenderappen</string>
   <string name="enddatesensor">"Sensorns slutdatum "</string>
   <string name="open">Öppna</string>
+  <string name="copy">Kopiera</string>
   <string name="share">Dela</string>
   <string name="withoutsensor">Utan sensor</string>
   <string name="wronglibrary">Programbiblioteket fungerar inte korrekt. Prova ett annat.</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -775,6 +775,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Senaste BLE-felet</string>
+    <string name="sensor_connection_log">Anslutningslogg</string>
     <string name="libre_setup_done">Klart</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Justera det experimentella Libre 3-skanningsbeteendet innan parkoppling.</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -813,6 +813,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Son BLE hatası</string>
+    <string name="sensor_connection_log">Bağlantı günlüğü</string>
     <string name="libre_setup_done">Bitti</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Eşleştirmeden önce deneysel Libre 3 tarama davranışını ayarlayın.</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -167,6 +167,7 @@
  <string name="addsensorenddate">Takvime sensör bitiş tarihi ekle</string>
  <string name="enddatesensor">"Sensör bitiş tarihi"</string>
  <string name="open">Aç</string>
+ <string name="copy">Kopyala</string>
  <string name="share">Paylaş</string>
  <string name="withoutsensor">Sensör olmadan</string>
  <string name="wronglibrary">Kütüphane düzgün çalışmıyor, farklı bir tane deneyin.</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -167,6 +167,7 @@
  <string name="addsensorenddate">Додайте кінцеву дату датчика до календаря</string>
  <string name="enddatesensor">"Датчик кінцевої дати "</string>
  <string name="open">Відкрити</string>
+ <string name="copy">Копіювати</string>
  <string name="share">Поділитися</string>
  <string name="withoutsensor">Без датчика</string>
  <string name="wronglibrary">Бібліотека не працює належним чином, спробуйте іншу</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -787,6 +787,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Остання помилка BLE</string>
+    <string name="sensor_connection_log">Журнал підключень</string>
     <string name="libre_setup_done">Готово</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">Налаштуйте експериментальну поведінку сканування Libre 3 перед сполученням.</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -168,6 +168,7 @@
  <string name="addsensorenddate">将传感器结束日期添加到日历应用程序</string>
  <string name="enddatesensor">"传感器结束日期 "</string>
  <string name="open">打开</string>
+ <string name="copy">复制</string>
  <string name="share">分享</string>
  <string name="withoutsensor">没有传感器</string>
  <string name="wronglibrary">库功能不正常，请尝试另一个</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -787,6 +787,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="last">"Last: "</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">上次 BLE 错误</string>
+    <string name="sensor_connection_log">连接日志</string>
     <string name="libre_setup_done">完成</string>
     <string name="libre_setup_libreview_note_title">Libre 3 + LibreView</string>
     <string name="libre_setup_advanced_options_desc">在配对前调整 Libre 3 的实验性扫描行为。</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -679,6 +679,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="disabled_status">Disabled</string>
     <string name="last_ble_status">Last BLE status</string>
     <string name="last_ble_error">Last BLE error</string>
+    <string name="sensor_connection_log">Connection log</string>
     <string name="sensor_address">Address</string>
     <string name="sensor_started">Started</string>
     <string name="sensor_ends_officially">Ends Officially</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -168,6 +168,7 @@
  <string name="addsensorenddate">Add sensor end date to calendar app</string>
  <string name="enddatesensor">"End date sensor "</string>
  <string name="open">Open</string>
+ <string name="copy">Copy</string>
  <string name="share">Share</string>
  <string name="withoutsensor">Without sensor</string>
  <string name="wronglibrary">Library not functioning properly, try a different one</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/DebugSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/DebugSettingsScreen.kt
@@ -161,6 +161,11 @@ fun DebugSettingsScreen(navController: NavController) {
     }
 
     var logType by remember { mutableStateOf(LogType.TRACE) }
+    // Only the legacy GATT callbacks (Libre 2/3, Dexcom, Accu-Chek, Sibionics) route through
+    // setConStatus and record here; the managed drivers set their status directly. Offering
+    // the tab to someone whose sensors cannot produce an entry just shows them an empty view
+    // and leaves them wondering what they did wrong, so it appears once one exists.
+    var bleErrorsAvailable by remember { mutableStateOf(false) }
     var isRecording by remember { mutableStateOf(false) }
     var snapshot by remember { mutableStateOf(LogSnapshot()) }
     var loading by remember { mutableStateOf(true) }
@@ -183,6 +188,16 @@ fun DebugSettingsScreen(navController: NavController) {
             LogType.BLE_ERRORS -> DebugLogExportSource.TextContent(bleErrorHistoryText())
         }
         return source.takeUnless(DebugLogExportSource::isEmpty)
+    }
+
+    LaunchedEffect(Unit) {
+        while (isActive) {
+            val available = withContext(Dispatchers.IO) { BleErrorHistory.events().isNotEmpty() }
+            bleErrorsAvailable = available
+            // Clearing the history while it is on screen must not strand the selection.
+            if (!available && logType == LogType.BLE_ERRORS) logType = LogType.TRACE
+            delay(10_000L)
+        }
     }
 
     LaunchedEffect(logType) {
@@ -385,8 +400,11 @@ fun DebugSettingsScreen(navController: NavController) {
                 LogType.LOGCAT to stringResource(R.string.logcat),
                 LogType.BLE_ERRORS to stringResource(R.string.ble_error_history),
             )
+            val logTypes = remember(bleErrorsAvailable) {
+                LogType.entries.filter { it != LogType.BLE_ERRORS || bleErrorsAvailable }
+            }
             ConnectedButtonGroup(
-                options = LogType.entries,
+                options = logTypes,
                 selectedOption = logType,
                 onOptionSelected = { logType = it },
                 labelText = { logTypeLabels[it].orEmpty() },

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -1853,13 +1853,10 @@ fun SensorCard(
                 color = MaterialTheme.colorScheme.surfaceContainer // Tonal separation
             ) {
                 Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
                     Column(
-                        modifier = Modifier.padding(horizontal = 16.dp),
+                        modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         // Clean Label-Value rows
@@ -2088,8 +2085,8 @@ fun SensorCard(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable(role = Role.Button) { connectionLogExpanded = !connectionLogExpanded }
-                            .heightIn(min = 48.dp)
-                            .padding(horizontal = 16.dp),
+                            .heightIn(min = ButtonDefaults.MinHeight)
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
@@ -2118,7 +2115,7 @@ fun SensorCard(
                         enter = expandVertically() + fadeIn(),
                         exit = shrinkVertically() + fadeOut(),
                     ) {
-                        Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                        Box(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp)) {
                             SensorTraceLog(sensor)
                         }
                     }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -2078,15 +2078,16 @@ fun SensorCard(
                         }
                     }
 
-                    HorizontalDivider(
-                        modifier = Modifier.padding(top = 4.dp),
-                        color = MaterialTheme.colorScheme.outlineVariant,
-                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    // 48dp is the touch target, not the visual height: the row carries no
+                    // padding of its own, so the tappable area stays reachable while the
+                    // collapsed header costs a single line of the card.
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .heightIn(min = 48.dp)
-                            .clickable { connectionLogExpanded = !connectionLogExpanded },
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable { connectionLogExpanded = !connectionLogExpanded }
+                            .heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -2080,12 +2080,19 @@ fun SensorCard(
                         }
                     }
 
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    // Inset and softened: this separates two parts of one card, and at full
+                    // strength edge to edge it read as a rule between two cards instead.
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                    )
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable(role = Role.Button) { connectionLogExpanded = !connectionLogExpanded }
-                            .heightIn(min = ButtonDefaults.MinHeight)
+                            // A whole-width row that only toggles one thing can afford the list
+                            // item's own height, and it is the easiest thing on the card to hit.
+                            .heightIn(min = 56.dp)
                             .padding(horizontal = 16.dp, vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
@@ -2115,7 +2122,9 @@ fun SensorCard(
                         enter = expandVertically() + fadeIn(),
                         exit = shrinkVertically() + fadeOut(),
                     ) {
-                        Box(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp)) {
+                        // The taller header already spaces the log off the rows above, so the
+                        // gap that matters is the one under it -- and Copy/Share bring their own.
+                        Box(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 4.dp)) {
                             SensorTraceLog(sensor)
                         }
                     }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -1855,239 +1855,241 @@ fun SensorCard(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                        .padding(vertical = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    // Clean Label-Value rows
-                    val labelStyle = MaterialTheme.typography.labelMedium.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    val valueStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface)
-                    var batteryRefreshAnimation by remember(sensor.serial) { mutableIntStateOf(0) }
-
-                    @Composable
-                    fun DataRow(
-                        label: String,
-                        value: String,
-                        onClick: (() -> Unit)? = null,
-                        valueAnimationKey: Int? = null,
+                    Column(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        val rowModifier = if (onClick != null) {
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable(
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    indication = null,
-                                    onClick = onClick,
-                                )
-                        } else {
-                            Modifier.fillMaxWidth()
-                        }
-                        Row(
-                            modifier = rowModifier,
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.Top
+                        // Clean Label-Value rows
+                        val labelStyle = MaterialTheme.typography.labelMedium.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        val valueStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface)
+                        var batteryRefreshAnimation by remember(sensor.serial) { mutableIntStateOf(0) }
+
+                        @Composable
+                        fun DataRow(
+                            label: String,
+                            value: String,
+                            onClick: (() -> Unit)? = null,
+                            valueAnimationKey: Int? = null,
                         ) {
-                            Text(
-                                text = label,
-                                style = labelStyle,
-                                maxLines = 2,
-                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(0.42f)
-                            )
-                            if (valueAnimationKey == null) {
+                            val rowModifier = if (onClick != null) {
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = null,
+                                        onClick = onClick,
+                                    )
+                            } else {
+                                Modifier.fillMaxWidth()
+                            }
+                            Row(
+                                modifier = rowModifier,
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.Top
+                            ) {
                                 Text(
-                                    text = value,
-                                    style = valueStyle,
+                                    text = label,
+                                    style = labelStyle,
                                     maxLines = 2,
                                     overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                                    textAlign = androidx.compose.ui.text.style.TextAlign.End,
-                                    modifier = Modifier.weight(0.58f)
+                                    modifier = Modifier.weight(0.42f)
                                 )
-                            } else {
-                                AnimatedContent(
-                                    targetState = value to valueAnimationKey,
-                                    transitionSpec = {
-                                        (fadeIn(tween(180)) + slideInVertically(tween(180)) { it / 3 })
-                                            .togetherWith(
-                                                fadeOut(tween(120)) + slideOutVertically(tween(120)) { -it / 3 },
-                                            )
-                                    },
-                                    contentAlignment = Alignment.CenterEnd,
-                                    label = "sensorBatteryValue",
-                                    modifier = Modifier.weight(0.58f),
-                                ) { (animatedValue, _) ->
+                                if (valueAnimationKey == null) {
                                     Text(
-                                        text = animatedValue,
+                                        text = value,
                                         style = valueStyle,
                                         maxLines = 2,
                                         overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                                         textAlign = androidx.compose.ui.text.style.TextAlign.End,
-                                        modifier = Modifier.fillMaxWidth(),
+                                        modifier = Modifier.weight(0.58f)
                                     )
+                                } else {
+                                    AnimatedContent(
+                                        targetState = value to valueAnimationKey,
+                                        transitionSpec = {
+                                            (fadeIn(tween(180)) + slideInVertically(tween(180)) { it / 3 })
+                                                .togetherWith(
+                                                    fadeOut(tween(120)) + slideOutVertically(tween(120)) { -it / 3 },
+                                                )
+                                        },
+                                        contentAlignment = Alignment.CenterEnd,
+                                        label = "sensorBatteryValue",
+                                        modifier = Modifier.weight(0.58f),
+                                    ) { (animatedValue, _) ->
+                                        Text(
+                                            text = animatedValue,
+                                            style = valueStyle,
+                                            maxLines = 2,
+                                            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                                            textAlign = androidx.compose.ui.text.style.TextAlign.End,
+                                            modifier = Modifier.fillMaxWidth(),
+                                        )
+                                    }
                                 }
                             }
                         }
-                    }
 
-                    val connectedStatus = stringResource(R.string.status_connected)
-                    val errorEventAt = bleErrorEventTimeForDisplay(
-                        sensor.connectionStatusAtMs,
-                        bleErrorNow,
-                    )
-                    if (errorEventAt != null &&
-                        sensor.connectionStatus.isNotEmpty() &&
-                        !sensor.connectionStatus.equals(connectedStatus, ignoreCase = true)
-                    ) {
-                        DataRow(
-                            stringResource(R.string.last_ble_error),
-                            bleErrorValue(
-                                sensor.connectionStatus,
-                                DateUtils.getRelativeTimeSpanString(
-                                    errorEventAt,
-                                    bleErrorNow,
-                                    DateUtils.MINUTE_IN_MILLIS,
+                        val connectedStatus = stringResource(R.string.status_connected)
+                        val errorEventAt = bleErrorEventTimeForDisplay(
+                            sensor.connectionStatusAtMs,
+                            bleErrorNow,
+                        )
+                        if (errorEventAt != null &&
+                            sensor.connectionStatus.isNotEmpty() &&
+                            !sensor.connectionStatus.equals(connectedStatus, ignoreCase = true)
+                        ) {
+                            DataRow(
+                                stringResource(R.string.last_ble_error),
+                                bleErrorValue(
+                                    sensor.connectionStatus,
+                                    DateUtils.getRelativeTimeSpanString(
+                                        errorEventAt,
+                                        bleErrorNow,
+                                        DateUtils.MINUTE_IN_MILLIS,
+                                    ),
                                 ),
-                            ),
-                        )
-                    } else if (sensor.connectionStatusAtMs <= 0L &&
-                        sensor.connectionStatus.isNotEmpty() &&
-                        !sensor.connectionStatus.equals(connectedStatus, ignoreCase = true)
-                    ) {
-                        // Managed drivers can publish a current diagnostic status without an
-                        // event timestamp. Keep that live status; only timestamped history ages
-                        // off after the one-hour card window.
-                        DataRow(stringResource(R.string.last_ble_status), sensor.connectionStatus)
-                    }
-                    DataRow(stringResource(R.string.sensor_address), sensor.deviceAddress)
-                    
-                    // FIX: Use Long timestamp directly to avoid String Parsing Locale bugs in formatSensorTime
-                    // User reported "100% Fill / Red Color" bug in English Locale, likely due to startMs being 0 or parse fail.
-                    // We also ensure we only show valid dates.
-                    if (sensor.startMs > 1577836800000L) { // > Jan 1 2020
-                        DataRow(stringResource(R.string.sensor_started), formatSensorTime(sensor.startMs.toString()))
-                    }
-
-                    if (sensor.officialEndMs > 0) {
-                        DataRow(stringResource(R.string.sensor_ends_officially), formatSensorTime(sensor.officialEndMs.toString()))
-                    } else if (sensor.officialEnd.isNotEmpty()) {
-                        DataRow(stringResource(R.string.sensor_ends_officially), formatSensorTime(sensor.officialEnd))
-                    }
-
-                    if (sensor.expectedEndMs > 0) {
-                        DataRow(stringResource(R.string.sensor_expected_end), formatSensorTime(sensor.expectedEndMs.toString()))
-                    } else if (sensor.expectedEnd.isNotEmpty()) {
-                       DataRow(stringResource(R.string.sensor_expected_end), formatSensorTime(sensor.expectedEnd))
-                    }
-
-                    if (sensor.isAnytime && sensor.batteryMillivolts > 0) {
-                        // Anytime: surface both percent and voltage — voltage is the
-                        // health-critical metric (low-battery cutoff is 4.05 V on CT3).
-                        val voltsText = String.format(java.util.Locale.getDefault(), "%.2f V", sensor.batteryMillivolts / 1000.0)
-                        val combined = if (sensor.batteryPercent >= 0) {
-                            "${sensor.batteryPercent}% · $voltsText"
-                        } else {
-                            voltsText
+                            )
+                        } else if (sensor.connectionStatusAtMs <= 0L &&
+                            sensor.connectionStatus.isNotEmpty() &&
+                            !sensor.connectionStatus.equals(connectedStatus, ignoreCase = true)
+                        ) {
+                            // Managed drivers can publish a current diagnostic status without an
+                            // event timestamp. Keep that live status; only timestamped history ages
+                            // off after the one-hour card window.
+                            DataRow(stringResource(R.string.last_ble_status), sensor.connectionStatus)
                         }
-                        DataRow(stringResource(R.string.sensor_battery_voltage), combined)
-                    } else if (sensor.batteryPercent >= 0) {
-                        val refreshBattery = if (sensor.isSibionics && sensor.isVendorConnected) {
-                            {
-                                if (viewModel.refreshSensorBattery(sensor.serial)) {
-                                    batteryRefreshAnimation++
+                        DataRow(stringResource(R.string.sensor_address), sensor.deviceAddress)
+                    
+                        // FIX: Use Long timestamp directly to avoid String Parsing Locale bugs in formatSensorTime
+                        // User reported "100% Fill / Red Color" bug in English Locale, likely due to startMs being 0 or parse fail.
+                        // We also ensure we only show valid dates.
+                        if (sensor.startMs > 1577836800000L) { // > Jan 1 2020
+                            DataRow(stringResource(R.string.sensor_started), formatSensorTime(sensor.startMs.toString()))
+                        }
+
+                        if (sensor.officialEndMs > 0) {
+                            DataRow(stringResource(R.string.sensor_ends_officially), formatSensorTime(sensor.officialEndMs.toString()))
+                        } else if (sensor.officialEnd.isNotEmpty()) {
+                            DataRow(stringResource(R.string.sensor_ends_officially), formatSensorTime(sensor.officialEnd))
+                        }
+
+                        if (sensor.expectedEndMs > 0) {
+                            DataRow(stringResource(R.string.sensor_expected_end), formatSensorTime(sensor.expectedEndMs.toString()))
+                        } else if (sensor.expectedEnd.isNotEmpty()) {
+                           DataRow(stringResource(R.string.sensor_expected_end), formatSensorTime(sensor.expectedEnd))
+                        }
+
+                        if (sensor.isAnytime && sensor.batteryMillivolts > 0) {
+                            // Anytime: surface both percent and voltage — voltage is the
+                            // health-critical metric (low-battery cutoff is 4.05 V on CT3).
+                            val voltsText = String.format(java.util.Locale.getDefault(), "%.2f V", sensor.batteryMillivolts / 1000.0)
+                            val combined = if (sensor.batteryPercent >= 0) {
+                                "${sensor.batteryPercent}% · $voltsText"
+                            } else {
+                                voltsText
+                            }
+                            DataRow(stringResource(R.string.sensor_battery_voltage), combined)
+                        } else if (sensor.batteryPercent >= 0) {
+                            val refreshBattery = if (sensor.isSibionics && sensor.isVendorConnected) {
+                                {
+                                    if (viewModel.refreshSensorBattery(sensor.serial)) {
+                                        batteryRefreshAnimation++
+                                    }
+                                }
+                            } else {
+                                null
+                            }
+                            DataRow(
+                                label = stringResource(R.string.sensor_battery_voltage),
+                                value = "${sensor.batteryPercent}%",
+                                onClick = refreshBattery,
+                                valueAnimationKey = if (sensor.isSibionics) batteryRefreshAnimation else null,
+                            )
+                        } else if (sensor.batteryMillivolts > 0) {
+                            DataRow(stringResource(R.string.sensor_battery_voltage), String.format(java.util.Locale.getDefault(), "%.3f V", sensor.batteryMillivolts / 1000.0))
+                        }
+
+                        if (sensor.sensorRemainingHours >= 0) {
+                            val remainText = when {
+                                sensor.isSensorExpired -> stringResource(R.string.expired)
+                                sensor.sensorRemainingHours <= 0 -> stringResource(R.string.expired)
+                                sensor.sensorRemainingHours <= 24 -> stringResource(R.string.hours_remaining, sensor.sensorRemainingHours)
+                                else -> {
+                                    val days = sensor.sensorRemainingHours / 24
+                                    val hours = sensor.sensorRemainingHours % 24
+                                    stringResource(R.string.days_hours_remaining, days, hours)
                                 }
                             }
-                        } else {
-                            null
-                        }
-                        DataRow(
-                            label = stringResource(R.string.sensor_battery_voltage),
-                            value = "${sensor.batteryPercent}%",
-                            onClick = refreshBattery,
-                            valueAnimationKey = if (sensor.isSibionics) batteryRefreshAnimation else null,
-                        )
-                    } else if (sensor.batteryMillivolts > 0) {
-                        DataRow(stringResource(R.string.sensor_battery_voltage), String.format(java.util.Locale.getDefault(), "%.3f V", sensor.batteryMillivolts / 1000.0))
-                    }
-
-                    if (sensor.sensorRemainingHours >= 0) {
-                        val remainText = when {
-                            sensor.isSensorExpired -> stringResource(R.string.expired)
-                            sensor.sensorRemainingHours <= 0 -> stringResource(R.string.expired)
-                            sensor.sensorRemainingHours <= 24 -> stringResource(R.string.hours_remaining, sensor.sensorRemainingHours)
-                            else -> {
-                                val days = sensor.sensorRemainingHours / 24
-                                val hours = sensor.sensorRemainingHours % 24
-                                stringResource(R.string.days_hours_remaining, days, hours)
+                            val remainColor = when {
+                                sensor.isSensorExpired || sensor.sensorRemainingHours <= 0 -> MaterialTheme.colorScheme.error
+                                sensor.sensorRemainingHours <= 24 -> MaterialTheme.colorScheme.error
+                                sensor.sensorRemainingHours <= 48 -> MaterialTheme.colorScheme.tertiary
+                                else -> MaterialTheme.colorScheme.onSurface
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(stringResource(R.string.sensor_life), style = labelStyle)
+                                Text(
+                                    remainText,
+                                    style = valueStyle.copy(color = remainColor),
+                                    fontWeight = if (sensor.sensorRemainingHours <= 24) FontWeight.Bold else FontWeight.Normal
+                                )
                             }
                         }
-                        val remainColor = when {
-                            sensor.isSensorExpired || sensor.sensorRemainingHours <= 0 -> MaterialTheme.colorScheme.error
-                            sensor.sensorRemainingHours <= 24 -> MaterialTheme.colorScheme.error
-                            sensor.sensorRemainingHours <= 48 -> MaterialTheme.colorScheme.tertiary
-                            else -> MaterialTheme.colorScheme.onSurface
-                        }
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Text(stringResource(R.string.sensor_life), style = labelStyle)
-                            Text(
-                                remainText,
-                                style = valueStyle.copy(color = remainColor),
-                                fontWeight = if (sensor.sensorRemainingHours <= 24) FontWeight.Bold else FontWeight.Normal
-                            )
-                        }
-                    }
 
-                    if (sensor.sensorAgeHours >= 0) {
-                        val ageText = if (sensor.sensorAgeHours < 24) {
-                            stringResource(R.string.sensor_age_hours, sensor.sensorAgeHours)
-                        } else {
-                            val days = sensor.sensorAgeHours / 24
-                            val hours = sensor.sensorAgeHours % 24
-                            stringResource(R.string.sensor_age_days_hours, days, hours)
+                        if (sensor.sensorAgeHours >= 0) {
+                            val ageText = if (sensor.sensorAgeHours < 24) {
+                                stringResource(R.string.sensor_age_hours, sensor.sensorAgeHours)
+                            } else {
+                                val days = sensor.sensorAgeHours / 24
+                                val hours = sensor.sensorAgeHours % 24
+                                stringResource(R.string.sensor_age_days_hours, days, hours)
+                            }
+                            DataRow(stringResource(R.string.sensor_age), ageText)
                         }
-                        DataRow(stringResource(R.string.sensor_age), ageText)
-                    }
 
-                    if (sensor.vendorModel.isNotEmpty()) {
-                        DataRow(stringResource(R.string.model), sensor.vendorModel)
-                    }
-                    if (sensor.sensorDetailTelemetry.isNotBlank()) {
-                        DataRow(stringResource(R.string.anytime_sensor_telemetry), sensor.sensorDetailTelemetry)
-                    }
-                    if (sensor.vendorFirmware.isNotEmpty()) {
-                        val firmwareText = if (sensor.vendorFirmware.startsWith("v", ignoreCase = true)) {
-                            sensor.vendorFirmware
-                        } else {
-                            "v${sensor.vendorFirmware}"
+                        if (sensor.vendorModel.isNotEmpty()) {
+                            DataRow(stringResource(R.string.model), sensor.vendorModel)
                         }
-                        DataRow(stringResource(R.string.firmware), firmwareText)
-                    }
+                        if (sensor.sensorDetailTelemetry.isNotBlank()) {
+                            DataRow(stringResource(R.string.anytime_sensor_telemetry), sensor.sensorDetailTelemetry)
+                        }
+                        if (sensor.vendorFirmware.isNotEmpty()) {
+                            val firmwareText = if (sensor.vendorFirmware.startsWith("v", ignoreCase = true)) {
+                                sensor.vendorFirmware
+                            } else {
+                                "v${sensor.vendorFirmware}"
+                            }
+                            DataRow(stringResource(R.string.firmware), firmwareText)
+                        }
 
-                    if (sensor.isSensorExpired) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Text(stringResource(R.string.status), style = labelStyle)
-                            Text(
-                                stringResource(R.string.sensor_expired_text),
-                                style = valueStyle.copy(color = MaterialTheme.colorScheme.error),
-                                fontWeight = FontWeight.Bold
-                            )
+                        if (sensor.isSensorExpired) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(stringResource(R.string.status), style = labelStyle)
+                                Text(
+                                    stringResource(R.string.sensor_expired_text),
+                                    style = valueStyle.copy(color = MaterialTheme.colorScheme.error),
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
                         }
                     }
 
                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                    // 48dp is the touch target, not the visual height: the row carries no
-                    // padding of its own, so the tappable area stays reachable while the
-                    // collapsed header costs a single line of the card.
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
-                            .clickable { connectionLogExpanded = !connectionLogExpanded }
-                            .heightIn(min = 48.dp),
+                            .clickable(role = Role.Button) { connectionLogExpanded = !connectionLogExpanded }
+                            .heightIn(min = 48.dp)
+                            .padding(horizontal = 16.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
@@ -2116,7 +2118,9 @@ fun SensorCard(
                         enter = expandVertically() + fadeIn(),
                         exit = shrinkVertically() + fadeOut(),
                     ) {
-                        SensorTraceLog(sensor)
+                        Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                            SensorTraceLog(sensor)
+                        }
                     }
 
                 }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -49,6 +49,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
@@ -64,6 +67,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.rotate
 
 import androidx.compose.material.icons.filled.AccessTime
 import tk.glucodata.CurrentDisplaySource
@@ -520,6 +524,7 @@ fun SensorCard(
     var showAiDexUnpairDialog by remember { mutableStateOf(false) }
     var showMqRestoreSheet by remember { mutableStateOf(false) }
     var showMqCalibrationSheet by remember { mutableStateOf(false) }
+    var connectionLogExpanded by remember(sensor.serial) { mutableStateOf(false) }
     var calibrationInputText by remember { mutableStateOf("") }
     var mqCalibrationInputText by remember { mutableStateOf("") }
     var mqQrInput by remember(context, sensor.serial) {
@@ -2071,6 +2076,46 @@ fun SensorCard(
                                 fontWeight = FontWeight.Bold
                             )
                         }
+                    }
+
+                    HorizontalDivider(
+                        modifier = Modifier.padding(top = 4.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 48.dp)
+                            .clickable { connectionLogExpanded = !connectionLogExpanded },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.History,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            text = stringResource(R.string.sensor_connection_log),
+                            style = MaterialTheme.typography.titleSmall,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Icon(
+                            imageVector = Icons.Default.ExpandMore,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .size(20.dp)
+                                .rotate(if (connectionLogExpanded) 180f else 0f),
+                        )
+                    }
+                    AnimatedVisibility(
+                        visible = connectionLogExpanded,
+                        enter = expandVertically() + fadeIn(),
+                        exit = shrinkVertically() + fadeOut(),
+                    ) {
+                        SensorTraceLog(sensor)
                     }
 
                 }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorCard.kt
@@ -2092,7 +2092,7 @@ fun SensorCard(
                             .clickable(role = Role.Button) { connectionLogExpanded = !connectionLogExpanded }
                             // A whole-width row that only toggles one thing can afford the list
                             // item's own height, and it is the easiest thing on the card to hit.
-                            .heightIn(min = 56.dp)
+                            .heightIn(min = 48.dp)
                             .padding(horizontal = 16.dp, vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
@@ -1,0 +1,97 @@
+package tk.glucodata.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import tk.glucodata.R
+import tk.glucodata.SensorIdentity
+import tk.glucodata.ui.viewmodel.SensorInfo
+
+private const val TRACE_TAIL_BYTES = 64L * 1024L
+private const val TRACE_LINE_LIMIT = 10
+
+internal fun filterRecentSensorTraceLines(
+    lines: List<String>,
+    identifiers: Collection<String>,
+    limit: Int = TRACE_LINE_LIMIT,
+): List<String> {
+    val needles = identifiers.mapNotNull { value -> value.trim().takeIf { it.isNotEmpty() } }
+    if (needles.isEmpty()) return emptyList()
+    return lines.asReversed()
+        .filter { line -> needles.any { needle -> line.contains(needle, ignoreCase = true) } }
+        .take(limit)
+        .asReversed()
+}
+
+private fun readRecentSensorTraceLines(file: File, identifiers: Collection<String>): List<String> {
+    if (!file.exists()) return emptyList()
+    return runCatching {
+        val size = file.length()
+        file.inputStream().use { stream ->
+            if (size > TRACE_TAIL_BYTES) stream.skip(size - TRACE_TAIL_BYTES)
+            val lines = stream.bufferedReader().readLines()
+            filterRecentSensorTraceLines(
+                lines = if (size > TRACE_TAIL_BYTES) lines.drop(1) else lines,
+                identifiers = identifiers,
+            )
+        }
+    }.getOrDefault(emptyList())
+}
+
+@Composable
+internal fun SensorTraceLog(sensor: SensorInfo) {
+    val context = LocalContext.current
+    val identifiers = remember(sensor.serial, sensor.deviceAddress) {
+        buildSet {
+            add(sensor.serial)
+            sensor.deviceAddress.takeUnless { it.equals("Unknown", ignoreCase = true) }?.let(::add)
+            runCatching { SensorIdentity.resolveNativeHistorySensorNames(sensor.serial) }
+                .getOrDefault(emptyList())
+                .forEach(::add)
+        }
+    }
+    var lines by remember(sensor.serial) { mutableStateOf<List<String>>(emptyList()) }
+
+    LaunchedEffect(context, identifiers) {
+        val file = File(context.filesDir, "logs/trace.log")
+        while (isActive) {
+            lines = withContext(Dispatchers.IO) {
+                readRecentSensorTraceLines(file, identifiers)
+            }
+            delay(2_000L)
+        }
+    }
+
+    SelectionContainer {
+        Text(
+            text = if (lines.isEmpty()) {
+                stringResource(R.string.no_data_available)
+            } else {
+                lines.joinToString("\n")
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 32.dp, end = 8.dp, bottom = 8.dp),
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
@@ -1,8 +1,14 @@
+@file:OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
+
 package tk.glucodata.ui
 
 import android.content.Intent
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -13,6 +19,7 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -23,6 +30,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,6 +57,7 @@ import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tk.glucodata.R
 import tk.glucodata.SensorIdentity
@@ -198,6 +207,13 @@ private fun readRecentSensorTraceLines(
     }.getOrDefault(emptyList())
 }
 
+/** Named for the sensor and the moment, the way the debug log export is. */
+internal fun sensorTraceExportName(serial: String, at: Date = Date()): String {
+    val stamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(at)
+    val safe = serial.filter { it.isLetterOrDigit() }.take(24).ifEmpty { "sensor" }
+    return "juggluco-connection-$safe-$stamp.txt"
+}
+
 @Composable
 internal fun SensorTraceLog(sensor: SensorInfo) {
     val context = LocalContext.current
@@ -234,6 +250,35 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
     val rendered = remember(lines) {
         lines.joinToString("\n") { line ->
             formatSensorTraceLine(line) { millis -> timeFormat.format(Date(millis)) }
+        }
+    }
+
+    val scope = rememberCoroutineScope()
+    val savingError = stringResource(R.string.error_saving_file)
+    val saveLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("text/plain")
+    ) { uri ->
+        uri ?: return@rememberLauncherForActivityResult
+        val text = rendered
+        scope.launch {
+            val error = withContext(Dispatchers.IO) {
+                var opened = false
+                runCatching {
+                    val output = context.contentResolver.openOutputStream(uri, "wt")
+                        ?: throw java.io.IOException("Could not open export destination")
+                    opened = true
+                    output.use { it.write(text.toByteArray()) }
+                }.exceptionOrNull().also {
+                    // The picker created the file before we ever wrote to it; a failure here
+                    // would otherwise leave an empty one behind with the name of a real export.
+                    if (it != null && opened) {
+                        runCatching { context.contentResolver.delete(uri, null, null) }
+                    }
+                }
+            }
+            if (error != null) {
+                Toast.makeText(context, savingError + error.message, Toast.LENGTH_LONG).show()
+            }
         }
     }
 
@@ -313,10 +358,12 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
         }
         // A text button carries its own 8dp of vertical padding inside a 40dp target, so any
         // gap added here lands on top of that and the log ends up floating above its actions.
-        Row(
+        // Three labelled buttons do not fit a card on one line in every language -- Kopieren,
+        // Teilen, Speichern already overflow -- so they wrap rather than being clipped.
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
-            verticalAlignment = Alignment.CenterVertically,
+            verticalArrangement = Arrangement.spacedBy(0.dp),
         ) {
             TextButton(onClick = { clipboard.setText(AnnotatedString(rendered)) }) {
                 Icon(Icons.Default.ContentCopy, contentDescription = null)
@@ -339,6 +386,13 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
                 Icon(Icons.Default.Share, contentDescription = null)
                 Spacer8()
                 Text(stringResource(R.string.share))
+            }
+            TextButton(
+                onClick = { saveLauncher.launch(sensorTraceExportName(sensor.serial)) },
+            ) {
+                Icon(Icons.Default.Save, contentDescription = null)
+                Spacer8()
+                Text(stringResource(R.string.save))
             }
         }
     }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
@@ -192,8 +192,19 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
     LaunchedEffect(context, identifiers, driverTags) {
         val file = File(context.filesDir, "logs/trace.log")
         while (isActive) {
-            lines = withContext(Dispatchers.IO) {
-                readRecentSensorTraceLines(file, identifiers, driverTags)
+            // trace.log is the richer source -- it has the native lines too and it survives a
+            // restart -- but it is only written while logging is on. With logging off the
+            // in-memory ring is all there is, and reading it costs no IO.
+            lines = if (tk.glucodata.Log.doLog) {
+                withContext(Dispatchers.IO) {
+                    readRecentSensorTraceLines(file, identifiers, driverTags)
+                }
+            } else {
+                filterRecentSensorTraceLines(
+                    lines = tk.glucodata.SensorTraceRing.snapshot().asList(),
+                    identifiers = identifiers,
+                    driverTags = driverTags,
+                )
             }
             delay(2_000L)
         }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
@@ -30,6 +30,9 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -37,6 +40,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.sp
 import java.io.File
 import java.text.SimpleDateFormat
@@ -214,6 +218,19 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
     }
 
     val verticalScroll = rememberScrollState()
+    val scrollBoundary = remember {
+        object : NestedScrollConnection {
+            // Keep leftover drag distance and fling velocity inside the log at either edge.
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset = Offset(0f, available.y)
+
+            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity =
+                Velocity(0f, available.y)
+        }
+    }
     val scrollbarColor = MaterialTheme.colorScheme.onSurfaceVariant
     // Follow the tail, the way a person watching a live log expects.
     LaunchedEffect(rendered) { verticalScroll.animateScrollTo(verticalScroll.maxValue) }
@@ -250,6 +267,7 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
                             )
                         }
                     }
+                    .nestedScroll(scrollBoundary)
                     .verticalScroll(verticalScroll)
                     .padding(end = 12.dp),
                 style = MaterialTheme.typography.bodySmall.copy(

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
@@ -1,47 +1,154 @@
 package tk.glucodata.ui
 
+import android.content.Intent
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import tk.glucodata.R
 import tk.glucodata.SensorIdentity
+import tk.glucodata.SensorVendor
 import tk.glucodata.ui.viewmodel.SensorInfo
 
-private const val TRACE_TAIL_BYTES = 64L * 1024L
-private const val TRACE_LINE_LIMIT = 10
+private const val TRACE_TAIL_BYTES = 256L * 1024L
+private const val TRACE_LINE_LIMIT = 200
+
+/**
+ * Native bookkeeping that says nothing about a connection. These lines dominated the log —
+ * a sensor id appears in each of them, so identity matching alone surfaced almost nothing
+ * else — while the driver traffic worth reading was filtered out for *not* naming the sensor.
+ */
+private val TRACE_NOISE_MARKERS = listOf(
+    "get previous state",
+    "setSensorWearDays",
+    "ensureDirectStreamShell",
+    "savepollallIDsonly",
+    "hasSensorStreamCapacity",
+    "wakebackup",
+    "wakesender",
+    "setstreaming",
+    "getdataptr",
+    "freedataptr",
+    "incUsage",
+    "decUsage",
+    "locknew",
+    "scanstate",
+    "updateDevices",
+    "checkBluetoothAddress",
+    "deactivated",
+    "makefilename",
+)
+
+/**
+ * Driver tags whose lines belong to this sensor. Most of what a person needs when a
+ * connection misbehaves — handshake stages, protocol frames, end-cycle results — is logged
+ * against the driver tag and never mentions the sensor id, so tag attribution is the only
+ * way to surface it. Two sensors of the same family share a tag; that is better than
+ * showing neither.
+ */
+internal fun sensorTraceDriverTags(vendor: SensorVendor?): List<String> = when (vendor) {
+    SensorVendor.YUWELL -> listOf("Anytime")
+    SensorVendor.OTTAI -> listOf("Ottai")
+    SensorVendor.SIBIONICS -> listOf("Sibionics")
+    SensorVendor.MICROTECH -> listOf("AiDex")
+    SensorVendor.GLUTEC -> listOf("MQ")
+    SensorVendor.SINOCARE -> listOf("ICan")
+    SensorVendor.NIGHTSCOUT -> listOf("Nightscout")
+    else -> emptyList()
+}
+
+/** `1788437835 22712 I/Anytime CT5 identity check OK` -> level `I`, or 0 when the line has none. */
+private fun traceLevel(line: String): Char {
+    val marker = line.indexOf('/')
+    if (marker <= 0) return ' '
+    val level = line[marker - 1]
+    return if (level in "VDIWEA" && (marker < 2 || line[marker - 2] == ' ')) level else ' '
+}
+
+internal fun isUsefulSensorTraceLine(line: String): Boolean {
+    // A warning or an error is the whole reason someone opened this log.
+    val level = traceLevel(line)
+    if (level == 'W' || level == 'E') return true
+    return TRACE_NOISE_MARKERS.none { marker -> line.contains(marker, ignoreCase = true) }
+}
+
+/**
+ * Trade the epoch seconds and pid for a wall clock, which is what a reader is actually
+ * matching against when they say "it dropped out around twenty past".
+ */
+internal fun formatSensorTraceLine(line: String, formatTime: (Long) -> String): String {
+    val firstGap = line.indexOf(' ')
+    if (firstGap <= 0) return line
+    val seconds = line.substring(0, firstGap).toLongOrNull() ?: return line
+    val secondGap = line.indexOf(' ', firstGap + 1)
+    if (secondGap <= 0) return line
+    val rest = line.substring(secondGap + 1).trim()
+    if (rest.isEmpty()) return line
+    return "${formatTime(seconds * 1_000L)}  $rest"
+}
 
 internal fun filterRecentSensorTraceLines(
     lines: List<String>,
     identifiers: Collection<String>,
+    driverTags: Collection<String> = emptyList(),
     limit: Int = TRACE_LINE_LIMIT,
 ): List<String> {
     val needles = identifiers.mapNotNull { value -> value.trim().takeIf { it.isNotEmpty() } }
-    if (needles.isEmpty()) return emptyList()
+    val tags = driverTags.mapNotNull { value -> value.trim().takeIf { it.isNotEmpty() } }
+    if (needles.isEmpty() && tags.isEmpty()) return emptyList()
     return lines.asReversed()
-        .filter { line -> needles.any { needle -> line.contains(needle, ignoreCase = true) } }
+        .asSequence()
+        .filter(::isUsefulSensorTraceLine)
+        .filter { line ->
+            needles.any { needle -> line.contains(needle, ignoreCase = true) } ||
+                tags.any { tag -> line.contains("/$tag", ignoreCase = true) }
+        }
         .take(limit)
+        .toList()
         .asReversed()
 }
 
-private fun readRecentSensorTraceLines(file: File, identifiers: Collection<String>): List<String> {
+private fun readRecentSensorTraceLines(
+    file: File,
+    identifiers: Collection<String>,
+    driverTags: Collection<String>,
+): List<String> {
     if (!file.exists()) return emptyList()
     return runCatching {
         val size = file.length()
@@ -51,6 +158,7 @@ private fun readRecentSensorTraceLines(file: File, identifiers: Collection<Strin
             filterRecentSensorTraceLines(
                 lines = if (size > TRACE_TAIL_BYTES) lines.drop(1) else lines,
                 identifiers = identifiers,
+                driverTags = driverTags,
             )
         }
     }.getOrDefault(emptyList())
@@ -59,6 +167,7 @@ private fun readRecentSensorTraceLines(file: File, identifiers: Collection<Strin
 @Composable
 internal fun SensorTraceLog(sensor: SensorInfo) {
     val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
     val identifiers = remember(sensor.serial, sensor.deviceAddress) {
         buildSet {
             add(sensor.serial)
@@ -68,30 +177,87 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
                 .forEach(::add)
         }
     }
+    val driverTags = remember(sensor.vendor) { sensorTraceDriverTags(sensor.vendor) }
     var lines by remember(sensor.serial) { mutableStateOf<List<String>>(emptyList()) }
 
-    LaunchedEffect(context, identifiers) {
+    LaunchedEffect(context, identifiers, driverTags) {
         val file = File(context.filesDir, "logs/trace.log")
         while (isActive) {
             lines = withContext(Dispatchers.IO) {
-                readRecentSensorTraceLines(file, identifiers)
+                readRecentSensorTraceLines(file, identifiers, driverTags)
             }
             delay(2_000L)
         }
     }
 
-    SelectionContainer {
-        Text(
-            text = if (lines.isEmpty()) {
-                stringResource(R.string.no_data_available)
-            } else {
-                lines.joinToString("\n")
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 32.dp, end = 8.dp, bottom = 8.dp),
-            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+    val timeFormat = remember { SimpleDateFormat("HH:mm:ss", Locale.getDefault()) }
+    val rendered = remember(lines) {
+        lines.joinToString("\n") { line ->
+            formatSensorTraceLine(line) { millis -> timeFormat.format(Date(millis)) }
+        }
     }
+
+    if (lines.isEmpty()) {
+        // Nothing to act on, so no container: a caption says it without pretending to be a component.
+        Text(
+            text = stringResource(R.string.no_data_available),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+        )
+        return
+    }
+
+    val verticalScroll = rememberScrollState()
+    // Follow the tail, the way a person watching a live log expects.
+    LaunchedEffect(rendered) { verticalScroll.animateScrollTo(verticalScroll.maxValue) }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        SelectionContainer {
+            Text(
+                text = rendered,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 220.dp)
+                    .verticalScroll(verticalScroll)
+                    .horizontalScroll(rememberScrollState()),
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                softWrap = false,
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextButton(onClick = { clipboard.setText(AnnotatedString(rendered)) }) {
+                Icon(Icons.Default.ContentCopy, contentDescription = null)
+                Spacer8()
+                Text(stringResource(R.string.copy))
+            }
+            TextButton(
+                onClick = {
+                    val share = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, rendered)
+                    }
+                    runCatching {
+                        context.startActivity(
+                            Intent.createChooser(share, context.getString(R.string.sensor_connection_log))
+                        )
+                    }
+                },
+            ) {
+                Icon(Icons.Default.Share, contentDescription = null)
+                Spacer8()
+                Text(stringResource(R.string.share))
+            }
+        }
+    }
+}
+
+@Composable
+private fun Spacer8() {
+    androidx.compose.foundation.layout.Spacer(Modifier.width(8.dp))
 }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
@@ -291,8 +291,10 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
                 softWrap = true,
             )
         }
+        // A text button carries its own 8dp of vertical padding inside a 40dp target, so any
+        // gap added here lands on top of that and the log ends up floating above its actions.
         Row(
-            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
@@ -121,6 +121,31 @@ internal fun isUsefulSensorTraceLine(line: String): Boolean {
  * Trade the epoch seconds and pid for a wall clock, which is what a reader is actually
  * matching against when they say "it dropped out around twenty past".
  */
+/** Epoch seconds off the front of a trace line, or null when it does not carry one. */
+internal fun traceLineSeconds(line: String): Long? {
+    val firstGap = line.indexOf(' ')
+    if (firstGap <= 0) return null
+    return line.substring(0, firstGap).toLongOrNull()
+}
+
+/**
+ * Both sources answer the same question and neither is always right: trace.log stops being
+ * written the moment logging is turned off but keeps whatever it already had, and the ring
+ * only holds this process's lifetime. Asking Log.doLog which one to read trusts a flag; the
+ * lines themselves say which source is actually current, so take the fresher one.
+ */
+internal fun newerTraceSource(fromFile: List<String>, fromRing: List<String>): List<String> {
+    if (fromFile.isEmpty()) return fromRing
+    if (fromRing.isEmpty()) return fromFile
+    val fileAt = fromFile.lastNotNullSeconds() ?: return fromRing
+    val ringAt = fromRing.lastNotNullSeconds() ?: return fromFile
+    // Ties go to the file: with logging on it holds the same lines plus the native ones.
+    return if (ringAt > fileAt) fromRing else fromFile
+}
+
+private fun List<String>.lastNotNullSeconds(): Long? =
+    asReversed().firstNotNullOfOrNull(::traceLineSeconds)
+
 internal fun formatSensorTraceLine(line: String, formatTime: (Long) -> String): String {
     val firstGap = line.indexOf(' ')
     if (firstGap <= 0) return line
@@ -192,20 +217,15 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
     LaunchedEffect(context, identifiers, driverTags) {
         val file = File(context.filesDir, "logs/trace.log")
         while (isActive) {
-            // trace.log is the richer source -- it has the native lines too and it survives a
-            // restart -- but it is only written while logging is on. With logging off the
-            // in-memory ring is all there is, and reading it costs no IO.
-            lines = if (tk.glucodata.Log.doLog) {
-                withContext(Dispatchers.IO) {
-                    readRecentSensorTraceLines(file, identifiers, driverTags)
-                }
-            } else {
-                filterRecentSensorTraceLines(
-                    lines = tk.glucodata.SensorTraceRing.snapshot().asList(),
-                    identifiers = identifiers,
-                    driverTags = driverTags,
-                )
+            val fromFile = withContext(Dispatchers.IO) {
+                readRecentSensorTraceLines(file, identifiers, driverTags)
             }
+            val fromRing = filterRecentSensorTraceLines(
+                lines = tk.glucodata.SensorTraceRing.snapshot().asList(),
+                identifiers = identifiers,
+                driverTags = driverTags,
+            )
+            lines = newerTraceSource(fromFile, fromRing)
             delay(2_000L)
         }
     }

--- a/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/SensorTraceLog.kt
@@ -1,7 +1,6 @@
 package tk.glucodata.ui
 
 import android.content.Intent
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,12 +26,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.sp
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -209,6 +214,7 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
     }
 
     val verticalScroll = rememberScrollState()
+    val scrollbarColor = MaterialTheme.colorScheme.onSurfaceVariant
     // Follow the tail, the way a person watching a live log expects.
     LaunchedEffect(rendered) { verticalScroll.animateScrollTo(verticalScroll.maxValue) }
 
@@ -219,11 +225,41 @@ internal fun SensorTraceLog(sensor: SensorInfo) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .heightIn(max = 220.dp)
+                    .drawWithContent {
+                        drawContent()
+                        val maxScroll = verticalScroll.maxValue
+                        if (maxScroll > 0 && maxScroll != Int.MAX_VALUE) {
+                            val trackHeight = size.height
+                            val thumbHeight = (trackHeight * trackHeight / (trackHeight + maxScroll))
+                                .coerceIn(24.dp.toPx().coerceAtMost(trackHeight), trackHeight)
+                            val thumbTop = (trackHeight - thumbHeight) * verticalScroll.value / maxScroll
+                            val width = 4.dp.toPx()
+                            val left = if (layoutDirection == LayoutDirection.Rtl) 0f else size.width - width
+                            val radius = CornerRadius(width / 2)
+                            drawRoundRect(
+                                color = scrollbarColor.copy(alpha = 0.12f),
+                                topLeft = Offset(left, 0f),
+                                size = Size(width, trackHeight),
+                                cornerRadius = radius,
+                            )
+                            drawRoundRect(
+                                color = scrollbarColor.copy(alpha = 0.65f),
+                                topLeft = Offset(left, thumbTop),
+                                size = Size(width, thumbHeight),
+                                cornerRadius = radius,
+                            )
+                        }
+                    }
                     .verticalScroll(verticalScroll)
-                    .horizontalScroll(rememberScrollState()),
-                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    .padding(end = 12.dp),
+                style = MaterialTheme.typography.bodySmall.copy(
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 10.sp,
+                    lineHeight = 14.sp,
+                    letterSpacing = 0.sp,
+                ),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                softWrap = false,
+                softWrap = true,
             )
         }
         Row(

--- a/Common/src/test/java/tk/glucodata/LogRingWiringTests.kt
+++ b/Common/src/test/java/tk/glucodata/LogRingWiringTests.kt
@@ -1,0 +1,25 @@
+package tk.glucodata
+
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/** The ring is only worth anything if the calls the drivers actually make reach it. */
+class LogRingWiringTests {
+    @Before
+    fun clear() = SensorTraceRing.reset()
+
+    @Test
+    fun taggedCallsReachTheRingWithLoggingOff() {
+        Log.doLog = false
+        Log.i("Anytime", "CT5 raw id=8175")
+        Log.d("Anytime", "onCharacteristicWrite status=0")
+        Log.w("Ottai", "no data for 300s")
+        Log.e("Ottai", "handshake failed")
+
+        val lines = SensorTraceRing.snapshot().toList()
+        assertTrue("expected four captured lines, got $lines", lines.size == 4)
+        assertTrue(lines[0].contains("I/Anytime CT5 raw id=8175"))
+        assertTrue(lines[3].contains("E/Ottai handshake failed"))
+    }
+}

--- a/Common/src/test/java/tk/glucodata/SensorTraceRingTests.kt
+++ b/Common/src/test/java/tk/glucodata/SensorTraceRingTests.kt
@@ -1,0 +1,72 @@
+package tk.glucodata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import tk.glucodata.ui.filterRecentSensorTraceLines
+import tk.glucodata.ui.isUsefulSensorTraceLine
+
+/**
+ * The ring exists so the connection log has a source when trace.log is off, and it is only
+ * useful if the one reader can parse both. These pin the line shape against that reader
+ * rather than against a literal.
+ */
+class SensorTraceRingTests {
+    @Before
+    fun clear() = SensorTraceRing.reset()
+
+    @Test
+    fun aCapturedLineParsesTheWayATraceLogLineDoes() {
+        SensorTraceRing.add('E', "Anytime", "CT5 end-cycle failed (no response)")
+        val line = SensorTraceRing.snapshot().single()
+
+        // <epoch seconds> <pid> <level>/<tag> <message>
+        val fields = line.split(" ", limit = 3)
+        assertTrue("expected epoch seconds, got ${fields[0]}", fields[0].toLongOrNull() != null)
+        assertTrue("expected a pid, got ${fields[1]}", fields[1].toIntOrNull() != null)
+        assertTrue(fields[2].startsWith("E/Anytime "))
+
+        assertEquals(
+            listOf(line),
+            filterRecentSensorTraceLines(lines = listOf(line), identifiers = emptyList(), driverTags = listOf("Anytime")),
+        )
+    }
+
+    @Test
+    fun anUntaggedLineKeepsItsMessageWhole() {
+        SensorTraceRing.add(' ', null, "mirror: marking D76C7BB368A3 as Clone")
+        val line = SensorTraceRing.snapshot().single()
+
+        assertTrue(line.endsWith(" mirror: marking D76C7BB368A3 as Clone"))
+        assertEquals(
+            listOf(line),
+            filterRecentSensorTraceLines(lines = listOf(line), identifiers = listOf("D76C7BB368A3")),
+        )
+    }
+
+    @Test
+    fun theNoiseFilterStillAppliesToCapturedLines() {
+        SensorTraceRing.add('I', "SensorBluetooth", "getdataptr(D76C7BB368A3) Libre2")
+        SensorTraceRing.add('W', "Anytime", "No sensor data for 300s - forcing reconnect")
+        val lines = SensorTraceRing.snapshot().toList()
+
+        assertEquals(2, lines.size)
+        assertEquals(listOf(lines[1]), lines.filter(::isUsefulSensorTraceLine))
+    }
+
+    @Test
+    fun theRingKeepsTheNewestLinesOldestFirst() {
+        repeat(450) { SensorTraceRing.add('I', "Anytime", "reading $it") }
+        val lines = SensorTraceRing.snapshot()
+
+        assertEquals(400, lines.size)
+        assertTrue(lines.first().endsWith("reading 50"))
+        assertTrue(lines.last().endsWith("reading 449"))
+    }
+
+    @Test
+    fun anEmptyRingReadsAsNothingRatherThanBlankLines() {
+        assertEquals(0, SensorTraceRing.snapshot().size)
+    }
+}

--- a/Common/src/test/java/tk/glucodata/SensorTraceRingTests.kt
+++ b/Common/src/test/java/tk/glucodata/SensorTraceRingTests.kt
@@ -69,4 +69,31 @@ class SensorTraceRingTests {
     fun anEmptyRingReadsAsNothingRatherThanBlankLines() {
         assertEquals(0, SensorTraceRing.snapshot().size)
     }
+
+    @Test
+    fun aRunawayLineIsTruncatedRatherThanPinnedWhole() {
+        SensorTraceRing.add('D', "Anytime", "payload " + "AB".repeat(4_000))
+        val line = SensorTraceRing.snapshot().single()
+
+        assertTrue("expected an ellipsis marking the cut, got ${line.takeLast(8)}", line.endsWith("…"))
+        // prefix + the 256 kept characters + the marker, nothing like the 8k that went in.
+        assertTrue("line was ${line.length} chars", line.length < 320)
+        assertTrue(line.contains("D/Anytime payload AB"))
+    }
+
+    @Test
+    fun whatTheRingHoldsDoesNotGrowWithUptime() {
+        repeat(400) { SensorTraceRing.add('I', "Anytime", "reading $it") }
+        val afterOnePass = SensorTraceRing.snapshot().sumOf { it.length }
+
+        repeat(40_000) { SensorTraceRing.add('I', "Anytime", "reading $it") }
+        val afterManyMore = SensorTraceRing.snapshot().sumOf { it.length }
+
+        assertEquals(400, SensorTraceRing.snapshot().size)
+        // Same shape of line either way, so a hundred times the traffic is the same footprint.
+        assertTrue(
+            "held $afterOnePass chars then $afterManyMore",
+            afterManyMore < afterOnePass * 2,
+        )
+    }
 }

--- a/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
@@ -1,0 +1,25 @@
+package tk.glucodata.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SensorTraceLogTests {
+    @Test
+    fun filterRecentSensorTraceLines_matchesIdentifiersAndKeepsNewestLines() {
+        val lines = listOf(
+            "1 10 unrelated",
+            "2 10 sensor ABC123 connecting",
+            "3 10 address aa:bb:cc:dd:ee:ff",
+            "4 10 ABC123 connected",
+        )
+
+        assertEquals(
+            listOf(lines[2], lines[3]),
+            filterRecentSensorTraceLines(
+                lines = lines,
+                identifiers = listOf("ABC123", "AA:BB:CC:DD:EE:FF"),
+                limit = 2,
+            ),
+        )
+    }
+}

--- a/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
@@ -104,4 +104,49 @@ class SensorTraceLogTests {
 
         assertEquals(odd, formatSensorTraceLine(odd) { "never" })
     }
+
+    // The reader used to pick its source from Log.doLog. That flag says whether trace.log is
+    // being written, not whether what it already holds is still current, and a stale file
+    // beat a live ring. These pin the choice to the lines instead.
+    @Test
+    fun aLiveRingBeatsAStaleTraceFile() {
+        val file = listOf("1000 10 I/Anytime connected", "1100 10 I/Anytime reading")
+        val ring = listOf("5000 20 I/Anytime connected", "5100 20 I/Anytime reading")
+
+        assertEquals(ring, newerTraceSource(fromFile = file, fromRing = ring))
+    }
+
+    @Test
+    fun aLiveTraceFileBeatsARingFromEarlierInTheSession() {
+        val file = listOf("5000 10 I/Anytime reading", "5200 10 GLU: streamstart")
+        val ring = listOf("4000 10 I/Anytime reading")
+
+        assertEquals(file, newerTraceSource(fromFile = file, fromRing = ring))
+    }
+
+    @Test
+    fun theFileWinsATieBecauseItAlsoCarriesTheNativeLines() {
+        val file = listOf("5000 10 I/Anytime reading", "5000 10 GLU: streamstart")
+        val ring = listOf("5000 10 I/Anytime reading")
+
+        assertEquals(file, newerTraceSource(fromFile = file, fromRing = ring))
+    }
+
+    @Test
+    fun eitherSourceStandsAloneWhenTheOtherHasNothing() {
+        val only = listOf("5000 10 I/Anytime reading")
+
+        assertEquals(only, newerTraceSource(fromFile = emptyList(), fromRing = only))
+        assertEquals(only, newerTraceSource(fromFile = only, fromRing = emptyList()))
+        assertEquals(emptyList<String>(), newerTraceSource(emptyList(), emptyList()))
+    }
+
+    @Test
+    fun aSourceWithNoParsableTimestampYieldsToOneThatHasOne() {
+        val timeless = listOf("no timestamp here at all")
+        val timed = listOf("5000 10 I/Anytime reading")
+
+        assertEquals(timed, newerTraceSource(fromFile = timeless, fromRing = timed))
+        assertEquals(timed, newerTraceSource(fromFile = timed, fromRing = timeless))
+    }
 }

--- a/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
@@ -149,4 +149,30 @@ class SensorTraceLogTests {
         assertEquals(timed, newerTraceSource(fromFile = timeless, fromRing = timed))
         assertEquals(timed, newerTraceSource(fromFile = timed, fromRing = timeless))
     }
+
+    @Test
+    fun theExportFileNamesTheSensorAndTheMoment() {
+        val at = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US)
+            .apply { timeZone = java.util.TimeZone.getDefault() }
+            .parse("2026-09-09 22:57:04")!!
+
+        assertEquals(
+            "juggluco-connection-70D07E2552DB-20260909-225704.txt",
+            sensorTraceExportName("70D07E2552DB", at),
+        )
+    }
+
+    @Test
+    fun anExportNameSurvivesAWkwardSerials() {
+        // A picker filename is not a place for path separators or colons.
+        assertEquals(
+            "juggluco-connection-70D07E2552DB-20260909-225704.txt",
+            sensorTraceExportName("70:D0:7E:25:52:DB", stamp),
+        )
+        assertTrue(sensorTraceExportName("", stamp).startsWith("juggluco-connection-sensor-"))
+        assertTrue(sensorTraceExportName("../../etc/passwd", stamp).let { "/" !in it })
+    }
+
+    private val stamp = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US)
+        .parse("2026-09-09 22:57:04")!!
 }

--- a/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
+++ b/Common/src/test/java/tk/glucodata/ui/SensorTraceLogTests.kt
@@ -1,7 +1,10 @@
 package tk.glucodata.ui
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import tk.glucodata.SensorVendor
 
 class SensorTraceLogTests {
     @Test
@@ -21,5 +24,84 @@ class SensorTraceLogTests {
                 limit = 2,
             ),
         )
+    }
+
+    // Real lines from the 2026-09-03 trace. Identity matching alone returned only the
+    // storage bookkeeping, which is exactly what the log showed on screen.
+    private val realTrace = listOf(
+        "1788437835 22678 I/SensorBluetooth D76C7BB368A3 checkBluetoothAddress(D7:6C:7B:B3:68:A3) succeeded",
+        "1788437839 22689 I/Anytime Connected to D7:6C:7B:B3:68:A3",
+        "1788437841 22690 get previous state /data/user/0/tk.glucodata.ng.debug/files/sensors/D76C7BB368A3",
+        "1788437841 22690 setSensorWearDays: D76C7BB368A3 days=32 wear=46080",
+        "1788437841 22690 getdataptr(D76C7BB368A3) Libre2",
+        "1788437944 22793 D/Anytime TX ct5-endCycle-querySSN bytes=3F 55 AA 3E",
+        "1788437953 22709 E/Anytime CT5 end-cycle failed (no response); preserving the existing session",
+    )
+
+    @Test
+    fun storageBookkeepingIsDroppedEvenThoughItNamesTheSensor() {
+        assertFalse(isUsefulSensorTraceLine(realTrace[2]))
+        assertFalse(isUsefulSensorTraceLine(realTrace[3]))
+        assertFalse(isUsefulSensorTraceLine(realTrace[4]))
+        assertFalse(isUsefulSensorTraceLine(realTrace[0]))
+    }
+
+    @Test
+    fun driverTrafficIsKeptEvenThoughItNeverNamesTheSensor() {
+        // The lines worth reading carry the driver tag and no identifier at all.
+        val kept = filterRecentSensorTraceLines(
+            lines = realTrace,
+            identifiers = listOf("D76C7BB368A3"),
+            driverTags = sensorTraceDriverTags(SensorVendor.YUWELL),
+        )
+
+        assertEquals(
+            listOf(realTrace[1], realTrace[5], realTrace[6]),
+            kept,
+        )
+    }
+
+    @Test
+    fun anErrorSurvivesEveryNoiseRule() {
+        // A noise marker inside a failure must not hide the failure.
+        val failure = "1788437953 22709 E/Anytime get previous state failed for D76C7BB368A3"
+
+        assertTrue(isUsefulSensorTraceLine(failure))
+    }
+
+    @Test
+    fun otherFamiliesDoNotBorrowEachOthersTraffic() {
+        val lines = listOf(
+            "1788437944 1 I/Ottai BG dataNo=15794 mmol=4,50",
+            "1788437945 1 I/Anytime CT5 identity check OK",
+        )
+
+        assertEquals(
+            listOf(lines[0]),
+            filterRecentSensorTraceLines(
+                lines = lines,
+                identifiers = emptyList(),
+                driverTags = sensorTraceDriverTags(SensorVendor.OTTAI),
+            ),
+        )
+        assertEquals(emptyList<String>(), sensorTraceDriverTags(SensorVendor.ABBOTT))
+    }
+
+    @Test
+    fun formattingTradesEpochAndPidForAWallClock() {
+        val formatted = formatSensorTraceLine(realTrace[6]) { millis -> "17:19:13[$millis]" }
+
+        assertEquals(
+            "17:19:13[1788437953000]  E/Anytime CT5 end-cycle failed (no response); preserving the existing session",
+            formatted,
+        )
+    }
+
+    @Test
+    fun aLineWithoutTheExpectedShapeIsLeftAlone() {
+        // Native lines and stack traces do not carry the epoch/pid prefix.
+        val odd = "INFO: Initialized TensorFlow Lite runtime."
+
+        assertEquals(odd, formatSensorTraceLine(odd) { "never" })
     }
 }


### PR DESCRIPTION
A sensor card can now show why its connection is misbehaving without leaving the app, and without turning debug logging on first — which never worked anyway, because by the time you turn it on the reason has already happened.

### What it shows

An expandable "Connection log" section on each sensor card: the recent lines belonging to that sensor, newest at the bottom, monospaced, with Copy, Share and Save. Save writes the visible log through the document picker the way Debug Logs does, named for the sensor and the moment; a failed write deletes the file the picker had already created rather than leaving an empty one wearing the name of a real export. Three labelled buttons do not fit one line inside a card in every language, so the row wraps.

Attribution is by sensor id *and* by driver tag. Identity matching alone surfaced almost nothing useful — a sensor id appears in the native storage bookkeeping (`get previous state`, `getdataptr`, `setSensorWearDays`) and in very little else, while the handshake stages, protocol frames and end-cycle results a person actually needs are logged against the driver tag and never name the sensor. Two sensors of the same family share a tag, which is better than showing neither. A short noise list drops the storage chatter; warnings and errors are never dropped, since they are the reason someone opened the log.

Epoch seconds and pid become a wall clock, because "it dropped out around twenty past" is what a reader is matching against.

### Reading it with logging off

`trace.log` is only written while debug logging is on, so the panel started out empty for everyone who had not turned that on.

The drivers call `Log` unguarded and Kotlin string templates are eager, so every one of those messages is already built on every call today and thrown away when logging is off. `SensorTraceRing` keeps the last four hundred instead: four array stores and an index bump per line. No allocation, no JNI, no file, no thread, nothing in the background. The line text is only assembled when someone opens the panel, in `trace.log`'s own shape so one reader parses both sources.

Bounded on both axes — four hundred slots overwritten oldest-first, 256 characters per message — so a week of uptime costs what the first minute did. Ceiling around 210 kB, real traffic around 90 kB. It dies with the process; `trace.log` is what survives a restart.

`Log.format` is deliberately not captured, and says so: it is the one call whose message does not exist yet, and capturing it would mean running `String.format` on every call with logging off. No driver uses it.

### Which source wins

Not `Log.doLog` — that flag says whether `trace.log` is being written, not whether what it already holds is current, and it is seeded true and refreshed only at startup and when the toggle is touched. Reading it sent the panel at a file nobody was writing while the ring held every line.

Both sources are read and the fresher one wins, decided by the timestamp each line already carries. Logging on: the file, native lines and all. Logging off: the ring. A file left by an earlier session loses to a live ring instead of shadowing it. Ties go to the file, since it is a superset.

### Presentation

The divider is inset and softened — full width at full strength read as a rule between two cards rather than a seam inside one. The header row is the list-item height it should always have been: it is a whole row that toggles one thing and it was the hardest control on the card to hit. Expanded, the log had nothing above it and two stacked gaps below before Copy and Share, which already carry their own padding inside a 40dp target; the added gap is gone. The log keeps leftover drag and fling at its own edges so scrolling it does not drag the page.

The BLE error row only appears where a sensor can actually produce one.

### Verified

21 tests across the ring and the reader, including the wiring (the calls the drivers really make reach the ring), the runaway-line cap, the footprint not moving over 40,000 lines, and the stale-file-versus-live-ring case that was a real bug during review, and the export filename against serials carrying colons. `:Common:testMobileDebugUnitTest`, `:Common:assembleMobileDebug` and `:Common:assembleWearDebug` green, plus on device with Ottai and Anytime CT5 sensors, logging both on and off.

