### PR TITLE
Fix the CT5 reconnect storm and the timeline anchor that outlived it

### DIFF
--- a/Common/src/main/java/tk/glucodata/SuperGattCallback.java
+++ b/Common/src/main/java/tk/glucodata/SuperGattCallback.java
@@ -154,6 +154,14 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
     protected final void markLocalReadingAccepted(long sampleTimeMs) {
         WearSensorClaim.onLocalReadingAccepted(SerialNumber, sampleTimeMs);
         SensorOwnershipRuntime.noteLocalReading(SerialNumber, sampleTimeMs);
+        // charcha[0] is the shared "last successful glucose" slot, read by
+        // shouldreconnect() and by connectionStatusOutdated() to tell a stale "Loss of
+        // signal" label from a current one. The classic drivers set it from their own
+        // onCharacteristicChanged; a managed driver publishes through
+        // processExternalCurrentReading and never reached that line, so for those
+        // sensors the slot stayed 0 and both checks read every session as if no reading
+        // had ever arrived.
+        charcha[0] = sampleTimeMs;
     }
 
     public void disconnect() {
@@ -188,6 +196,28 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
             Log.i(LOG_ID, "setPause " + pause);
     }
 
+    /**
+     * Record the shared "Loss of signal" state. Extracted so a driver that recovers the
+     * link its own way still reports it the same to the UI and the error history.
+     */
+    protected final void noteLossOfSignal(long now) {
+        constatstatusstr = "Loss of signal";
+        constatchange[1] = now;
+        BleErrorHistory.record(SerialNumber, constatstatusstr, now);
+    }
+
+    /**
+     * A frame arrived from the sensor that carried no usable glucose.
+     *
+     * charcha[1] is the shared "last failed glucose attempt" slot and the only thing
+     * holding {@link #reconnect} back, so a driver that decodes its own frames has to
+     * report this or a sensor talking on schedule without producing readings looks, to
+     * the loss-of-signal alarm, exactly like a sensor that has gone silent.
+     */
+    protected final void noteLiveFrameWithoutReading(long whenMs) {
+        charcha[1] = whenMs;
+    }
+
     public boolean reconnect(long now) {
         final var old = now - showtime + 20;
         if (charcha[1] < old && connectTime < (now - 60 * 1000)) {
@@ -196,9 +226,7 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
                     Log.i(LOG_ID, "reconnect " + SerialNumber);
                 }
                 ;
-                constatstatusstr = "Loss of signal";
-                constatchange[1] = now;
-                BleErrorHistory.record(SerialNumber, constatstatusstr, now);
+                noteLossOfSignal(now);
                 final var thegatt = mBluetoothGatt;
                 if (thegatt != null) {
                     thegatt.disconnect();

--- a/Common/src/main/java/tk/glucodata/SuperGattCallback.java
+++ b/Common/src/main/java/tk/glucodata/SuperGattCallback.java
@@ -1063,9 +1063,15 @@ public abstract class SuperGattCallback extends BluetoothGattCallback {
      * constructor overwrites from {@code Natives.getAndroid13()}, so until this hook existed a
      * driver had no say at all: every one of the 103 connect attempts logged during the
      * 2026-08-01 jamming storm (52 + 51, two Ottai sensors) used autoConnect=true and not one
-     * used false. Whether a direct connect would do better on any particular peripheral is still
+     * used false. Whether a direct connect would do better on any particular peripheral was
      * unmeasured — see {@link #noteFirstGattCallback} for the number that would decide it — so
-     * every driver deliberately keeps inheriting the user's setting here.
+     * every driver inherited the user's setting here.
+     * <p>
+     * The Anytime driver is the one exception, and only because that number came in: a CT5 told
+     * to go low-power is unreachable between its 3-minute pushes, where a direct connect can only
+     * spend Android's 30-second timer and report status 147. It overrides this to fall back to
+     * autoConnect once an attempt has actually timed out; every other driver still has nothing
+     * deciding between the modes and keeps inheriting the setting.
      */
     protected boolean useAutoConnect() {
         return autoconnect;

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
@@ -77,15 +77,20 @@ class AnytimeBleManager(
          * How long a soft reconnect waits between closing the old GATT and opening
          * a new one.
          *
-         * BluetoothGatt.close() returns immediately but unregisters the client
-         * asynchronously, and connecting again inside that window leaves two clients
-         * on one link. In the 2026-09-09 CT5 trace the 250ms this used to be produced
-         * a session with two onMtuChanged callbacks for a single requestMtu and an
-         * 8s service discovery — against under a second on the clean retry two minutes
-         * later — and the stack then dropped the link with GATT_FAILURE (257) a second
-         * after the low-power ack, as the retired client finally went away. A quiet
-         * gap costs nothing here: the alternative is the ~90s of blind reconnects that
-         * followed.
+         * Defensive, and not a proven mechanism. What the 2026-09-09 CT5 trace shows
+         * is that reconnecting 250ms after close() produced a visibly unhealthy
+         * session — two onMtuChanged callbacks for a single requestMtu, service
+         * discovery taking 8s where the clean retry two minutes later took under one,
+         * and the link dropped with GATT_FAILURE (257) a second after the low-power
+         * ack. The likely reading is that close() had not finished unregistering the
+         * old client, since BluetoothGatt.close() returns before the stack is done
+         * with it; the trace does not establish that, and neither duplicate callback
+         * proves a second registered client on its own.
+         *
+         * Widening the gap is cheap either way — the reconnect is already 250ms late
+         * and nothing waits on it — while the failure it guards against cost ~90s of
+         * blind reconnects. Making the GATT lifecycle itself safe against overlapping
+         * attempts would be the real fix.
          */
         private const val SOFT_RECONNECT_SETTLE_MS = 750L
         private const val SERVICE_DISCOVERY_TIMEOUT_MS = 15_000L
@@ -277,12 +282,9 @@ class AnytimeBleManager(
     @Volatile private var pendingCccdGatt: BluetoothGatt? = null
     @Volatile private var lastConnectRequestAtMs: Long = 0L
 
-    /**
-     * Direct connects in a row that expired without reaching the transmitter.
-     * Drives [useAutoConnect] and the reconnect backoff; any connection at all
-     * clears it.
-     */
-    @Volatile private var consecutiveConnectTimeouts: Int = 0
+    /** What direct connects to this transmitter have actually achieved so far. */
+    private val connectMode = AnytimeConnectModeState()
+
     @Volatile private var pendingFingerstickMgdl: Int = -1
     @Volatile private var pendingFingerstickTargetGlucoseId: Int = -1
     @Volatile private var pendingKrPush: Boolean = false
@@ -2015,23 +2017,12 @@ class AnytimeBleManager(
     }
 
     /**
-     * Inherit the user's setting until a direct connect has actually proved itself
-     * unable to reach this transmitter, then let the stack wait for an
-     * advertisement instead of burning another 30-second timer. See
-     * [shouldUseAutoConnect] for the measurement behind that.
+     * Inherit the user's setting until a direct connect has proved itself unable to
+     * reach this transmitter, then let the stack wait for an advertisement instead of
+     * burning another 30-second timer. Kept free of side effects: it is read again to
+     * record which mode a connection was established with.
      */
-    override fun useAutoConnect(): Boolean {
-        val user = super.useAutoConnect()
-        val auto = shouldUseAutoConnect(user, consecutiveConnectTimeouts)
-        if (auto && !user) {
-            Log.i(
-                TAG,
-                "Using autoConnect after $consecutiveConnectTimeouts direct connect " +
-                        "timeout(s); waiting for the transmitter to advertise"
-            )
-        }
-        return auto
-    }
+    override fun useAutoConnect(): Boolean = connectMode.useAutoConnect(super.useAutoConnect())
 
     private fun scheduleReconnect(reason: String, delayMs: Long = ACTIVE_SESSION_RECONNECT_DELAY_MS) {
         if (stop) return
@@ -2311,7 +2302,9 @@ class AnytimeBleManager(
         when (newState) {
             BluetoothProfile.STATE_CONNECTED -> {
                 Log.i(TAG, "Connected to ${gatt.device?.address}")
-                consecutiveConnectTimeouts = 0
+                // Nothing between opening the attempt and this callback can change the
+                // mode, so asking again reports what this connection was opened with.
+                connectMode.onConnected(usedAutoConnect = useAutoConnect())
                 cancelReconnect()
                 clearGattCallbacks()
                 mBluetoothGatt = gatt
@@ -2340,12 +2333,16 @@ class AnytimeBleManager(
             BluetoothProfile.STATE_DISCONNECTED -> {
                 Log.i(TAG, "Disconnected (status=$status)")
                 // A disconnect out of CONNECTING never reached the transmitter, so
-                // status 147 here is the 30-second direct-connect timer, not a lost
-                // link. Anything that did connect resets the count.
-                consecutiveConnectTimeouts = if (phase == Phase.CONNECTING && isConnectTimeoutStatus(status)) {
-                    consecutiveConnectTimeouts + 1
-                } else {
-                    0
+                // status 147 here is Android's direct-connect timer expiring rather
+                // than a link that dropped.
+                val couldReachDirectly = !connectMode.directConnectUnreachable
+                connectMode.onDisconnected(status, wasConnecting = phase == Phase.CONNECTING)
+                if (couldReachDirectly && connectMode.directConnectUnreachable) {
+                    Log.i(
+                        TAG,
+                        "Direct connect timed out without reaching $SerialNumber; waiting for it " +
+                                "to advertise instead until a direct connect succeeds again"
+                    )
                 }
                 phase = Phase.IDLE
                 streamingSinceMs = 0L
@@ -2391,8 +2388,7 @@ class AnytimeBleManager(
                     if (!stop) {
                         scheduleReconnect(
                             "GATT disconnect status=$status",
-                            connectRetryDelayMs(
-                                consecutiveConnectTimeouts = consecutiveConnectTimeouts,
+                            connectMode.retryDelayMs(
                                 baseDelayMs = ACTIVE_SESSION_RECONNECT_DELAY_MS,
                                 readingIntervalMs = profile.readingIntervalMinutes * 60L * 1000L,
                             ),

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
@@ -93,6 +93,15 @@ class AnytimeBleManager(
          * attempts would be the real fix.
          */
         private const val SOFT_RECONNECT_SETTLE_MS = 750L
+
+        /**
+         * How long a CT5 already past its rated life must keep repeating one id before
+         * the driver stops estimating readings for it.
+         *
+         * An hour is twenty pushes at cadence — long past a hiccup, and short enough
+         * that a finished sensor is not left inventing values for a whole evening.
+         */
+        private const val CT5_FROZEN_ID_END_OF_LIFE_MS = 60L * 60L * 1000L
         private const val SERVICE_DISCOVERY_TIMEOUT_MS = 15_000L
         private const val SERVICE_DISCOVERY_HARD_RECOVERY_DELAY_MS = 5_000L
         private const val SERVICE_DISCOVERY_RETRY_DELAY_MS = 1_500L
@@ -284,6 +293,9 @@ class AnytimeBleManager(
 
     /** What direct connects to this transmitter have actually achieved so far. */
     private val connectMode = AnytimeConnectModeState()
+
+    /** Keeps the end-of-life notice to once per sensor rather than once per push. */
+    @Volatile private var ct5FinishedLogged: Boolean = false
 
     @Volatile private var pendingFingerstickMgdl: Int = -1
     @Volatile private var pendingFingerstickTargetGlucoseId: Int = -1
@@ -1716,6 +1728,38 @@ class AnytimeBleManager(
      * field is in-memory only, so after an app restart a days-old sensor looked
      * like it was warming up until its next push.
      */
+    /**
+     * True once this CT5 is finished: past its rated life and no longer advancing its id.
+     *
+     * Requires the persisted timeline anchor. Without one, sensor age is a guess, and a
+     * guess must not be what stops a sensor reporting.
+     */
+    private fun isCt5Finished(): Boolean {
+        if (!isCt5()) return false
+        if (glucoseTimelineStartAtMs <= 0L) return false
+        val intervalMs = profile.readingIntervalMinutes * 60L * 1000L
+        val ageMs = ct5SensorAgeMs()
+        return isCt5SensorFinished(
+            sensorAgeMs = ageMs,
+            ratedLifetimeMs = profile.ratedLifetimeMs(),
+            frozenIdAgeMs = frozenIdAgeMs(ageMs, lastGlucoseId, intervalMs),
+            frozenGraceMs = CT5_FROZEN_ID_END_OF_LIFE_MS,
+        )
+    }
+
+    private fun noteCt5Finished() {
+        if (ct5FinishedLogged) return
+        ct5FinishedLogged = true
+        Log.w(
+            TAG,
+            "CT5 $SerialNumber has repeated id=$lastGlucoseId for over " +
+                    "${CT5_FROZEN_ID_END_OF_LIFE_MS / 60_000L}min past its " +
+                    "${profile.ratedLifetimeDays}-day rated life; it is finished. No further " +
+                    "readings will be estimated from its working current."
+        )
+        UiRefreshBus.requestStatusRefresh()
+    }
+
     private fun isCt5WarmingUp(): Boolean {
         if (!isCt5()) return false
         if (lastGlucoseAtMs > 0L) return false
@@ -2001,16 +2045,41 @@ class AnytimeBleManager(
      * means "handled, no scan needed" — the link is up.
      */
     override fun reconnect(now: Long): Boolean {
-        if (!stop &&
-            phase == Phase.STREAMING &&
-            shouldDeferLossOfSignalReconnect(streamingSinceMs, now, reconnectGraceMs())
-        ) {
-            Log.i(
-                TAG,
-                "Ignoring loss-of-signal reconnect: streaming session is only " +
-                        "${(now - streamingSinceMs) / 1000}s old; waiting for the next " +
-                        "${profile.readingIntervalMinutes}-minute push"
-            )
+        if (!stop && phase == Phase.STREAMING) {
+            if (shouldDeferLossOfSignalReconnect(streamingSinceMs, now, reconnectGraceMs())) {
+                Log.i(
+                    TAG,
+                    "Ignoring loss-of-signal reconnect: streaming session is only " +
+                            "${(now - streamingSinceMs) / 1000}s old; waiting for the next " +
+                            "${profile.readingIntervalMinutes}-minute push"
+                )
+                return true
+            }
+            // A push that carried no glucose is still proof the link works. The alarm
+            // is armed from the last reading and cannot see the difference; the driver
+            // can, and noDataWatchdog has always used exactly this timestamp.
+            val lastDataMs = lastSensorDataAtMs()
+            if (hasRecentSensorData(lastDataMs, now, reconnectGraceMs())) {
+                Log.i(
+                    TAG,
+                    "Ignoring loss-of-signal reconnect: last push was " +
+                            "${(now - lastDataMs) / 1000}s ago, inside the " +
+                            "${profile.readingIntervalMinutes}-minute cadence"
+                )
+                return true
+            }
+        }
+        // Genuinely out of contact. Take the disconnect ourselves rather than letting
+        // the base class disconnect and open a new connection in the same breath: the
+        // GATT is closed on the disconnect callback, and scheduleReconnect from there
+        // reconnects in a defined order with the usual backoff.
+        val gatt = mBluetoothGatt
+        if (!stop && gatt != null) {
+            Log.i(TAG, "Loss-of-signal reconnect: closing the link before reconnecting")
+            noteLossOfSignal(now)
+            runCatching { gatt.disconnect() }
+                .onFailure { Log.stack(TAG, "reconnect(disconnect)", it) }
+            UiRefreshBus.requestStatusRefresh()
             return true
         }
         return super.reconnect(now)
@@ -3564,6 +3633,9 @@ class AnytimeBleManager(
             // moves: a transmitter still advancing its id is a working sensor having a bad
             // reading, and a working sensor's bad readings must be dropped, not invented.
             val idAdvanced = record.glucoseId > lastGlucoseId
+            // An id that moves again is a sensor that is not finished after all; let a
+            // later end-of-life notice be reported rather than swallowed as a repeat.
+            if (idAdvanced) ct5FinishedLogged = false
             if (idAdvanced) lastGlucoseId = record.glucoseId
             persistAlgorithmState()
             if (!idAdvanced && emitCt5RawEstimate(record, now, intervalMs)) return
@@ -3584,6 +3656,10 @@ class AnytimeBleManager(
                     if (isCt5WarmingUp() && remainingMin >= 0L) " ~${remainingMin}min left" else "",
                 ),
             )
+            // The sensor is talking on schedule; only the reading is missing. Without
+            // this the shared loss-of-signal alarm reads the silence in charcha[1] as a
+            // dead link and tears down a working one.
+            noteLiveFrameWithoutReading(now)
             armNoDataWatchdog()
             armPullFallback()
             maybeRunReconnectTelemetryAfterLivePush()
@@ -3647,6 +3723,15 @@ class AnytimeBleManager(
         // Warm-up genuinely has no glucose to estimate: the electrode has not settled,
         // and a scale learned from a previous sensor would be a fabrication.
         if (isCt5WarmingUp()) return false
+        // A finished sensor still reports a working current, and the learned scale will
+        // still turn it into a plausible number: this one produced 51 mg/dL from 3.84nA
+        // three minutes after the same electrode read 0.13nA. Estimating through that is
+        // how a dead sensor raises a hypo alarm, so the estimate stops when the sensor
+        // does. The frame is still logged and its telemetry still shown.
+        if (isCt5Finished()) {
+            noteCt5Finished()
+            return false
+        }
         val estimate = ct5RawScale.estimateMgdl(record.iwNa)
         if (!estimate.isFinite()) return false
 
@@ -5094,7 +5179,9 @@ class AnytimeBleManager(
             Phase.CONNECTING -> "Connecting"
             Phase.DISCOVERING -> "Discovering"
             Phase.HANDSHAKING -> "Handshaking"
-            Phase.STREAMING -> if (isCt5WarmingUp()) {
+            Phase.STREAMING -> if (isCt5Finished()) {
+                Applic.app?.getString(R.string.sensor_expired_text) ?: "Sensor expired"
+            } else if (isCt5WarmingUp()) {
                 warmingUpStatus()
             } else if (historyBackfillActive) {
                 historyProgressStatus()

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
@@ -93,15 +93,6 @@ class AnytimeBleManager(
          * attempts would be the real fix.
          */
         private const val SOFT_RECONNECT_SETTLE_MS = 750L
-
-        /**
-         * How long a CT5 already past its rated life must keep repeating one id before
-         * the driver stops estimating readings for it.
-         *
-         * An hour is twenty pushes at cadence — long past a hiccup, and short enough
-         * that a finished sensor is not left inventing values for a whole evening.
-         */
-        private const val CT5_FROZEN_ID_END_OF_LIFE_MS = 60L * 60L * 1000L
         private const val SERVICE_DISCOVERY_TIMEOUT_MS = 15_000L
         private const val SERVICE_DISCOVERY_HARD_RECOVERY_DELAY_MS = 5_000L
         private const val SERVICE_DISCOVERY_RETRY_DELAY_MS = 1_500L
@@ -293,9 +284,6 @@ class AnytimeBleManager(
 
     /** What direct connects to this transmitter have actually achieved so far. */
     private val connectMode = AnytimeConnectModeState()
-
-    /** Keeps the end-of-life notice to once per sensor rather than once per push. */
-    @Volatile private var ct5FinishedLogged: Boolean = false
 
     @Volatile private var pendingFingerstickMgdl: Int = -1
     @Volatile private var pendingFingerstickTargetGlucoseId: Int = -1
@@ -1728,38 +1716,6 @@ class AnytimeBleManager(
      * field is in-memory only, so after an app restart a days-old sensor looked
      * like it was warming up until its next push.
      */
-    /**
-     * True once this CT5 is finished: past its rated life and no longer advancing its id.
-     *
-     * Requires the persisted timeline anchor. Without one, sensor age is a guess, and a
-     * guess must not be what stops a sensor reporting.
-     */
-    private fun isCt5Finished(): Boolean {
-        if (!isCt5()) return false
-        if (glucoseTimelineStartAtMs <= 0L) return false
-        val intervalMs = profile.readingIntervalMinutes * 60L * 1000L
-        val ageMs = ct5SensorAgeMs()
-        return isCt5SensorFinished(
-            sensorAgeMs = ageMs,
-            ratedLifetimeMs = profile.ratedLifetimeMs(),
-            frozenIdAgeMs = frozenIdAgeMs(ageMs, lastGlucoseId, intervalMs),
-            frozenGraceMs = CT5_FROZEN_ID_END_OF_LIFE_MS,
-        )
-    }
-
-    private fun noteCt5Finished() {
-        if (ct5FinishedLogged) return
-        ct5FinishedLogged = true
-        Log.w(
-            TAG,
-            "CT5 $SerialNumber has repeated id=$lastGlucoseId for over " +
-                    "${CT5_FROZEN_ID_END_OF_LIFE_MS / 60_000L}min past its " +
-                    "${profile.ratedLifetimeDays}-day rated life; it is finished. No further " +
-                    "readings will be estimated from its working current."
-        )
-        UiRefreshBus.requestStatusRefresh()
-    }
-
     private fun isCt5WarmingUp(): Boolean {
         if (!isCt5()) return false
         if (lastGlucoseAtMs > 0L) return false
@@ -3633,9 +3589,6 @@ class AnytimeBleManager(
             // moves: a transmitter still advancing its id is a working sensor having a bad
             // reading, and a working sensor's bad readings must be dropped, not invented.
             val idAdvanced = record.glucoseId > lastGlucoseId
-            // An id that moves again is a sensor that is not finished after all; let a
-            // later end-of-life notice be reported rather than swallowed as a repeat.
-            if (idAdvanced) ct5FinishedLogged = false
             if (idAdvanced) lastGlucoseId = record.glucoseId
             persistAlgorithmState()
             if (!idAdvanced && emitCt5RawEstimate(record, now, intervalMs)) return
@@ -3723,15 +3676,6 @@ class AnytimeBleManager(
         // Warm-up genuinely has no glucose to estimate: the electrode has not settled,
         // and a scale learned from a previous sensor would be a fabrication.
         if (isCt5WarmingUp()) return false
-        // A finished sensor still reports a working current, and the learned scale will
-        // still turn it into a plausible number: this one produced 51 mg/dL from 3.84nA
-        // three minutes after the same electrode read 0.13nA. Estimating through that is
-        // how a dead sensor raises a hypo alarm, so the estimate stops when the sensor
-        // does. The frame is still logged and its telemetry still shown.
-        if (isCt5Finished()) {
-            noteCt5Finished()
-            return false
-        }
         val estimate = ct5RawScale.estimateMgdl(record.iwNa)
         if (!estimate.isFinite()) return false
 
@@ -5179,9 +5123,7 @@ class AnytimeBleManager(
             Phase.CONNECTING -> "Connecting"
             Phase.DISCOVERING -> "Discovering"
             Phase.HANDSHAKING -> "Handshaking"
-            Phase.STREAMING -> if (isCt5Finished()) {
-                Applic.app?.getString(R.string.sensor_expired_text) ?: "Sensor expired"
-            } else if (isCt5WarmingUp()) {
+            Phase.STREAMING -> if (isCt5WarmingUp()) {
                 warmingUpStatus()
             } else if (historyBackfillActive) {
                 historyProgressStatus()

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt
@@ -72,6 +72,22 @@ class AnytimeBleManager(
         const val SENSOR_GEN = 0
 
         private const val ACTIVE_SESSION_RECONNECT_DELAY_MS = 2_000L
+
+        /**
+         * How long a soft reconnect waits between closing the old GATT and opening
+         * a new one.
+         *
+         * BluetoothGatt.close() returns immediately but unregisters the client
+         * asynchronously, and connecting again inside that window leaves two clients
+         * on one link. In the 2026-09-09 CT5 trace the 250ms this used to be produced
+         * a session with two onMtuChanged callbacks for a single requestMtu and an
+         * 8s service discovery — against under a second on the clean retry two minutes
+         * later — and the stack then dropped the link with GATT_FAILURE (257) a second
+         * after the low-power ack, as the retired client finally went away. A quiet
+         * gap costs nothing here: the alternative is the ~90s of blind reconnects that
+         * followed.
+         */
+        private const val SOFT_RECONNECT_SETTLE_MS = 750L
         private const val SERVICE_DISCOVERY_TIMEOUT_MS = 15_000L
         private const val SERVICE_DISCOVERY_HARD_RECOVERY_DELAY_MS = 5_000L
         private const val SERVICE_DISCOVERY_RETRY_DELAY_MS = 1_500L
@@ -260,6 +276,13 @@ class AnytimeBleManager(
     @Volatile private var forceScanResultAtMs: Long = 0L
     @Volatile private var pendingCccdGatt: BluetoothGatt? = null
     @Volatile private var lastConnectRequestAtMs: Long = 0L
+
+    /**
+     * Direct connects in a row that expired without reaching the transmitter.
+     * Drives [useAutoConnect] and the reconnect backoff; any connection at all
+     * clears it.
+     */
+    @Volatile private var consecutiveConnectTimeouts: Int = 0
     @Volatile private var pendingFingerstickMgdl: Int = -1
     @Volatile private var pendingFingerstickTargetGlucoseId: Int = -1
     @Volatile private var pendingKrPush: Boolean = false
@@ -407,6 +430,11 @@ class AnytimeBleManager(
         transmitterVersion = AnytimeRegistry.loadTransmitterVersion(context, id)
         val persistedLastGlucoseId = AnytimeRegistry.loadLastGlucoseId(context, id)
         sensorStartAtMs = AnytimeRegistry.loadSensorStartAt(context, id)
+        glucoseTimelineStartAtMs = restoredTimelineStartMs(
+            persistedTimelineStartMs = AnytimeRegistry.loadTimelineStartAt(context, id),
+            persistedSensorStartMs = sensorStartAtMs,
+            persistedLastGlucoseId = persistedLastGlucoseId,
+        )
         warmupStartedAtMs = AnytimeRegistry.loadWarmupStartedAt(context, id)
         bound = AnytimeRegistry.loadBound(context, id)
         lastReferenceBgMgdlTimes10 = AnytimeRegistry.loadReferenceBgMgdlTimes10(context, id)
@@ -613,6 +641,7 @@ class AnytimeBleManager(
         AnytimeRegistry.saveBound(ctx, id, bound)
         AnytimeRegistry.saveLastGlucoseId(ctx, id, lastGlucoseId)
         AnytimeRegistry.saveSensorStartAt(ctx, id, sensorStartAtMs)
+        AnytimeRegistry.saveTimelineStartAt(ctx, id, glucoseTimelineStartAtMs)
         AnytimeRegistry.saveWarmupStartedAt(ctx, id, warmupStartedAtMs)
         AnytimeRegistry.saveReferenceBgMgdlTimes10(ctx, id, lastReferenceBgMgdlTimes10)
         AnytimeRegistry.saveReferenceBgGlucoseId(ctx, id, lastReferenceBgGlucoseId)
@@ -1985,6 +2014,25 @@ class AnytimeBleManager(
         return super.reconnect(now)
     }
 
+    /**
+     * Inherit the user's setting until a direct connect has actually proved itself
+     * unable to reach this transmitter, then let the stack wait for an
+     * advertisement instead of burning another 30-second timer. See
+     * [shouldUseAutoConnect] for the measurement behind that.
+     */
+    override fun useAutoConnect(): Boolean {
+        val user = super.useAutoConnect()
+        val auto = shouldUseAutoConnect(user, consecutiveConnectTimeouts)
+        if (auto && !user) {
+            Log.i(
+                TAG,
+                "Using autoConnect after $consecutiveConnectTimeouts direct connect " +
+                        "timeout(s); waiting for the transmitter to advertise"
+            )
+        }
+        return auto
+    }
+
     private fun scheduleReconnect(reason: String, delayMs: Long = ACTIVE_SESSION_RECONNECT_DELAY_MS) {
         if (stop) return
         reconnectReason = reason
@@ -2263,6 +2311,7 @@ class AnytimeBleManager(
         when (newState) {
             BluetoothProfile.STATE_CONNECTED -> {
                 Log.i(TAG, "Connected to ${gatt.device?.address}")
+                consecutiveConnectTimeouts = 0
                 cancelReconnect()
                 clearGattCallbacks()
                 mBluetoothGatt = gatt
@@ -2290,6 +2339,14 @@ class AnytimeBleManager(
             }
             BluetoothProfile.STATE_DISCONNECTED -> {
                 Log.i(TAG, "Disconnected (status=$status)")
+                // A disconnect out of CONNECTING never reached the transmitter, so
+                // status 147 here is the 30-second direct-connect timer, not a lost
+                // link. Anything that did connect resets the count.
+                consecutiveConnectTimeouts = if (phase == Phase.CONNECTING && isConnectTimeoutStatus(status)) {
+                    consecutiveConnectTimeouts + 1
+                } else {
+                    0
+                }
                 phase = Phase.IDLE
                 streamingSinceMs = 0L
                 writeInFlight = false
@@ -2332,7 +2389,14 @@ class AnytimeBleManager(
                         ct5EndCycleSsnInFlight = false
                     }
                     if (!stop) {
-                        scheduleReconnect("GATT disconnect status=$status")
+                        scheduleReconnect(
+                            "GATT disconnect status=$status",
+                            connectRetryDelayMs(
+                                consecutiveConnectTimeouts = consecutiveConnectTimeouts,
+                                baseDelayMs = ACTIVE_SESSION_RECONNECT_DELAY_MS,
+                                readingIntervalMs = profile.readingIntervalMinutes * 60L * 1000L,
+                            ),
+                        )
                     }
                 }
                 UiRefreshBus.requestStatusRefresh()
@@ -4633,7 +4697,7 @@ class AnytimeBleManager(
         }
         handler.postDelayed({
             if (!stop) connectDevice(0)
-        }, 250L)
+        }, SOFT_RECONNECT_SETTLE_MS)
         UiRefreshBus.requestStatusRefresh()
     }
 

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConnectRetryPolicy.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConnectRetryPolicy.kt
@@ -1,0 +1,54 @@
+package tk.glucodata.drivers.anytime
+
+/**
+ * When a reconnect should stop hammering the peripheral directly.
+ *
+ * A direct connect (autoConnect=false) gives Android 30 seconds to reach the
+ * peripheral and then reports status 147. That is the right trade for a device
+ * that is advertising now; it is the wrong one for an Anytime transmitter that
+ * has been told `lowPower` and only becomes connectable near its next scheduled
+ * push. The 2026-09-09 CT5 trace lost 96 seconds to three back-to-back 30-second
+ * timeouts (30016ms, 30027ms, 30038ms) before the transmitter woke on its own.
+ *
+ * autoConnect=true has no timeout: the stack keeps the address on its background
+ * connect list and links up on the first advertisement, which is exactly the
+ * behaviour a duty-cycled transmitter needs.
+ *
+ * Nothing here changes an attempt that has not timed out, so a family whose
+ * connects land promptly keeps the user's setting and this policy never applies.
+ */
+
+/**
+ * `BluetoothGatt.GATT_CONNECTION_TIMEOUT`, added in API 33. Spelled out because
+ * the constant is not available on the minimum SDK this driver supports.
+ */
+internal const val GATT_CONNECTION_TIMEOUT_STATUS = 147
+
+/** One timeout is already 30 seconds of silence — do not spend a second one to be sure. */
+internal const val AUTO_CONNECT_AFTER_TIMEOUTS = 1
+
+/** Overflow guard only: the reading-interval cap below is what actually bounds the wait. */
+internal const val MAX_CONNECT_BACKOFF_DOUBLINGS = 30
+
+internal fun isConnectTimeoutStatus(status: Int): Boolean =
+    status == GATT_CONNECTION_TIMEOUT_STATUS
+
+internal fun shouldUseAutoConnect(userSetting: Boolean, consecutiveConnectTimeouts: Int): Boolean =
+    userSetting || consecutiveConnectTimeouts >= AUTO_CONNECT_AFTER_TIMEOUTS
+
+/**
+ * Reconnect delay after [consecutiveConnectTimeouts] attempts that never reached
+ * the peripheral. Doubles from [baseDelayMs] and stops at one reading interval:
+ * waiting longer than a full cadence slot cannot help, because the transmitter is
+ * connectable at least once per slot.
+ */
+internal fun connectRetryDelayMs(
+    consecutiveConnectTimeouts: Int,
+    baseDelayMs: Long,
+    readingIntervalMs: Long,
+): Long {
+    if (consecutiveConnectTimeouts <= 0 || baseDelayMs <= 0L) return baseDelayMs
+    val cap = maxOf(readingIntervalMs, baseDelayMs)
+    val scaled = baseDelayMs shl consecutiveConnectTimeouts.coerceAtMost(MAX_CONNECT_BACKOFF_DOUBLINGS)
+    return scaled.coerceIn(baseDelayMs, cap)
+}

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConnectRetryPolicy.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConnectRetryPolicy.kt
@@ -1,26 +1,27 @@
 package tk.glucodata.drivers.anytime
 
-/**
- * When a reconnect should stop hammering the peripheral directly.
- *
- * A direct connect (autoConnect=false) gives Android 30 seconds to reach the
- * peripheral and then reports status 147. That is the right trade for a device
- * that is advertising now; it is the wrong one for an Anytime transmitter that
- * has been told `lowPower` and only becomes connectable near its next scheduled
- * push. The 2026-09-09 CT5 trace lost 96 seconds to three back-to-back 30-second
- * timeouts (30016ms, 30027ms, 30038ms) before the transmitter woke on its own.
- *
- * autoConnect=true has no timeout: the stack keeps the address on its background
- * connect list and links up on the first advertisement, which is exactly the
- * behaviour a duty-cycled transmitter needs.
- *
- * Nothing here changes an attempt that has not timed out, so a family whose
- * connects land promptly keeps the user's setting and this policy never applies.
- */
+// When a reconnect should stop trying to reach the transmitter directly.
+//
+// A direct connect (autoConnect=false) gives Android roughly 30 seconds to reach the
+// peripheral and then reports status 147. That is the right trade for a device that is
+// advertising now; it is the wrong one for a transmitter that has been told `lowPower`
+// and is only reliably connectable near its next scheduled push. The 2026-09-09 CT5
+// trace spent 96 seconds on three back-to-back timeouts (30016ms, 30027ms, 30038ms)
+// before the transmitter woke on its own.
+//
+// A background connect is not documented to be timeout-free, and OEM stacks vary, but
+// it is the mode meant for a peripheral that is not advertising yet: the stack holds
+// the address and links up when it appears, rather than expiring a fixed timer. After
+// an attempt that already burned that timer, it is the better of the two bets.
+//
+// Note this is keyed on an observed timeout, not on a sensor family. Every Anytime
+// generation sends `lowPower` on entering streaming, so any of them can end up
+// unreachable between pushes; equally, a transmitter that answers a direct connect
+// never trips this and keeps the user's setting.
 
 /**
- * `BluetoothGatt.GATT_CONNECTION_TIMEOUT`, added in API 33. Spelled out because
- * the constant is not available on the minimum SDK this driver supports.
+ * `BluetoothGatt.GATT_CONNECTION_TIMEOUT`, which is API 35. Spelled out because the
+ * driver compiles against a lower minimum and the constant is not available there.
  */
 internal const val GATT_CONNECTION_TIMEOUT_STATUS = 147
 
@@ -33,14 +34,14 @@ internal const val MAX_CONNECT_BACKOFF_DOUBLINGS = 30
 internal fun isConnectTimeoutStatus(status: Int): Boolean =
     status == GATT_CONNECTION_TIMEOUT_STATUS
 
-internal fun shouldUseAutoConnect(userSetting: Boolean, consecutiveConnectTimeouts: Int): Boolean =
-    userSetting || consecutiveConnectTimeouts >= AUTO_CONNECT_AFTER_TIMEOUTS
+internal fun shouldUseAutoConnect(userSetting: Boolean, directConnectUnreachable: Boolean): Boolean =
+    userSetting || directConnectUnreachable
 
 /**
- * Reconnect delay after [consecutiveConnectTimeouts] attempts that never reached
- * the peripheral. Doubles from [baseDelayMs] and stops at one reading interval:
- * waiting longer than a full cadence slot cannot help, because the transmitter is
- * connectable at least once per slot.
+ * Reconnect delay after [consecutiveConnectTimeouts] attempts that never reached the
+ * transmitter. Doubles from [baseDelayMs] and stops at one reading interval: waiting
+ * longer than a full cadence slot cannot help, because the transmitter is connectable
+ * at least once per slot.
  */
 internal fun connectRetryDelayMs(
     consecutiveConnectTimeouts: Int,
@@ -51,4 +52,58 @@ internal fun connectRetryDelayMs(
     val cap = maxOf(readingIntervalMs, baseDelayMs)
     val scaled = baseDelayMs shl consecutiveConnectTimeouts.coerceAtMost(MAX_CONNECT_BACKOFF_DOUBLINGS)
     return scaled.coerceIn(baseDelayMs, cap)
+}
+
+/**
+ * What the driver has learned about reaching this transmitter, across a process.
+ *
+ * Two things are tracked because they expire differently. The backoff counts the
+ * failures happening right now and any connection at all ends that run. Whether a
+ * direct connect can reach this transmitter at all is a property of the transmitter,
+ * and connecting over a background connect says nothing about it — clearing the mode
+ * there would send the next outage back through another 30-second timer, every time.
+ * Only a direct connect that actually succeeded is evidence that direct connects work.
+ */
+internal class AnytimeConnectModeState {
+
+    /** Failed attempts in the current run, for the reconnect backoff. */
+    @Volatile
+    var consecutiveConnectTimeouts: Int = 0
+        private set
+
+    /** Set once a direct connect has demonstrably failed to reach the transmitter. */
+    @Volatile
+    var directConnectUnreachable: Boolean = false
+        private set
+
+    /**
+     * [usedAutoConnect] is the mode the attempt that just connected was opened with.
+     */
+    fun onConnected(usedAutoConnect: Boolean) {
+        consecutiveConnectTimeouts = 0
+        if (!usedAutoConnect) {
+            directConnectUnreachable = false
+        }
+    }
+
+    /**
+     * [wasConnecting] separates an attempt that never reached the transmitter from a
+     * link that was up and dropped; only the former says anything about reachability.
+     */
+    fun onDisconnected(status: Int, wasConnecting: Boolean) {
+        if (!wasConnecting || !isConnectTimeoutStatus(status)) {
+            consecutiveConnectTimeouts = 0
+            return
+        }
+        consecutiveConnectTimeouts += 1
+        if (consecutiveConnectTimeouts >= AUTO_CONNECT_AFTER_TIMEOUTS) {
+            directConnectUnreachable = true
+        }
+    }
+
+    fun useAutoConnect(userSetting: Boolean): Boolean =
+        shouldUseAutoConnect(userSetting, directConnectUnreachable)
+
+    fun retryDelayMs(baseDelayMs: Long, readingIntervalMs: Long): Long =
+        connectRetryDelayMs(consecutiveConnectTimeouts, baseDelayMs, readingIntervalMs)
 }

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConstants.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConstants.kt
@@ -480,6 +480,16 @@ object AnytimeConstants {
     const val PREF_LAST_GLUCOSE_ID_PREFIX = "anytime_last_id_"
     const val PREF_SENSOR_START_AT_PREFIX = "anytime_started_at_"
     const val PREF_WARMUP_STARTED_AT_PREFIX = "anytime_warmup_at_"
+
+    /**
+     * Start of the glucose-id timeline: the wall-clock time id 0 would have had.
+     *
+     * Persisted separately from PREF_SENSOR_START_AT_PREFIX because the two answer
+     * different questions. The sensor start is a display value the check frame can
+     * also supply; this one records that a timeline anchor already exists, which is
+     * what keeps a repeated live id from re-anchoring the session after a restart.
+     */
+    const val PREF_TIMELINE_START_AT_PREFIX = "anytime_timeline_at_"
     const val PREF_VOLTAGE_PREFIX = "anytime_voltage_"
     const val PREF_DEVICE_NAME_PREFIX = "anytime_device_name_"
     const val PREF_TRANSMITTER_VERSION_PREFIX = "anytime_tx_version_"

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillState.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillState.kt
@@ -87,39 +87,6 @@ internal fun liveIdLooksRolledBack(
  * Keyed on the previous highest id, which a genuine restart resets to -1, so a re-activation
  * anchors from its own first id exactly as before.
  */
-/**
- * How long the transmitter's own clock has stood still, in wall-clock terms.
- *
- * One id is one cadence tick, so a working sensor's id timeline `(id + 1) * interval`
- * tracks its actual age. When the firmware stops advancing the id the two diverge, and
- * the gap is exactly how long it has been repeating itself. This only reads true once
- * the timeline anchor is stable — while the anchor was being re-derived from every push
- * it walked forward in step with the repeats and hid the divergence completely.
- */
-internal fun frozenIdAgeMs(sensorAgeMs: Long, lastGlucoseId: Int, intervalMs: Long): Long {
-    if (sensorAgeMs <= 0L || lastGlucoseId < 0 || intervalMs <= 0L) return 0L
-    val idTimelineMs = (lastGlucoseId.toLong() + 1L) * intervalMs
-    return (sensorAgeMs - idTimelineMs).coerceAtLeast(0L)
-}
-
-/**
- * True when a sensor has stopped being one.
- *
- * Both conditions are needed. Past its rated life a CT5 may still be advancing ids and
- * reading perfectly well, so age alone means nothing; and a transmitter can repeat an id
- * briefly inside its life without being finished. Together — rated life over, and the id
- * standing still for [frozenGraceMs] on top of that — there is no reading left to have.
- */
-internal fun isCt5SensorFinished(
-    sensorAgeMs: Long,
-    ratedLifetimeMs: Long,
-    frozenIdAgeMs: Long,
-    frozenGraceMs: Long,
-): Boolean =
-    ratedLifetimeMs > 0L &&
-        sensorAgeMs >= ratedLifetimeMs &&
-        frozenIdAgeMs >= frozenGraceMs
-
 internal fun shouldReanchorTimeline(
     liveId: Int,
     previousMaxId: Int,

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillState.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillState.kt
@@ -87,6 +87,29 @@ internal fun liveIdLooksRolledBack(
  * Keyed on the previous highest id, which a genuine restart resets to -1, so a re-activation
  * anchors from its own first id exactly as before.
  */
+/**
+ * The timeline anchor to start a process with.
+ *
+ * [shouldReanchorTimeline] treats a missing anchor as "bootstrap, take whatever the
+ * first live id says". That is right for a new sensor and wrong after a restart: the
+ * anchor used to live only in memory, so every process start re-anchored on the first
+ * push, and a transmitter repeating an id it had already sent walked the stored sensor
+ * start forward by however long the app had been down.
+ *
+ * The sensor start is the fallback for installs that predate the persisted anchor, and
+ * only when an id has been seen before — without one there is nothing the anchor could
+ * have been derived from.
+ */
+internal fun restoredTimelineStartMs(
+    persistedTimelineStartMs: Long,
+    persistedSensorStartMs: Long,
+    persistedLastGlucoseId: Int,
+): Long = when {
+    persistedTimelineStartMs > 0L -> persistedTimelineStartMs
+    persistedSensorStartMs > 0L && persistedLastGlucoseId >= 0 -> persistedSensorStartMs
+    else -> 0L
+}
+
 internal fun shouldReanchorTimeline(
     liveId: Int,
     previousMaxId: Int,

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillState.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillState.kt
@@ -87,6 +87,12 @@ internal fun liveIdLooksRolledBack(
  * Keyed on the previous highest id, which a genuine restart resets to -1, so a re-activation
  * anchors from its own first id exactly as before.
  */
+internal fun shouldReanchorTimeline(
+    liveId: Int,
+    previousMaxId: Int,
+    haveTimelineStart: Boolean,
+): Boolean = liveId >= 0 && (!haveTimelineStart || liveId > previousMaxId)
+
 /**
  * The timeline anchor to start a process with.
  *
@@ -109,12 +115,6 @@ internal fun restoredTimelineStartMs(
     persistedSensorStartMs > 0L && persistedLastGlucoseId >= 0 -> persistedSensorStartMs
     else -> 0L
 }
-
-internal fun shouldReanchorTimeline(
-    liveId: Int,
-    previousMaxId: Int,
-    haveTimelineStart: Boolean,
-): Boolean = liveId >= 0 && (!haveTimelineStart || liveId > previousMaxId)
 
 /**
  * Legacy families use the profile record count as a hard history boundary.

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillState.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillState.kt
@@ -87,6 +87,39 @@ internal fun liveIdLooksRolledBack(
  * Keyed on the previous highest id, which a genuine restart resets to -1, so a re-activation
  * anchors from its own first id exactly as before.
  */
+/**
+ * How long the transmitter's own clock has stood still, in wall-clock terms.
+ *
+ * One id is one cadence tick, so a working sensor's id timeline `(id + 1) * interval`
+ * tracks its actual age. When the firmware stops advancing the id the two diverge, and
+ * the gap is exactly how long it has been repeating itself. This only reads true once
+ * the timeline anchor is stable — while the anchor was being re-derived from every push
+ * it walked forward in step with the repeats and hid the divergence completely.
+ */
+internal fun frozenIdAgeMs(sensorAgeMs: Long, lastGlucoseId: Int, intervalMs: Long): Long {
+    if (sensorAgeMs <= 0L || lastGlucoseId < 0 || intervalMs <= 0L) return 0L
+    val idTimelineMs = (lastGlucoseId.toLong() + 1L) * intervalMs
+    return (sensorAgeMs - idTimelineMs).coerceAtLeast(0L)
+}
+
+/**
+ * True when a sensor has stopped being one.
+ *
+ * Both conditions are needed. Past its rated life a CT5 may still be advancing ids and
+ * reading perfectly well, so age alone means nothing; and a transmitter can repeat an id
+ * briefly inside its life without being finished. Together — rated life over, and the id
+ * standing still for [frozenGraceMs] on top of that — there is no reading left to have.
+ */
+internal fun isCt5SensorFinished(
+    sensorAgeMs: Long,
+    ratedLifetimeMs: Long,
+    frozenIdAgeMs: Long,
+    frozenGraceMs: Long,
+): Boolean =
+    ratedLifetimeMs > 0L &&
+        sensorAgeMs >= ratedLifetimeMs &&
+        frozenIdAgeMs >= frozenGraceMs
+
 internal fun shouldReanchorTimeline(
     liveId: Int,
     previousMaxId: Int,
@@ -428,10 +461,25 @@ internal fun shouldDeferLossOfSignalReconnect(
     streamingSinceMs: Long,
     nowMs: Long,
     graceMs: Long,
-): Boolean {
-    if (streamingSinceMs <= 0L) return false
-    val age = nowMs - streamingSinceMs
-    return age in 0 until graceMs
+): Boolean = isWithinWindow(streamingSinceMs, nowMs, graceMs)
+
+/**
+ * True when the sensor has been heard from inside [withinMs].
+ *
+ * The shared alarm is armed from the last *reading*, so a sensor pushing on cadence
+ * without producing glucose — a terminated CT5 does this for days — reads to it as
+ * silence, and it tears down a working link. A decoded push is proof the link works
+ * whether or not it carried a reading.
+ */
+internal fun hasRecentSensorData(
+    lastSensorDataAtMs: Long,
+    nowMs: Long,
+    withinMs: Long,
+): Boolean = isWithinWindow(lastSensorDataAtMs, nowMs, withinMs)
+
+private fun isWithinWindow(sinceMs: Long, nowMs: Long, windowMs: Long): Boolean {
+    if (sinceMs <= 0L) return false
+    return (nowMs - sinceMs) in 0 until windowMs
 }
 
 /**

--- a/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeRegistry.kt
+++ b/Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeRegistry.kt
@@ -169,6 +169,12 @@ object AnytimeRegistry {
         prefs(c).edit().putLong(AnytimeConstants.PREF_SENSOR_START_AT_PREFIX + id, ms).apply()
     }
 
+    @JvmStatic fun loadTimelineStartAt(c: Context, id: String): Long =
+        prefs(c).getLong(AnytimeConstants.PREF_TIMELINE_START_AT_PREFIX + id, 0L)
+    @JvmStatic fun saveTimelineStartAt(c: Context, id: String, ms: Long) {
+        prefs(c).edit().putLong(AnytimeConstants.PREF_TIMELINE_START_AT_PREFIX + id, ms).apply()
+    }
+
     @JvmStatic fun loadWarmupStartedAt(c: Context, id: String): Long =
         prefs(c).getLong(AnytimeConstants.PREF_WARMUP_STARTED_AT_PREFIX + id, 0L)
     @JvmStatic fun saveWarmupStartedAt(c: Context, id: String, ms: Long) {

--- a/Common/src/test/java/tk/glucodata/ConnectModeLeverTests.kt
+++ b/Common/src/test/java/tk/glucodata/ConnectModeLeverTests.kt
@@ -92,16 +92,22 @@ class ConnectModeLeverTests {
             "Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt",
         ).readText().replace(Regex("\\s+"), " ")
         assertTrue(
-            "the Anytime override must start from the application-wide setting",
-            text.contains("val user = super.useAutoConnect()"),
+            "the Anytime override must start from the application-wide setting and go " +
+                "through the measured-timeout policy",
+            text.contains(
+                "override fun useAutoConnect(): Boolean = " +
+                    "connectMode.useAutoConnect(super.useAutoConnect())"
+            ),
         )
-        assertTrue(
-            "the Anytime override must go through the measured-timeout policy",
-            text.contains("shouldUseAutoConnect(user, consecutiveConnectTimeouts)"),
-        )
-        assertTrue(
-            "only a connect that timed out may raise the counter that flips the mode",
-            text.contains("phase == Phase.CONNECTING && isConnectTimeoutStatus(status)"),
+        val policy = File(
+            repoRoot(),
+            "Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeConnectRetryPolicy.kt",
+        ).readText()
+        assertEquals(
+            "the mode may only be changed where an observed timeout and a successful " +
+                "direct connect decide it; AnytimeConnectModeState is that one place",
+            2,
+            Regex("directConnectUnreachable = (true|false)").findAll(policy).count(),
         )
     }
 

--- a/Common/src/test/java/tk/glucodata/ConnectModeLeverTests.kt
+++ b/Common/src/test/java/tk/glucodata/ConnectModeLeverTests.kt
@@ -12,10 +12,15 @@ import org.junit.Test
  * constructor overwrites from Natives.getAndroid13(); while the connectGatt call sites read it
  * directly no driver could choose its own mode, and the 2026-08-01 jamming storm accordingly
  * logged 103 connect attempts (52 + 51, two Ottai sensors) at autoConnect=true and none at false.
- * useAutoConnect() makes a per-driver choice expressible — deliberately with no override anywhere
- * yet, because the modelled effect of a direct connect on these sensors ranges from 1071s saved to
- * 280s lost and nothing in the dataset decides between them. These are source scans because the
- * classes involved need the Android runtime and the native library to be constructed at all.
+ * useAutoConnect() makes a per-driver choice expressible, and the 2026-09-09 CT5 trace is the
+ * first measurement that decides it for one peripheral: after a lowPower frame the transmitter is
+ * only connectable near its 3-minute push, and three direct connects in a row reported their first
+ * callback at 30016ms, 30027ms and 30038ms — Android's connect timer expiring, status 147 — for 96
+ * seconds of dead air. That is the number noteFirstGattCallback exists to collect, so the Anytime
+ * driver may answer it; every other driver still has nothing in the dataset deciding between the
+ * modes (a modelled 1071s saved to 280s lost) and keeps inheriting the application-wide setting.
+ * These are source scans because the classes involved need the Android runtime and the native
+ * library to be constructed at all.
  */
 class ConnectModeLeverTests {
 
@@ -57,17 +62,46 @@ class ConnectModeLeverTests {
     }
 
     @Test
-    fun noDriverOverridesTheDefault() {
+    fun noUnmeasuredDriverOverridesTheDefault() {
         // R2(a) is a lever, not a change of behaviour: an override appearing here means some
-        // driver now connects in a mode the 2026-08-01 dataset never measured.
+        // driver now connects in a mode the 2026-08-01 dataset never measured. The Anytime
+        // files are listed because the 2026-09-09 CT5 trace did measure it — see the next test
+        // for what that override is still held to.
+        val measured = setOf(
+            "AnytimeBleManager.kt",
+            "AnytimeConnectRetryPolicy.kt",
+            "AnytimeConnectRetryPolicyTests.kt",
+        )
         val overriders = sources("Common/src")
             .filter { it.name != "SuperGattCallback.java" && it.name != "ConnectModeLeverTests.kt" }
             .filter { it.readText().contains("useAutoConnect") }
             .map { it.name }
         assertTrue(
             "no driver may override useAutoConnect() without field measurements of the other " +
-                "mode; found $overriders",
-            overriders.isEmpty(),
+                "mode; found ${overriders - measured}",
+            (overriders - measured).isEmpty(),
+        )
+    }
+
+    @Test
+    fun theMeasuredOverrideStaysGatedOnAnObservedTimeout() {
+        // The measurement licenses reacting to a direct connect that demonstrably failed, not
+        // switching modes generally: a session that connects keeps the user's setting.
+        val text = File(
+            repoRoot(),
+            "Common/src/main/java/tk/glucodata/drivers/anytime/AnytimeBleManager.kt",
+        ).readText().replace(Regex("\\s+"), " ")
+        assertTrue(
+            "the Anytime override must start from the application-wide setting",
+            text.contains("val user = super.useAutoConnect()"),
+        )
+        assertTrue(
+            "the Anytime override must go through the measured-timeout policy",
+            text.contains("shouldUseAutoConnect(user, consecutiveConnectTimeouts)"),
+        )
+        assertTrue(
+            "only a connect that timed out may raise the counter that flips the mode",
+            text.contains("phase == Phase.CONNECTING && isConnectTimeoutStatus(status)"),
         )
     }
 

--- a/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeConnectRetryPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeConnectRetryPolicyTests.kt
@@ -1,0 +1,91 @@
+package tk.glucodata.drivers.anytime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Reconnect policy after a direct connect that never reaches the transmitter.
+ * Numbers come from the 2026-09-09 CT5 trace: three 30-second timeouts (status
+ * 147) at a flat 2-second retry cost 96 seconds of dead air.
+ */
+class AnytimeConnectRetryPolicyTests {
+
+    private val threeMinutesMs = 3L * 60L * 1000L
+    private val baseMs = 2_000L
+
+    @Test
+    fun onlyTheThirtySecondTimeoutStatusCountsAsAConnectTimeout() {
+        assertTrue(isConnectTimeoutStatus(147))
+        // 257 (GATT_FAILURE) and 133 (GATT_ERROR) are lost links, not unreachable
+        // peripherals: they say nothing about whether the transmitter is advertising.
+        assertFalse(isConnectTimeoutStatus(257))
+        assertFalse(isConnectTimeoutStatus(133))
+        assertFalse(isConnectTimeoutStatus(0))
+    }
+
+    @Test
+    fun firstAttemptKeepsTheUsersDirectConnectSetting() {
+        assertFalse(shouldUseAutoConnect(userSetting = false, consecutiveConnectTimeouts = 0))
+    }
+
+    @Test
+    fun oneTimeoutIsEnoughToStopBurningThirtySecondTimers() {
+        assertTrue(shouldUseAutoConnect(userSetting = false, consecutiveConnectTimeouts = 1))
+        assertTrue(shouldUseAutoConnect(userSetting = false, consecutiveConnectTimeouts = 3))
+    }
+
+    @Test
+    fun aUserWhoAskedForAutoConnectAlwaysGetsIt() {
+        assertTrue(shouldUseAutoConnect(userSetting = true, consecutiveConnectTimeouts = 0))
+    }
+
+    @Test
+    fun aConnectionThatSucceededRetriesAtTheNormalDelay() {
+        assertEquals(
+            baseMs,
+            connectRetryDelayMs(
+                consecutiveConnectTimeouts = 0,
+                baseDelayMs = baseMs,
+                readingIntervalMs = threeMinutesMs,
+            )
+        )
+    }
+
+    @Test
+    fun repeatedTimeoutsBackOffInsteadOfRetryingEveryTwoSeconds() {
+        val delays = (1..4).map {
+            connectRetryDelayMs(
+                consecutiveConnectTimeouts = it,
+                baseDelayMs = baseMs,
+                readingIntervalMs = threeMinutesMs,
+            )
+        }
+        assertEquals(listOf(4_000L, 8_000L, 16_000L, 32_000L), delays)
+    }
+
+    @Test
+    fun backoffNeverOutlastsOneCadenceSlot() {
+        // The transmitter is connectable at least once per reading interval, so
+        // waiting longer than one slot only delays recovery.
+        val delay = connectRetryDelayMs(
+            consecutiveConnectTimeouts = 20,
+            baseDelayMs = baseMs,
+            readingIntervalMs = threeMinutesMs,
+        )
+        assertEquals(threeMinutesMs, delay)
+    }
+
+    @Test
+    fun aBaseDelayLongerThanTheIntervalIsStillHonoured() {
+        assertEquals(
+            10_000L,
+            connectRetryDelayMs(
+                consecutiveConnectTimeouts = 5,
+                baseDelayMs = 10_000L,
+                readingIntervalMs = 1_000L,
+            )
+        )
+    }
+}

--- a/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeConnectRetryPolicyTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeConnectRetryPolicyTests.kt
@@ -27,18 +27,104 @@ class AnytimeConnectRetryPolicyTests {
 
     @Test
     fun firstAttemptKeepsTheUsersDirectConnectSetting() {
-        assertFalse(shouldUseAutoConnect(userSetting = false, consecutiveConnectTimeouts = 0))
-    }
-
-    @Test
-    fun oneTimeoutIsEnoughToStopBurningThirtySecondTimers() {
-        assertTrue(shouldUseAutoConnect(userSetting = false, consecutiveConnectTimeouts = 1))
-        assertTrue(shouldUseAutoConnect(userSetting = false, consecutiveConnectTimeouts = 3))
+        assertFalse(shouldUseAutoConnect(userSetting = false, directConnectUnreachable = false))
     }
 
     @Test
     fun aUserWhoAskedForAutoConnectAlwaysGetsIt() {
-        assertTrue(shouldUseAutoConnect(userSetting = true, consecutiveConnectTimeouts = 0))
+        assertTrue(shouldUseAutoConnect(userSetting = true, directConnectUnreachable = false))
+    }
+
+    @Test
+    fun aSensorThatAnswersDirectConnectsNeverChangesMode() {
+        // The policy is keyed on an observed timeout, not on a sensor family, so this
+        // is what every generation that connects normally gets — CT2.5 through CT4 as
+        // much as a healthy CT5. Nothing here has timed out, so nothing changes.
+        val state = AnytimeConnectModeState()
+
+        repeat(5) {
+            state.onConnected(usedAutoConnect = false)
+            // Ordinary end of a session: remote hung up, link was up at the time.
+            state.onDisconnected(status = 19, wasConnecting = false)
+            assertFalse(state.directConnectUnreachable)
+            assertFalse(state.useAutoConnect(userSetting = false))
+            assertEquals(baseMs, state.retryDelayMs(baseMs, threeMinutesMs))
+        }
+    }
+
+    @Test
+    fun aLinkThatDropsAfterConnectingSaysNothingAboutReachability() {
+        val state = AnytimeConnectModeState()
+        state.onConnected(usedAutoConnect = false)
+
+        // 257 one second after the low-power ack — the 2026-09-09 disconnect. The link
+        // was up, so it is not evidence that a direct connect cannot reach the sensor.
+        state.onDisconnected(status = 257, wasConnecting = false)
+
+        assertFalse(state.directConnectUnreachable)
+        assertFalse(state.useAutoConnect(userSetting = false))
+    }
+
+    @Test
+    fun oneTimeoutIsEnoughToStopBurningThirtySecondTimers() {
+        val state = AnytimeConnectModeState()
+
+        state.onDisconnected(status = 147, wasConnecting = true)
+
+        assertTrue(state.directConnectUnreachable)
+        assertTrue(state.useAutoConnect(userSetting = false))
+    }
+
+    @Test
+    fun theCt5ReconnectStormBacksOffInsteadOfRepeatingThirtySecondTimeouts() {
+        val state = AnytimeConnectModeState()
+
+        // 22:57:22 — the link we had drops.
+        state.onDisconnected(status = 257, wasConnecting = false)
+        assertFalse(state.useAutoConnect(userSetting = false))
+        assertEquals(baseMs, state.retryDelayMs(baseMs, threeMinutesMs))
+
+        // 22:57:54, 22:58:26, 22:58:58 — three direct connects that never arrive.
+        state.onDisconnected(status = 147, wasConnecting = true)
+        assertTrue(state.useAutoConnect(userSetting = false))
+        assertEquals(4_000L, state.retryDelayMs(baseMs, threeMinutesMs))
+
+        state.onDisconnected(status = 147, wasConnecting = true)
+        state.onDisconnected(status = 147, wasConnecting = true)
+        assertEquals(16_000L, state.retryDelayMs(baseMs, threeMinutesMs))
+
+        // 22:59:23 — it advertises and the stack links up.
+        state.onConnected(usedAutoConnect = true)
+        assertEquals(baseMs, state.retryDelayMs(baseMs, threeMinutesMs))
+    }
+
+    @Test
+    fun connectingOverAutoConnectDoesNotBuyBackAnotherThirtySecondTimeout() {
+        // The transmitter is still only connectable near its push; a background connect
+        // succeeding proves nothing about direct connects, so the next outage must not
+        // start by spending the timer again.
+        val state = AnytimeConnectModeState()
+        state.onDisconnected(status = 147, wasConnecting = true)
+
+        state.onConnected(usedAutoConnect = true)
+        state.onDisconnected(status = 19, wasConnecting = false)
+
+        assertTrue(state.directConnectUnreachable)
+        assertTrue(state.useAutoConnect(userSetting = false))
+    }
+
+    @Test
+    fun aDirectConnectThatSucceedsAgainReturnsTheUsersSetting() {
+        // The only evidence that direct connects work is one that worked: a new sensor,
+        // a firmware that advertises differently, or simply better conditions.
+        val state = AnytimeConnectModeState()
+        state.onDisconnected(status = 147, wasConnecting = true)
+        assertTrue(state.useAutoConnect(userSetting = false))
+
+        state.onConnected(usedAutoConnect = false)
+
+        assertFalse(state.directConnectUnreachable)
+        assertFalse(state.useAutoConnect(userSetting = false))
     }
 
     @Test

--- a/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillStateTests.kt
@@ -26,6 +26,78 @@ class AnytimeHistoryBackfillStateTests {
     }
 
     @Test
+    fun aPersistedTimelineAnchorSurvivesARestart() {
+        assertEquals(
+            1_787_503_820_003L,
+            restoredTimelineStartMs(
+                persistedTimelineStartMs = 1_787_503_820_003L,
+                persistedSensorStartMs = 1_787_503_820_003L,
+                persistedLastGlucoseId = 8_175,
+            )
+        )
+    }
+
+    @Test
+    fun anInstallWithoutAPersistedAnchorFallsBackToTheStoredSensorStart() {
+        // Upgrades from before the anchor was persisted: an id has been seen, so a
+        // start exists and the first push must not be allowed to re-derive it.
+        assertEquals(
+            1_787_503_820_003L,
+            restoredTimelineStartMs(
+                persistedTimelineStartMs = 0L,
+                persistedSensorStartMs = 1_787_503_820_003L,
+                persistedLastGlucoseId = 8_175,
+            )
+        )
+    }
+
+    @Test
+    fun aSensorThatHasNeverReportedAnIdStillBootstrapsFromItsFirstPush() {
+        assertEquals(
+            0L,
+            restoredTimelineStartMs(
+                persistedTimelineStartMs = 0L,
+                persistedSensorStartMs = 1_787_503_820_003L,
+                persistedLastGlucoseId = -1,
+            )
+        )
+        assertEquals(
+            0L,
+            restoredTimelineStartMs(
+                persistedTimelineStartMs = 0L,
+                persistedSensorStartMs = 0L,
+                persistedLastGlucoseId = -1,
+            )
+        )
+    }
+
+    @Test
+    fun aRestoredAnchorStopsARepeatedIdFromWalkingTheSensorStartForward() {
+        // The 2026-09-09 CT5 trace: id 8175 was frozen past the rated life and every
+        // push re-anchored the session because the anchor lived only in memory.
+        val restored = restoredTimelineStartMs(
+            persistedTimelineStartMs = 0L,
+            persistedSensorStartMs = 1_787_503_820_003L,
+            persistedLastGlucoseId = 8_175,
+        )
+        assertFalse(
+            shouldReanchorTimeline(
+                liveId = 8_175,
+                previousMaxId = 8_175,
+                haveTimelineStart = restored > 0L,
+            )
+        )
+        // A genuinely newer id still moves the timeline.
+        assertTrue(
+            shouldReanchorTimeline(
+                liveId = 8_176,
+                previousMaxId = 8_175,
+                haveTimelineStart = restored > 0L,
+            )
+        )
+    }
+
+    @Test
     fun caughtUpCooldownSuppressesImmediateSameIdBackfillUntilNewerDataArrives() {
         var nowMs = 10_000L
         val cooldown = AnytimeHistoryCaughtUpCooldown(

--- a/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillStateTests.kt
@@ -7,9 +7,6 @@ import org.junit.Test
 
 class AnytimeHistoryBackfillStateTests {
 
-    private val HOUR_MS = 60L * 60L * 1000L
-    private val DAY_MS = 24L * HOUR_MS
-
     @Test
     fun ct5ProfileHorizonDoesNotStopLiveBoundedHistory() {
         assertFalse(
@@ -114,86 +111,6 @@ class AnytimeHistoryBackfillStateTests {
         val cadencePlusSlack = 3L * 60_000L + 90_000L
         assertFalse(hasRecentSensorData(lastSensorDataAtMs = 1_000L, nowMs = 600_000L, withinMs = cadencePlusSlack))
         assertFalse(hasRecentSensorData(lastSensorDataAtMs = 0L, nowMs = 600_000L, withinMs = cadencePlusSlack))
-    }
-
-    @Test
-    fun anAdvancingIdKeepsPaceWithTheSensorsOwnAge() {
-        val interval = 3L * 60_000L
-        // id 8175 at cadence is 17.03 days of sensor; a sensor that age is not frozen.
-        val idTimeline = 8_176L * interval
-        assertEquals(0L, frozenIdAgeMs(sensorAgeMs = idTimeline, lastGlucoseId = 8_175, intervalMs = interval))
-    }
-
-    @Test
-    fun aRepeatedIdShowsUpAsTheGapBetweenTheClocks() {
-        val interval = 3L * 60_000L
-        val idTimeline = 8_176L * interval
-        assertEquals(
-            26L * 60L * 60_000L,
-            frozenIdAgeMs(
-                sensorAgeMs = idTimeline + 26L * 60L * 60_000L,
-                lastGlucoseId = 8_175,
-                intervalMs = interval,
-            )
-        )
-    }
-
-    @Test
-    fun aSensorPastItsLifeStillAdvancingIdsIsNotFinished() {
-        // CT5 ids run past the nominal 7695 horizon; age alone must never end a sensor.
-        assertFalse(
-            isCt5SensorFinished(
-                sensorAgeMs = 17L * DAY_MS,
-                ratedLifetimeMs = 16L * DAY_MS,
-                frozenIdAgeMs = 0L,
-                frozenGraceMs = HOUR_MS,
-            )
-        )
-    }
-
-    @Test
-    fun aBriefRepeatInsideTheRatedLifeIsNotFinished() {
-        assertFalse(
-            isCt5SensorFinished(
-                sensorAgeMs = 9L * DAY_MS,
-                ratedLifetimeMs = 16L * DAY_MS,
-                frozenIdAgeMs = 6L * HOUR_MS,
-                frozenGraceMs = HOUR_MS,
-            )
-        )
-        // And a repeat too short to be anything but a hiccup, even past the rated life.
-        assertFalse(
-            isCt5SensorFinished(
-                sensorAgeMs = 17L * DAY_MS,
-                ratedLifetimeMs = 16L * DAY_MS,
-                frozenIdAgeMs = 20L * 60_000L,
-                frozenGraceMs = HOUR_MS,
-            )
-        )
-    }
-
-    @Test
-    fun ratedLifeOverAndTheIdStandingStillIsFinished() {
-        assertTrue(
-            isCt5SensorFinished(
-                sensorAgeMs = 18L * DAY_MS,
-                ratedLifetimeMs = 16L * DAY_MS,
-                frozenIdAgeMs = 26L * HOUR_MS,
-                frozenGraceMs = HOUR_MS,
-            )
-        )
-    }
-
-    @Test
-    fun anUnknownRatedLifeNeverEndsASensor() {
-        assertFalse(
-            isCt5SensorFinished(
-                sensorAgeMs = 40L * DAY_MS,
-                ratedLifetimeMs = 0L,
-                frozenIdAgeMs = 40L * DAY_MS,
-                frozenGraceMs = HOUR_MS,
-            )
-        )
     }
 
     @Test

--- a/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillStateTests.kt
+++ b/Common/src/test/java/tk/glucodata/drivers/anytime/AnytimeHistoryBackfillStateTests.kt
@@ -7,6 +7,9 @@ import org.junit.Test
 
 class AnytimeHistoryBackfillStateTests {
 
+    private val HOUR_MS = 60L * 60L * 1000L
+    private val DAY_MS = 24L * HOUR_MS
+
     @Test
     fun ct5ProfileHorizonDoesNotStopLiveBoundedHistory() {
         assertFalse(
@@ -93,6 +96,102 @@ class AnytimeHistoryBackfillStateTests {
                 liveId = 8_176,
                 previousMaxId = 8_175,
                 haveTimelineStart = restored > 0L,
+            )
+        )
+    }
+
+    @Test
+    fun aPushWithoutGlucoseStillCountsAsProofTheLinkWorks() {
+        // 2026-09-10: the 15:14:19 push decoded cleanly and carried err=2 and no reading.
+        // The alarm armed from the 15:11:19 reading fired at 15:17:09 and tore the link
+        // down; 170s after a push is well inside a 3-minute cadence.
+        val cadencePlusSlack = 3L * 60_000L + 90_000L
+        assertTrue(hasRecentSensorData(lastSensorDataAtMs = 170_000L, nowMs = 340_000L, withinMs = cadencePlusSlack))
+    }
+
+    @Test
+    fun aSensorThatHasReallyGoneSilentIsNotDefended() {
+        val cadencePlusSlack = 3L * 60_000L + 90_000L
+        assertFalse(hasRecentSensorData(lastSensorDataAtMs = 1_000L, nowMs = 600_000L, withinMs = cadencePlusSlack))
+        assertFalse(hasRecentSensorData(lastSensorDataAtMs = 0L, nowMs = 600_000L, withinMs = cadencePlusSlack))
+    }
+
+    @Test
+    fun anAdvancingIdKeepsPaceWithTheSensorsOwnAge() {
+        val interval = 3L * 60_000L
+        // id 8175 at cadence is 17.03 days of sensor; a sensor that age is not frozen.
+        val idTimeline = 8_176L * interval
+        assertEquals(0L, frozenIdAgeMs(sensorAgeMs = idTimeline, lastGlucoseId = 8_175, intervalMs = interval))
+    }
+
+    @Test
+    fun aRepeatedIdShowsUpAsTheGapBetweenTheClocks() {
+        val interval = 3L * 60_000L
+        val idTimeline = 8_176L * interval
+        assertEquals(
+            26L * 60L * 60_000L,
+            frozenIdAgeMs(
+                sensorAgeMs = idTimeline + 26L * 60L * 60_000L,
+                lastGlucoseId = 8_175,
+                intervalMs = interval,
+            )
+        )
+    }
+
+    @Test
+    fun aSensorPastItsLifeStillAdvancingIdsIsNotFinished() {
+        // CT5 ids run past the nominal 7695 horizon; age alone must never end a sensor.
+        assertFalse(
+            isCt5SensorFinished(
+                sensorAgeMs = 17L * DAY_MS,
+                ratedLifetimeMs = 16L * DAY_MS,
+                frozenIdAgeMs = 0L,
+                frozenGraceMs = HOUR_MS,
+            )
+        )
+    }
+
+    @Test
+    fun aBriefRepeatInsideTheRatedLifeIsNotFinished() {
+        assertFalse(
+            isCt5SensorFinished(
+                sensorAgeMs = 9L * DAY_MS,
+                ratedLifetimeMs = 16L * DAY_MS,
+                frozenIdAgeMs = 6L * HOUR_MS,
+                frozenGraceMs = HOUR_MS,
+            )
+        )
+        // And a repeat too short to be anything but a hiccup, even past the rated life.
+        assertFalse(
+            isCt5SensorFinished(
+                sensorAgeMs = 17L * DAY_MS,
+                ratedLifetimeMs = 16L * DAY_MS,
+                frozenIdAgeMs = 20L * 60_000L,
+                frozenGraceMs = HOUR_MS,
+            )
+        )
+    }
+
+    @Test
+    fun ratedLifeOverAndTheIdStandingStillIsFinished() {
+        assertTrue(
+            isCt5SensorFinished(
+                sensorAgeMs = 18L * DAY_MS,
+                ratedLifetimeMs = 16L * DAY_MS,
+                frozenIdAgeMs = 26L * HOUR_MS,
+                frozenGraceMs = HOUR_MS,
+            )
+        )
+    }
+
+    @Test
+    fun anUnknownRatedLifeNeverEndsASensor() {
+        assertFalse(
+            isCt5SensorFinished(
+                sensorAgeMs = 40L * DAY_MS,
+                ratedLifetimeMs = 0L,
+                frozenIdAgeMs = 40L * DAY_MS,
+                frozenGraceMs = HOUR_MS,
             )
         )
     }


### PR DESCRIPTION
Follow-up to #261, from a CT5 trace on 2026-09-09 where a pause/play turned into a two-minute outage and a corrupted sensor start. Three independent faults lined up.

## 1. `softReconnect` reconnected inside the teardown window

It closed the GATT and called `connectDevice` 250 ms later. `BluetoothGatt.close()` returns immediately but unregisters the client asynchronously, so the new connection came up on a link the retired client was still on:

| | after `softReconnect` | clean retry, two minutes later |
|---|---|---|
| `MTU=512 status=0` | twice, for one `requestMtu` | once |
| connect → services discovered | 8 s | < 1 s |
| outcome | `GATT_FAILURE` (257) one second after the low-power ack | streamed normally |

It now waits `SOFT_RECONNECT_SETTLE_MS` (750 ms) for the stack to let go.

## 2. Three 30-second direct connects into a transmitter that was asleep

By that point the CT5 had taken the `lowPower` frame and was only connectable near its next 3-minute push. The reconnects that followed each burned Android's full direct-connect timer — 30016 ms, 30027 ms, 30038 ms, status 147 (`GATT_CONNECTION_TIMEOUT`) — at a flat 2 s retry, for ~96 s of dead air.

That is exactly the number `noteFirstGattCallback` was added to collect and `useAutoConnect()` was waiting on. After a connect that demonstrably timed out, the Anytime driver now hands the wait to the stack, which links up on the first advertisement rather than expiring another timer, and the retry backs off to at most one cadence slot.

A connect that succeeds resets the counter and keeps the user's setting, so no other family changes behaviour. `ConnectModeLeverTests` keeps holding every driver with no measurement to the application-wide default, and gains a test that this one override stays gated on an observed timeout rather than flipping modes generally.

## 3. The timeline anchor was never persisted — this is the one that also hits restarts

`glucoseTimelineStartAtMs` was written on every anchor but never read back, while `sensorStartAtMs` and `lastGlucoseId` both were. So `shouldReanchorTimeline` saw `haveTimelineStart = false` on every process start and took the bootstrap path, skipping the `liveId > previousMaxId` guard entirely:

```
Sensor start from live glucose id=8175 (oldStart=1787503820003 newStart=1787505439584)
Glucose timeline from live id=8175 (oldStart=0 newStart=1787505439584)
```

This transmitter has been repeating id 8175 past its rated life, so each first push walked the stored sensor start forward by however long the app had been down and re-faked warm-up. It needs no reconnect to happen — an app update or restart is enough, which matches the reports of it firing at random.

The anchor is now persisted alongside the sensor start, and falls back to the stored sensor start (only once an id has been seen) for installs upgrading without one.

## Testing

`./gradlew :Common:testMobileDebugUnitTest` — 2143 tests, 0 failures. New coverage in `AnytimeConnectRetryPolicyTests` (timeout classification, the autoConnect threshold, backoff and its cadence cap) and `AnytimeHistoryBackfillStateTests` (anchor restore, the upgrade fallback, and that a restored anchor stops a repeated id from re-anchoring while a newer id still does).

Not yet exercised on hardware — the same commit is on `test/3sep` for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)