### PR TITLE
Make the web server's port editable and its HTTPS setup self-serve

### DIFF
--- a/Common/src/main/cpp/net/watchserver/watchserver.cpp
+++ b/Common/src/main/cpp/net/watchserver/watchserver.cpp
@@ -144,6 +144,7 @@ static bool startwatchserver(bool secure,int port,int *sockptr) {
    }
 
 #include <thread>
+#include <chrono>
 #include <algorithm>
 #include "sensoren.hpp"
 
@@ -240,6 +241,33 @@ void stopwatchthread() {
 #ifdef USE_SSL
    stopsslwatchthread();
 #endif
+   }
+extern void restartwatchthread(int port) ;
+/*
+   Rebinding to a different port means dropping the listening socket and taking
+   a new one. stopwatchthread() only shuts the socket down: the accept() loop
+   that owns it is what clears xdripserversock, one wakeup later. Calling
+   startwatchthread() before that happens hits its xdripserversock==-1 guard,
+   does nothing, and leaves the server down until the app is restarted -- so
+   wait for the handover. On a detached thread, because the caller is the UI
+   thread coming through JNI.
+*/
+void restartwatchthread(int port) {
+   std::thread restart([port] {
+      stopwatchthread();
+      constexpr const int waitstepms=10;
+      constexpr const int maxwaitms=3000;
+      for(int waited=0;xdripserversock!=-1&&waited<maxwaitms;waited+=waitstepms) {
+         std::this_thread::sleep_for(std::chrono::milliseconds(waitstepms));
+         }
+      if(xdripserversock!=-1) {
+         LOGGERWEB("restartwatchthread: listener still on %d, not rebinding to %d\n",xdripserversock,port);
+         return;
+         }
+      LOGGERWEB("restartwatchthread: rebinding to %d\n",port);
+      startwatchthread(port);
+      });
+   restart.detach();
    }
 
 //&hosts[hostlen-1]

--- a/Common/src/main/cpp/net/watchserver/watchserver.cpp
+++ b/Common/src/main/cpp/net/watchserver/watchserver.cpp
@@ -257,11 +257,20 @@ void restartwatchthread(int port) {
       stopwatchthread();
       constexpr const int waitstepms=10;
       constexpr const int maxwaitms=3000;
-      for(int waited=0;xdripserversock!=-1&&waited<maxwaitms;waited+=waitstepms) {
+      /*
+         Both sockets, not just the one whose port changed. stopwatchthread()
+         takes the SSL listener down too, and startwatchthread() only brings SSL
+         back up while xdripserversslsock is still -1 -- so waiting on the plain
+         socket alone can rebind HTTP at the moment SSL has not finished letting
+         go, and leave HTTPS down until the app restarts.
+      */
+      auto released=[]{ return xdripserversock==-1&&xdripserversslsock==-1; };
+      for(int waited=0;!released()&&waited<maxwaitms;waited+=waitstepms) {
          std::this_thread::sleep_for(std::chrono::milliseconds(waitstepms));
          }
-      if(xdripserversock!=-1) {
-         LOGGERWEB("restartwatchthread: listener still on %d, not rebinding to %d\n",xdripserversock,port);
+      if(!released()) {
+         LOGGERWEB("restartwatchthread: listeners still on %d/%d, not rebinding to %d\n",
+            xdripserversock,xdripserversslsock,port);
          return;
          }
       LOGGERWEB("restartwatchthread: rebinding to %d\n",port);

--- a/Common/src/main/cpp/settings/javasettings.cpp
+++ b/Common/src/main/cpp/settings/javasettings.cpp
@@ -923,15 +923,38 @@ fromjava(getusexdripwebserver)(JNIEnv *env, jclass cl) {
 }
 extern void stopwatchthread();
 extern void startwatchthread(int port);
+extern void restartwatchthread(int port);
 extern "C" JNIEXPORT void JNICALL fromjava(setusexdripwebserver)(JNIEnv *env,
                                                                  jclass cl,
                                                                  jboolean val) {
 #ifndef WEAROS
   settings->data()->usexdripwebserver = val;
   if (val) {
-    startwatchthread(defaulthttpport);
+    startwatchthread(settings->data()->effectivehttpport());
   } else {
     stopwatchthread();
+  }
+#endif
+}
+
+extern "C" JNIEXPORT jint JNICALL fromjava(getxdripport)(JNIEnv *env,
+                                                         jclass cl) {
+  return settings->data()->effectivehttpport();
+}
+
+// The port was always in the settings file and always honoured by the desktop
+// build; on Android both start sites passed the compile-time default instead,
+// so it could not be reached from the phone at all.
+extern "C" JNIEXPORT void JNICALL fromjava(setxdripport)(JNIEnv *env, jclass cl,
+                                                         jint val) {
+#ifndef WEAROS
+  if (val < 1024 || val > UINT16_MAX)
+    return;
+  if (settings->data()->effectivehttpport() == val)
+    return;
+  settings->data()->httpport = static_cast<uint16_t>(val);
+  if (settings->data()->usexdripwebserver) {
+    restartwatchthread(val);
   }
 #endif
 }

--- a/Common/src/main/cpp/settings/settings.cpp
+++ b/Common/src/main/cpp/settings/settings.cpp
@@ -325,7 +325,7 @@ void startthreads() {
 #ifndef WEAROS
 #ifdef ANDROID__APP
    if(settings->data()->usexdripwebserver) {
-        startwatchthread(defaulthttpport);
+        startwatchthread(settings->data()->effectivehttpport());
         }
 #ifndef DONT_USE_LIBREVIEW
     if(settings->data()->uselibre) {

--- a/Common/src/main/cpp/settings/settings.hpp
+++ b/Common/src/main/cpp/settings/settings.hpp
@@ -447,6 +447,13 @@ struct Tings {
       meter = self.newGlucoseMeter(deviceName);
     return meter;
   }
+  // Settings files written before httpport was populated leave it zero. The
+  // desktop build has always read this field; on Android the port was hardcoded
+  // at the call sites instead, so an install upgrading into an editable port
+  // must not be told the server runs on port 0.
+  uint16_t effectivehttpport() const {
+    return httpport ? httpport : static_cast<uint16_t>(defaulthttpport);
+  }
   void defaultshows() {
     showcalibrated = false;
     showscans = true;

--- a/Common/src/main/java/tk/glucodata/Natives.java
+++ b/Common/src/main/java/tk/glucodata/Natives.java
@@ -1018,6 +1018,16 @@ public class Natives {
 
         public static native int getsslport();
 
+        /**
+         * Port the plain-HTTP web server listens on. The setting was always in the native
+         * settings file and always honoured by the desktop build; both Android start sites
+         * passed the compile-time default instead, so it could not be changed from the
+         * phone. Setting it rebinds a running server on a background thread.
+         */
+        public static native int getxdripport();
+
+        public static native void setxdripport(int val);
+
         public static native void setsaytreatments(boolean val);
 
         public static native boolean getsaytreatments();

--- a/Common/src/main/java/tk/glucodata/webserver/Der.kt
+++ b/Common/src/main/java/tk/glucodata/webserver/Der.kt
@@ -1,0 +1,131 @@
+package tk.glucodata.webserver
+
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+
+/**
+ * The slice of DER needed to write an X.509 certificate, and nothing more.
+ *
+ * Android has good key generation but no public API for building an arbitrary
+ * certificate, and the usual answer — Bouncy Castle — is several megabytes of
+ * dependency for one screen in an app that already drops ABIs to save size. The
+ * structure of a self-signed certificate is fixed and small, so it is written
+ * out directly here and checked in tests by parsing the result back with the
+ * platform's own `CertificateFactory`.
+ */
+internal object Der {
+
+    private const val TAG_BOOLEAN = 0x01
+    private const val TAG_INTEGER = 0x02
+    private const val TAG_BIT_STRING = 0x03
+    private const val TAG_OCTET_STRING = 0x04
+    private const val TAG_NULL = 0x05
+    private const val TAG_OID = 0x06
+    private const val TAG_UTF8_STRING = 0x0C
+    private const val TAG_IA5_STRING = 0x16
+    private const val TAG_UTC_TIME = 0x17
+    private const val TAG_GENERALIZED_TIME = 0x18
+    private const val TAG_SEQUENCE = 0x30
+    private const val TAG_SET = 0x31
+
+    /** Wraps [content] in an element with the given identifier octet. */
+    fun tagged(tag: Int, content: ByteArray): ByteArray {
+        val out = ByteArrayOutputStream(content.size + 6)
+        out.write(tag)
+        writeLength(out, content.size)
+        out.write(content)
+        return out.toByteArray()
+    }
+
+    fun sequence(vararg parts: ByteArray): ByteArray = tagged(TAG_SEQUENCE, concat(*parts))
+
+    fun set(vararg parts: ByteArray): ByteArray = tagged(TAG_SET, concat(*parts))
+
+    /** `[n]` in EXPLICIT form: a constructed context-specific tag around [content]. */
+    fun explicit(number: Int, content: ByteArray): ByteArray = tagged(0xA0 or number, content)
+
+    /** `[n]` in IMPLICIT form for a primitive value, as GeneralName uses. */
+    fun implicitPrimitive(number: Int, content: ByteArray): ByteArray = tagged(0x80 or number, content)
+
+    fun boolean(value: Boolean): ByteArray =
+        tagged(TAG_BOOLEAN, byteArrayOf(if (value) 0xFF.toByte() else 0x00))
+
+    fun integer(value: BigInteger): ByteArray = tagged(TAG_INTEGER, value.toByteArray())
+
+    fun integer(value: Int): ByteArray = integer(BigInteger.valueOf(value.toLong()))
+
+    /**
+     * [unusedBits] is the count of ignored trailing bits in the final octet, and
+     * it is part of the content — a BIT STRING is not an OCTET STRING with a
+     * different tag.
+     */
+    fun bitString(bytes: ByteArray, unusedBits: Int = 0): ByteArray =
+        tagged(TAG_BIT_STRING, concat(byteArrayOf(unusedBits.toByte()), bytes))
+
+    fun octetString(bytes: ByteArray): ByteArray = tagged(TAG_OCTET_STRING, bytes)
+
+    fun nullValue(): ByteArray = byteArrayOf(TAG_NULL.toByte(), 0x00)
+
+    fun utf8String(value: String): ByteArray = tagged(TAG_UTF8_STRING, value.toByteArray(Charsets.UTF_8))
+
+    fun ia5String(value: String): ByteArray = tagged(TAG_IA5_STRING, value.toByteArray(Charsets.US_ASCII))
+
+    fun utcTime(value: String): ByteArray = tagged(TAG_UTC_TIME, value.toByteArray(Charsets.US_ASCII))
+
+    fun generalizedTime(value: String): ByteArray =
+        tagged(TAG_GENERALIZED_TIME, value.toByteArray(Charsets.US_ASCII))
+
+    /**
+     * Dotted-decimal to DER. The first two arcs share one byte as `40*a + b`;
+     * every arc after that is base-128, high bit set on all but the last octet.
+     */
+    fun oid(dotted: String): ByteArray {
+        val arcs = dotted.split('.').map { it.toLong() }
+        require(arcs.size >= 2) { "OID needs at least two arcs: $dotted" }
+        val out = ByteArrayOutputStream()
+        out.write((arcs[0] * 40 + arcs[1]).toInt())
+        for (index in 2 until arcs.size) {
+            writeBase128(out, arcs[index])
+        }
+        return tagged(TAG_OID, out.toByteArray())
+    }
+
+    fun concat(vararg parts: ByteArray): ByteArray {
+        val out = ByteArrayOutputStream(parts.sumOf { it.size })
+        parts.forEach(out::write)
+        return out.toByteArray()
+    }
+
+    private fun writeLength(out: ByteArrayOutputStream, length: Int) {
+        if (length < 0x80) {
+            out.write(length)
+            return
+        }
+        // Long form: one byte saying how many length bytes follow, then the
+        // length itself, big-endian and with no leading zero.
+        var shift = 24
+        while (shift > 0 && (length ushr shift) and 0xFF == 0) shift -= 8
+        val byteCount = shift / 8 + 1
+        out.write(0x80 or byteCount)
+        while (shift >= 0) {
+            out.write((length ushr shift) and 0xFF)
+            shift -= 8
+        }
+    }
+
+    private fun writeBase128(out: ByteArrayOutputStream, value: Long) {
+        if (value < 0x80) {
+            out.write(value.toInt())
+            return
+        }
+        val digits = ArrayDeque<Int>()
+        var remaining = value
+        while (remaining > 0) {
+            digits.addFirst((remaining and 0x7F).toInt())
+            remaining = remaining ushr 7
+        }
+        digits.forEachIndexed { index, digit ->
+            out.write(if (index == digits.size - 1) digit else digit or 0x80)
+        }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/webserver/SelfSignedCertificate.kt
+++ b/Common/src/main/java/tk/glucodata/webserver/SelfSignedCertificate.kt
@@ -1,0 +1,213 @@
+package tk.glucodata.webserver
+
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.MessageDigest
+import java.security.Signature
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Builds a self-signed X.509 v3 server certificate for the built-in web server.
+ *
+ * Turning on HTTPS should not require the user to know what a private key or a
+ * full chain is. The native server reads `fullchain.pem` and `privkey.pem` out
+ * of the app's files directory and does not care who wrote them, so the app can
+ * write its own pair and the import path stays for people who have a real
+ * CA-issued certificate.
+ */
+internal object SelfSignedCertificate {
+
+    /**
+     * Certificate lifetime. iOS rejects any TLS server certificate valid for
+     * more than 825 days, including a self-signed one the user has trusted by
+     * hand, so a longer life would silently cost iPhone access rather than
+     * saving anyone a regeneration. The expiry is shown in the settings screen
+     * with a button to reissue.
+     */
+    const val VALIDITY_DAYS = 825
+
+    private const val OID_SHA256_WITH_RSA = "1.2.840.113549.1.1.11"
+    private const val OID_COMMON_NAME = "2.5.4.3"
+    private const val OID_SUBJECT_KEY_IDENTIFIER = "2.5.29.14"
+    private const val OID_KEY_USAGE = "2.5.29.15"
+    private const val OID_SUBJECT_ALT_NAME = "2.5.29.17"
+    private const val OID_BASIC_CONSTRAINTS = "2.5.29.19"
+    private const val OID_EXT_KEY_USAGE = "2.5.29.37"
+    private const val OID_SERVER_AUTH = "1.3.6.1.5.5.7.3.1"
+
+    private const val GENERAL_NAME_DNS = 2
+    private const val GENERAL_NAME_IP = 7
+
+    /** The names a certificate should answer to, in the order they are encoded. */
+    data class SubjectAltNames(
+        val dnsNames: List<String> = emptyList(),
+        val ipAddresses: List<ByteArray> = emptyList(),
+    ) {
+        val isEmpty: Boolean get() = dnsNames.isEmpty() && ipAddresses.isEmpty()
+    }
+
+    /**
+     * Returns the DER of a certificate for [keyPair], signed by its own private
+     * key, valid from [notBeforeMillis] for [VALIDITY_DAYS].
+     */
+    fun create(
+        keyPair: KeyPair,
+        commonName: String,
+        subjectAltNames: SubjectAltNames,
+        notBeforeMillis: Long,
+        serialNumber: BigInteger = BigInteger.valueOf(notBeforeMillis),
+    ): ByteArray {
+        // A backdated notBefore absorbs clock skew between the phone and
+        // whatever is browsing it, which is otherwise a "not yet valid" error
+        // on a certificate that was correct when it was written.
+        val notBefore = notBeforeMillis - 24L * 60L * 60L * 1000L
+        val notAfter = notBeforeMillis + VALIDITY_DAYS * 24L * 60L * 60L * 1000L
+
+        val algorithm = Der.sequence(Der.oid(OID_SHA256_WITH_RSA), Der.nullValue())
+        val name = Der.sequence(
+            Der.set(Der.sequence(Der.oid(OID_COMMON_NAME), Der.utf8String(commonName)))
+        )
+        // publicKey.encoded is already a DER SubjectPublicKeyInfo, which is
+        // exactly the field this slot wants.
+        val publicKeyInfo = keyPair.public.encoded
+
+        val tbsCertificate = Der.sequence(
+            Der.explicit(0, Der.integer(2)), // v3
+            Der.integer(serialNumber.abs().max(BigInteger.ONE)),
+            algorithm,
+            name,
+            Der.sequence(time(notBefore), time(notAfter)),
+            name,
+            publicKeyInfo,
+            Der.explicit(3, Der.sequence(*extensions(publicKeyInfo, subjectAltNames))),
+        )
+
+        val signature = Signature.getInstance("SHA256withRSA").run {
+            initSign(keyPair.private)
+            update(tbsCertificate)
+            sign()
+        }
+
+        return Der.sequence(tbsCertificate, algorithm, Der.bitString(signature))
+    }
+
+    private fun extensions(
+        publicKeyInfo: ByteArray,
+        subjectAltNames: SubjectAltNames,
+    ): Array<ByteArray> {
+        val extensions = mutableListOf<ByteArray>()
+
+        // cA defaults to FALSE, so a leaf certificate's BasicConstraints is an
+        // empty SEQUENCE rather than an explicit FALSE.
+        extensions += extension(OID_BASIC_CONSTRAINTS, critical = true, value = Der.sequence())
+
+        // digitalSignature | keyEncipherment: bits 0 and 2 of the leading octet,
+        // leaving five unused bits at the end.
+        extensions += extension(
+            OID_KEY_USAGE,
+            critical = true,
+            value = Der.bitString(byteArrayOf(0xA0.toByte()), unusedBits = 5),
+        )
+
+        extensions += extension(
+            OID_EXT_KEY_USAGE,
+            critical = false,
+            value = Der.sequence(Der.oid(OID_SERVER_AUTH)),
+        )
+
+        extensions += extension(
+            OID_SUBJECT_KEY_IDENTIFIER,
+            critical = false,
+            value = Der.octetString(subjectKeyIdentifier(publicKeyInfo)),
+        )
+
+        if (!subjectAltNames.isEmpty) {
+            val names = subjectAltNames.dnsNames.map {
+                Der.implicitPrimitive(GENERAL_NAME_DNS, it.toByteArray(Charsets.US_ASCII))
+            } + subjectAltNames.ipAddresses.map {
+                Der.implicitPrimitive(GENERAL_NAME_IP, it)
+            }
+            extensions += extension(
+                OID_SUBJECT_ALT_NAME,
+                critical = false,
+                value = Der.sequence(*names.toTypedArray()),
+            )
+        }
+
+        return extensions.toTypedArray()
+    }
+
+    private fun extension(oid: String, critical: Boolean, value: ByteArray): ByteArray {
+        // The DEFAULT FALSE on `critical` means a non-critical extension omits
+        // the field entirely; writing an explicit FALSE is not valid DER.
+        val parts = if (critical) {
+            arrayOf(Der.oid(oid), Der.boolean(true), Der.octetString(value))
+        } else {
+            arrayOf(Der.oid(oid), Der.octetString(value))
+        }
+        return Der.sequence(*parts)
+    }
+
+    /** RFC 5280's method 1: SHA-1 over the public key BIT STRING's own bits. */
+    private fun subjectKeyIdentifier(publicKeyInfo: ByteArray): ByteArray =
+        MessageDigest.getInstance("SHA-1").digest(publicKeyBits(publicKeyInfo))
+
+    /**
+     * Pulls the raw key bits out of a SubjectPublicKeyInfo. Walking the DER by
+     * hand is the price of not depending on a parser; if the structure is not
+     * what is expected the whole encoding is hashed instead, which still yields
+     * a stable, unique identifier.
+     */
+    private fun publicKeyBits(publicKeyInfo: ByteArray): ByteArray {
+        var index = readHeader(publicKeyInfo, 0, 0x30) ?: return publicKeyInfo
+        // Skip the AlgorithmIdentifier that precedes the key.
+        val algorithmStart = readHeader(publicKeyInfo, index, 0x30) ?: return publicKeyInfo
+        index = algorithmStart + lengthAt(publicKeyInfo, index)
+        val bitsStart = readHeader(publicKeyInfo, index, 0x03) ?: return publicKeyInfo
+        val bitsLength = lengthAt(publicKeyInfo, index)
+        if (bitsLength < 1 || bitsStart + bitsLength > publicKeyInfo.size) return publicKeyInfo
+        // The first content octet is the unused-bit count, not key material.
+        return publicKeyInfo.copyOfRange(bitsStart + 1, bitsStart + bitsLength)
+    }
+
+    /** Returns the offset of the content of the element at [offset], or null on a mismatch. */
+    private fun readHeader(bytes: ByteArray, offset: Int, expectedTag: Int): Int? {
+        if (offset >= bytes.size || (bytes[offset].toInt() and 0xFF) != expectedTag) return null
+        val first = bytes.getOrNull(offset + 1)?.toInt()?.and(0xFF) ?: return null
+        return if (first < 0x80) offset + 2 else offset + 2 + (first and 0x7F)
+    }
+
+    private fun lengthAt(bytes: ByteArray, offset: Int): Int {
+        val first = bytes[offset + 1].toInt() and 0xFF
+        if (first < 0x80) return first
+        var length = 0
+        for (index in 1..(first and 0x7F)) {
+            length = (length shl 8) or (bytes[offset + 1 + index].toInt() and 0xFF)
+        }
+        return length
+    }
+
+    /** RFC 5280: UTCTime through 2049, GeneralizedTime from 2050. */
+    private fun time(epochMillis: Long): ByteArray {
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.US).apply {
+            timeInMillis = epochMillis
+        }
+        val year = calendar.get(Calendar.YEAR)
+        val rest = String.format(
+            Locale.US,
+            "%02d%02d%02d%02d%02dZ",
+            calendar.get(Calendar.MONTH) + 1,
+            calendar.get(Calendar.DAY_OF_MONTH),
+            calendar.get(Calendar.HOUR_OF_DAY),
+            calendar.get(Calendar.MINUTE),
+            calendar.get(Calendar.SECOND),
+        )
+        return if (year < 2050) {
+            Der.utcTime(String.format(Locale.US, "%02d", year % 100) + rest)
+        } else {
+            Der.generalizedTime(String.format(Locale.US, "%04d", year) + rest)
+        }
+    }
+}

--- a/Common/src/main/java/tk/glucodata/webserver/WebServerCertificate.kt
+++ b/Common/src/main/java/tk/glucodata/webserver/WebServerCertificate.kt
@@ -1,0 +1,186 @@
+package tk.glucodata.webserver
+
+import android.content.Context
+import android.util.Base64
+import java.io.File
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.NetworkInterface
+import java.security.KeyPairGenerator
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Collections
+import tk.glucodata.Log
+
+/**
+ * The web server's TLS material: where it lives, how to generate it, and what to
+ * tell the user about what is currently installed.
+ *
+ * The native server reads `fullchain.pem` and `privkey.pem` from the app's files
+ * directory (`sslserver.cpp` resolves them against `globalbasedir`, which
+ * `settings.cpp` sets to the files dir). It does not care where they came from,
+ * so a generated pair and an imported one are interchangeable as far as it is
+ * concerned — the difference is only ever presented in the UI.
+ */
+object WebServerCertificate {
+
+    private const val TAG = "WebServerCert"
+    private const val CERTIFICATE_FILE = "fullchain.pem"
+    private const val PRIVATE_KEY_FILE = "privkey.pem"
+
+    /** Marks a pair this app wrote, so the screen can tell it apart from an import. */
+    private const val MARKER_FILE = "selfsigned.marker"
+
+    private const val COMMON_NAME = "JugglucoNG"
+    private const val KEY_SIZE_BITS = 2048
+
+    /** What the settings screen needs to describe the installed certificate. */
+    data class Installed(
+        val selfSigned: Boolean,
+        val subject: String,
+        val hostnames: List<String>,
+        val notAfterMillis: Long,
+    ) {
+        fun isExpired(nowMillis: Long): Boolean = notAfterMillis in 1 until nowMillis
+
+        /** True when [host] is not covered, so a browser will add a name warning. */
+        fun covers(host: String): Boolean = hostnames.any { it.equals(host, ignoreCase = true) }
+    }
+
+    fun certificateFile(context: Context): File = File(filesDir(context), CERTIFICATE_FILE)
+
+    fun privateKeyFile(context: Context): File = File(filesDir(context), PRIVATE_KEY_FILE)
+
+    fun hasCertificate(context: Context): Boolean =
+        certificateFile(context).canRead() && privateKeyFile(context).canRead()
+
+    /**
+     * Reads back whatever is installed. Returns null when nothing is installed or
+     * the files cannot be parsed — an imported certificate the app cannot read is
+     * still perfectly usable by the server, so this only drives what is shown.
+     */
+    fun installed(context: Context): Installed? {
+        if (!hasCertificate(context)) return null
+        return runCatching {
+            val certificate = certificateFile(context).inputStream().use { stream ->
+                CertificateFactory.getInstance("X.509").generateCertificate(stream) as X509Certificate
+            }
+            Installed(
+                selfSigned = File(filesDir(context), MARKER_FILE).exists(),
+                subject = commonNameOf(certificate) ?: certificate.subjectX500Principal.name,
+                hostnames = hostnamesOf(certificate),
+                notAfterMillis = certificate.notAfter?.time ?: 0L,
+            )
+        }.onFailure { Log.stack(TAG, "installed", it) }.getOrNull()
+    }
+
+    /**
+     * Generates a fresh key pair and self-signed certificate covering localhost
+     * plus every address this device currently holds, and writes both PEM files.
+     * Returns null on success or a message to show the user.
+     *
+     * Slow enough to be worth keeping off the main thread: RSA key generation
+     * runs to a second or two on a phone.
+     */
+    fun generate(context: Context, nowMillis: Long = System.currentTimeMillis()): String? {
+        return runCatching {
+            val keyPair = KeyPairGenerator.getInstance("RSA")
+                .apply { initialize(KEY_SIZE_BITS) }
+                .generateKeyPair()
+
+            val der = SelfSignedCertificate.create(
+                keyPair = keyPair,
+                commonName = COMMON_NAME,
+                subjectAltNames = localSubjectAltNames(),
+                notBeforeMillis = nowMillis,
+            )
+
+            // Write the key first and the certificate second: the server checks
+            // for the certificate, so a half-written pair should not look ready.
+            writeAtomically(privateKeyFile(context), pem("PRIVATE KEY", keyPair.private.encoded))
+            writeAtomically(certificateFile(context), pem("CERTIFICATE", der))
+            File(filesDir(context), MARKER_FILE).writeText(nowMillis.toString())
+            null
+        }.onFailure { Log.stack(TAG, "generate", it) }
+            .getOrElse { it.message ?: "Could not generate a certificate" }
+    }
+
+    /** Called after an imported certificate lands, so it stops claiming to be ours. */
+    fun clearSelfSignedMarker(context: Context) {
+        runCatching { File(filesDir(context), MARKER_FILE).delete() }
+    }
+
+    /**
+     * localhost and 127.0.0.1 always, plus whatever addresses the device holds
+     * right now so LAN access does not add a name mismatch on top of the
+     * untrusted-issuer warning. DHCP can move the phone, which is what the
+     * settings screen's "does not cover this address" hint is for.
+     */
+    internal fun localSubjectAltNames(): SelfSignedCertificate.SubjectAltNames {
+        val addresses = linkedMapOf<String, ByteArray>()
+        addresses["127.0.0.1"] = byteArrayOf(127, 0, 0, 1)
+        addresses["::1"] = ByteArray(16).also { it[15] = 1 }
+        localAddresses().forEach { address ->
+            address.hostAddress?.substringBefore('%')?.let { addresses[it] = address.address }
+        }
+        return SelfSignedCertificate.SubjectAltNames(
+            dnsNames = listOf("localhost"),
+            ipAddresses = addresses.values.toList(),
+        )
+    }
+
+    private fun localAddresses(): List<InetAddress> = runCatching {
+        Collections.list(NetworkInterface.getNetworkInterfaces())
+            .asSequence()
+            .filter { it.isUp && !it.isLoopback }
+            .flatMap { Collections.list(it.inetAddresses).asSequence() }
+            .filter { it is Inet4Address || (it is Inet6Address && !it.isLinkLocalAddress) }
+            .filterNot { it.isAnyLocalAddress || it.isMulticastAddress }
+            .toList()
+    }.getOrDefault(emptyList())
+
+    private fun filesDir(context: Context): File = context.applicationContext.filesDir
+
+    private fun commonNameOf(certificate: X509Certificate): String? =
+        certificate.subjectX500Principal.name
+            .split(',')
+            .map { it.trim() }
+            .firstOrNull { it.startsWith("CN=", ignoreCase = true) }
+            ?.substring(3)
+
+    /**
+     * SAN entries as plain strings for display. `getSubjectAlternativeNames`
+     * returns pairs of (type, value) where 2 is dNSName and 7 is iPAddress.
+     */
+    private fun hostnamesOf(certificate: X509Certificate): List<String> = runCatching {
+        certificate.subjectAlternativeNames
+            ?.mapNotNull { entry ->
+                val type = entry.getOrNull(0) as? Int ?: return@mapNotNull null
+                val value = entry.getOrNull(1) as? String ?: return@mapNotNull null
+                if (type == 2 || type == 7) value else null
+            }
+            .orEmpty()
+    }.getOrDefault(emptyList())
+
+    private fun pem(label: String, der: ByteArray): String {
+        val body = Base64.encodeToString(der, Base64.NO_WRAP)
+            .chunked(64)
+            .joinToString("\n")
+        return "-----BEGIN $label-----\n$body\n-----END $label-----\n"
+    }
+
+    /**
+     * A torn PEM file is worse than no PEM file: the server would fail to start
+     * with an error about the key rather than about the missing certificate.
+     */
+    private fun writeAtomically(target: File, contents: String) {
+        val temporary = File(target.parentFile, "${target.name}.tmp")
+        temporary.writeText(contents)
+        if (!temporary.renameTo(target)) {
+            target.writeText(contents)
+            temporary.delete()
+        }
+        target.setReadable(true, true)
+    }
+}

--- a/Common/src/main/java/tk/glucodata/webserver/WebServerCertificate.kt
+++ b/Common/src/main/java/tk/glucodata/webserver/WebServerCertificate.kt
@@ -35,6 +35,11 @@ object WebServerCertificate {
     private const val COMMON_NAME = "JugglucoNG"
     private const val KEY_SIZE_BITS = 2048
 
+    /** Names the export files carry. They match the two import buttons. */
+    private const val EXPORT_CERTIFICATE_NAME = "jugglucong-fullchain.pem"
+    private const val EXPORT_PRIVATE_KEY_NAME = "jugglucong-privkey.pem"
+    private const val EXPORT_DIRECTORY = "exports"
+
     /** What the settings screen needs to describe the installed certificate. */
     data class Installed(
         val selfSigned: Boolean,
@@ -44,8 +49,45 @@ object WebServerCertificate {
     ) {
         fun isExpired(nowMillis: Long): Boolean = notAfterMillis in 1 until nowMillis
 
-        /** True when [host] is not covered, so a browser will add a name warning. */
+        /** True when [host] is one of the names a browser will accept for this certificate. */
         fun covers(host: String): Boolean = hostnames.any { it.equals(host, ignoreCase = true) }
+    }
+
+    /** What the screen should say, and which action it should offer first. */
+    enum class Status {
+        /** Nothing installed. HTTPS cannot start until something is. */
+        MISSING,
+
+        /** Installed and answering for the address people are using. */
+        READY,
+
+        /**
+         * Ours, still valid, but the device has moved to an address it was not
+         * issued for. Worth offering to reissue, not worth doing silently: the
+         * fingerprint would change under a certificate the user may already have
+         * exported and trusted elsewhere.
+         */
+        ADDRESS_CHANGED,
+
+        /** Past its notAfter. Browsers refuse it outright. */
+        EXPIRED,
+    }
+
+    /**
+     * [lanAddress] is the address the screen is telling people to visit, or null
+     * when the server is loopback-only and no LAN name matters.
+     *
+     * A certificate the user imported is deliberately never reported as
+     * ADDRESS_CHANGED: it may be issued to a domain name that has nothing to do
+     * with whatever IP the phone holds today, and offering to replace someone's
+     * CA-issued certificate because their DHCP lease moved would be wrong.
+     */
+    fun statusOf(installed: Installed?, lanAddress: String?, nowMillis: Long): Status = when {
+        installed == null -> Status.MISSING
+        installed.isExpired(nowMillis) -> Status.EXPIRED
+        !installed.selfSigned -> Status.READY
+        lanAddress != null && !installed.covers(lanAddress) -> Status.ADDRESS_CHANGED
+        else -> Status.READY
     }
 
     fun certificateFile(context: Context): File = File(filesDir(context), CERTIFICATE_FILE)
@@ -104,6 +146,37 @@ object WebServerCertificate {
             null
         }.onFailure { Log.stack(TAG, "generate", it) }
             .getOrElse { it.message ?: "Could not generate a certificate" }
+    }
+
+    /**
+     * Copies the installed certificate — and, when [includePrivateKey], the key
+     * beside it — into the directory the app's FileProvider serves, and returns
+     * the files to hand to a share intent.
+     *
+     * Staged rather than shared in place because the PEMs live in the app's
+     * private files directory, which the provider does not expose; only
+     * `cacheDir/exports` is declared in export_file_paths.xml. Previous staged
+     * copies are cleared first so a private key does not sit in the cache longer
+     * than the export that asked for it.
+     */
+    fun stageForExport(context: Context, includePrivateKey: Boolean): List<File> {
+        val certificate = certificateFile(context)
+        if (!certificate.canRead()) return emptyList()
+        return runCatching {
+            val directory = File(context.applicationContext.cacheDir, EXPORT_DIRECTORY)
+            directory.mkdirs()
+            directory.listFiles { file -> file.name.startsWith("jugglucong-") }
+                ?.forEach { it.delete() }
+
+            val staged = mutableListOf<File>()
+            staged += File(directory, EXPORT_CERTIFICATE_NAME).also { certificate.copyTo(it, overwrite = true) }
+            if (includePrivateKey) {
+                val key = privateKeyFile(context)
+                if (!key.canRead()) return emptyList()
+                staged += File(directory, EXPORT_PRIVATE_KEY_NAME).also { key.copyTo(it, overwrite = true) }
+            }
+            staged
+        }.onFailure { Log.stack(TAG, "stageForExport", it) }.getOrDefault(emptyList())
     }
 
     /** Called after an imported certificate lands, so it stops claiming to be ours. */

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2693,7 +2693,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">Шыфраванне HTTPS</string>
     <string name="webserver_certificate">Сертыфікат</string>
-    <string name="webserver_cert_selfsigned">Самападпісаны, створаны на гэтай прыладзе</string>
+    <string name="webserver_cert_selfsigned">Самападпісаны, створаны для гэтай прылады і бягучай сеткі</string>
     <string name="webserver_cert_custom">Уласны сертыфікат</string>
     <string name="webserver_cert_none">Сертыфіката яшчэ няма</string>
     <string name="webserver_cert_generate">Стварыць</string>
@@ -2703,6 +2703,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="webserver_cert_generating">Стварэнне сертыфіката…</string>
     <string name="webserver_cert_expires">Дзейнічае да %1$s</string>
     <string name="webserver_cert_expired">Тэрмін мінуў</string>
-    <string name="webserver_cert_missing_address">Не ахоплівае %1$s</string>
     <string name="webserver_cert_created">Сертыфікат створаны</string>
+    <string name="webserver_cert_update">Абнавіць</string>
+    <string name="webserver_cert_needs_update">Сертыфікат патрабуе абнаўлення</string>
+    <string name="webserver_cert_address_changed">Сеткавы адрас зменены на %1$s</string>
+    <string name="webserver_cert_export">Экспарт</string>
+    <string name="webserver_cert_export_hint">Усталюйце сертыфікат на іншай прыладзе, каб давяраць гэтаму серверу.</string>
+    <string name="webserver_cert_export_certificate">Сертыфікат</string>
+    <string name="webserver_cert_export_with_key">Сертыфікат і прыватны ключ</string>
+    <string name="webserver_cert_export_key_warning">Прыватны ключ дазваляе іншай прыладзе выдаваць сябе за гэты сервер. Трымайце яго ў сакрэце.</string>
 </resources>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -2689,4 +2689,20 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Правяраць новыя значэнні</string>
     <string name="nightscout_follow_interval_desc">Як часта падпісчык апытвае сервер. Гэта таксама тое, наколькі старым можа быць значэнне, а значыць і наколькі позна прыйдзе трывога па сачыльным значэнні. У падпісчыка няма свайго сэнсара, які трымаў бы тэлефон абуджаным, таму кожная праверка — гэта абуджэнне.</string>
     <string name="nightscout_follow_interval_doze">Менш за 9 хвілін Android усё роўна можа разводзіць праверкі, пакуль тэлефон бяздзейнічае. Выключэнне Juggluco з аптымізацыі батарэі захоўвае выбраны інтэрвал.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">Шыфраванне HTTPS</string>
+    <string name="webserver_certificate">Сертыфікат</string>
+    <string name="webserver_cert_selfsigned">Самападпісаны, створаны на гэтай прыладзе</string>
+    <string name="webserver_cert_custom">Уласны сертыфікат</string>
+    <string name="webserver_cert_none">Сертыфіката яшчэ няма</string>
+    <string name="webserver_cert_generate">Стварыць</string>
+    <string name="webserver_cert_regenerate">Стварыць нанова</string>
+    <string name="webserver_cert_import">Імпарт</string>
+    <string name="webserver_cert_import_hint">Імпартуйце абодва файлы ад вашага цэнтра сертыфікацыі.</string>
+    <string name="webserver_cert_generating">Стварэнне сертыфіката…</string>
+    <string name="webserver_cert_expires">Дзейнічае да %1$s</string>
+    <string name="webserver_cert_expired">Тэрмін мінуў</string>
+    <string name="webserver_cert_missing_address">Не ахоплівае %1$s</string>
+    <string name="webserver_cert_created">Сертыфікат створаны</string>
 </resources>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2657,4 +2657,20 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="nightscout_follow_interval_title">Neue Werte abrufen</string>
     <string name="nightscout_follow_interval_desc">Wie oft der Follower den Server fragt. Das ist zugleich, wie alt ein Wert sein kann, und damit auch, wie spät ein Alarm auf einen gefolgten Wert kommen kann. Ein Follower hat keinen eigenen Sensor, der das Telefon wach hält, also ist jede Abfrage ein Aufwecken.</string>
     <string name="nightscout_follow_interval_doze">Unter 9 Minuten kann Android die Abfragen im Ruhezustand trotzdem weiter auseinanderziehen. Juggluco von der Akku-Optimierung auszunehmen hält das eingestellte Intervall.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">HTTPS-Verschlüsselung</string>
+    <string name="webserver_certificate">Zertifikat</string>
+    <string name="webserver_cert_selfsigned">Selbstsigniert, auf diesem Gerät erzeugt</string>
+    <string name="webserver_cert_custom">Eigenes Zertifikat</string>
+    <string name="webserver_cert_none">Noch kein Zertifikat</string>
+    <string name="webserver_cert_generate">Erzeugen</string>
+    <string name="webserver_cert_regenerate">Neu erzeugen</string>
+    <string name="webserver_cert_import">Importieren</string>
+    <string name="webserver_cert_import_hint">Importieren Sie beide Dateien von Ihrer Zertifizierungsstelle.</string>
+    <string name="webserver_cert_generating">Zertifikat wird erzeugt…</string>
+    <string name="webserver_cert_expires">Gültig bis %1$s</string>
+    <string name="webserver_cert_expired">Abgelaufen</string>
+    <string name="webserver_cert_missing_address">Deckt %1$s nicht ab</string>
+    <string name="webserver_cert_created">Zertifikat erzeugt</string>
 </resources>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -2661,7 +2661,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">HTTPS-Verschlüsselung</string>
     <string name="webserver_certificate">Zertifikat</string>
-    <string name="webserver_cert_selfsigned">Selbstsigniert, auf diesem Gerät erzeugt</string>
+    <string name="webserver_cert_selfsigned">Selbstsigniert, für dieses Gerät und das aktuelle Netzwerk erzeugt</string>
     <string name="webserver_cert_custom">Eigenes Zertifikat</string>
     <string name="webserver_cert_none">Noch kein Zertifikat</string>
     <string name="webserver_cert_generate">Erzeugen</string>
@@ -2671,6 +2671,13 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="webserver_cert_generating">Zertifikat wird erzeugt…</string>
     <string name="webserver_cert_expires">Gültig bis %1$s</string>
     <string name="webserver_cert_expired">Abgelaufen</string>
-    <string name="webserver_cert_missing_address">Deckt %1$s nicht ab</string>
     <string name="webserver_cert_created">Zertifikat erzeugt</string>
+    <string name="webserver_cert_update">Aktualisieren</string>
+    <string name="webserver_cert_needs_update">Zertifikat muss aktualisiert werden</string>
+    <string name="webserver_cert_address_changed">Netzwerkadresse zu %1$s gewechselt</string>
+    <string name="webserver_cert_export">Exportieren</string>
+    <string name="webserver_cert_export_hint">Installieren Sie das Zertifikat auf einem anderen Gerät, um diesem Server zu vertrauen.</string>
+    <string name="webserver_cert_export_certificate">Zertifikat</string>
+    <string name="webserver_cert_export_with_key">Zertifikat und privater Schlüssel</string>
+    <string name="webserver_cert_export_key_warning">Mit dem privaten Schlüssel kann sich ein anderes Gerät als dieser Server ausgeben. Bewahren Sie ihn geheim auf.</string>
 </resources>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2624,4 +2624,20 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Rechercher de nouvelles valeurs</string>
     <string name="nightscout_follow_interval_desc">À quelle fréquence le suiveur interroge le serveur. C\'est aussi l\'âge que peut avoir une valeur, et donc le retard possible d\'une alarme déclenchée sur une valeur suivie. Un suiveur n\'a pas de capteur à lui pour garder le téléphone éveillé, donc chaque interrogation est un réveil.</string>
     <string name="nightscout_follow_interval_doze">En dessous de 9 minutes, Android peut malgré tout espacer les interrogations lorsque le téléphone est inactif. Exclure Juggluco de l\'optimisation de la batterie préserve l\'intervalle choisi.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">Chiffrement HTTPS</string>
+    <string name="webserver_certificate">Certificat</string>
+    <string name="webserver_cert_selfsigned">Auto-signé, généré sur cet appareil</string>
+    <string name="webserver_cert_custom">Certificat personnalisé</string>
+    <string name="webserver_cert_none">Aucun certificat</string>
+    <string name="webserver_cert_generate">Générer</string>
+    <string name="webserver_cert_regenerate">Régénérer</string>
+    <string name="webserver_cert_import">Importer</string>
+    <string name="webserver_cert_import_hint">Importez les deux fichiers fournis par votre autorité de certification.</string>
+    <string name="webserver_cert_generating">Génération du certificat…</string>
+    <string name="webserver_cert_expires">Expire le %1$s</string>
+    <string name="webserver_cert_expired">Expiré</string>
+    <string name="webserver_cert_missing_address">Ne couvre pas %1$s</string>
+    <string name="webserver_cert_created">Certificat généré</string>
 </resources>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -2628,7 +2628,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">Chiffrement HTTPS</string>
     <string name="webserver_certificate">Certificat</string>
-    <string name="webserver_cert_selfsigned">Auto-signé, généré sur cet appareil</string>
+    <string name="webserver_cert_selfsigned">Auto-signé, généré pour cet appareil et le réseau actuel</string>
     <string name="webserver_cert_custom">Certificat personnalisé</string>
     <string name="webserver_cert_none">Aucun certificat</string>
     <string name="webserver_cert_generate">Générer</string>
@@ -2638,6 +2638,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="webserver_cert_generating">Génération du certificat…</string>
     <string name="webserver_cert_expires">Expire le %1$s</string>
     <string name="webserver_cert_expired">Expiré</string>
-    <string name="webserver_cert_missing_address">Ne couvre pas %1$s</string>
     <string name="webserver_cert_created">Certificat généré</string>
+    <string name="webserver_cert_update">Mettre à jour</string>
+    <string name="webserver_cert_needs_update">Le certificat doit être mis à jour</string>
+    <string name="webserver_cert_address_changed">L\'adresse réseau est passée à %1$s</string>
+    <string name="webserver_cert_export">Exporter</string>
+    <string name="webserver_cert_export_hint">Installez le certificat sur un autre appareil pour faire confiance à ce serveur.</string>
+    <string name="webserver_cert_export_certificate">Certificat</string>
+    <string name="webserver_cert_export_with_key">Certificat et clé privée</string>
+    <string name="webserver_cert_export_key_warning">La clé privée permet à un autre appareil de se faire passer pour ce serveur. Gardez-la secrète.</string>
 </resources>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2608,4 +2608,20 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Cerca nuovi valori</string>
     <string name="nightscout_follow_interval_desc">Ogni quanto il follower interroga il server. È anche quanto può essere vecchio un valore, e quindi quanto può ritardare un allarme su un valore seguito. Un follower non ha un sensore proprio che tenga sveglio il telefono, quindi ogni controllo è un risveglio.</string>
     <string name="nightscout_follow_interval_doze">Sotto i 9 minuti Android può comunque distanziare i controlli mentre il telefono è inattivo. Escludere Juggluco dall\'ottimizzazione della batteria mantiene l\'intervallo scelto.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">Crittografia HTTPS</string>
+    <string name="webserver_certificate">Certificato</string>
+    <string name="webserver_cert_selfsigned">Autofirmato, generato su questo dispositivo</string>
+    <string name="webserver_cert_custom">Certificato personalizzato</string>
+    <string name="webserver_cert_none">Nessun certificato</string>
+    <string name="webserver_cert_generate">Genera</string>
+    <string name="webserver_cert_regenerate">Rigenera</string>
+    <string name="webserver_cert_import">Importa</string>
+    <string name="webserver_cert_import_hint">Importa entrambi i file dalla tua autorità di certificazione.</string>
+    <string name="webserver_cert_generating">Generazione del certificato…</string>
+    <string name="webserver_cert_expires">Scade il %1$s</string>
+    <string name="webserver_cert_expired">Scaduto</string>
+    <string name="webserver_cert_missing_address">Non copre %1$s</string>
+    <string name="webserver_cert_created">Certificato generato</string>
 </resources>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -2612,7 +2612,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">Crittografia HTTPS</string>
     <string name="webserver_certificate">Certificato</string>
-    <string name="webserver_cert_selfsigned">Autofirmato, generato su questo dispositivo</string>
+    <string name="webserver_cert_selfsigned">Autofirmato, generato per questo dispositivo e la rete attuale</string>
     <string name="webserver_cert_custom">Certificato personalizzato</string>
     <string name="webserver_cert_none">Nessun certificato</string>
     <string name="webserver_cert_generate">Genera</string>
@@ -2622,6 +2622,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="webserver_cert_generating">Generazione del certificato…</string>
     <string name="webserver_cert_expires">Scade il %1$s</string>
     <string name="webserver_cert_expired">Scaduto</string>
-    <string name="webserver_cert_missing_address">Non copre %1$s</string>
     <string name="webserver_cert_created">Certificato generato</string>
+    <string name="webserver_cert_update">Aggiorna</string>
+    <string name="webserver_cert_needs_update">Il certificato va aggiornato</string>
+    <string name="webserver_cert_address_changed">Indirizzo di rete cambiato in %1$s</string>
+    <string name="webserver_cert_export">Esporta</string>
+    <string name="webserver_cert_export_hint">Installa il certificato su un altro dispositivo per fidarti di questo server.</string>
+    <string name="webserver_cert_export_certificate">Certificato</string>
+    <string name="webserver_cert_export_with_key">Certificato e chiave privata</string>
+    <string name="webserver_cert_export_key_warning">La chiave privata consente a un altro dispositivo di spacciarsi per questo server. Tienila riservata.</string>
 </resources>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2729,7 +2729,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">HTTPS шифрлэлт</string>
     <string name="webserver_certificate">Гэрчилгээ</string>
-    <string name="webserver_cert_selfsigned">Энэ төхөөрөмж дээр үүсгэсэн, өөрөө гарын үсэг зурсан</string>
+    <string name="webserver_cert_selfsigned">Энэ төхөөрөмж болон одоогийн сүлжээнд зориулж үүсгэсэн, өөрөө гарын үсэг зурсан</string>
     <string name="webserver_cert_custom">Хэрэглэгчийн гэрчилгээ</string>
     <string name="webserver_cert_none">Гэрчилгээ алга</string>
     <string name="webserver_cert_generate">Үүсгэх</string>
@@ -2739,6 +2739,13 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="webserver_cert_generating">Гэрчилгээ үүсгэж байна…</string>
     <string name="webserver_cert_expires">%1$s-д дуусна</string>
     <string name="webserver_cert_expired">Хугацаа дууссан</string>
-    <string name="webserver_cert_missing_address">%1$s-г хамрахгүй</string>
     <string name="webserver_cert_created">Гэрчилгээ үүслээ</string>
+    <string name="webserver_cert_update">Шинэчлэх</string>
+    <string name="webserver_cert_needs_update">Гэрчилгээг шинэчлэх шаардлагатай</string>
+    <string name="webserver_cert_address_changed">Сүлжээний хаяг %1$s болж өөрчлөгдсөн</string>
+    <string name="webserver_cert_export">Экспортлох</string>
+    <string name="webserver_cert_export_hint">Энэ серверт итгэхийн тулд гэрчилгээг өөр төхөөрөмж дээр суулгана уу.</string>
+    <string name="webserver_cert_export_certificate">Гэрчилгээ</string>
+    <string name="webserver_cert_export_with_key">Гэрчилгээ ба хувийн түлхүүр</string>
+    <string name="webserver_cert_export_key_warning">Хувийн түлхүүр нь өөр төхөөрөмжид энэ сервер мэт дүр эсгэх боломж олгоно. Нууц байлгана уу.</string>
 </resources>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -2725,4 +2725,20 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="nightscout_follow_interval_title">Шинэ утга шалгах</string>
     <string name="nightscout_follow_interval_desc">Дагагч сервер рүү ямар давтамжтай хандахыг заана. Энэ нь мөн утга хэр хуучин байж болохыг, тиймээс дагасан утган дээр сэрэмжлүүлэг хэр хожуу ирэхийг тодорхойлно. Дагагчид утсыг сэрүүн байлгах өөрийн мэдрэгч байхгүй тул шалгалт бүр нь сэрээх үйлдэл юм.</string>
     <string name="nightscout_follow_interval_doze">9 минутаас бага бол утас сул зогсож байх үед Android шалгалтуудыг улам сунгаж болно. Juggluco-г батерейны оновчлолоос хасвал сонгосон интервал хэвээр үлдэнэ.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">HTTPS шифрлэлт</string>
+    <string name="webserver_certificate">Гэрчилгээ</string>
+    <string name="webserver_cert_selfsigned">Энэ төхөөрөмж дээр үүсгэсэн, өөрөө гарын үсэг зурсан</string>
+    <string name="webserver_cert_custom">Хэрэглэгчийн гэрчилгээ</string>
+    <string name="webserver_cert_none">Гэрчилгээ алга</string>
+    <string name="webserver_cert_generate">Үүсгэх</string>
+    <string name="webserver_cert_regenerate">Дахин үүсгэх</string>
+    <string name="webserver_cert_import">Импортлох</string>
+    <string name="webserver_cert_import_hint">Гэрчилгээжүүлэх байгууллагаасаа хоёр файлыг импортлоно уу.</string>
+    <string name="webserver_cert_generating">Гэрчилгээ үүсгэж байна…</string>
+    <string name="webserver_cert_expires">%1$s-д дуусна</string>
+    <string name="webserver_cert_expired">Хугацаа дууссан</string>
+    <string name="webserver_cert_missing_address">%1$s-г хамрахгүй</string>
+    <string name="webserver_cert_created">Гэрчилгээ үүслээ</string>
 </resources>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2661,4 +2661,20 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="nightscout_follow_interval_title">Naar nieuwe waarden kijken</string>
     <string name="nightscout_follow_interval_desc">Hoe vaak de volger de server bevraagt. Dat is ook hoe oud een waarde kan zijn, en dus hoe laat een alarm op een gevolgde waarde kan komen. Een volger heeft geen eigen sensor die de telefoon wakker houdt, dus elke controle is een wekmoment.</string>
     <string name="nightscout_follow_interval_doze">Onder 9 minuten kan Android de controles alsnog verder uit elkaar leggen terwijl de telefoon inactief is. Juggluco uitsluiten van batterijoptimalisatie behoudt het gekozen interval.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">HTTPS-versleuteling</string>
+    <string name="webserver_certificate">Certificaat</string>
+    <string name="webserver_cert_selfsigned">Zelfondertekend, op dit apparaat gemaakt</string>
+    <string name="webserver_cert_custom">Eigen certificaat</string>
+    <string name="webserver_cert_none">Nog geen certificaat</string>
+    <string name="webserver_cert_generate">Aanmaken</string>
+    <string name="webserver_cert_regenerate">Opnieuw aanmaken</string>
+    <string name="webserver_cert_import">Importeren</string>
+    <string name="webserver_cert_import_hint">Importeer beide bestanden van uw certificaatautoriteit.</string>
+    <string name="webserver_cert_generating">Certificaat wordt aangemaakt…</string>
+    <string name="webserver_cert_expires">Verloopt op %1$s</string>
+    <string name="webserver_cert_expired">Verlopen</string>
+    <string name="webserver_cert_missing_address">Dekt %1$s niet</string>
+    <string name="webserver_cert_created">Certificaat aangemaakt</string>
 </resources>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -2665,7 +2665,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">HTTPS-versleuteling</string>
     <string name="webserver_certificate">Certificaat</string>
-    <string name="webserver_cert_selfsigned">Zelfondertekend, op dit apparaat gemaakt</string>
+    <string name="webserver_cert_selfsigned">Zelfondertekend, gemaakt voor dit apparaat en het huidige netwerk</string>
     <string name="webserver_cert_custom">Eigen certificaat</string>
     <string name="webserver_cert_none">Nog geen certificaat</string>
     <string name="webserver_cert_generate">Aanmaken</string>
@@ -2675,6 +2675,13 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="webserver_cert_generating">Certificaat wordt aangemaakt…</string>
     <string name="webserver_cert_expires">Verloopt op %1$s</string>
     <string name="webserver_cert_expired">Verlopen</string>
-    <string name="webserver_cert_missing_address">Dekt %1$s niet</string>
     <string name="webserver_cert_created">Certificaat aangemaakt</string>
+    <string name="webserver_cert_update">Bijwerken</string>
+    <string name="webserver_cert_needs_update">Certificaat moet worden bijgewerkt</string>
+    <string name="webserver_cert_address_changed">Netwerkadres gewijzigd in %1$s</string>
+    <string name="webserver_cert_export">Exporteren</string>
+    <string name="webserver_cert_export_hint">Installeer het certificaat op een ander apparaat om deze server te vertrouwen.</string>
+    <string name="webserver_cert_export_certificate">Certificaat</string>
+    <string name="webserver_cert_export_with_key">Certificaat en privésleutel</string>
+    <string name="webserver_cert_export_key_warning">Met de privésleutel kan een ander apparaat zich voordoen als deze server. Houd hem geheim.</string>
 </resources>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2660,7 +2660,7 @@
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">Szyfrowanie HTTPS</string>
     <string name="webserver_certificate">Certyfikat</string>
-    <string name="webserver_cert_selfsigned">Samopodpisany, utworzony na tym urządzeniu</string>
+    <string name="webserver_cert_selfsigned">Samopodpisany, utworzony dla tego urządzenia i bieżącej sieci</string>
     <string name="webserver_cert_custom">Własny certyfikat</string>
     <string name="webserver_cert_none">Brak certyfikatu</string>
     <string name="webserver_cert_generate">Utwórz</string>
@@ -2670,6 +2670,13 @@
     <string name="webserver_cert_generating">Tworzenie certyfikatu…</string>
     <string name="webserver_cert_expires">Wygasa %1$s</string>
     <string name="webserver_cert_expired">Wygasł</string>
-    <string name="webserver_cert_missing_address">Nie obejmuje %1$s</string>
     <string name="webserver_cert_created">Utworzono certyfikat</string>
+    <string name="webserver_cert_update">Zaktualizuj</string>
+    <string name="webserver_cert_needs_update">Certyfikat wymaga aktualizacji</string>
+    <string name="webserver_cert_address_changed">Adres sieciowy zmienił się na %1$s</string>
+    <string name="webserver_cert_export">Eksportuj</string>
+    <string name="webserver_cert_export_hint">Zainstaluj certyfikat na innym urządzeniu, aby zaufać temu serwerowi.</string>
+    <string name="webserver_cert_export_certificate">Certyfikat</string>
+    <string name="webserver_cert_export_with_key">Certyfikat i klucz prywatny</string>
+    <string name="webserver_cert_export_key_warning">Klucz prywatny pozwala innemu urządzeniu podszyć się pod ten serwer. Zachowaj go w tajemnicy.</string>
 </resources>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -2656,4 +2656,20 @@
     <string name="nightscout_follow_interval_title">Sprawdzanie nowych wartości</string>
     <string name="nightscout_follow_interval_desc">Jak często obserwator odpytuje serwer. To zarazem wiek, jaki może mieć wartość, a więc i opóźnienie alarmu opartego na obserwowanej wartości. Obserwator nie ma własnego sensora, który utrzymywałby telefon wybudzony, więc każde sprawdzenie to wybudzenie.</string>
     <string name="nightscout_follow_interval_doze">Poniżej 9 minut Android i tak może rozsuwać sprawdzenia, gdy telefon jest bezczynny. Wyłączenie Juggluco z optymalizacji baterii zachowuje wybrany odstęp.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">Szyfrowanie HTTPS</string>
+    <string name="webserver_certificate">Certyfikat</string>
+    <string name="webserver_cert_selfsigned">Samopodpisany, utworzony na tym urządzeniu</string>
+    <string name="webserver_cert_custom">Własny certyfikat</string>
+    <string name="webserver_cert_none">Brak certyfikatu</string>
+    <string name="webserver_cert_generate">Utwórz</string>
+    <string name="webserver_cert_regenerate">Utwórz ponownie</string>
+    <string name="webserver_cert_import">Importuj</string>
+    <string name="webserver_cert_import_hint">Zaimportuj oba pliki od swojego urzędu certyfikacji.</string>
+    <string name="webserver_cert_generating">Tworzenie certyfikatu…</string>
+    <string name="webserver_cert_expires">Wygasa %1$s</string>
+    <string name="webserver_cert_expired">Wygasł</string>
+    <string name="webserver_cert_missing_address">Nie obejmuje %1$s</string>
+    <string name="webserver_cert_created">Utworzono certyfikat</string>
 </resources>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2623,7 +2623,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">Encriptação HTTPS</string>
     <string name="webserver_certificate">Certificado</string>
-    <string name="webserver_cert_selfsigned">Autoassinado, gerado neste dispositivo</string>
+    <string name="webserver_cert_selfsigned">Autoassinado, gerado para este dispositivo e a rede atual</string>
     <string name="webserver_cert_custom">Certificado personalizado</string>
     <string name="webserver_cert_none">Ainda sem certificado</string>
     <string name="webserver_cert_generate">Gerar</string>
@@ -2633,6 +2633,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="webserver_cert_generating">A gerar certificado…</string>
     <string name="webserver_cert_expires">Expira a %1$s</string>
     <string name="webserver_cert_expired">Expirado</string>
-    <string name="webserver_cert_missing_address">Não abrange %1$s</string>
     <string name="webserver_cert_created">Certificado gerado</string>
+    <string name="webserver_cert_update">Atualizar</string>
+    <string name="webserver_cert_needs_update">O certificado precisa de ser atualizado</string>
+    <string name="webserver_cert_address_changed">Endereço de rede mudou para %1$s</string>
+    <string name="webserver_cert_export">Exportar</string>
+    <string name="webserver_cert_export_hint">Instale o certificado noutro dispositivo para confiar neste servidor.</string>
+    <string name="webserver_cert_export_certificate">Certificado</string>
+    <string name="webserver_cert_export_with_key">Certificado e chave privada</string>
+    <string name="webserver_cert_export_key_warning">A chave privada permite que outro dispositivo se faça passar por este servidor. Mantenha-a privada.</string>
 </resources>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -2619,4 +2619,20 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Procurar novos valores</string>
     <string name="nightscout_follow_interval_desc">Com que frequência o seguidor pergunta ao servidor. É também a idade que um valor pode ter e, portanto, o atraso possível de um alarme baseado num valor seguido. Um seguidor não tem sensor próprio para manter o telemóvel acordado, por isso cada verificação é um despertar.</string>
     <string name="nightscout_follow_interval_doze">Abaixo de 9 minutos, o Android pode ainda assim afastar as verificações enquanto o telemóvel está inativo. Excluir o Juggluco da otimização da bateria mantém o intervalo escolhido.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">Encriptação HTTPS</string>
+    <string name="webserver_certificate">Certificado</string>
+    <string name="webserver_cert_selfsigned">Autoassinado, gerado neste dispositivo</string>
+    <string name="webserver_cert_custom">Certificado personalizado</string>
+    <string name="webserver_cert_none">Ainda sem certificado</string>
+    <string name="webserver_cert_generate">Gerar</string>
+    <string name="webserver_cert_regenerate">Gerar novamente</string>
+    <string name="webserver_cert_import">Importar</string>
+    <string name="webserver_cert_import_hint">Importe os dois ficheiros da sua autoridade de certificação.</string>
+    <string name="webserver_cert_generating">A gerar certificado…</string>
+    <string name="webserver_cert_expires">Expira a %1$s</string>
+    <string name="webserver_cert_expired">Expirado</string>
+    <string name="webserver_cert_missing_address">Não abrange %1$s</string>
+    <string name="webserver_cert_created">Certificado gerado</string>
 </resources>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2665,4 +2665,20 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Проверять новые значения</string>
     <string name="nightscout_follow_interval_desc">Как часто подписчик опрашивает сервер. Это же определяет, насколько старым может быть значение, а значит и насколько поздно придёт тревога по отслеживаемому значению. У подписчика нет своего сенсора, который держал бы телефон активным, поэтому каждая проверка — это пробуждение.</string>
     <string name="nightscout_follow_interval_doze">Меньше 9 минут Android всё равно может разносить проверки, пока телефон простаивает. Исключение Juggluco из оптимизации батареи сохраняет выбранный интервал.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">Шифрование HTTPS</string>
+    <string name="webserver_certificate">Сертификат</string>
+    <string name="webserver_cert_selfsigned">Самоподписанный, создан на этом устройстве</string>
+    <string name="webserver_cert_custom">Собственный сертификат</string>
+    <string name="webserver_cert_none">Сертификата пока нет</string>
+    <string name="webserver_cert_generate">Создать</string>
+    <string name="webserver_cert_regenerate">Создать заново</string>
+    <string name="webserver_cert_import">Импорт</string>
+    <string name="webserver_cert_import_hint">Импортируйте оба файла из вашего центра сертификации.</string>
+    <string name="webserver_cert_generating">Создание сертификата…</string>
+    <string name="webserver_cert_expires">Действует до %1$s</string>
+    <string name="webserver_cert_expired">Истёк</string>
+    <string name="webserver_cert_missing_address">Не охватывает %1$s</string>
+    <string name="webserver_cert_created">Сертификат создан</string>
 </resources>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -2669,7 +2669,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">Шифрование HTTPS</string>
     <string name="webserver_certificate">Сертификат</string>
-    <string name="webserver_cert_selfsigned">Самоподписанный, создан на этом устройстве</string>
+    <string name="webserver_cert_selfsigned">Самоподписанный, создан для этого устройства и текущей сети</string>
     <string name="webserver_cert_custom">Собственный сертификат</string>
     <string name="webserver_cert_none">Сертификата пока нет</string>
     <string name="webserver_cert_generate">Создать</string>
@@ -2679,6 +2679,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="webserver_cert_generating">Создание сертификата…</string>
     <string name="webserver_cert_expires">Действует до %1$s</string>
     <string name="webserver_cert_expired">Истёк</string>
-    <string name="webserver_cert_missing_address">Не охватывает %1$s</string>
     <string name="webserver_cert_created">Сертификат создан</string>
+    <string name="webserver_cert_update">Обновить</string>
+    <string name="webserver_cert_needs_update">Сертификат нужно обновить</string>
+    <string name="webserver_cert_address_changed">Сетевой адрес изменился на %1$s</string>
+    <string name="webserver_cert_export">Экспорт</string>
+    <string name="webserver_cert_export_hint">Установите сертификат на другом устройстве, чтобы доверять этому серверу.</string>
+    <string name="webserver_cert_export_certificate">Сертификат</string>
+    <string name="webserver_cert_export_with_key">Сертификат и закрытый ключ</string>
+    <string name="webserver_cert_export_key_warning">Закрытый ключ позволяет другому устройству выдать себя за этот сервер. Храните его в секрете.</string>
 </resources>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2814,7 +2814,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">Sirdoonka HTTPS</string>
     <string name="webserver_certificate">Shahaado</string>
-    <string name="webserver_cert_selfsigned">Is-saxiixday, waxaa lagu sameeyay qalabkan</string>
+    <string name="webserver_cert_selfsigned">Is-saxiixday, waxaa loo sameeyay qalabkan iyo shabakadda hadda</string>
     <string name="webserver_cert_custom">Shahaado gaar ah</string>
     <string name="webserver_cert_none">Weli shahaado ma jirto</string>
     <string name="webserver_cert_generate">Samee</string>
@@ -2824,6 +2824,13 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="webserver_cert_generating">Shahaadada waa la samaynayaa…</string>
     <string name="webserver_cert_expires">Waxay dhacaysaa %1$s</string>
     <string name="webserver_cert_expired">Dhacay</string>
-    <string name="webserver_cert_missing_address">Ma daboosho %1$s</string>
     <string name="webserver_cert_created">Shahaadada waa la sameeyay</string>
+    <string name="webserver_cert_update">Cusboonaysii</string>
+    <string name="webserver_cert_needs_update">Shahaadada waa in la cusboonaysiiyaa</string>
+    <string name="webserver_cert_address_changed">Cinwaanka shabakadu wuxuu u beddelmay %1$s</string>
+    <string name="webserver_cert_export">Dhoofi</string>
+    <string name="webserver_cert_export_hint">Ku rakib shahaadada qalab kale si aad ugu kalsoonaato server-kan.</string>
+    <string name="webserver_cert_export_certificate">Shahaado</string>
+    <string name="webserver_cert_export_with_key">Shahaado iyo furaha gaarka ah</string>
+    <string name="webserver_cert_export_key_warning">Furaha gaarka ah wuxuu qalab kale u oggolaanayaa inuu iska dhigo server-kan. Sir ahaan u hay.</string>
 </resources>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -2810,4 +2810,20 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="nightscout_follow_interval_title">Hubi qiimayaal cusub</string>
     <string name="nightscout_follow_interval_desc">Inta jeer ee raacuhu weydiiyo server-ka. Waxay sidoo kale tahay sida uu qiime u duugoobi karo, sidaas darteedna sida uu digniin ku salaysan qiime la raacayo u soo daahi karto. Raacuhu ma laha dareeme u gaar ah oo taleefanka soo jeeda ka dhiga, sidaas darteed hubin kastaa waa toosin.</string>
     <string name="nightscout_follow_interval_doze">Ka hooseeya 9 daqiiqo, Android weli wuu kala fogayn karaa hubinnada inta taleefanku shaqo la\'yahay. In Juggluco laga saaro wanaajinta baytariga waxay ilaalinaysaa waqtiga aad dooratay.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">Sirdoonka HTTPS</string>
+    <string name="webserver_certificate">Shahaado</string>
+    <string name="webserver_cert_selfsigned">Is-saxiixday, waxaa lagu sameeyay qalabkan</string>
+    <string name="webserver_cert_custom">Shahaado gaar ah</string>
+    <string name="webserver_cert_none">Weli shahaado ma jirto</string>
+    <string name="webserver_cert_generate">Samee</string>
+    <string name="webserver_cert_regenerate">Dib u samee</string>
+    <string name="webserver_cert_import">Soo deji</string>
+    <string name="webserver_cert_import_hint">Labada fayl ka soo dejiso hay\'addaada shahaadooyinka.</string>
+    <string name="webserver_cert_generating">Shahaadada waa la samaynayaa…</string>
+    <string name="webserver_cert_expires">Waxay dhacaysaa %1$s</string>
+    <string name="webserver_cert_expired">Dhacay</string>
+    <string name="webserver_cert_missing_address">Ma daboosho %1$s</string>
+    <string name="webserver_cert_created">Shahaadada waa la sameeyay</string>
 </resources>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2618,4 +2618,20 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Leta efter nya värden</string>
     <string name="nightscout_follow_interval_desc">Hur ofta följaren frågar servern. Det är också hur gammalt ett värde kan vara, och därmed hur sent ett larm på ett följt värde kan komma. En följare har ingen egen sensor som håller telefonen vaken, så varje kontroll är en väckning.</string>
     <string name="nightscout_follow_interval_doze">Under 9 minuter kan Android ändå glesa ut kontrollerna medan telefonen är inaktiv. Att undanta Juggluco från batterioptimering behåller det valda intervallet.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">HTTPS-kryptering</string>
+    <string name="webserver_certificate">Certifikat</string>
+    <string name="webserver_cert_selfsigned">Självsignerat, skapat på den här enheten</string>
+    <string name="webserver_cert_custom">Eget certifikat</string>
+    <string name="webserver_cert_none">Inget certifikat ännu</string>
+    <string name="webserver_cert_generate">Skapa</string>
+    <string name="webserver_cert_regenerate">Skapa nytt</string>
+    <string name="webserver_cert_import">Importera</string>
+    <string name="webserver_cert_import_hint">Importera båda filerna från din certifikatutfärdare.</string>
+    <string name="webserver_cert_generating">Skapar certifikat…</string>
+    <string name="webserver_cert_expires">Går ut %1$s</string>
+    <string name="webserver_cert_expired">Har gått ut</string>
+    <string name="webserver_cert_missing_address">Täcker inte %1$s</string>
+    <string name="webserver_cert_created">Certifikat skapat</string>
 </resources>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -2622,7 +2622,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">HTTPS-kryptering</string>
     <string name="webserver_certificate">Certifikat</string>
-    <string name="webserver_cert_selfsigned">Självsignerat, skapat på den här enheten</string>
+    <string name="webserver_cert_selfsigned">Självsignerat, skapat för den här enheten och det aktuella nätverket</string>
     <string name="webserver_cert_custom">Eget certifikat</string>
     <string name="webserver_cert_none">Inget certifikat ännu</string>
     <string name="webserver_cert_generate">Skapa</string>
@@ -2632,6 +2632,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="webserver_cert_generating">Skapar certifikat…</string>
     <string name="webserver_cert_expires">Går ut %1$s</string>
     <string name="webserver_cert_expired">Har gått ut</string>
-    <string name="webserver_cert_missing_address">Täcker inte %1$s</string>
     <string name="webserver_cert_created">Certifikat skapat</string>
+    <string name="webserver_cert_update">Uppdatera</string>
+    <string name="webserver_cert_needs_update">Certifikatet behöver uppdateras</string>
+    <string name="webserver_cert_address_changed">Nätverksadressen ändrades till %1$s</string>
+    <string name="webserver_cert_export">Exportera</string>
+    <string name="webserver_cert_export_hint">Installera certifikatet på en annan enhet för att lita på den här servern.</string>
+    <string name="webserver_cert_export_certificate">Certifikat</string>
+    <string name="webserver_cert_export_with_key">Certifikat och privat nyckel</string>
+    <string name="webserver_cert_export_key_warning">Den privata nyckeln låter en annan enhet utge sig för att vara den här servern. Håll den hemlig.</string>
 </resources>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2646,4 +2646,20 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="nightscout_follow_interval_title">Yeni değerleri kontrol et</string>
     <string name="nightscout_follow_interval_desc">Takipçinin sunucuya ne sıklıkla sorduğu. Bu aynı zamanda bir değerin ne kadar eski olabileceği, dolayısıyla takip edilen bir değere dayanan alarmın ne kadar geç gelebileceğidir. Takipçinin telefonu uyanık tutan kendi sensörü yoktur, bu yüzden her kontrol bir uyandırmadır.</string>
     <string name="nightscout_follow_interval_doze">9 dakikanın altında Android, telefon boştayken kontrolleri yine de aralayabilir. Juggluco\'yu pil optimizasyonundan çıkarmak seçilen aralığı korur.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">HTTPS şifrelemesi</string>
+    <string name="webserver_certificate">Sertifika</string>
+    <string name="webserver_cert_selfsigned">Kendinden imzalı, bu cihazda oluşturuldu</string>
+    <string name="webserver_cert_custom">Özel sertifika</string>
+    <string name="webserver_cert_none">Henüz sertifika yok</string>
+    <string name="webserver_cert_generate">Oluştur</string>
+    <string name="webserver_cert_regenerate">Yeniden oluştur</string>
+    <string name="webserver_cert_import">İçe aktar</string>
+    <string name="webserver_cert_import_hint">Sertifika yetkilinizden her iki dosyayı da içe aktarın.</string>
+    <string name="webserver_cert_generating">Sertifika oluşturuluyor…</string>
+    <string name="webserver_cert_expires">Bitiş: %1$s</string>
+    <string name="webserver_cert_expired">Süresi doldu</string>
+    <string name="webserver_cert_missing_address">%1$s adresini kapsamıyor</string>
+    <string name="webserver_cert_created">Sertifika oluşturuldu</string>
 </resources>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -2650,7 +2650,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">HTTPS şifrelemesi</string>
     <string name="webserver_certificate">Sertifika</string>
-    <string name="webserver_cert_selfsigned">Kendinden imzalı, bu cihazda oluşturuldu</string>
+    <string name="webserver_cert_selfsigned">Kendinden imzalı, bu cihaz ve mevcut ağ için oluşturuldu</string>
     <string name="webserver_cert_custom">Özel sertifika</string>
     <string name="webserver_cert_none">Henüz sertifika yok</string>
     <string name="webserver_cert_generate">Oluştur</string>
@@ -2660,6 +2660,13 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="webserver_cert_generating">Sertifika oluşturuluyor…</string>
     <string name="webserver_cert_expires">Bitiş: %1$s</string>
     <string name="webserver_cert_expired">Süresi doldu</string>
-    <string name="webserver_cert_missing_address">%1$s adresini kapsamıyor</string>
     <string name="webserver_cert_created">Sertifika oluşturuldu</string>
+    <string name="webserver_cert_update">Güncelle</string>
+    <string name="webserver_cert_needs_update">Sertifikanın güncellenmesi gerekiyor</string>
+    <string name="webserver_cert_address_changed">Ağ adresi %1$s olarak değişti</string>
+    <string name="webserver_cert_export">Dışa aktar</string>
+    <string name="webserver_cert_export_hint">Bu sunucuya güvenmek için sertifikayı başka bir cihaza yükleyin.</string>
+    <string name="webserver_cert_export_certificate">Sertifika</string>
+    <string name="webserver_cert_export_with_key">Sertifika ve özel anahtar</string>
+    <string name="webserver_cert_export_key_warning">Özel anahtar, başka bir cihazın bu sunucu gibi davranmasına izin verir. Gizli tutun.</string>
 </resources>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2698,7 +2698,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">Шифрування HTTPS</string>
     <string name="webserver_certificate">Сертифікат</string>
-    <string name="webserver_cert_selfsigned">Самопідписаний, створений на цьому пристрої</string>
+    <string name="webserver_cert_selfsigned">Самопідписаний, створений для цього пристрою та поточної мережі</string>
     <string name="webserver_cert_custom">Власний сертифікат</string>
     <string name="webserver_cert_none">Сертифіката ще немає</string>
     <string name="webserver_cert_generate">Створити</string>
@@ -2708,6 +2708,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="webserver_cert_generating">Створення сертифіката…</string>
     <string name="webserver_cert_expires">Діє до %1$s</string>
     <string name="webserver_cert_expired">Прострочений</string>
-    <string name="webserver_cert_missing_address">Не охоплює %1$s</string>
     <string name="webserver_cert_created">Сертифікат створено</string>
+    <string name="webserver_cert_update">Оновити</string>
+    <string name="webserver_cert_needs_update">Сертифікат потребує оновлення</string>
+    <string name="webserver_cert_address_changed">Мережеву адресу змінено на %1$s</string>
+    <string name="webserver_cert_export">Експорт</string>
+    <string name="webserver_cert_export_hint">Встановіть сертифікат на іншому пристрої, щоб довіряти цьому серверу.</string>
+    <string name="webserver_cert_export_certificate">Сертифікат</string>
+    <string name="webserver_cert_export_with_key">Сертифікат і закритий ключ</string>
+    <string name="webserver_cert_export_key_warning">Закритий ключ дозволяє іншому пристрою видавати себе за цей сервер. Тримайте його в таємниці.</string>
 </resources>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -2694,4 +2694,20 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">Перевіряти нові значення</string>
     <string name="nightscout_follow_interval_desc">Як часто підписник опитує сервер. Це водночас і те, наскільки старим може бути значення, а отже і наскільки пізно надійде тривога за відстежуваним значенням. Підписник не має власного сенсора, який тримав би телефон активним, тож кожна перевірка — це пробудження.</string>
     <string name="nightscout_follow_interval_doze">Менше 9 хвилин Android усе одно може розсувати перевірки, поки телефон бездіяльний. Виключення Juggluco з оптимізації батареї зберігає вибраний інтервал.</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">Шифрування HTTPS</string>
+    <string name="webserver_certificate">Сертифікат</string>
+    <string name="webserver_cert_selfsigned">Самопідписаний, створений на цьому пристрої</string>
+    <string name="webserver_cert_custom">Власний сертифікат</string>
+    <string name="webserver_cert_none">Сертифіката ще немає</string>
+    <string name="webserver_cert_generate">Створити</string>
+    <string name="webserver_cert_regenerate">Створити заново</string>
+    <string name="webserver_cert_import">Імпорт</string>
+    <string name="webserver_cert_import_hint">Імпортуйте обидва файли з вашого центру сертифікації.</string>
+    <string name="webserver_cert_generating">Створення сертифіката…</string>
+    <string name="webserver_cert_expires">Діє до %1$s</string>
+    <string name="webserver_cert_expired">Прострочений</string>
+    <string name="webserver_cert_missing_address">Не охоплює %1$s</string>
+    <string name="webserver_cert_created">Сертифікат створено</string>
 </resources>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2638,7 +2638,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">HTTPS 加密</string>
     <string name="webserver_certificate">证书</string>
-    <string name="webserver_cert_selfsigned">自签名，在本设备上生成</string>
+    <string name="webserver_cert_selfsigned">自签名，为本设备和当前网络生成</string>
     <string name="webserver_cert_custom">自定义证书</string>
     <string name="webserver_cert_none">尚无证书</string>
     <string name="webserver_cert_generate">生成</string>
@@ -2648,6 +2648,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="webserver_cert_generating">正在生成证书…</string>
     <string name="webserver_cert_expires">有效期至 %1$s</string>
     <string name="webserver_cert_expired">已过期</string>
-    <string name="webserver_cert_missing_address">未包含 %1$s</string>
     <string name="webserver_cert_created">证书已生成</string>
+    <string name="webserver_cert_update">更新</string>
+    <string name="webserver_cert_needs_update">证书需要更新</string>
+    <string name="webserver_cert_address_changed">网络地址已变为 %1$s</string>
+    <string name="webserver_cert_export">导出</string>
+    <string name="webserver_cert_export_hint">在另一台设备上安装此证书即可信任本服务器。</string>
+    <string name="webserver_cert_export_certificate">证书</string>
+    <string name="webserver_cert_export_with_key">证书和私钥</string>
+    <string name="webserver_cert_export_key_warning">私钥可让其他设备冒充本服务器，请妥善保管。</string>
 </resources>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -2634,4 +2634,20 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="nightscout_follow_interval_title">检查新数值</string>
     <string name="nightscout_follow_interval_desc">跟随者向服务器询问的频率。它同时决定数值可能有多旧，因此也决定基于跟随数值的警报可能有多晚。跟随者没有自己的传感器让手机保持唤醒，所以每次检查都是一次唤醒。</string>
     <string name="nightscout_follow_interval_doze">低于 9 分钟时，手机闲置期间 Android 仍可能拉长检查间隔。将 Juggluco 排除在电池优化之外可保持所选间隔。</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">HTTPS 加密</string>
+    <string name="webserver_certificate">证书</string>
+    <string name="webserver_cert_selfsigned">自签名，在本设备上生成</string>
+    <string name="webserver_cert_custom">自定义证书</string>
+    <string name="webserver_cert_none">尚无证书</string>
+    <string name="webserver_cert_generate">生成</string>
+    <string name="webserver_cert_regenerate">重新生成</string>
+    <string name="webserver_cert_import">导入</string>
+    <string name="webserver_cert_import_hint">请从您的证书颁发机构导入这两个文件。</string>
+    <string name="webserver_cert_generating">正在生成证书…</string>
+    <string name="webserver_cert_expires">有效期至 %1$s</string>
+    <string name="webserver_cert_expired">已过期</string>
+    <string name="webserver_cert_missing_address">未包含 %1$s</string>
+    <string name="webserver_cert_created">证书已生成</string>
 </resources>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2839,7 +2839,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <!-- Web server TLS certificate -->
     <string name="webserver_https_subtitle">HTTPS encryption</string>
     <string name="webserver_certificate">Certificate</string>
-    <string name="webserver_cert_selfsigned">Self-signed, generated on this device</string>
+    <string name="webserver_cert_selfsigned">Self-signed, generated for this device and current network</string>
     <string name="webserver_cert_custom">Custom certificate</string>
     <string name="webserver_cert_none">No certificate yet</string>
     <string name="webserver_cert_generate">Generate</string>
@@ -2849,6 +2849,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="webserver_cert_generating">Generating certificate…</string>
     <string name="webserver_cert_expires">Expires %1$s</string>
     <string name="webserver_cert_expired">Expired</string>
-    <string name="webserver_cert_missing_address">Does not cover %1$s</string>
     <string name="webserver_cert_created">Certificate created</string>
+    <string name="webserver_cert_update">Update</string>
+    <string name="webserver_cert_needs_update">Certificate needs updating</string>
+    <string name="webserver_cert_address_changed">Network address changed to %1$s</string>
+    <string name="webserver_cert_export">Export</string>
+    <string name="webserver_cert_export_hint">Install the certificate on another device to trust this server.</string>
+    <string name="webserver_cert_export_certificate">Certificate</string>
+    <string name="webserver_cert_export_with_key">Certificate and private key</string>
+    <string name="webserver_cert_export_key_warning">The private key lets another device impersonate this server. Keep it private.</string>
 </resources>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2835,4 +2835,20 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="anytime_restart_title">Restart sensor?</string>
     <string name="anytime_restart_warning">End the current transmitter session and start a fresh pairing cycle? Existing glucose history will stay in the app.</string>
     <string name="anytime_history_action">History</string>
+
+    <!-- Web server TLS certificate -->
+    <string name="webserver_https_subtitle">HTTPS encryption</string>
+    <string name="webserver_certificate">Certificate</string>
+    <string name="webserver_cert_selfsigned">Self-signed, generated on this device</string>
+    <string name="webserver_cert_custom">Custom certificate</string>
+    <string name="webserver_cert_none">No certificate yet</string>
+    <string name="webserver_cert_generate">Generate</string>
+    <string name="webserver_cert_regenerate">Regenerate</string>
+    <string name="webserver_cert_import">Import</string>
+    <string name="webserver_cert_import_hint">Import both files from your certificate authority.</string>
+    <string name="webserver_cert_generating">Generating certificate…</string>
+    <string name="webserver_cert_expires">Expires %1$s</string>
+    <string name="webserver_cert_expired">Expired</string>
+    <string name="webserver_cert_missing_address">Does not cover %1$s</string>
+    <string name="webserver_cert_created">Certificate created</string>
 </resources>

--- a/Common/src/mobile/java/tk/glucodata/ui/ExchangeSettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExchangeSettingsScreens.kt
@@ -73,6 +73,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.core.content.FileProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -905,6 +906,13 @@ fun GarminStatusScreen(navController: NavController) {
     }
 }
 
+/**
+ * The accurate type for a PEM file, and the one Android's certificate installer
+ * registers for -- so a shared certificate can be opened and trusted directly on
+ * the receiving device rather than only saved.
+ */
+private const val PEM_MIME_TYPE = "application/x-pem-file"
+
 @Composable
 fun WebServerSettingsScreen(navController: NavController) {
     val context = LocalContext.current
@@ -923,6 +931,7 @@ fun WebServerSettingsScreen(navController: NavController) {
     var certificate by remember { mutableStateOf(WebServerCertificate.installed(context)) }
     var generatingCertificate by remember { mutableStateOf(false) }
     var showCertificateImport by rememberSaveable { mutableStateOf(false) }
+    var showCertificateExport by rememberSaveable { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
     val privateKeyPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
@@ -1099,6 +1108,42 @@ fun WebServerSettingsScreen(navController: NavController) {
     fun openUrl(url: String) {
         if (!applyCurrentInputs(showErrors = true)) return
         uriHandler.openUri(url)
+    }
+
+    /**
+     * Hands the PEMs to the share sheet, which is both halves of what people
+     * want here: send it to the other device, or save it to Files as a backup.
+     */
+    fun exportCertificate(includePrivateKey: Boolean) {
+        showCertificateExport = false
+        val staged = WebServerCertificate.stageForExport(context, includePrivateKey)
+        if (staged.isEmpty()) {
+            Toast.makeText(context, context.getString(R.string.wentwrong), Toast.LENGTH_LONG).show()
+            return
+        }
+        val uris = ArrayList<Uri>(
+            staged.map {
+                FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", it)
+            }
+        )
+        val intent = if (uris.size == 1) {
+            Intent(Intent.ACTION_SEND).apply {
+                type = PEM_MIME_TYPE
+                putExtra(Intent.EXTRA_STREAM, uris.first())
+            }
+        } else {
+            Intent(Intent.ACTION_SEND_MULTIPLE).apply {
+                type = PEM_MIME_TYPE
+                putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
+            }
+        }.apply { addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION) }
+        runCatching {
+            context.startActivity(
+                Intent.createChooser(intent, context.getString(R.string.webserver_cert_export))
+            )
+        }.onFailure {
+            Toast.makeText(context, context.getString(R.string.wentwrong), Toast.LENGTH_LONG).show()
+        }
     }
 
     fun shareUrl(url: String) {
@@ -1278,87 +1323,122 @@ fun WebServerSettingsScreen(navController: NavController) {
                                     .padding(horizontal = 12.dp, vertical = 10.dp),
                                 verticalArrangement = Arrangement.spacedBy(10.dp)
                             ) {
-                                Text(
-                                    text = stringResource(R.string.webserver_certificate),
-                                    style = MaterialTheme.typography.labelLarge
-                                )
                                 val installed = certificate
+                                // Loopback-only means no LAN name is in play, so
+                                // a certificate that omits this phone's address
+                                // is not a problem worth raising.
+                                val lanAddress = lanHost?.takeIf { !localOnly }
+                                val status = WebServerCertificate.statusOf(
+                                    installed = installed,
+                                    lanAddress = lanAddress,
+                                    nowMillis = System.currentTimeMillis(),
+                                )
+                                val needsAttention = status == WebServerCertificate.Status.ADDRESS_CHANGED ||
+                                    status == WebServerCertificate.Status.EXPIRED
+
                                 Text(
                                     text = when {
                                         generatingCertificate ->
                                             stringResource(R.string.webserver_cert_generating)
-                                        installed == null ->
-                                            stringResource(R.string.webserver_cert_none)
-                                        installed.selfSigned ->
-                                            stringResource(R.string.webserver_cert_selfsigned)
-                                        else -> stringResource(R.string.webserver_cert_custom)
+                                        needsAttention ->
+                                            stringResource(R.string.webserver_cert_needs_update)
+                                        else -> stringResource(R.string.webserver_certificate)
                                     },
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    style = MaterialTheme.typography.labelLarge,
+                                    color = if (needsAttention && !generatingCertificate) {
+                                        MaterialTheme.colorScheme.error
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurface
+                                    }
                                 )
-                                if (installed != null && !generatingCertificate) {
-                                    val expired = installed.isExpired(System.currentTimeMillis())
+
+                                if (!generatingCertificate) {
                                     Text(
-                                        text = if (expired) {
-                                            stringResource(R.string.webserver_cert_expired)
-                                        } else {
-                                            stringResource(
-                                                R.string.webserver_cert_expires,
-                                                formatExpiryDate(installed.notAfterMillis)
-                                            )
+                                        text = when {
+                                            installed == null -> stringResource(R.string.webserver_cert_none)
+                                            status == WebServerCertificate.Status.EXPIRED ->
+                                                stringResource(R.string.webserver_cert_expired)
+                                            status == WebServerCertificate.Status.ADDRESS_CHANGED ->
+                                                stringResource(
+                                                    R.string.webserver_cert_address_changed,
+                                                    lanAddress.orEmpty()
+                                                )
+                                            installed.selfSigned ->
+                                                stringResource(R.string.webserver_cert_selfsigned)
+                                            else -> stringResource(R.string.webserver_cert_custom)
                                         },
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = if (expired) {
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = if (needsAttention) {
                                             MaterialTheme.colorScheme.error
                                         } else {
                                             MaterialTheme.colorScheme.onSurfaceVariant
                                         }
                                     )
-                                    // DHCP moves phones. A certificate that was
-                                    // right when it was written stops matching
-                                    // the address people are typing, and the
-                                    // browser blames the name rather than the
-                                    // lease.
-                                    val uncovered = lanHost
-                                        ?.takeIf { !localOnly && !installed.covers(it) }
-                                    if (uncovered != null) {
+                                }
+
+                                if (installed != null && !generatingCertificate) {
+                                    // The names the certificate actually answers
+                                    // to. Spelling them out is what gives
+                                    // Regenerate a meaning the user can act on:
+                                    // remake this for the addresses I have now.
+                                    if (installed.hostnames.isNotEmpty()) {
+                                        Text(
+                                            text = installed.hostnames.joinToString(", "),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                    if (status != WebServerCertificate.Status.EXPIRED) {
                                         Text(
                                             text = stringResource(
-                                                R.string.webserver_cert_missing_address,
-                                                uncovered
+                                                R.string.webserver_cert_expires,
+                                                formatExpiryDate(installed.notAfterMillis)
                                             ),
                                             style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.error
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
                                         )
                                     }
                                 }
+
                                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    FilledTonalButton(
-                                        onClick = { generateCertificate(thenEnableSsl = false) },
-                                        enabled = childEnabled && !generatingCertificate,
-                                        modifier = Modifier.weight(1f)
-                                    ) {
-                                        Icon(Icons.Filled.Autorenew, contentDescription = null)
-                                        Spacer(Modifier.width(8.dp))
-                                        Text(
-                                            stringResource(
-                                                if (installed == null) {
-                                                    R.string.webserver_cert_generate
-                                                } else {
-                                                    R.string.webserver_cert_regenerate
-                                                }
-                                            )
-                                        )
+                                    val primaryLabel = stringResource(
+                                        when (status) {
+                                            WebServerCertificate.Status.MISSING ->
+                                                R.string.webserver_cert_generate
+                                            WebServerCertificate.Status.ADDRESS_CHANGED,
+                                            WebServerCertificate.Status.EXPIRED ->
+                                                R.string.webserver_cert_update
+                                            else -> R.string.webserver_cert_regenerate
+                                        }
+                                    )
+                                    val onPrimary = { generateCertificate(thenEnableSsl = false) }
+                                    val primaryEnabled = childEnabled && !generatingCertificate
+                                    // Filled only while something is actually
+                                    // wrong; the rest of the time reissuing is
+                                    // just one of three equal options.
+                                    if (needsAttention) {
+                                        Button(
+                                            onClick = onPrimary,
+                                            enabled = primaryEnabled,
+                                            modifier = Modifier.weight(1f)
+                                        ) { Text(primaryLabel) }
+                                    } else {
+                                        FilledTonalButton(
+                                            onClick = onPrimary,
+                                            enabled = primaryEnabled,
+                                            modifier = Modifier.weight(1f)
+                                        ) { Text(primaryLabel) }
                                     }
                                     OutlinedButton(
-                                        onClick = { showCertificateImport = true },
-                                        enabled = childEnabled && !generatingCertificate,
+                                        onClick = { showCertificateExport = true },
+                                        enabled = primaryEnabled && installed != null,
                                         modifier = Modifier.weight(1f)
-                                    ) {
-                                        Icon(Icons.Filled.Shield, contentDescription = null)
-                                        Spacer(Modifier.width(8.dp))
-                                        Text(stringResource(R.string.webserver_cert_import))
-                                    }
+                                    ) { Text(stringResource(R.string.webserver_cert_export)) }
+                                    OutlinedButton(
+                                        onClick = { showCertificateImport = true },
+                                        enabled = primaryEnabled,
+                                        modifier = Modifier.weight(1f)
+                                    ) { Text(stringResource(R.string.webserver_cert_import)) }
                                 }
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
@@ -1515,6 +1595,47 @@ fun WebServerSettingsScreen(navController: NavController) {
                 }
             }
         }
+    }
+    if (showCertificateExport) {
+        AlertDialog(
+            onDismissRequest = { showCertificateExport = false },
+            title = { Text(stringResource(R.string.webserver_cert_export)) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = stringResource(R.string.webserver_cert_export_hint),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    OutlinedButton(
+                        onClick = { exportCertificate(includePrivateKey = false) },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(Icons.Filled.Shield, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.webserver_cert_export_certificate))
+                    }
+                    Spacer(Modifier.height(4.dp))
+                    OutlinedButton(
+                        onClick = { exportCertificate(includePrivateKey = true) },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(Icons.Filled.Key, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.webserver_cert_export_with_key))
+                    }
+                    Text(
+                        text = stringResource(R.string.webserver_cert_export_key_warning),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showCertificateExport = false }) {
+                    Text(stringResource(R.string.close))
+                }
+            }
+        )
     }
     if (showCertificateImport) {
         AlertDialog(

--- a/Common/src/mobile/java/tk/glucodata/ui/ExchangeSettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExchangeSettingsScreens.kt
@@ -1304,7 +1304,7 @@ fun WebServerSettingsScreen(navController: NavController) {
                                         } else {
                                             stringResource(
                                                 R.string.webserver_cert_expires,
-                                                formatEpoch(installed.notAfterMillis)
+                                                formatExpiryDate(installed.notAfterMillis)
                                             )
                                         },
                                         style = MaterialTheme.typography.bodySmall,
@@ -1616,6 +1616,20 @@ private fun findLocalIpv4Address(): String? {
             ?.hostAddress
     } catch (_: Throwable) {
         null
+    }
+}
+
+/**
+ * Date only. A certificate expires two years out, so the time of day it happens
+ * is noise -- unlike [formatEpoch], whose other callers are showing when the
+ * mirror last sent or received.
+ */
+private fun formatExpiryDate(epochMs: Long): String {
+    if (epochMs <= 0L) return ""
+    return try {
+        DateFormat.getDateInstance(DateFormat.MEDIUM).format(Date(epochMs))
+    } catch (_: Throwable) {
+        ""
     }
 }
 

--- a/Common/src/mobile/java/tk/glucodata/ui/ExchangeSettingsScreens.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/ExchangeSettingsScreens.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.BluetoothSearching
 import androidx.compose.material.icons.filled.CheckCircle
@@ -42,6 +43,7 @@ import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SettingsEthernet
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.SwapHoriz
@@ -91,6 +93,7 @@ import java.util.Date
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import tk.glucodata.webserver.WebServerCertificate
 import tk.glucodata.Applic
 import tk.glucodata.AutoSensorSwitch
 import tk.glucodata.GoogleServices
@@ -913,9 +916,14 @@ fun WebServerSettingsScreen(navController: NavController) {
     var showSecret by rememberSaveable { mutableStateOf(false) }
     var sslEnabled by rememberSaveable { mutableStateOf(Natives.getuseSSL()) }
     var sslExpanded by rememberSaveable { mutableStateOf(sslEnabled) }
+    var httpPortText by rememberSaveable { mutableStateOf(Natives.getxdripport().toString()) }
     var sslPortText by rememberSaveable { mutableStateOf(Natives.getsslport().toString()) }
     var intervalText by rememberSaveable { mutableStateOf(Natives.getinterval().toString()) }
     var showHelp by rememberSaveable { mutableStateOf(false) }
+    var certificate by remember { mutableStateOf(WebServerCertificate.installed(context)) }
+    var generatingCertificate by remember { mutableStateOf(false) }
+    var showCertificateImport by rememberSaveable { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
 
     val privateKeyPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
         if (uri == null) return@rememberLauncherForActivityResult
@@ -924,6 +932,8 @@ fun WebServerSettingsScreen(navController: NavController) {
             Toast.makeText(context, error, Toast.LENGTH_LONG).show()
         } else {
             Toast.makeText(context, context.getString(R.string.saved), Toast.LENGTH_SHORT).show()
+            WebServerCertificate.clearSelfSignedMarker(context)
+            certificate = WebServerCertificate.installed(context)
             if (sslEnabled) {
                 val sslError = Natives.setuseSSL(true)
                 if (sslError != null) Toast.makeText(context, sslError, Toast.LENGTH_LONG).show()
@@ -937,6 +947,8 @@ fun WebServerSettingsScreen(navController: NavController) {
             Toast.makeText(context, error, Toast.LENGTH_LONG).show()
         } else {
             Toast.makeText(context, context.getString(R.string.saved), Toast.LENGTH_SHORT).show()
+            WebServerCertificate.clearSelfSignedMarker(context)
+            certificate = WebServerCertificate.installed(context)
             if (sslEnabled) {
                 val sslError = Natives.setuseSSL(true)
                 if (sslError != null) Toast.makeText(context, sslError, Toast.LENGTH_LONG).show()
@@ -953,6 +965,13 @@ fun WebServerSettingsScreen(navController: NavController) {
             return false
         }
 
+        val httpPort = httpPortText.toIntOrNull()
+        if (httpPort == null) {
+            if (showErrors) {
+                Toast.makeText(context, "$httpPortText${context.getString(R.string.invalidport)}", Toast.LENGTH_LONG).show()
+            }
+            return false
+        }
         val port = sslPortText.toIntOrNull()
         if (port == null) {
             if (showErrors) {
@@ -961,19 +980,22 @@ fun WebServerSettingsScreen(navController: NavController) {
             return false
         }
         val receivePort = Natives.getreceiveport().toIntOrNull()
-        if (receivePort != null && port == receivePort) {
+        if (receivePort != null && (port == receivePort || httpPort == receivePort)) {
             if (showErrors) {
                 Toast.makeText(context, context.getString(R.string.nomirrorport), Toast.LENGTH_LONG).show()
             }
             return false
         }
-        if (port == 17580) {
+        // The two servers listen at the same time, so they cannot share a port.
+        // This used to compare against the literal 17580 because that was the
+        // only value the HTTP server could ever have.
+        if (port == httpPort) {
             if (showErrors) {
                 Toast.makeText(context, context.getString(R.string.nohttpport), Toast.LENGTH_LONG).show()
             }
             return false
         }
-        if (port !in 1024..65535) {
+        if (port !in 1024..65535 || httpPort !in 1024..65535) {
             if (showErrors) {
                 Toast.makeText(context, context.getString(R.string.portrange), Toast.LENGTH_LONG).show()
             }
@@ -991,6 +1013,10 @@ fun WebServerSettingsScreen(navController: NavController) {
         Natives.setApiSecret(key)
         if (port != Natives.getsslport()) {
             Natives.setsslport(port)
+        }
+        // Rebinds a running server, so only call it when the value moved.
+        if (httpPort != Natives.getxdripport()) {
+            Natives.setxdripport(httpPort)
         }
         Natives.setinterval(interval)
         Natives.setXdripServerLocal(localOnly)
@@ -1010,13 +1036,55 @@ fun WebServerSettingsScreen(navController: NavController) {
 
     fun buildBaseUrl(host: String): String {
         val scheme = if (sslEnabled) "https" else "http"
-        val port = if (sslEnabled) sslPortText.toIntOrNull() ?: Natives.getsslport() else 17580
+        val port = if (sslEnabled) {
+            sslPortText.toIntOrNull() ?: Natives.getsslport()
+        } else {
+            httpPortText.toIntOrNull() ?: Natives.getxdripport()
+        }
         val key = apiSecret.trim()
         val keyPrefix = if (key.isEmpty()) "" else "$key/"
         return "$scheme://$host:$port/$keyPrefix"
     }
 
+    /**
+     * Writes a fresh self-signed pair, then hands the server back to whatever
+     * state it was in. Key generation is slow enough to be visible, so it runs
+     * off the main thread and the switch is held disabled meanwhile.
+     */
+    fun generateCertificate(thenEnableSsl: Boolean) {
+        if (generatingCertificate) return
+        generatingCertificate = true
+        scope.launch {
+            val error = withContext(Dispatchers.IO) { WebServerCertificate.generate(context) }
+            certificate = WebServerCertificate.installed(context)
+            generatingCertificate = false
+            if (error != null) {
+                Toast.makeText(context, error, Toast.LENGTH_LONG).show()
+                return@launch
+            }
+            Toast.makeText(context, context.getString(R.string.webserver_cert_created), Toast.LENGTH_SHORT).show()
+            // A running server holds the old certificate open; re-enabling is
+            // what makes it read the new one.
+            if (thenEnableSsl || sslEnabled) {
+                val sslError = Natives.setuseSSL(true)
+                if (sslError != null) {
+                    Toast.makeText(context, sslError, Toast.LENGTH_LONG).show()
+                } else {
+                    sslEnabled = true
+                }
+            }
+        }
+    }
+
     fun setSslEnabled(enabled: Boolean) {
+        // Turning HTTPS on used to fail unless the user had already side-loaded
+        // two PEM files. Nothing about wanting encrypted traffic implies owning
+        // a certificate, so make one.
+        if (enabled && !WebServerCertificate.hasCertificate(context)) {
+            sslExpanded = true
+            generateCertificate(thenEnableSsl = true)
+            return
+        }
         val err = Natives.setuseSSL(enabled)
         if (err != null) {
             Toast.makeText(context, err, Toast.LENGTH_LONG).show()
@@ -1042,9 +1110,11 @@ fun WebServerSettingsScreen(navController: NavController) {
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.sendto)))
     }
 
-    val localBaseUrl = remember(apiSecret, sslEnabled, sslPortText) { buildBaseUrl("127.0.0.1") }
-    val lanHost = remember(apiSecret, sslEnabled, sslPortText) { findLocalIpv4Address() }
-    val lanBaseUrl = remember(lanHost, apiSecret, sslEnabled, sslPortText) { lanHost?.let { buildBaseUrl(it) } }
+    val localBaseUrl = remember(apiSecret, sslEnabled, sslPortText, httpPortText) { buildBaseUrl("127.0.0.1") }
+    val lanHost = remember(apiSecret, sslEnabled, sslPortText, httpPortText) { findLocalIpv4Address() }
+    val lanBaseUrl = remember(lanHost, apiSecret, sslEnabled, sslPortText, httpPortText) {
+        lanHost?.let { buildBaseUrl(it) }
+    }
     val primaryUrl = if (localOnly) localBaseUrl else (lanBaseUrl ?: localBaseUrl)
     val rootUrl = primaryUrl
     val currentUrl = remember(primaryUrl) { "${primaryUrl}api/v1/entries/current" }
@@ -1147,8 +1217,34 @@ fun WebServerSettingsScreen(navController: NavController) {
                     )
 
                     SettingsItem(
+                        title = stringResource(R.string.port),
+                        icon = Icons.Filled.SettingsEthernet,
+                        iconTint = MaterialTheme.colorScheme.secondary,
+                        position = CardPosition.MIDDLE,
+                        trailingContent = {
+                            OutlinedTextField(
+                                value = httpPortText,
+                                onValueChange = { httpPortText = it },
+                                enabled = childEnabled,
+                                singleLine = true,
+                                textStyle = MaterialTheme.typography.bodyMedium,
+                                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                    keyboardType = KeyboardType.Number,
+                                    imeAction = ImeAction.Done
+                                ),
+                                keyboardActions = KeyboardActions(
+                                    onDone = { applyCurrentInputs(showErrors = true) }
+                                ),
+                                modifier = Modifier
+                                    .width(96.dp)
+                                    .height(52.dp)
+                            )
+                        }
+                    )
+
+                    SettingsItem(
                         title = stringResource(R.string.usessl),
-                        subtitle = "HTTPS with certificate files",
+                        subtitle = stringResource(R.string.webserver_https_subtitle),
                         icon = Icons.Filled.Lock,
                         iconTint = MaterialTheme.colorScheme.primary,
                         position = CardPosition.MIDDLE,
@@ -1182,6 +1278,88 @@ fun WebServerSettingsScreen(navController: NavController) {
                                     .padding(horizontal = 12.dp, vertical = 10.dp),
                                 verticalArrangement = Arrangement.spacedBy(10.dp)
                             ) {
+                                Text(
+                                    text = stringResource(R.string.webserver_certificate),
+                                    style = MaterialTheme.typography.labelLarge
+                                )
+                                val installed = certificate
+                                Text(
+                                    text = when {
+                                        generatingCertificate ->
+                                            stringResource(R.string.webserver_cert_generating)
+                                        installed == null ->
+                                            stringResource(R.string.webserver_cert_none)
+                                        installed.selfSigned ->
+                                            stringResource(R.string.webserver_cert_selfsigned)
+                                        else -> stringResource(R.string.webserver_cert_custom)
+                                    },
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                if (installed != null && !generatingCertificate) {
+                                    val expired = installed.isExpired(System.currentTimeMillis())
+                                    Text(
+                                        text = if (expired) {
+                                            stringResource(R.string.webserver_cert_expired)
+                                        } else {
+                                            stringResource(
+                                                R.string.webserver_cert_expires,
+                                                formatEpoch(installed.notAfterMillis)
+                                            )
+                                        },
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = if (expired) {
+                                            MaterialTheme.colorScheme.error
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                        }
+                                    )
+                                    // DHCP moves phones. A certificate that was
+                                    // right when it was written stops matching
+                                    // the address people are typing, and the
+                                    // browser blames the name rather than the
+                                    // lease.
+                                    val uncovered = lanHost
+                                        ?.takeIf { !localOnly && !installed.covers(it) }
+                                    if (uncovered != null) {
+                                        Text(
+                                            text = stringResource(
+                                                R.string.webserver_cert_missing_address,
+                                                uncovered
+                                            ),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.error
+                                        )
+                                    }
+                                }
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    FilledTonalButton(
+                                        onClick = { generateCertificate(thenEnableSsl = false) },
+                                        enabled = childEnabled && !generatingCertificate,
+                                        modifier = Modifier.weight(1f)
+                                    ) {
+                                        Icon(Icons.Filled.Autorenew, contentDescription = null)
+                                        Spacer(Modifier.width(8.dp))
+                                        Text(
+                                            stringResource(
+                                                if (installed == null) {
+                                                    R.string.webserver_cert_generate
+                                                } else {
+                                                    R.string.webserver_cert_regenerate
+                                                }
+                                            )
+                                        )
+                                    }
+                                    OutlinedButton(
+                                        onClick = { showCertificateImport = true },
+                                        enabled = childEnabled && !generatingCertificate,
+                                        modifier = Modifier.weight(1f)
+                                    ) {
+                                        Icon(Icons.Filled.Shield, contentDescription = null)
+                                        Spacer(Modifier.width(8.dp))
+                                        Text(stringResource(R.string.webserver_cert_import))
+                                    }
+                                }
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
                                     horizontalArrangement = Arrangement.spacedBy(10.dp)
@@ -1208,31 +1386,6 @@ fun WebServerSettingsScreen(navController: NavController) {
                                             .height(52.dp)
                                     )
                                 }
-                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    OutlinedButton(
-                                        onClick = { privateKeyPicker.launch(arrayOf("*/*")) },
-                                        enabled = childEnabled,
-                                        modifier = Modifier.weight(1f)
-                                    ) {
-                                        Icon(Icons.Filled.Key, contentDescription = null)
-                                        Spacer(Modifier.width(8.dp))
-                                        Text(stringResource(R.string.privatekey))
-                                    }
-                                    OutlinedButton(
-                                        onClick = { fullChainPicker.launch(arrayOf("*/*")) },
-                                        enabled = childEnabled,
-                                        modifier = Modifier.weight(1f)
-                                    ) {
-                                        Icon(Icons.Filled.Shield, contentDescription = null)
-                                        Spacer(Modifier.width(8.dp))
-                                        Text(stringResource(R.string.fullchain))
-                                    }
-                                }
-                                Text(
-                                    text = "Import key files first, then enable Use SSL.",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
                             }
                         }
                     }
@@ -1363,6 +1516,41 @@ fun WebServerSettingsScreen(navController: NavController) {
             }
         }
     }
+    if (showCertificateImport) {
+        AlertDialog(
+            onDismissRequest = { showCertificateImport = false },
+            title = { Text(stringResource(R.string.webserver_cert_import)) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = stringResource(R.string.webserver_cert_import_hint),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    OutlinedButton(
+                        onClick = { privateKeyPicker.launch(arrayOf("*/*")) },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(Icons.Filled.Key, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.privatekey))
+                    }
+                    OutlinedButton(
+                        onClick = { fullChainPicker.launch(arrayOf("*/*")) },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(Icons.Filled.Shield, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.fullchain))
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showCertificateImport = false }) {
+                    Text(stringResource(R.string.close))
+                }
+            }
+        )
+    }
     if (showHelp) {
         AlertDialog(
             onDismissRequest = { showHelp = false },
@@ -1372,7 +1560,7 @@ fun WebServerSettingsScreen(navController: NavController) {
                     Text("Nightscout-compatible endpoints are served directly from this phone.")
                     Text("Base URL exposes api/v1/entries/current, api/v1/entries, and x/report paths.")
                     Text("Use Local only for same-device loopback testing. Disable it for LAN.")
-                    Text("For HTTPS: import Private Key + Full Chain, then enable Use SSL.")
+                    Text("Enable Use SSL and the app writes its own certificate. Import one instead if you have a CA-issued certificate.")
                 }
             },
             confirmButton = {

--- a/Common/src/test/java/tk/glucodata/webserver/SelfSignedCertificateTests.kt
+++ b/Common/src/test/java/tk/glucodata/webserver/SelfSignedCertificateTests.kt
@@ -1,0 +1,200 @@
+package tk.glucodata.webserver
+
+import java.io.ByteArrayInputStream
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.cert.CertificateExpiredException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Date
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.Test
+
+/**
+ * The certificate is hand-encoded, so every test here parses the bytes back with
+ * the platform's own X.509 parser rather than checking them against a fixture.
+ * If the DER is malformed in any way that matters, `generateCertificate` throws.
+ */
+class SelfSignedCertificateTests {
+
+    companion object {
+        private lateinit var keyPair: KeyPair
+
+        @BeforeClass
+        @JvmStatic
+        fun generateKeyPairOnce() {
+            // One 2048-bit key pair for the whole class: generating one per test
+            // is most of the runtime.
+            keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+        }
+    }
+
+    private val now = 1_760_000_000_000L
+
+    private val sans = SelfSignedCertificate.SubjectAltNames(
+        dnsNames = listOf("localhost"),
+        ipAddresses = listOf(
+            byteArrayOf(127, 0, 0, 1),
+            byteArrayOf(192.toByte(), 168.toByte(), 1, 42),
+        ),
+    )
+
+    private fun parse(der: ByteArray): X509Certificate =
+        CertificateFactory.getInstance("X.509")
+            .generateCertificate(ByteArrayInputStream(der)) as X509Certificate
+
+    private fun certificate(
+        subjectAltNames: SelfSignedCertificate.SubjectAltNames = sans,
+        commonName: String = "JugglucoNG",
+    ): X509Certificate = parse(
+        SelfSignedCertificate.create(
+            keyPair = keyPair,
+            commonName = commonName,
+            subjectAltNames = subjectAltNames,
+            notBeforeMillis = now,
+        )
+    )
+
+    @Test
+    fun theEncodingParsesAsAnX509V3Certificate() {
+        val certificate = certificate()
+
+        assertEquals(3, certificate.version)
+        assertEquals("CN=JugglucoNG", certificate.subjectX500Principal.name)
+        assertEquals("CN=JugglucoNG", certificate.issuerX500Principal.name)
+    }
+
+    @Test
+    fun itVerifiesUnderItsOwnPublicKey() {
+        // A self-signed certificate whose signature does not check out is the
+        // failure mode a hand-rolled encoder is most likely to produce: it means
+        // the bytes signed are not the bytes written.
+        certificate().verify(keyPair.public)
+    }
+
+    @Test
+    fun subjectAlternativeNamesCarryTheHostAndEveryAddress() {
+        val entries = certificate().subjectAlternativeNames!!
+            .map { (it[0] as Int) to (it[1] as String) }
+
+        assertTrue(entries.contains(2 to "localhost"))
+        assertTrue(entries.contains(7 to "127.0.0.1"))
+        assertTrue(entries.contains(7 to "192.168.1.42"))
+    }
+
+    @Test
+    fun anIpv6AddressSurvivesTheRoundTrip() {
+        val loopbackV6 = ByteArray(16).also { it[15] = 1 }
+        val certificate = certificate(
+            SelfSignedCertificate.SubjectAltNames(ipAddresses = listOf(loopbackV6))
+        )
+
+        val addresses = certificate.subjectAlternativeNames!!
+            .filter { it[0] == 7 }
+            .map { it[1] as String }
+        assertEquals(listOf("0:0:0:0:0:0:0:1"), addresses)
+    }
+
+    @Test
+    fun aCertificateWithNoAlternativeNamesOmitsTheExtension() {
+        val certificate = certificate(SelfSignedCertificate.SubjectAltNames())
+
+        // An empty SAN SEQUENCE is invalid DER, so the extension has to be left
+        // out rather than written empty.
+        assertEquals(null, certificate.subjectAlternativeNames)
+    }
+
+    @Test
+    fun itIsValidNowAndForTheStatedLifetime() {
+        val certificate = certificate()
+
+        certificate.checkValidity(Date(now))
+        certificate.checkValidity(Date(now + (SelfSignedCertificate.VALIDITY_DAYS - 1) * 86_400_000L))
+    }
+
+    @Test
+    fun itToleratesAClientClockThatRunsBehind() {
+        // Backdating notBefore is what keeps a freshly written certificate from
+        // reading as "not yet valid" on a browser with a slightly slow clock.
+        certificate().checkValidity(Date(now - 60L * 60L * 1000L))
+    }
+
+    @Test(expected = CertificateExpiredException::class)
+    fun itStopsBeingValidAfterTheLifetime() {
+        certificate().checkValidity(
+            Date(now + (SelfSignedCertificate.VALIDITY_DAYS + 2) * 86_400_000L)
+        )
+    }
+
+    @Test
+    fun theLifetimeStaysUnderTheLimitIosEnforcesOnServerCertificates() {
+        assertTrue(SelfSignedCertificate.VALIDITY_DAYS <= 825)
+    }
+
+    @Test
+    fun itIsUsableAsAServerCertificateAndNotAsACa() {
+        val certificate = certificate()
+
+        assertEquals(-1, certificate.basicConstraints)
+        assertTrue(certificate.extendedKeyUsage.contains("1.3.6.1.5.5.7.3.1"))
+        val keyUsage = certificate.keyUsage!!
+        assertTrue("digitalSignature", keyUsage[0])
+        assertTrue("keyEncipherment", keyUsage[2])
+        assertFalse("keyCertSign", keyUsage[5])
+    }
+
+    @Test
+    fun criticalExtensionsAreTheOnesThatShouldBeCritical() {
+        val certificate = certificate()
+
+        assertEquals(
+            setOf("2.5.29.19", "2.5.29.15"),
+            certificate.criticalExtensionOIDs,
+        )
+    }
+
+    @Test
+    fun theSubjectKeyIdentifierNamesTheKeyNotTheCertificate() {
+        val first = certificate().getExtensionValue("2.5.29.14")
+        val second = certificate(commonName = "Something else").getExtensionValue("2.5.29.14")
+
+        assertNotNull(first)
+        // extnValue OCTET STRING wrapping the extension's own OCTET STRING
+        // wrapping 20 bytes of SHA-1.
+        assertEquals(24, first!!.size)
+        // Two different certificates over one key share an identifier; that is
+        // the whole point of the extension.
+        assertArrayEquals(first, second)
+    }
+
+    @Test
+    fun theSerialNumberIsPositive() {
+        // A negative or zero serial is a hard parse failure for some clients.
+        val certificate = parse(
+            SelfSignedCertificate.create(
+                keyPair = keyPair,
+                commonName = "JugglucoNG",
+                subjectAltNames = sans,
+                notBeforeMillis = now,
+                serialNumber = BigInteger.valueOf(-5L),
+            )
+        )
+
+        assertTrue(certificate.serialNumber.signum() > 0)
+    }
+
+    @Test
+    fun aLongCommonNameStillEncodesItsLengthCorrectly() {
+        // Anything over 127 bytes moves DER into long-form lengths, which is a
+        // separate branch of the encoder.
+        val longName = "j".repeat(200)
+
+        assertEquals("CN=$longName", certificate(commonName = longName).subjectX500Principal.name)
+    }
+}

--- a/Common/src/test/java/tk/glucodata/webserver/WebServerCertificateStatusTests.kt
+++ b/Common/src/test/java/tk/glucodata/webserver/WebServerCertificateStatusTests.kt
@@ -1,0 +1,119 @@
+package tk.glucodata.webserver
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * What the settings screen offers about the installed certificate. The whole
+ * point of this decision is that it stays a decision — the certificate is never
+ * reissued behind the user's back, because that would change the fingerprint of
+ * something they may already have exported and trusted elsewhere.
+ */
+class WebServerCertificateStatusTests {
+
+    private val now = 1_760_000_000_000L
+
+    private fun installed(
+        selfSigned: Boolean = true,
+        hostnames: List<String> = listOf("localhost", "127.0.0.1", "192.168.1.42"),
+        notAfterMillis: Long = now + 200L * 86_400_000L,
+    ) = WebServerCertificate.Installed(
+        selfSigned = selfSigned,
+        subject = "JugglucoNG",
+        hostnames = hostnames,
+        notAfterMillis = notAfterMillis,
+    )
+
+    private fun status(
+        installed: WebServerCertificate.Installed?,
+        lanAddress: String?,
+    ) = WebServerCertificate.statusOf(installed, lanAddress, now)
+
+    @Test
+    fun nothingInstalledIsMissing() {
+        assertEquals(WebServerCertificate.Status.MISSING, status(null, "192.168.1.42"))
+    }
+
+    @Test
+    fun aCertificateCoveringTheCurrentAddressIsReady() {
+        assertEquals(WebServerCertificate.Status.READY, status(installed(), "192.168.1.42"))
+    }
+
+    @Test
+    fun movingToAnAddressTheCertificateDoesNotCoverAsksForAnUpdate() {
+        assertEquals(
+            WebServerCertificate.Status.ADDRESS_CHANGED,
+            status(installed(), "10.0.0.117"),
+        )
+    }
+
+    @Test
+    fun loopbackOnlyNeverAsksForAnUpdate() {
+        // With no LAN address in play there is no name to be wrong about, so a
+        // certificate listing only localhost is exactly right.
+        assertEquals(
+            WebServerCertificate.Status.READY,
+            status(installed(hostnames = listOf("localhost", "127.0.0.1")), null),
+        )
+    }
+
+    @Test
+    fun anImportedCertificateIsNeverReportedAsNeedingAnAddressUpdate() {
+        // A CA-issued certificate is usually issued to a domain name and has no
+        // business listing whatever IP the phone's lease handed it today.
+        // Offering to replace it because the network moved would be wrong.
+        assertEquals(
+            WebServerCertificate.Status.READY,
+            status(installed(selfSigned = false, hostnames = listOf("cgm.example.org")), "10.0.0.117"),
+        )
+    }
+
+    @Test
+    fun anExpiredCertificateOutranksAnAddressChange() {
+        val expired = installed(notAfterMillis = now - 86_400_000L)
+
+        // Both are wrong, but a browser refuses an expired certificate outright,
+        // so that is the thing to say.
+        assertEquals(WebServerCertificate.Status.EXPIRED, status(expired, "10.0.0.117"))
+        assertEquals(WebServerCertificate.Status.EXPIRED, status(expired, "192.168.1.42"))
+    }
+
+    @Test
+    fun anImportedCertificateStillReportsExpiry() {
+        assertEquals(
+            WebServerCertificate.Status.EXPIRED,
+            status(installed(selfSigned = false, notAfterMillis = now - 1L), null),
+        )
+    }
+
+    @Test
+    fun aCertificateWithNoRecordedExpiryIsNotTreatedAsExpired() {
+        // notAfter comes back as 0 when the certificate could not be parsed. An
+        // unreadable certificate is still perfectly usable by the server, so it
+        // must not be reported as broken.
+        assertEquals(
+            WebServerCertificate.Status.READY,
+            status(installed(notAfterMillis = 0L, hostnames = emptyList()), null),
+        )
+    }
+
+    @Test
+    fun coverageIgnoresCase() {
+        val certificate = installed(hostnames = listOf("localhost", "MyPhone.local"))
+
+        assertTrue(certificate.covers("myphone.local"))
+        assertTrue(certificate.covers("LOCALHOST"))
+        assertFalse(certificate.covers("otherphone.local"))
+    }
+
+    @Test
+    fun aSelfSignedCertificateWithNoNamesAsksForAnUpdateOnALan() {
+        // Nothing to match against means nothing a browser will accept.
+        assertEquals(
+            WebServerCertificate.Status.ADDRESS_CHANGED,
+            status(installed(hostnames = emptyList()), "192.168.1.42"),
+        )
+    }
+}


### PR DESCRIPTION
Two things the web server screen could not express, and one native bug found while fixing them.

## The HTTP port was never missing — just unreachable

`settings.hpp` has held `uint16_t httpport` all along, `defaultshows()` initialises it, and the desktop build reads it (`main.cpp:841` starts on `settings->data()->httpport`, `-W` sets it). Android was the odd one out: both start sites — `javasettings.cpp:932` and `settings.cpp:328` — passed the compile-time `defaulthttpport` instead. The stored value was written by nothing and read by nothing, so 17580 was effectively hardcoded and the SSL port, which lives in a different field and took a different path, was the only editable port on a screen with two of them.

Both start sites now read the stored port, and it is exposed as `getxdripport` / `setxdripport`. A settings file predating the field leaves it zero, so `effectivehttpport()` falls back to the compile-time default rather than reporting port 0.

## Rebinding needed more care than it looks

`stopwatchthread()` only shuts the listening socket down; the `accept()` loop that owns it clears `xdripserversock` a moment later. Calling `startwatchthread()` before that lands hits its `xdripserversock == -1` guard, does nothing, and leaves the server down until the app restarts. `restartwatchthread()` waits for the handover, on a detached thread so the UI thread coming through JNI never blocks.

It has to wait for **both** listeners. `stopwatchthread()` takes SSL down too, and `startwatchthread()` only brings SSL back while `xdripserversslsock` is still -1 — so waiting on the plain socket alone could rebind HTTP in the window where the SSL loop had not yet let go, and silently leave HTTPS down. Verified on the emulator: HTTPS still answers 200 after an HTTP port change.

## HTTPS now generates its own certificate

`Use SSL` was a switch that failed until the user had produced `privkey.pem` and `fullchain.pem` by hand and side-loaded both. Nothing about wanting encrypted traffic implies owning a certificate.

`sslserver.cpp:101` resolves both files against `globalbasedir`, which `settings.cpp:195` sets to the app's files directory — the same place the existing import already writes. So the app writes its own pair and the import path stays for people with a CA-issued certificate.

**No Bouncy Castle.** Android generates keys well but has no public API for building a certificate, and bcprov + bcpkix is several megabytes for one screen in a repo that already dropped ABIs to save size. The structure of a self-signed certificate is small and fixed, so the DER is written directly in `Der.kt` / `SelfSignedCertificate.kt`.

Names cover `localhost`, `127.0.0.1`, `::1` and every address the device currently holds, so LAN access does not add a name mismatch on top of the untrusted-issuer warning. Lifetime is **825 days** — iOS refuses any server certificate valid for longer, including one the user trusted by hand, so a longer life would cost iPhone access rather than save a regeneration. The panel shows the expiry and whether the certificate still covers the address the phone answers on, since DHCP moves phones and browsers blame the name rather than the lease.

## Verified on an emulator, not just described

- Flipping `Use SSL` with no certificate present generated one and brought HTTPS up.
- `https://127.0.0.1:17581/` answers **200**; `openssl s_client` reads back exactly what was intended:
  `CN=JugglucoNG`, self-signed, `CA:FALSE`, `Digital Signature, Key Encipherment`, `TLS Web Server Authentication`, SANs `localhost, 127.0.0.1, ::1, 10.0.2.15, 10.0.2.16` and the link-local v6 addresses.
- OpenSSL parsed the hand-written DER and loaded the PKCS#8 key without complaint, which is the real test of the encoder.
- Changing the port to 17599 moved the listener: 17580 refused, 17599 answered 200, and the value survived an app restart with the UI reading back the port that is actually bound.
- `SelfSignedCertificateTests` — 14 tests that parse the output with the platform's own `CertificateFactory` and verify the signature; if the bytes signed ever stop being the bytes written, that test fails.
- `./gradlew :Common:testMobileDebugUnitTest` green; native rebuilt for arm64-v8a.

## Strings

14 new keys in `values/strings.xml` and all 14 `values-*` locales, translated.

## Worth flagging

The web server help dialog is hardcoded English in code rather than in `strings.xml`. That predates this change; I corrected the one line that now described the wrong flow but did not move the dialog into resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)