### PR TITLE
Give follower sources a native mirror so the web server can see them

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/VirtualGlucoseSensorBridge.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/VirtualGlucoseSensorBridge.kt
@@ -4,6 +4,7 @@ import java.util.Locale
 import tk.glucodata.Applic
 import tk.glucodata.HistorySyncAccess
 import tk.glucodata.Log
+import tk.glucodata.Natives
 import tk.glucodata.SuperGattCallback
 import tk.glucodata.UiRefreshBus
 
@@ -12,12 +13,60 @@ import tk.glucodata.UiRefreshBus
  * Values are stored in Room as mg/dL and published through the same live path as
  * managed BLE sensors, so dashboard, notification history, widgets, and alerts can
  * consume them without source-specific UI code.
+ *
+ * Sources that own no native sensor record ask for [mirrorToNative]. Room is what
+ * the phone's own UI reads, so stopping there looks complete — but everything
+ * served out of native reads the native sensor list instead, and a sensor with no
+ * poll data there is skipped entirely. That is why a follower-only setup answered
+ * the built-in web server's /api/v1/entries endpoints with "{}". BLE drivers that
+ * already keep their own native shell must leave the flag off so exactly one
+ * writer owns each sensor's window.
  */
 object VirtualGlucoseSensorBridge {
     private const val TAG = "VirtualGlucose"
     private const val MMOL_TO_MGDL = 18.0182f
     private const val MIN_REASONABLE_TIMESTAMP_MS = 946_684_800_000L
     private const val MAX_FUTURE_TIMESTAMP_DRIFT_MS = 10L * 60L * 1000L
+    private val mirrorLock = Any()
+
+    private val nativeMirror = VirtualSensorNativeMirror(
+        readShellStartSeconds = { serial ->
+            val sensorPtr = Natives.str2sensorptr(serial)
+            if (sensorPtr == 0L) 0L else Natives.getSensorStartmsecFromSensorptr(sensorPtr) / 1000L
+        },
+        openShell = { serial, startSeconds, minimumRecords ->
+            if (Natives.ensureSensorShellWithCapacity(serial, startSeconds, minimumRecords) == 0L) {
+                // Geometry is chosen once, at creation; a shell that already
+                // exists at a smaller size is still perfectly usable.
+                Natives.ensureSensorShell(serial, startSeconds)
+            }
+        },
+        rebaseShell = { serial, startSeconds -> Natives.rebaseDirectStreamWindow(serial, startSeconds) },
+        writeBatch = { timestampsSec, glucose, raws, serial ->
+            Natives.addGlucoseStreamBatchWithRawTemp(
+                timestampsSec,
+                glucose,
+                raws,
+                FloatArray(timestampsSec.size),
+                serial,
+            )
+        },
+    )
+
+    /**
+     * Serialised because the window's start is read, then written, then used to
+     * decide which readings are in range; two poll threads interleaving there
+     * would filter against a start the other had already moved.
+     */
+    private fun mirrorIntoNative(
+        sensorSerial: String,
+        readings: List<Reading>,
+        logLabel: String,
+    ): Int = synchronized(mirrorLock) {
+        runCatching { nativeMirror.mirror(sensorSerial, readings, logLabel) }
+            .onFailure { Log.stack(TAG, "mirrorIntoNative($sensorSerial)", it) }
+            .getOrDefault(0)
+    }
 
     data class Reading(
         val timestampMs: Long,
@@ -41,6 +90,7 @@ object VirtualGlucoseSensorBridge {
         logLabel: String = "virtual",
         backfill: Boolean = true,
         nearDuplicateWindowMs: Long = 0L,
+        mirrorToNative: Boolean = false,
     ): Int {
         if (sensorSerial.isBlank() || readings.isEmpty()) return 0
         val nowMs = System.currentTimeMillis()
@@ -50,6 +100,14 @@ object VirtualGlucoseSensorBridge {
             Log.w(TAG, "Skipped $skippedInvalid invalid $logLabel history points for $sensorSerial")
         }
         if (validReadings.isEmpty()) return 0
+        // Deliberately before the Room dedup below: on an app that already holds
+        // this history in Room, every point is a duplicate there and nothing
+        // would reach native, leaving the mirror empty forever. Native writes are
+        // addressed by minute slot and idempotent, so re-offering the whole page
+        // each poll is what refills a mirror that started out behind.
+        if (mirrorToNative) {
+            mirrorIntoNative(sensorSerial, validReadings, logLabel)
+        }
         val latestRoomTimestamp = if (backfill) 0L else HistorySyncAccess.getLatestTimestampForSensor(sensorSerial)
         val existingTimestamps = if (nearDuplicateWindowMs > 0L) {
             val minTimestamp = validReadings.minOf { it.timestampMs }
@@ -151,6 +209,7 @@ object VirtualGlucoseSensorBridge {
         reading: Reading,
         sensorGen: Int,
         logLabel: String = "virtual",
+        mirrorToNative: Boolean = false,
     ) {
         if (sensorSerial.isBlank()) return
         if (!isUsableCurrentReading(reading, System.currentTimeMillis())) {
@@ -167,6 +226,9 @@ object VirtualGlucoseSensorBridge {
             rate,
             sensorSerial,
         )
+        if (mirrorToNative) {
+            mirrorIntoNative(sensorSerial, listOf(reading), logLabel)
+        }
 
         val primaryMgdl = reading.primaryGlucoseMgdl
         val glucoseDisplay = if (Applic.unit == 1) {

--- a/Common/src/main/java/tk/glucodata/drivers/VirtualSensorNativeMirror.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/VirtualSensorNativeMirror.kt
@@ -1,0 +1,174 @@
+package tk.glucodata.drivers
+
+import tk.glucodata.Log
+
+/**
+ * Keeps a native stream shell in step with a source that owns no BLE packet
+ * stream of its own — the API source, the Nightscout follower, the MQ follower.
+ *
+ * Those sources stored their readings in Room and stopped, which looks complete
+ * because Room is what the phone's own UI reads. Everything served out of native
+ * walks the native sensor list instead and skips any sensor with no poll data,
+ * so a follower-only setup was invisible to the built-in web server (it answered
+ * `{}`), to the /data stream, and to the Nightscout uploader.
+ *
+ * The native side addresses poll storage by minute offset from the shell's start
+ * time — `lifeCount = (timestamp - start) / 60` in g.cpp's
+ * `storeGlucoseStreamSample()` — and fixes the shell's geometry when it is
+ * created. Two consequences shape this class:
+ *
+ *  - A reading *older* than the start is not refused. `lifeCount` stays 0 and the
+ *    sample lands on slot 0, overwriting a good reading with a stale one. Points
+ *    below the window have to be dropped here, not by native.
+ *  - A reading past the end is dropped by native. A follower runs indefinitely,
+ *    so its window is eventually outgrown and has to be rebased — and rebasing
+ *    clears the poll store. Placing the newest reading at the far end of the
+ *    fresh window would wipe the mirror again one reading later, so it goes near
+ *    the start instead and the wipe happens roughly twice a month.
+ *
+ * The native calls are injected so the window arithmetic can be exercised on the
+ * JVM, the same way [tk.glucodata.drivers.ottai.OttaiNativeGlucoseMirror] is.
+ */
+internal class VirtualSensorNativeMirror(
+    private val readShellStartSeconds: (String) -> Long,
+    private val openShell: (String, Long, Int) -> Unit,
+    private val rebaseShell: (String, Long) -> Unit,
+    private val writeBatch: (LongArray, FloatArray, FloatArray, String) -> Int,
+) {
+
+    companion object {
+        private const val TAG = "VirtualGlucose"
+
+        /** Minute slots a freshly created mirror shell asks for: 14 days' worth. */
+        const val WINDOW_MINUTES: Int = 14 * 24 * 60
+
+        const val WINDOW_SECONDS: Long = WINDOW_MINUTES * 60L
+
+        /**
+         * How much room a rebase leaves *behind* the newest reading. A follower's
+         * next history page reaches back a few hours; six hours keeps those
+         * points writable instead of dropping them for being under the window.
+         */
+        const val REBASE_LOOKBACK_SECONDS: Long = 6L * 60L * 60L
+
+        /** First second past the end of the window opened at [startSeconds]. */
+        fun windowEndSeconds(startSeconds: Long): Long = startSeconds + WINDOW_SECONDS
+
+        /** True when a reading at [readingSeconds] maps to a slot native will accept. */
+        fun isWritable(startSeconds: Long, readingSeconds: Long): Boolean =
+            startSeconds > 0L &&
+                readingSeconds >= startSeconds &&
+                readingSeconds < windowEndSeconds(startSeconds)
+
+        /**
+         * Start time for a shell that does not exist yet, given the batch about
+         * to be written. The oldest reading sets the start so a first import is
+         * kept whole; a batch wider than the window gives up its oldest end
+         * rather than its newest.
+         */
+        fun initialStartSeconds(oldestReadingSeconds: Long, newestReadingSeconds: Long): Long {
+            if (oldestReadingSeconds <= 0L || newestReadingSeconds <= 0L) return 0L
+            val widestStart = newestReadingSeconds - WINDOW_SECONDS + 60L
+            return maxOf(oldestReadingSeconds - 60L, widestStart).coerceAtLeast(1L)
+        }
+
+        /** True when [newestReadingSeconds] has run past the window at [startSeconds]. */
+        fun needsRebase(startSeconds: Long, newestReadingSeconds: Long): Boolean =
+            startSeconds > 0L && newestReadingSeconds >= windowEndSeconds(startSeconds)
+
+        /** Start time an outgrown window is moved to. */
+        fun rebasedStartSeconds(newestReadingSeconds: Long): Long =
+            (newestReadingSeconds - REBASE_LOOKBACK_SECONDS).coerceAtLeast(1L)
+
+        /**
+         * Native multiplies its glucose argument by 10 before storing it
+         * (`mgVal = glucose * 10`), so callers hand it mg/dL ÷ 10. The raw
+         * argument is passed as plain mg/dL and converted by native itself.
+         */
+        fun nativeGlucose(mgdl: Float): Float = mgdl / 10f
+    }
+
+    /**
+     * Writes whichever of [readings] the current mirror window can hold,
+     * creating or rebasing that window first. Returns the number of points
+     * native accepted.
+     */
+    fun mirror(
+        sensorSerial: String,
+        readings: List<VirtualGlucoseSensorBridge.Reading>,
+        logLabel: String,
+    ): Int {
+        if (sensorSerial.isBlank() || readings.isEmpty()) return 0
+        val ordered = readings
+            .asSequence()
+            .filter { it.storageGlucoseMgdl.isFinite() && it.storageGlucoseMgdl > 0f }
+            .map { (it.timestampMs / 1000L) to it }
+            .filter { (seconds, _) -> seconds > 0L }
+            .sortedBy { (seconds, _) -> seconds }
+            .toList()
+        if (ordered.isEmpty()) return 0
+
+        val startSeconds = openWindow(
+            sensorSerial = sensorSerial,
+            oldestSeconds = ordered.first().first,
+            newestSeconds = ordered.last().first,
+            logLabel = logLabel,
+        )
+        if (startSeconds <= 0L) return 0
+
+        val writable = ordered.filter { (seconds, _) -> isWritable(startSeconds, seconds) }
+        if (writable.size < ordered.size) {
+            Log.i(
+                TAG,
+                "Skipped ${ordered.size - writable.size} $logLabel points outside the native " +
+                    "mirror window of $sensorSerial (start=$startSeconds)"
+            )
+        }
+        if (writable.isEmpty()) return 0
+
+        val stored = writeBatch(
+            LongArray(writable.size) { writable[it].first },
+            FloatArray(writable.size) { nativeGlucose(writable[it].second.storageGlucoseMgdl) },
+            FloatArray(writable.size) {
+                writable[it].second.rawMgdl.takeIf { raw -> raw.isFinite() && raw > 0f } ?: 0f
+            },
+            sensorSerial,
+        )
+        if (stored <= 0) {
+            Log.w(TAG, "Native mirror stored no $logLabel points for $sensorSerial")
+        }
+        return stored
+    }
+
+    /**
+     * Returns the start second the window is addressed from, creating the shell
+     * on first use and rebasing it once the source has outlived it.
+     */
+    private fun openWindow(
+        sensorSerial: String,
+        oldestSeconds: Long,
+        newestSeconds: Long,
+        logLabel: String,
+    ): Long {
+        val existing = readShellStartSeconds(sensorSerial)
+        if (existing <= 0L) {
+            val start = initialStartSeconds(oldestSeconds, newestSeconds)
+            if (start <= 0L) return 0L
+            openShell(sensorSerial, start, WINDOW_MINUTES)
+            Log.i(TAG, "Opened native $logLabel mirror for $sensorSerial at $start")
+        } else if (needsRebase(existing, newestSeconds)) {
+            val rebased = rebasedStartSeconds(newestSeconds)
+            Log.w(
+                TAG,
+                "Rebasing native $logLabel mirror of $sensorSerial from $existing to $rebased; " +
+                    "the window it held is cleared"
+            )
+            rebaseShell(sensorSerial, rebased)
+        } else {
+            return existing
+        }
+        // Read back rather than trusting the value just asked for: native only
+        // ever lowers an existing start, so the window may not be where we put it.
+        return readShellStartSeconds(sensorSerial)
+    }
+}

--- a/Common/src/main/java/tk/glucodata/drivers/api/ApiGlucoseSourceManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/api/ApiGlucoseSourceManager.kt
@@ -252,6 +252,7 @@ class ApiGlucoseSourceManager(
             sensorSerial = SerialNumber,
             readings = readings,
             logLabel = "API source",
+            mirrorToNative = true,
         )
         if (tailMs > 0L) {
             lastImportedHistoryTailMs = tailMs
@@ -280,6 +281,7 @@ class ApiGlucoseSourceManager(
             reading = latest.copy(rate = rate),
             sensorGen = SENSOR_GEN,
             logLabel = "API source",
+            mirrorToNative = true,
         )
     }
 

--- a/Common/src/main/java/tk/glucodata/drivers/mq/MQFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/mq/MQFollowerManager.kt
@@ -459,6 +459,7 @@ class MQFollowerManager(
                 )
             },
             logLabel = "MQ follower",
+            mirrorToNative = true,
         )
         if (tailMs > 0L) {
             lastImportedHistoryTailMs = tailMs
@@ -504,6 +505,7 @@ class MQFollowerManager(
                 ),
                 sensorGen = MQBleManager.SENSOR_GEN,
                 logLabel = "MQ follower",
+                mirrorToNative = true,
             )
         } else if (previousTimeMs > 0L && latest.timestampMs == previousTimeMs && previousMgdl != latest.glucoseMgdl) {
             UiRefreshBus.requestDataRefresh()

--- a/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/nightscout/NightscoutFollowerManager.kt
@@ -426,6 +426,7 @@ class NightscoutFollowerManager(
             sensorSerial = SerialNumber,
             readings = readings,
             logLabel = "Nightscout follower",
+            mirrorToNative = true,
         )
         if (tailMs > 0L) {
             lastImportedHistoryTailMs = tailMs
@@ -449,6 +450,7 @@ class NightscoutFollowerManager(
             reading = latest.copy(rate = rate),
             sensorGen = SENSOR_GEN,
             logLabel = "Nightscout follower",
+            mirrorToNative = true,
         )
     }
 

--- a/Common/src/test/java/tk/glucodata/drivers/VirtualSensorNativeMirrorTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/VirtualSensorNativeMirrorTests.kt
@@ -1,0 +1,209 @@
+package tk.glucodata.drivers
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VirtualSensorNativeMirrorTests {
+
+    private val serial = "API-1"
+    private val now = 1_760_000_000L
+
+    private data class Batch(
+        val timestampsSec: LongArray,
+        val glucose: FloatArray,
+        val raws: FloatArray,
+        val sensorSerial: String,
+    )
+
+    /** A stand-in for the native shell: one start second, and whatever was written. */
+    private class FakeNative(var startSeconds: Long = 0L) {
+        val batches = mutableListOf<Batch>()
+        val opened = mutableListOf<Pair<Long, Int>>()
+        val rebased = mutableListOf<Long>()
+    }
+
+    private fun mirrorOver(native: FakeNative) = VirtualSensorNativeMirror(
+        readShellStartSeconds = { native.startSeconds },
+        openShell = { _, startSeconds, minimumRecords ->
+            native.opened += startSeconds to minimumRecords
+            // Native only ever lowers an existing start.
+            if (native.startSeconds == 0L || startSeconds < native.startSeconds) {
+                native.startSeconds = startSeconds
+            }
+        },
+        rebaseShell = { _, startSeconds ->
+            native.rebased += startSeconds
+            native.startSeconds = startSeconds
+        },
+        writeBatch = { timestampsSec, glucose, raws, sensorSerial ->
+            native.batches += Batch(timestampsSec, glucose, raws, sensorSerial)
+            timestampsSec.size
+        },
+    )
+
+    private fun reading(atSeconds: Long, mgdl: Float, rawMgdl: Float = Float.NaN) =
+        VirtualGlucoseSensorBridge.Reading(
+            timestampMs = atSeconds * 1000L,
+            glucoseMgdl = mgdl,
+            rawMgdl = rawMgdl,
+        )
+
+    @Test
+    fun firstImportOpensAShellAndWritesEveryPointInNativeUnits() {
+        val native = FakeNative()
+
+        val stored = mirrorOver(native).mirror(
+            serial,
+            listOf(reading(now - 300L, 120f), reading(now, 55f)),
+            "API source",
+        )
+
+        assertEquals(2, stored)
+        assertEquals(1, native.opened.size)
+        assertEquals(VirtualSensorNativeMirror.WINDOW_MINUTES, native.opened.single().second)
+
+        val batch = native.batches.single()
+        assertEquals(serial, batch.sensorSerial)
+        assertArrayEquals(longArrayOf(now - 300L, now), batch.timestampsSec)
+        // g.cpp storeGlucoseStreamSample(): mgVal = glucose * 10.
+        assertEquals(12.0f, batch.glucose[0], 0.0001f)
+        assertEquals(5.5f, batch.glucose[1], 0.0001f)
+    }
+
+    @Test
+    fun aSecondPollReusesTheWindowInsteadOfReopeningIt() {
+        val native = FakeNative()
+        val mirror = mirrorOver(native)
+
+        mirror.mirror(serial, listOf(reading(now, 120f)), "API source")
+        mirror.mirror(serial, listOf(reading(now + 300L, 122f)), "API source")
+
+        assertEquals(1, native.opened.size)
+        assertTrue(native.rebased.isEmpty())
+        assertEquals(2, native.batches.size)
+    }
+
+    @Test
+    fun readingsUnderTheWindowAreDroppedRatherThanFoldedOntoSlotZero() {
+        // Native does not refuse a reading below the shell start; lifeCount stays
+        // 0 and the stale point overwrites whatever slot 0 holds.
+        val native = FakeNative(startSeconds = now)
+
+        val stored = mirrorOver(native).mirror(
+            serial,
+            listOf(reading(now - 3600L, 90f), reading(now, 120f)),
+            "API source",
+        )
+
+        assertEquals(1, stored)
+        assertArrayEquals(longArrayOf(now), native.batches.single().timestampsSec)
+    }
+
+    @Test
+    fun nothingIsWrittenWhenEveryPointIsBelowTheWindow() {
+        val native = FakeNative(startSeconds = now)
+
+        val stored = mirrorOver(native).mirror(serial, listOf(reading(now - 3600L, 90f)), "API source")
+
+        assertEquals(0, stored)
+        assertTrue(native.batches.isEmpty())
+    }
+
+    @Test
+    fun aFollowerThatOutlivesItsWindowIsRebasedAndKeepsWriting() {
+        val native = FakeNative(startSeconds = now)
+        val outgrown = VirtualSensorNativeMirror.windowEndSeconds(now) + 60L
+
+        val stored = mirrorOver(native).mirror(serial, listOf(reading(outgrown, 120f)), "API source")
+
+        assertEquals(1, stored)
+        assertEquals(1, native.rebased.size)
+        assertArrayEquals(longArrayOf(outgrown), native.batches.single().timestampsSec)
+    }
+
+    @Test
+    fun aRebaseLeavesRoomToRunOnRatherThanWipingAgainNextReading() {
+        val native = FakeNative(startSeconds = now)
+        val outgrown = VirtualSensorNativeMirror.windowEndSeconds(now) + 60L
+        val mirror = mirrorOver(native)
+
+        mirror.mirror(serial, listOf(reading(outgrown, 120f)), "API source")
+        mirror.mirror(serial, listOf(reading(outgrown + 13L * 24L * 60L * 60L, 121f)), "API source")
+
+        assertEquals(1, native.rebased.size)
+        assertEquals(2, native.batches.size)
+    }
+
+    @Test
+    fun aRebaseKeepsTheNextBackfillPageWritable() {
+        val native = FakeNative(startSeconds = now)
+        val outgrown = VirtualSensorNativeMirror.windowEndSeconds(now) + 60L
+
+        val stored = mirrorOver(native).mirror(
+            serial,
+            listOf(reading(outgrown - 3L * 60L * 60L, 118f), reading(outgrown, 120f)),
+            "API source",
+        )
+
+        assertEquals(2, stored)
+    }
+
+    @Test
+    fun aFirstImportWiderThanTheWindowGivesUpItsOldestEndNotItsNewest() {
+        val native = FakeNative()
+        val oldest = now - 30L * 24L * 60L * 60L
+
+        val stored = mirrorOver(native).mirror(
+            serial,
+            listOf(reading(oldest, 90f), reading(now, 120f)),
+            "API source",
+        )
+
+        assertEquals(1, stored)
+        assertArrayEquals(longArrayOf(now), native.batches.single().timestampsSec)
+    }
+
+    @Test
+    fun rawIsPassedThroughAsPlainMgdlAndAbsentRawWritesZero() {
+        val native = FakeNative()
+
+        mirrorOver(native).mirror(
+            serial,
+            listOf(reading(now - 60L, 120f, rawMgdl = 118f), reading(now, 122f)),
+            "API source",
+        )
+
+        val batch = native.batches.single()
+        assertEquals(118f, batch.raws[0], 0.0001f)
+        // 0 tells native to leave whatever raw the slot already had alone.
+        assertEquals(0f, batch.raws[1], 0.0001f)
+    }
+
+    @Test
+    fun unusableReadingsNeverReachNative() {
+        val native = FakeNative()
+
+        val stored = mirrorOver(native).mirror(
+            serial,
+            listOf(reading(now, 0f), reading(now + 60L, Float.NaN), reading(0L, 120f)),
+            "API source",
+        )
+
+        assertEquals(0, stored)
+        assertTrue(native.opened.isEmpty())
+        assertTrue(native.batches.isEmpty())
+    }
+
+    @Test
+    fun windowEndIsExclusive() {
+        val end = VirtualSensorNativeMirror.windowEndSeconds(now)
+
+        assertTrue(VirtualSensorNativeMirror.isWritable(now, end - 60L))
+        assertFalse(VirtualSensorNativeMirror.isWritable(now, end))
+        assertFalse(VirtualSensorNativeMirror.needsRebase(now, end - 60L))
+        assertTrue(VirtualSensorNativeMirror.needsRebase(now, end))
+    }
+}


### PR DESCRIPTION
## The report

> api destinations follower appears to be failing to transfer data into native which leads to web server displaying `{}`

Confirmed, and it affects all three virtual sources, not just the API one.

## What was wrong

`VirtualGlucoseSensorBridge` — the shared path for sources with no BLE packet stream of their own (API source, Nightscout follower, MQ follower) — writes to Room and calls `SuperGattCallback.processExternalCurrentReading`. Neither reaches native: `dowithglucose()` only drives notifications, alerts and broadcasts. The bridge contains no `Natives.*` call at all, and never has (it arrived that way in `1f5f73077`).

Everything the built-in web server serves reads the native sensor list instead of Room:

- `watchserver.cpp` `givecurrent()` → `getStreamSensor(sensors->last())`
- `getitems.hpp` `getStreamSensor()` skips any sensor with `pollcount() == 0`, and `givenothing()` writes `{}\n`

So a follower-only setup has no native sensor with poll data, every endpoint falls through to `givenothing()`, and the browser shows `{}`. The same gap hides follower data from the `/data` stream and the native Nightscout uploader.

Every BLE driver already mirrors into native (`Natives.ensureSensorShell` + `addGlucoseStream*` — Sibionics, Anytime, iCan, MQ, Ottai, and `WearSync2` for watch-received data). The virtual sources were the only readings path that never did.

## The fix

Mirror follower readings into the native stream store, behind an opt-in the three follower managers ask for. Drivers that keep their own native shell leave it off, so exactly one writer owns each sensor's window.

The window needs more care than a BLE sensor's:

- Native addresses poll storage by minute offset from the shell start (`lifeCount = (timestamp - start) / 60`) and fixes the geometry at creation.
- A reading **below** the start is not refused — `lifeCount` stays 0 and the stale point overwrites slot 0. Those are dropped here rather than by native.
- A follower runs indefinitely, unlike a sensor with a rated life, so the window is eventually outgrown and has to be rebased. `rebaseDirectStreamWindow()` clears the store, so the newest reading is placed near the **start** of the fresh window. Rebasing it to the far end (as iCan's 15-day mirror does, where it never triggers in practice) would wipe the mirror again one reading later.

History is mirrored **before** the Room dedup. On a phone that already holds this history in Room every point is a duplicate there, so nothing would ever reach native — leaving the mirror permanently empty on exactly the installs that have this bug. Native writes are minute-slot addressed and idempotent, so re-offering the page each poll is what backfills a mirror that started out behind.

## Note on Nightscout

Follower data now also reaches the native Nightscout uploader, which iterates every sensor in the list. This cannot echo a site back to itself: `NightscoutSettingsScreen` makes upload and follow mutually exclusive, and selecting follow calls `Natives.setNightUploader(..., uploadActive = false, ...)`.

## Testing

`VirtualSensorNativeMirrorTests` — 12 tests over the injected-seam mirror (same pattern as `OttaiNativeGlucoseMirror`): shell creation, window reuse across polls, native ×10 scaling, raw passthrough, dropping points under the window, rebasing an outgrown window and still having room to run, and a first import wider than the window giving up its oldest end rather than its newest.

`./gradlew :Common:testMobileDebugUnitTest` green.

Not yet verified on device — worth confirming the server answers with real entries on a follower-only install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)