### PR TITLE
Ottai: settle the 8-vs-9-byte record-size vote with the sensor's own …

### DIFF
--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiBleManager.kt
@@ -867,6 +867,10 @@ class OttaiBleManager(
     // sample is admitted and re-baselines the gate.
     @Volatile private var consecutiveContinuityRejects = 0
     @Volatile private var lastDataNo = -1
+    // frontDataNo of the last decrypted notify (live or history alike — one counter), used to
+    // settle chooseRecordSize's 8-vs-9-byte vote from the sensor's own advance rather than a
+    // content guess. -1 until the first successfully decrypted payload.
+    @Volatile private var lastFrameFront = -1
     @Volatile private var consecutiveCeilingFullDrops = 0
     @Volatile private var ceilingDistrusted = false
     // Set when the bounded wait for a fresh advertisement gave up. connectDevice()'s
@@ -2864,7 +2868,10 @@ class OttaiBleManager(
             Log.w(TAG, "$kind $source decrypt failed len=${cipher.size} blockMod=${cipher.size % 16}")
             return
         }
-        val records = OttaiParser.frameRecords(payload, materials.deviceVersion)
+        val front = OttaiParser.frontDataNo(payload)
+        val previousFront = lastFrameFront.takeIf { it >= 0 }
+        val records = OttaiParser.frameRecords(payload, materials.deviceVersion, previousFront)
+        lastFrameFront = front
         if (records.isEmpty()) {
             Log.w(TAG, "$kind $source no records payloadLen=${payload.size} hex=${OttaiCrypto.bytesToHex(payload).take(160)}")
             if (live) {
@@ -2883,7 +2890,7 @@ class OttaiBleManager(
             }
             return
         }
-        logi(TAG) { "$kind $source decrypted payloadLen=${payload.size} records=${records.size} front=${OttaiParser.frontDataNo(payload)}" }
+        logi(TAG) { "$kind $source decrypted payloadLen=${payload.size} records=${records.size} front=$front" }
         val readings = if (live) {
             listOf(OttaiParser.toReading(records.last(), materials.method, materials.coefficients, activeMs))
         } else {

--- a/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiParser.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/ottai/OttaiParser.kt
@@ -68,9 +68,29 @@ object OttaiParser {
      * is still valid, while the mis-aligned layout loses because it decodes an impossible
      * current/temperature (e.g. 505 °C).
      * 9-byte: current[0:2], temp[7:9]; 8-byte: current[4:6], temp[6:8].
+     *
+     * @param previousFront frontDataNo of the immediately preceding notify on this connection
+     * (live or history — the sensor's dataNo counter is one sequence), or null if unknown (first
+     * frame of a session/transfer). When the advance from [previousFront] to this payload's own
+     * frontDataNo exactly matches the record count ONE candidate size implies for this payload's
+     * length — and not the other — that settles it outright: the sensor's own counter is ground
+     * truth, unlike the content-based vote below, which a real device's still-unseen "unused"
+     * record bytes can tip either way (seen live: a 24-byte single-record 9-byte frame voted
+     * 8-byte, decoding to an all-zero trailing record — raw=0, runtime=0 — because the vote had
+     * only 1 nine-byte window to check against 2 eight-byte ones).
      */
-    internal fun chooseRecordSize(payload: ByteArray, deviceVersion: String): Int {
+    internal fun chooseRecordSize(payload: ByteArray, deviceVersion: String, previousFront: Int? = null): Int {
         confirmedRecordSize(deviceVersion)?.let { return it }
+        val bodyLen = payload.size - HEADER_SIZE
+        if (previousFront != null && bodyLen > 0) {
+            val delta = (frontDataNo(payload) - previousFront) and 0xFFFF
+            if (delta > 0) {
+                val nineCount = bodyLen / BLE_RECORD_SIZE_E12
+                val eightCount = bodyLen / BLE_RECORD_SIZE
+                if (delta == nineCount && delta != eightCount) return BLE_RECORD_SIZE_E12
+                if (delta == eightCount && delta != nineCount) return BLE_RECORD_SIZE
+            }
+        }
         val nine = vendorValidCount(payload, BLE_RECORD_SIZE_E12, curLo = 0, tempLo = 7)
         val eight = vendorValidCount(payload, BLE_RECORD_SIZE, curLo = 4, tempLo = 6)
         return if (nine > eight) BLE_RECORD_SIZE_E12 else BLE_RECORD_SIZE
@@ -123,10 +143,10 @@ object OttaiParser {
      * (`{0,0} || LE16(frontDataNo+idx) || record8`). Trailing partial bytes are
      * ignored. Returns empty if there is no record region.
      */
-    fun frameRecords(payload: ByteArray, deviceVersion: String = ""): List<ByteArray> {
+    fun frameRecords(payload: ByteArray, deviceVersion: String = "", previousFront: Int? = null): List<ByteArray> {
         if (payload.size <= HEADER_SIZE) return emptyList()
         val front = frontDataNo(payload)
-        val bleSize = chooseRecordSize(payload, deviceVersion)
+        val bleSize = chooseRecordSize(payload, deviceVersion, previousFront)
         val nineByte = bleSize == BLE_RECORD_SIZE_E12
         val bodyLen = payload.size - HEADER_SIZE
         val count = bodyLen / bleSize

--- a/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiParserTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/ottai/OttaiParserTests.kt
@@ -208,4 +208,64 @@ class OttaiParserTests {
         assertEquals(8000, r.rawCurrent)
         assertEquals(35.0, r.temperatureC, 1e-9)
     }
+
+    // 2026-09-09 field capture (a real Ottai CN V3 unit, vE1.1.4(V1.7.S2530.1)): the content vote has
+    // nothing to work with on a short, still-unpopulated live frame — one 9-byte window against
+    // two 8-byte ones — and a real device tipped it to 8-byte, decoding an all-zero trailing
+    // "record" (raw=0, runtime=0) that then failed every downstream sanity gate. Every notify on
+    // the wire still carries the sensor's own dataNo in its header, though, and that count is
+    // ground truth: whichever candidate size reproduces the observed advance from the previous
+    // notify is the real one, independent of what the record bytes happen to contain.
+    @Test
+    fun chooseRecordSize_frontDeltaOverridesAmbiguousContent() {
+        // 16-byte body, front=50: content is near-zero, so both candidates read current=0 and
+        // tie at zero valid records. Unresolved, that tie defaults to 8-byte (matches the field
+        // failure). A previous front of 49 says the sensor advanced by exactly 1 record, which
+        // only the 9-byte reading (16/9=1) reproduces — 8-byte would need 2 (16/8=2). Byte 16
+        // (the live-record's last byte) is nonzero only so frameRecords' zero-padding skip
+        // doesn't discard the sole 9-byte record outright; it lands in neither candidate's
+        // current field, so the content vote above is unaffected.
+        val payload = ByteArray(16 + OttaiParser.HEADER_SIZE).also {
+            it[4] = 50
+            it[16] = 1
+        }
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE,
+            OttaiParser.chooseRecordSize(payload, "E1.1.4(V1.7.S2530.1)"),
+        )
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE_E12,
+            OttaiParser.chooseRecordSize(payload, "E1.1.4(V1.7.S2530.1)", previousFront = 49),
+        )
+        val records = OttaiParser.frameRecords(payload, "E1.1.4(V1.7.S2530.1)", previousFront = 49)
+        assertEquals(1, records.size)
+        assertEquals(50, OttaiParser.parseRecord(records.single()).dataNo)
+    }
+
+    @Test
+    fun chooseRecordSize_frontDeltaCanConfirmEightByteToo() {
+        // Same ambiguous all-zero content, 24-byte body: nine-byte gives 24/9=2 candidate
+        // records, eight-byte gives 24/8=3. A previous front 3 behind this one matches only the
+        // 8-byte reading.
+        val payload = ByteArray(24 + OttaiParser.HEADER_SIZE).also { it[4] = 10 }
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE_E12,
+            OttaiParser.chooseRecordSize(payload, "E1.1.4(V1.7.S2530.1)", previousFront = 8),
+        )
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE,
+            OttaiParser.chooseRecordSize(payload, "E1.1.4(V1.7.S2530.1)", previousFront = 7),
+        )
+    }
+
+    @Test
+    fun chooseRecordSize_ignoresFrontDeltaWhenItMatchesNeitherCandidate() {
+        // A delta that fits neither candidate's record count (a reconnect, a history seek to an
+        // unrelated dataNo, 16-bit wraparound) must not force a size — fall back to content.
+        val payload = hex("000000000a000300" + "05010203401fac0d" + "05010203501fb00d" + "05010203601fb40d")
+        assertEquals(
+            OttaiParser.BLE_RECORD_SIZE,
+            OttaiParser.chooseRecordSize(payload, "E9.9.9(V9.9.UNK)", previousFront = 4096),
+        )
+    }
 }


### PR DESCRIPTION
…front counter

E1.1.4(V1.7.S2530.1) is ambiguous between the 8-byte Syai and 9-byte CN V3 layouts, so chooseRecordSize votes on which candidate's records pass the vendor sanity gate. On a short live frame (one real record) that vote has only 1 nine-byte window to weigh against 2 eight-byte ones, and a real CN V3 device tipped it to 8-byte — decoding an all-zero trailing "record" (raw=0, runtime=0) that failed every downstream check. History chunks from the same device landed on 8-byte too (21 records read out of a 176-byte frame that the sensor's own frontDataNo advance says holds 18), so every field decoded to garbage and every reading — live and historical — was rejected.

Every notify's frontDataNo already tells the true story: the advance from the previous notify equals the record count the sensor actually packed, and that's determinable without touching the ambiguous field bytes at all. chooseRecordSize now prefers that ground truth whenever it points at one candidate and not the other, falling back to the content vote otherwise (first frame of a session, or a delta that fits neither candidate, e.g. a history seek or reconnect). Existing callers are unaffected: the new parameter defaults to null, preserving prior behavior everywhere it isn't threaded through.
