### PR TITLE
Calibrate from fingersticks only, not every journal entry that knows its glucose

### DIFF
--- a/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
+++ b/Common/src/mobile/java/tk/glucodata/data/journal/JournalDao.kt
@@ -34,9 +34,18 @@ interface JournalDao {
         endMillis: Long
     ): List<JournalEntryEntity>
 
+    /**
+     * Blood-glucose measurements the user entered: fingersticks, and nothing else.
+     *
+     * Not "entries that have a glucose value". An insulin dose or a meal placed by
+     * tapping the chart stores the sensor value it was anchored to — that is how the
+     * dose calculator and the IOB anchor know what the user was at — and selecting on
+     * the column alone turned every such tap into a calibration point at the sensor's
+     * own value: a droplet on the line, saying the sensor agrees with itself.
+     */
     @Query(
-        "SELECT * FROM journal_entries WHERE glucoseValueMgDl IS NOT NULL AND timestamp >= :startMillis " +
-            "ORDER BY timestamp ASC, id ASC"
+        "SELECT * FROM journal_entries WHERE entryType = 'fingerstick' AND glucoseValueMgDl IS NOT NULL " +
+            "AND timestamp >= :startMillis ORDER BY timestamp ASC, id ASC"
     )
     suspend fun getGlucoseEntriesSince(startMillis: Long): List<JournalEntryEntity>
 

--- a/Common/src/test/java/tk/glucodata/data/journal/JournalGlucoseEntryQueryTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/journal/JournalGlucoseEntryQueryTests.kt
@@ -1,0 +1,30 @@
+package tk.glucodata.data.journal
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Only a fingerstick is a blood-glucose measurement. A dose or a meal placed
+ * by tapping the chart carries the sensor value it was anchored to, and must
+ * never be read back as a meter reading — every chart tap became a calibration
+ * point that said the sensor agreed with itself.
+ */
+class JournalGlucoseEntryQueryTests {
+    @Test
+    fun calibrationCandidatesAreFingersticksOnly() {
+        val dao = File("src/mobile/java/tk/glucodata/data/journal/JournalDao.kt").readText()
+        val query = dao.substringAfter("suspend fun getGlucoseEntriesSince").let { after ->
+            dao.substring(0, dao.indexOf("suspend fun getGlucoseEntriesSince")).substringAfterLast("@Query(")
+        }
+        assertTrue(
+            "the calibration source must select on entry type, not on the presence of a value",
+            query.contains("entryType = 'fingerstick'"),
+        )
+        assertTrue(
+            "the storage value must match JournalEntryType.FINGERSTICK",
+            File("src/mobile/java/tk/glucodata/data/journal/JournalModels.kt").readText()
+                .contains("FINGERSTICK(\"fingerstick\")"),
+        )
+    }
+}


### PR DESCRIPTION
Every insulin dose or meal added by tapping the chart was becoming a calibration point.

**Why:** since April, a chart-anchored entry stores the sensor value it was placed at in `glucoseValueMgDl` — deliberately, so the dose calculator and the IOB anchor know what the user was at. The journal calibration sync (`229201147`, 2026-08-14) selected its candidates with `WHERE glucoseValueMgDl IS NOT NULL`, with no type filter. So a 3 U dose placed on the chart was indistinguishable from a fingerstick, and became a calibration at the sensor's own value — a droplet sitting exactly on the line, telling the fit the sensor agrees with itself.

**Fix:** the query selects `entryType = 'fingerstick'`. Chart-anchored entries keep their anchor; the sync just stops reading it as a meter reading. One test pins the predicate to `JournalEntryType.FINGERSTICK`.

Latent since 14 August; surfaced after a week of heavy chart use with *Calibrate from journal* on. Unrelated to #300.

**Not handled here:** the spurious calibration points already created on affected devices. The planner should retire them on its next sync since their source entries no longer qualify; if it doesn't, they'll need removing from the calibration list by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)