### PR TITLE
Journal setup: Calculations page for the profile and everything computed from it

### DIFF
--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1653,10 +1653,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Мэтавае значэнне для дозы</string>
     <string name="predictive_dose_target_explanation">Прапановы інсуліну і вугляводаў карэктуюць да гэтага значэння. Яно не звязана з мэтавым дыяпазонам на графіку.</string>
-    <string name="state_dose_hint_title">Падказка па дозе</string>
-    <string name="state_dose_hint_desc">Прапануе вугляводы, калі значэнне ідзе ніжэй за мэту дозы, і карэкцыю, калі яно застаецца высокім і не зніжаецца. Рэшткавы інсулін адымаецца; разлік магчымы і пры нулявым IOB. Колькасці разлічваюцца з адчувальнасці і вугляводнага каэфіцыента мадэльнага профілю; спачатку задайце іх.</string>
-    <string name="state_dose_hint_in_range_title">Карэктаваць і ў верхняй частцы дыяпазону</string>
-    <string name="state_dose_hint_in_range_desc">Прапануе карэкцыю таксама тады, калі значэнне стаіць прыкметна вышэй за мэту дазавання і трымаецца там. Незанесеныя вугляводы могуць рабіць графік роўным, пакуль ежа яшчэ ўсмоктваецца; карэкцыя тады ляжа зверху. Лічба, гэта разлік з профілю, а не рэкамендацыя.</string>
+    <string name="state_dose_hint_title">Падказкі дозы</string>
+    <string name="state_dose_hint_desc">Прапаноўваць вугляводы пры зніжэнні і карэкцыю пры высокіх значэннях</string>
+    <string name="state_dose_hint_in_range_title">Дазволіць карэкцыі ў мэтавым дыяпазоне</string>
+    <string name="state_dose_hint_in_range_desc">Дазваляць карэкцыі вышэй за мэтавае значэнне дозы, пакуль паказчык яшчэ ў дыяпазоне</string>
+    <string name="journal_model_suggestions_section">Падказкі</string>
+    <string name="journal_model_desc">Профіль, засваенне і актыўны інсулін</string>
+    <string name="journal_model_title">Мадэль</string>
     <string name="state_dose_hint_horizon">Гарызонт падказкі па дозе</string>
     <string name="state_dose_hint_horizon_explanation">Наколькі далёка наперад глядзіць вугляводная прапанова пры падзенні значэння. Карацей — пазней і радзей, даўжэй — раней і часцей.</string>
     <string name="state_dose_hint_profile_notice_title">Праверце мадэльны профіль</string>
@@ -1668,7 +1671,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_horizon_value">%1$d хв</string>
     <string name="journal_dose_math_title">Калькулятар дозы</string>
     <string name="journal_food_macros_title">Пашыранае засваенне ежы</string>
-    <string name="journal_food_macros_desc">Улічваць неабавязковыя бялок і тлушч для адкладзеных крывых ежы і разліку дозы</string>
+    <string name="journal_food_macros_desc">Улічваць бялкі і тлушчы для запаволенага засваення ежы</string>
     <string name="journal_aaps_import_title">Імпартаваць тэрапію AAPS</string>
     <string name="journal_aaps_import_desc">Прымаць трансляцыі тэрапіі AAPS і дадаваць інсулін і вугляводы ў журнал</string>
     <string name="journal_aaps_carbs_title">Вугляводы AAPS</string>
@@ -1704,7 +1707,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_food_save_to_library">Захаваць у базу</string>
     <string name="journal_food_protein_short">%1$s г бялку</string>
     <string name="journal_food_fat_short">%1$s г тлушчу</string>
-    <string name="journal_dose_calculator_desc">Прапаноўваць парны інсулін або вугляводы з профілю мадэлі і актыўнага інсуліну</string>
+    <string name="journal_dose_calculator_desc">Прапаноўваць інсулін або вугляводы паводле вашай мадэлі</string>
     <string name="journal_meal_shape">Крывая ежы</string>
     <string name="journal_meal_shape_fast">Хутка</string>
     <string name="journal_meal_shape_mixed">Змешана</string>
@@ -1742,7 +1745,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_active_now_percent">Актыўна %1$d%%</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s АД</string>
-    <string name="journal_eiob_display_title">Паказваць эфектыўны IOB (eIOB)</string>
+    <string name="journal_eiob_display_title">Эфектыўны IOB (eIOB)</string>
     <string name="journal_eiob_display_desc">Паказваць інсулін з улікам актыўнасці побач з IOB</string>
     <string name="journal_iob_expanded">Засталося IoB: %1$s АД</string>
     <string name="journal_eiob_expanded">Дзейнічае eIoB: %1$s АД</string>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -1657,9 +1657,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="state_dose_hint_desc">Прапаноўваць вугляводы пры зніжэнні і карэкцыю пры высокіх значэннях</string>
     <string name="state_dose_hint_in_range_title">Дазволіць карэкцыі ў мэтавым дыяпазоне</string>
     <string name="state_dose_hint_in_range_desc">Дазваляць карэкцыі вышэй за мэтавае значэнне дозы, пакуль паказчык яшчэ ў дыяпазоне</string>
-    <string name="journal_model_suggestions_section">Падказкі</string>
-    <string name="journal_model_desc">Профіль, засваенне і актыўны інсулін</string>
-    <string name="journal_model_title">Мадэль</string>
+    <string name="journal_calculations_suggestions_section">Падказкі</string>
+    <string name="journal_calculations_desc">Профіль, засваенне, актыўны інсулін і падказкі дозы</string>
+    <string name="journal_calculations_title">Разлікі</string>
     <string name="state_dose_hint_horizon">Гарызонт падказкі па дозе</string>
     <string name="state_dose_hint_horizon_explanation">Наколькі далёка наперад глядзіць вугляводная прапанова пры падзенні значэння. Карацей — пазней і радзей, даўжэй — раней і часцей.</string>
     <string name="state_dose_hint_profile_notice_title">Праверце мадэльны профіль</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1661,9 +1661,9 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="state_dose_hint_desc">Kohlenhydrate bei Tiefs und Korrekturen bei Hochs vorschlagen</string>
     <string name="state_dose_hint_in_range_title">Korrekturen im Zielbereich erlauben</string>
     <string name="state_dose_hint_in_range_desc">Korrekturen über dem Dosisziel erlauben, solange der Wert noch im Zielbereich liegt</string>
-    <string name="journal_model_suggestions_section">Vorschläge</string>
-    <string name="journal_model_desc">Profil, Aufnahme und aktives Insulin</string>
-    <string name="journal_model_title">Modell</string>
+    <string name="journal_calculations_suggestions_section">Vorschläge</string>
+    <string name="journal_calculations_desc">Profil, Aufnahme, aktives Insulin und Dosishinweise</string>
+    <string name="journal_calculations_title">Berechnungen</string>
     <string name="state_dose_hint_horizon">Vorlauf des Dosishinweises</string>
     <string name="state_dose_hint_horizon_explanation">Wie weit der Kohlenhydratvorschlag bei fallendem Wert vorausschaut. Kürzer meldet sich später und seltener, länger früher und öfter.</string>
     <string name="state_dose_hint_profile_notice_title">Modellprofil prüfen</string>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -1657,10 +1657,13 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Zielwert für Dosierung</string>
     <string name="predictive_dose_target_explanation">Insulin- und Kohlenhydratvorschläge korrigieren auf diesen Wert. Er ist unabhängig vom Zielbereich im Diagramm.</string>
-    <string name="state_dose_hint_title">Dosishinweis</string>
-    <string name="state_dose_hint_desc">Schlägt Kohlenhydrate vor, wenn der Wert unter den Dosis-Zielwert läuft, und eine Korrektur, wenn er hoch bleibt und nicht fällt. Vorhandenes IOB wird abgezogen; auch bei null IOB ist eine Berechnung möglich. Die Mengen werden aus Sensitivität und Kohlenhydratfaktor des Modellprofils berechnet; diese also zuerst einstellen.</string>
-    <string name="state_dose_hint_in_range_title">Auch im oberen Zielbereich korrigieren</string>
-    <string name="state_dose_hint_in_range_desc">Schlägt auch dann eine Korrektur vor, wenn der Wert deutlich über dem Dosis-Zielwert steht und dort bleibt. Nicht eingetragene Kohlenhydrate können einen flachen Verlauf vortäuschen, während noch Nahrung resorbiert wird; die Korrektur käme dann obendrauf. Die Zahl ist eine Rechnung aus dem Profil, keine Empfehlung.</string>
+    <string name="state_dose_hint_title">Dosishinweise</string>
+    <string name="state_dose_hint_desc">Kohlenhydrate bei Tiefs und Korrekturen bei Hochs vorschlagen</string>
+    <string name="state_dose_hint_in_range_title">Korrekturen im Zielbereich erlauben</string>
+    <string name="state_dose_hint_in_range_desc">Korrekturen über dem Dosisziel erlauben, solange der Wert noch im Zielbereich liegt</string>
+    <string name="journal_model_suggestions_section">Vorschläge</string>
+    <string name="journal_model_desc">Profil, Aufnahme und aktives Insulin</string>
+    <string name="journal_model_title">Modell</string>
     <string name="state_dose_hint_horizon">Vorlauf des Dosishinweises</string>
     <string name="state_dose_hint_horizon_explanation">Wie weit der Kohlenhydratvorschlag bei fallendem Wert vorausschaut. Kürzer meldet sich später und seltener, länger früher und öfter.</string>
     <string name="state_dose_hint_profile_notice_title">Modellprofil prüfen</string>
@@ -1672,7 +1675,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="predictive_horizon_value">%1$d min</string>
     <string name="journal_dose_math_title">Dosisrechner</string>
     <string name="journal_food_macros_title">Erweiterte Nahrungsaufnahme</string>
-    <string name="journal_food_macros_desc">Optional Protein und Fett für verzögerte Essenskurven und Dosismathematik nutzen</string>
+    <string name="journal_food_macros_desc">Protein und Fett für verzögerte Nahrungsaufnahme nutzen</string>
     <string name="journal_aaps_import_title">AAPS-Behandlungen importieren</string>
     <string name="journal_aaps_import_desc">AAPS-Behandlungs-Broadcasts empfangen und Insulin sowie Kohlenhydrate ins Journal eintragen</string>
     <string name="journal_aaps_carbs_title">AAPS-Kohlenhydrate</string>
@@ -1708,7 +1711,7 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="journal_food_save_to_library">In Bibliothek speichern</string>
     <string name="journal_food_protein_short">%1$s g Protein</string>
     <string name="journal_food_fat_short">%1$s g Fett</string>
-    <string name="journal_dose_calculator_desc">Insulin oder Kohlenhydrate aus Modellprofil und aktivem Insulin vorschlagen</string>
+    <string name="journal_dose_calculator_desc">Insulin oder Kohlenhydrate anhand deines Modells vorschlagen</string>
     <string name="journal_meal_shape">Mahlzeitenkurve</string>
     <string name="journal_meal_shape_fast">Schnell</string>
     <string name="journal_meal_shape_mixed">Gemischt</string>
@@ -1746,8 +1749,8 @@ Durch Drücken von „OK“ wird eine Verbindung auf diesem Telefon hergestellt 
     <string name="journal_active_now_percent">%1$d%% aktiv</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s E</string>
-    <string name="journal_eiob_display_title">Effektives IOB (eIOB) anzeigen</string>
-    <string name="journal_eiob_display_desc">Aktivitätsbasiertes Insulin neben IOB anzeigen</string>
+    <string name="journal_eiob_display_title">Effektives IOB (eIOB)</string>
+    <string name="journal_eiob_display_desc">Aktivitätsbereinigtes Insulin neben IOB anzeigen</string>
     <string name="journal_dashboard_quickadd_title">Schnelleintrag auf dem Dashboard</string>
     <string name="journal_dashboard_quickadd_desc">Plus-Taste für das Journal anzeigen</string>
     <string name="journal_quickadd_always_now_title">Aktuelle Zeit verwenden</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1593,9 +1593,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="state_dose_hint_desc">Suggérer des glucides en cas de baisse et des corrections en cas de hausse</string>
     <string name="state_dose_hint_in_range_title">Autoriser les corrections dans la plage</string>
     <string name="state_dose_hint_in_range_desc">Autoriser les corrections au-dessus de la cible de dose tant que la valeur reste dans la plage</string>
-    <string name="journal_model_suggestions_section">Suggestions</string>
-    <string name="journal_model_desc">Profil, absorption et insuline active</string>
-    <string name="journal_model_title">Modèle</string>
+    <string name="journal_calculations_suggestions_section">Suggestions</string>
+    <string name="journal_calculations_desc">Profil, absorption, insuline active et suggestions de dose</string>
+    <string name="journal_calculations_title">Calculs</string>
     <string name="state_dose_hint_horizon">Horizon de la suggestion</string>
     <string name="state_dose_hint_horizon_explanation">Jusqu\'où la suggestion de glucides regarde en avant quand la valeur baisse. Plus court : plus tard et plus rare ; plus long : plus tôt et plus souvent.</string>
     <string name="state_dose_hint_profile_notice_title">Vérifiez votre profil de modèle</string>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -1589,10 +1589,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Cible de dose</string>
     <string name="predictive_dose_target_explanation">Les suggestions d\'insuline et de glucides corrigent vers cette valeur. Elle est distincte de la plage cible affichée sur le graphique.</string>
-    <string name="state_dose_hint_title">Suggestion de dose</string>
-    <string name="state_dose_hint_desc">Propose des glucides quand la valeur descend sous la cible de dose, et une correction quand elle reste haute sans baisser. L\'insuline à bord est déduite ; le calcul reste possible avec un IOB nul. Les quantités sont calculées à partir de la sensibilité et du ratio glucidique du profil du modèle : réglez-les d\'abord.</string>
-    <string name="state_dose_hint_in_range_title">Corriger aussi dans le haut de la plage</string>
-    <string name="state_dose_hint_in_range_desc">Propose aussi une correction quand la valeur reste nettement au-dessus de la cible de dose et n\'en bouge plus. Des glucides non enregistrés peuvent donner une courbe plate pendant que la digestion se poursuit, et la correction s\'ajouterait alors. Le chiffre est un calcul issu de votre profil, pas une recommandation.</string>
+    <string name="state_dose_hint_title">Suggestions de dose</string>
+    <string name="state_dose_hint_desc">Suggérer des glucides en cas de baisse et des corrections en cas de hausse</string>
+    <string name="state_dose_hint_in_range_title">Autoriser les corrections dans la plage</string>
+    <string name="state_dose_hint_in_range_desc">Autoriser les corrections au-dessus de la cible de dose tant que la valeur reste dans la plage</string>
+    <string name="journal_model_suggestions_section">Suggestions</string>
+    <string name="journal_model_desc">Profil, absorption et insuline active</string>
+    <string name="journal_model_title">Modèle</string>
     <string name="state_dose_hint_horizon">Horizon de la suggestion</string>
     <string name="state_dose_hint_horizon_explanation">Jusqu\'où la suggestion de glucides regarde en avant quand la valeur baisse. Plus court : plus tard et plus rare ; plus long : plus tôt et plus souvent.</string>
     <string name="state_dose_hint_profile_notice_title">Vérifiez votre profil de modèle</string>
@@ -1604,7 +1607,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_horizon_value">%1$d min</string>
     <string name="journal_dose_math_title">Calculateur de dose</string>
     <string name="journal_food_macros_title">Absorption alimentaire avancée</string>
-    <string name="journal_food_macros_desc">Utiliser les protéines et lipides optionnels pour les courbes retardées et le calcul de dose</string>
+    <string name="journal_food_macros_desc">Utiliser les protéines et lipides pour l’absorption retardée des aliments</string>
     <string name="journal_aaps_import_title">Importer les traitements AAPS</string>
     <string name="journal_aaps_import_desc">Recevoir les diffusions de traitements AAPS et ajouter insuline et glucides au journal</string>
     <string name="journal_aaps_carbs_title">Glucides AAPS</string>
@@ -1640,7 +1643,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_food_save_to_library">Enregistrer dans la bibliothèque</string>
     <string name="journal_food_protein_short">%1$s g protéines</string>
     <string name="journal_food_fat_short">%1$s g lipides</string>
-    <string name="journal_dose_calculator_desc">Suggérer l\'insuline ou les glucides associés selon le profil et l\'insuline active</string>
+    <string name="journal_dose_calculator_desc">Suggérer l’insuline ou les glucides à partir de votre modèle</string>
     <string name="journal_meal_shape">Courbe du repas</string>
     <string name="journal_meal_shape_fast">Rapide</string>
     <string name="journal_meal_shape_mixed">Mixte</string>
@@ -1678,7 +1681,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_active_now_percent">%1$d%% actif</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s U</string>
-    <string name="journal_eiob_display_title">Afficher l’IOB effectif (eIOB)</string>
+    <string name="journal_eiob_display_title">IOB effectif (eIOB)</string>
     <string name="journal_eiob_display_desc">Afficher l’insuline ajustée à l’activité à côté de l’IOB</string>
     <string name="journal_iob_expanded">IoB restant : %1$s U</string>
     <string name="journal_eiob_expanded">eIoB actif : %1$s U</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1577,9 +1577,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="state_dose_hint_desc">Suggerisci carboidrati per le ipo e correzioni per le iper</string>
     <string name="state_dose_hint_in_range_title">Consenti correzioni nel range</string>
     <string name="state_dose_hint_in_range_desc">Consenti correzioni sopra il target di dose mentre il valore è ancora nel range</string>
-    <string name="journal_model_suggestions_section">Suggerimenti</string>
-    <string name="journal_model_desc">Profilo, assorbimento e insulina attiva</string>
-    <string name="journal_model_title">Modello</string>
+    <string name="journal_calculations_suggestions_section">Suggerimenti</string>
+    <string name="journal_calculations_desc">Profilo, assorbimento, insulina attiva e suggerimenti di dose</string>
+    <string name="journal_calculations_title">Calcoli</string>
     <string name="state_dose_hint_horizon">Orizzonte del suggerimento</string>
     <string name="state_dose_hint_horizon_explanation">Quanto avanti guarda il suggerimento di carboidrati mentre il valore scende. Più corto: più tardi e più raro; più lungo: prima e più spesso.</string>
     <string name="state_dose_hint_profile_notice_title">Controlla il profilo del modello</string>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -1573,10 +1573,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Obiettivo per la dose</string>
     <string name="predictive_dose_target_explanation">I suggerimenti di insulina e carboidrati correggono verso questo valore. È separato dall\'intervallo target mostrato sul grafico.</string>
-    <string name="state_dose_hint_title">Suggerimento di dose</string>
-    <string name="state_dose_hint_desc">Propone carboidrati quando il valore sta scendendo sotto il target di dose, e una correzione quando resta alto senza scendere. L\'insulina a bordo viene sottratta; il calcolo è possibile anche con IOB pari a zero. Le quantità sono calcolate da sensibilità e rapporto carboidrati del profilo del modello: impostali prima.</string>
-    <string name="state_dose_hint_in_range_title">Correggi anche nella parte alta dell\'intervallo</string>
-    <string name="state_dose_hint_in_range_desc">Propone una correzione anche quando il valore resta ben sopra il target di dose e non si muove più. Carboidrati non registrati possono far sembrare piatta la curva mentre il cibo è ancora in assorbimento, e la correzione si aggiungerebbe. Il numero è un calcolo dal profilo, non una raccomandazione.</string>
+    <string name="state_dose_hint_title">Suggerimenti di dose</string>
+    <string name="state_dose_hint_desc">Suggerisci carboidrati per le ipo e correzioni per le iper</string>
+    <string name="state_dose_hint_in_range_title">Consenti correzioni nel range</string>
+    <string name="state_dose_hint_in_range_desc">Consenti correzioni sopra il target di dose mentre il valore è ancora nel range</string>
+    <string name="journal_model_suggestions_section">Suggerimenti</string>
+    <string name="journal_model_desc">Profilo, assorbimento e insulina attiva</string>
+    <string name="journal_model_title">Modello</string>
     <string name="state_dose_hint_horizon">Orizzonte del suggerimento</string>
     <string name="state_dose_hint_horizon_explanation">Quanto avanti guarda il suggerimento di carboidrati mentre il valore scende. Più corto: più tardi e più raro; più lungo: prima e più spesso.</string>
     <string name="state_dose_hint_profile_notice_title">Controlla il profilo del modello</string>
@@ -1588,7 +1591,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_horizon_value">%1$d min</string>
     <string name="journal_dose_math_title">Calcolatore dose</string>
     <string name="journal_food_macros_title">Assorbimento alimentare avanzato</string>
-    <string name="journal_food_macros_desc">Usa proteine e grassi opzionali per curve alimentari ritardate e calcolo dose</string>
+    <string name="journal_food_macros_desc">Usa proteine e grassi per l’assorbimento ritardato del cibo</string>
     <string name="journal_aaps_import_title">Importa trattamenti AAPS</string>
     <string name="journal_aaps_import_desc">Ricevi i broadcast dei trattamenti AAPS e aggiungi insulina e carboidrati al diario</string>
     <string name="journal_aaps_carbs_title">Carboidrati AAPS</string>
@@ -1624,7 +1627,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_food_save_to_library">Salva nella libreria</string>
     <string name="journal_food_protein_short">%1$s g proteine</string>
     <string name="journal_food_fat_short">%1$s g grassi</string>
-    <string name="journal_dose_calculator_desc">Suggerisci insulina o carboidrati abbinati dal profilo modello e dall\'insulina attiva</string>
+    <string name="journal_dose_calculator_desc">Suggerisci insulina o carboidrati in base al tuo modello</string>
     <string name="journal_meal_shape">Curva pasto</string>
     <string name="journal_meal_shape_fast">Rapida</string>
     <string name="journal_meal_shape_mixed">Mista</string>
@@ -1662,7 +1665,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_active_now_percent">%1$d%% attivo</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s U</string>
-    <string name="journal_eiob_display_title">Mostra IOB effettivo (eIOB)</string>
+    <string name="journal_eiob_display_title">IOB effettivo (eIOB)</string>
     <string name="journal_eiob_display_desc">Mostra l’insulina corretta per l’attività accanto all’IOB</string>
     <string name="journal_iob_expanded">IoB residuo: %1$s U</string>
     <string name="journal_eiob_expanded">eIoB attivo: %1$s U</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1588,9 +1588,9 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="state_dose_hint_desc">Буурахад нүүрс ус, өндөр үед залруулга санал болгох</string>
     <string name="state_dose_hint_in_range_title">Хүрээн доторх залруулгыг зөвшөөрөх</string>
     <string name="state_dose_hint_in_range_desc">Утга хүрээн дотор байхад тунгийн зорилтоос дээш залруулгыг зөвшөөрөх</string>
-    <string name="journal_model_suggestions_section">Зөвлөмж</string>
-    <string name="journal_model_desc">Профайл, шингээлт ба идэвхтэй инсулин</string>
-    <string name="journal_model_title">Загвар</string>
+    <string name="journal_calculations_suggestions_section">Зөвлөмж</string>
+    <string name="journal_calculations_desc">Профайл, шингээлт, идэвхтэй инсулин ба тунгийн зөвлөмж</string>
+    <string name="journal_calculations_title">Тооцоолол</string>
     <string name="state_dose_hint_horizon">Тунгийн зөвлөмжийн хугацаа</string>
     <string name="state_dose_hint_horizon_explanation">Утга буурч байхад нүүрс усны санал хэр хол урагш харахыг заана. Богино нь хожуу, урт нь эрт мэдэгдэнэ.</string>
     <string name="state_dose_hint_profile_notice_title">Загварын профилээ шалгана уу</string>

--- a/Common/src/main/res/values-mn/strings.xml
+++ b/Common/src/main/res/values-mn/strings.xml
@@ -1585,9 +1585,12 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="predictive_dose_target">Тунгийн зорилтот утга</string>
     <string name="predictive_dose_target_explanation">Инсулин болон нүүрс усны зөвлөмж энэ утга руу залруулна. Энэ нь графикт харуулсан зорилтот мужаас тусдаа.</string>
     <string name="state_dose_hint_title">Тунгийн зөвлөмж</string>
-    <string name="state_dose_hint_desc">Утга тунгийн зорилтоос доош чиглэж байвал нүүрс ус, буурахгүй өндөр хэвээр байвал залруулга санал болгоно. Биед үлдсэн инсулиныг хасна; IOB тэг байсан ч тооцоолж болно. Хэмжээг загварын профилийн мэдрэг байдал ба нүүрс усны харьцаанаас тооцно; эхлээд тэдгээрийг тохируулна уу.</string>
-    <string name="state_dose_hint_in_range_title">Зорилтот мужийн дээд хэсэгт ч залруулах</string>
-    <string name="state_dose_hint_in_range_desc">Утга тунгийн зорилтоос мэдэгдэхүйц дээгүүр тогтсон үед ч залруулга санал болгоно. Бүртгээгүй нүүрс ус хоол шингэж байхад муруйг тэгш мэт харагдуулж болох бөгөөд залруулга дээр нь нэмэгдэнэ. Тоо бол профилаас гарсан тооцоо, зөвлөмж биш.</string>
+    <string name="state_dose_hint_desc">Буурахад нүүрс ус, өндөр үед залруулга санал болгох</string>
+    <string name="state_dose_hint_in_range_title">Хүрээн доторх залруулгыг зөвшөөрөх</string>
+    <string name="state_dose_hint_in_range_desc">Утга хүрээн дотор байхад тунгийн зорилтоос дээш залруулгыг зөвшөөрөх</string>
+    <string name="journal_model_suggestions_section">Зөвлөмж</string>
+    <string name="journal_model_desc">Профайл, шингээлт ба идэвхтэй инсулин</string>
+    <string name="journal_model_title">Загвар</string>
     <string name="state_dose_hint_horizon">Тунгийн зөвлөмжийн хугацаа</string>
     <string name="state_dose_hint_horizon_explanation">Утга буурч байхад нүүрс усны санал хэр хол урагш харахыг заана. Богино нь хожуу, урт нь эрт мэдэгдэнэ.</string>
     <string name="state_dose_hint_profile_notice_title">Загварын профилээ шалгана уу</string>
@@ -1599,7 +1602,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="predictive_horizon_value">%1$d min</string>
     <string name="journal_dose_math_title">Dose calculator</string>
     <string name="journal_food_macros_title">Advanced food absorption</string>
-    <string name="journal_food_macros_desc">Use optional protein and fat for delayed food curves and dose math</string>
+    <string name="journal_food_macros_desc">Хойшилсон хоол шингээлтэд уураг, өөх тосыг ашиглах</string>
     <string name="journal_aaps_import_title">AAPS эмчилгээг импортлох</string>
     <string name="journal_aaps_import_desc">AAPS эмчилгээний broadcast-уудыг хүлээн авч, инсулин болон нүүрс усыг журналд нэмэх</string>
     <string name="journal_aaps_carbs_title">AAPS нүүрс ус</string>
@@ -1635,7 +1638,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="journal_food_save_to_library">Санд хадгалах</string>
     <string name="journal_food_protein_short">%1$s g protein</string>
     <string name="journal_food_fat_short">%1$s g fat</string>
-    <string name="journal_dose_calculator_desc">Suggest paired insulin or carbs from model profile and active insulin</string>
+    <string name="journal_dose_calculator_desc">Таны загварт үндэслэн инсулин эсвэл нүүрс ус санал болгох</string>
     <string name="journal_meal_shape">Meal curve</string>
     <string name="journal_meal_shape_fast">Fast</string>
     <string name="journal_meal_shape_mixed">Mixed</string>
@@ -1674,7 +1677,7 @@ OK дарснаар энэ утсан дээр холболт үүсч, өөр A
     <string name="journal_active_now_percent">%1$d%% идэвхтэй</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s U</string>
-    <string name="journal_eiob_display_title">Үр дүнтэй IOB (eIOB)-г харуулах</string>
+    <string name="journal_eiob_display_title">Бодит IOB (eIOB)</string>
     <string name="journal_eiob_display_desc">Идэвхээр тохируулсан инсулиныг IOB-ийн хажууд харуулах</string>
     <string name="journal_iob_expanded">IoB %1$s U үлдсэн</string>
     <string name="journal_eiob_expanded">eIoB %1$s U үйлчилж байна</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1630,9 +1630,9 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="state_dose_hint_desc">Koolhydraten voorstellen bij lage en correcties bij hoge waarden</string>
     <string name="state_dose_hint_in_range_title">Correcties binnen bereik toestaan</string>
     <string name="state_dose_hint_in_range_desc">Correcties boven het dosisdoel toestaan terwijl de waarde nog binnen bereik is</string>
-    <string name="journal_model_suggestions_section">Suggesties</string>
-    <string name="journal_model_desc">Profiel, opname en actieve insuline</string>
-    <string name="journal_model_title">Model</string>
+    <string name="journal_calculations_suggestions_section">Suggesties</string>
+    <string name="journal_calculations_desc">Profiel, opname, actieve insuline en dosishints</string>
+    <string name="journal_calculations_title">Berekeningen</string>
     <string name="state_dose_hint_horizon">Horizon van de hint</string>
     <string name="state_dose_hint_horizon_explanation">Hoe ver het koolhydraatvoorstel vooruitkijkt bij een dalende waarde. Korter meldt later en minder vaak, langer eerder en vaker.</string>
     <string name="state_dose_hint_profile_notice_title">Controleer je modelprofiel</string>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -1626,10 +1626,13 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Doelwaarde voor dosering</string>
     <string name="predictive_dose_target_explanation">Insuline- en koolhydraatsuggesties corrigeren naar deze waarde. Die staat los van het streefbereik op de grafiek.</string>
-    <string name="state_dose_hint_title">Doseringshint</string>
-    <string name="state_dose_hint_desc">Stelt koolhydraten voor als de waarde onder het doseerdoel zakt, en een correctie als ze hoog blijft zonder te dalen. Aanwezige insuline wordt afgetrokken; berekening is ook mogelijk bij nul IOB. De hoeveelheden komen uit de gevoeligheid en koolhydraatratio van het modelprofiel; stel die eerst in.</string>
-    <string name="state_dose_hint_in_range_title">Ook in het bovenste deel van het bereik corrigeren</string>
-    <string name="state_dose_hint_in_range_desc">Stelt ook een correctie voor als de waarde ruim boven het doseerdoel blijft staan. Niet-gelogde koolhydraten kunnen een vlakke lijn voorspiegelen terwijl er nog voedsel wordt opgenomen; de correctie komt er dan bovenop. Het getal is een berekening uit je profiel, geen advies.</string>
+    <string name="state_dose_hint_title">Dosishints</string>
+    <string name="state_dose_hint_desc">Koolhydraten voorstellen bij lage en correcties bij hoge waarden</string>
+    <string name="state_dose_hint_in_range_title">Correcties binnen bereik toestaan</string>
+    <string name="state_dose_hint_in_range_desc">Correcties boven het dosisdoel toestaan terwijl de waarde nog binnen bereik is</string>
+    <string name="journal_model_suggestions_section">Suggesties</string>
+    <string name="journal_model_desc">Profiel, opname en actieve insuline</string>
+    <string name="journal_model_title">Model</string>
     <string name="state_dose_hint_horizon">Horizon van de hint</string>
     <string name="state_dose_hint_horizon_explanation">Hoe ver het koolhydraatvoorstel vooruitkijkt bij een dalende waarde. Korter meldt later en minder vaak, langer eerder en vaker.</string>
     <string name="state_dose_hint_profile_notice_title">Controleer je modelprofiel</string>
@@ -1641,7 +1644,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="predictive_horizon_value">%1$d min</string>
     <string name="journal_dose_math_title">Dosiscalculator</string>
     <string name="journal_food_macros_title">Geavanceerde voedselabsorptie</string>
-    <string name="journal_food_macros_desc">Gebruik optioneel eiwit en vet voor vertraagde voedselcurves en dosisberekening</string>
+    <string name="journal_food_macros_desc">Eiwit en vet gebruiken voor vertraagde voedselopname</string>
     <string name="journal_aaps_import_title">AAPS-behandelingen importeren</string>
     <string name="journal_aaps_import_desc">Ontvang AAPS-behandelbroadcasts en voeg insuline en koolhydraten toe aan het dagboek</string>
     <string name="journal_aaps_carbs_title">AAPS-koolhydraten</string>
@@ -1677,7 +1680,7 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="journal_food_save_to_library">Opslaan in bibliotheek</string>
     <string name="journal_food_protein_short">%1$s g eiwit</string>
     <string name="journal_food_fat_short">%1$s g vet</string>
-    <string name="journal_dose_calculator_desc">Gekoppelde insuline of koolhydraten voorstellen op basis van modelprofiel en actieve insuline</string>
+    <string name="journal_dose_calculator_desc">Insuline of koolhydraten voorstellen op basis van je model</string>
     <string name="journal_meal_shape">Maaltijdcurve</string>
     <string name="journal_meal_shape_fast">Snel</string>
     <string name="journal_meal_shape_mixed">Gemengd</string>
@@ -1715,8 +1718,8 @@ Als je op OK drukt, wordt er een verbinding gemaakt op deze telefoon en wordt er
     <string name="journal_active_now_percent">%1$d%% actief</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s E</string>
-    <string name="journal_eiob_display_title">Effectieve IOB (eIOB) tonen</string>
-    <string name="journal_eiob_display_desc">Toon activiteitsgecorrigeerde insuline naast IOB</string>
+    <string name="journal_eiob_display_title">Effectieve IOB (eIOB)</string>
+    <string name="journal_eiob_display_desc">Activiteitsgecorrigeerde insuline naast IOB tonen</string>
     <string name="journal_iob_expanded">Resterende IoB: %1$s E</string>
     <string name="journal_eiob_expanded">Actieve eIoB: %1$s E</string>
     <string name="journal_dashboard_quickadd_title">Snel toevoegen op het dashboard</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1618,10 +1618,13 @@
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Cel dawkowania</string>
     <string name="predictive_dose_target_explanation">Sugestie insuliny i węglowodanów korygują do tej wartości. Jest niezależna od zakresu docelowego na wykresie.</string>
-    <string name="state_dose_hint_title">Podpowiedź dawki</string>
-    <string name="state_dose_hint_desc">Proponuje węglowodany, gdy wartość zmierza poniżej celu dawkowania, i korektę, gdy pozostaje wysoka i nie spada. Pozostała insulina jest odejmowana; obliczenie jest możliwe także przy zerowym IOB. Ilości wynikają z wrażliwości i przelicznika węglowodanowego w profilu modelu; ustaw je najpierw.</string>
-    <string name="state_dose_hint_in_range_title">Koryguj też w górnej części zakresu</string>
-    <string name="state_dose_hint_in_range_desc">Proponuje korektę także wtedy, gdy wartość stoi wyraźnie powyżej celu dawkowania i nie rusza się. Niezapisane węglowodany mogą upodobnić wykres do płaskiego, gdy jedzenie wciąż się wchłania, a korekta doszłaby wtedy na wierzch. Liczba to wyliczenie z profilu, nie zalecenie.</string>
+    <string name="state_dose_hint_title">Podpowiedzi dawki</string>
+    <string name="state_dose_hint_desc">Sugeruj węglowodany przy niskich i korekty przy wysokich wartościach</string>
+    <string name="state_dose_hint_in_range_title">Zezwalaj na korekty w zakresie</string>
+    <string name="state_dose_hint_in_range_desc">Zezwalaj na korekty powyżej celu dawki, gdy wartość jest jeszcze w zakresie</string>
+    <string name="journal_model_suggestions_section">Sugestie</string>
+    <string name="journal_model_desc">Profil, wchłanianie i aktywna insulina</string>
+    <string name="journal_model_title">Model</string>
     <string name="state_dose_hint_horizon">Horyzont podpowiedzi</string>
     <string name="state_dose_hint_horizon_explanation">Jak daleko wprzód patrzy propozycja węglowodanów przy spadającej wartości. Krócej: później i rzadziej; dłużej: wcześniej i częściej.</string>
     <string name="state_dose_hint_profile_notice_title">Sprawdź profil modelu</string>
@@ -1633,7 +1636,7 @@
     <string name="predictive_horizon_value">%1$d min</string>
     <string name="journal_dose_math_title">Kalkulator dawki</string>
     <string name="journal_food_macros_title">Zaawansowane wchłanianie posiłku</string>
-    <string name="journal_food_macros_desc">Opcjonalnie uwzględniaj białko i tłuszcz w opóźnionej krzywej posiłku i dawkowaniu</string>
+    <string name="journal_food_macros_desc">Uwzględniaj białko i tłuszcz przy opóźnionym wchłanianiu posiłku</string>
     <string name="journal_aaps_import_title">Importuj terapie AAPS</string>
     <string name="journal_aaps_import_desc">Odbieraj transmisje terapii AAPS i dodawaj insulinę oraz węglowodany do dziennika</string>
     <string name="journal_aaps_carbs_title">Węglowodany AAPS</string>
@@ -1669,7 +1672,7 @@
     <string name="journal_food_save_to_library">Zapisz w bibliotece</string>
     <string name="journal_food_protein_short">%1$s g białka</string>
     <string name="journal_food_fat_short">%1$s g tłuszczu</string>
-    <string name="journal_dose_calculator_desc">Sugeruj sparowaną insulinę lub węglowodany z profilu modelu i aktywnej insuliny</string>
+    <string name="journal_dose_calculator_desc">Sugeruj insulinę lub węglowodany na podstawie modelu</string>
     <string name="journal_meal_shape">Krzywa posiłku</string>
     <string name="journal_meal_shape_fast">Szybko</string>
     <string name="journal_meal_shape_mixed">Mieszane</string>
@@ -1707,8 +1710,8 @@
     <string name="journal_active_now_percent">%1$d%% aktywne</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s j.</string>
-    <string name="journal_eiob_display_title">Pokaż efektywne IOB (eIOB)</string>
-    <string name="journal_eiob_display_desc">Pokaż insulinę skorygowaną o aktywność obok IOB</string>
+    <string name="journal_eiob_display_title">Efektywne IOB (eIOB)</string>
+    <string name="journal_eiob_display_desc">Pokazuj insulinę skorygowaną o aktywność obok IOB</string>
     <string name="journal_iob_expanded">Pozostałe IoB: %1$s j.</string>
     <string name="journal_eiob_expanded">Aktywne eIoB: %1$s j.</string>
     <string name="journal_dashboard_quickadd_title">Szybkie dodawanie na pulpicie</string>

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -1622,9 +1622,9 @@
     <string name="state_dose_hint_desc">Sugeruj węglowodany przy niskich i korekty przy wysokich wartościach</string>
     <string name="state_dose_hint_in_range_title">Zezwalaj na korekty w zakresie</string>
     <string name="state_dose_hint_in_range_desc">Zezwalaj na korekty powyżej celu dawki, gdy wartość jest jeszcze w zakresie</string>
-    <string name="journal_model_suggestions_section">Sugestie</string>
-    <string name="journal_model_desc">Profil, wchłanianie i aktywna insulina</string>
-    <string name="journal_model_title">Model</string>
+    <string name="journal_calculations_suggestions_section">Sugestie</string>
+    <string name="journal_calculations_desc">Profil, wchłanianie, aktywna insulina i podpowiedzi dawki</string>
+    <string name="journal_calculations_title">Obliczenia</string>
     <string name="state_dose_hint_horizon">Horyzont podpowiedzi</string>
     <string name="state_dose_hint_horizon_explanation">Jak daleko wprzód patrzy propozycja węglowodanów przy spadającej wartości. Krócej: później i rzadziej; dłużej: wcześniej i częściej.</string>
     <string name="state_dose_hint_profile_notice_title">Sprawdź profil modelu</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1584,10 +1584,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Alvo de dose</string>
     <string name="predictive_dose_target_explanation">As sugestões de insulina e hidratos de carbono corrigem para este valor. É separado do intervalo alvo mostrado no gráfico.</string>
-    <string name="state_dose_hint_title">Sugestão de dose</string>
-    <string name="state_dose_hint_desc">Sugere hidratos quando o valor segue para baixo do alvo de dose, e uma correção quando se mantém alto sem descer. A insulina a bordo é subtraída; o cálculo também é possível com IOB zero. As quantidades vêm da sensibilidade e do rácio de hidratos do perfil do modelo; defina-os primeiro.</string>
-    <string name="state_dose_hint_in_range_title">Corrigir também na parte alta do intervalo</string>
-    <string name="state_dose_hint_in_range_desc">Sugere uma correção também quando o valor fica bem acima do alvo de dose e ali permanece. Hidratos não registados podem fazer a curva parecer estável enquanto a comida ainda está a ser absorvida, e a correção viria por cima. O número é um cálculo a partir do seu perfil, não uma recomendação.</string>
+    <string name="state_dose_hint_title">Dicas de dose</string>
+    <string name="state_dose_hint_desc">Sugerir carboidratos em quedas e correções em altas</string>
+    <string name="state_dose_hint_in_range_title">Permitir correções dentro da faixa</string>
+    <string name="state_dose_hint_in_range_desc">Permitir correções acima do alvo de dose enquanto o valor ainda está na faixa</string>
+    <string name="journal_model_suggestions_section">Sugestões</string>
+    <string name="journal_model_desc">Perfil, absorção e insulina ativa</string>
+    <string name="journal_model_title">Modelo</string>
     <string name="state_dose_hint_horizon">Horizonte da sugestão</string>
     <string name="state_dose_hint_horizon_explanation">Até onde a sugestão de hidratos olha em frente enquanto o valor desce. Mais curto: mais tarde e menos vezes; mais longo: mais cedo e mais vezes.</string>
     <string name="state_dose_hint_profile_notice_title">Verifique o perfil do modelo</string>
@@ -1599,7 +1602,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_horizon_value">%1$d min</string>
     <string name="journal_dose_math_title">Calculadora de dose</string>
     <string name="journal_food_macros_title">Absorção alimentar avançada</string>
-    <string name="journal_food_macros_desc">Usar proteína e gordura opcionais para curvas alimentares tardias e cálculo de dose</string>
+    <string name="journal_food_macros_desc">Usar proteína e gordura para absorção lenta dos alimentos</string>
     <string name="journal_aaps_import_title">Importar tratamentos do AAPS</string>
     <string name="journal_aaps_import_desc">Receber broadcasts de tratamentos do AAPS e adicionar insulina e carboidratos ao diário</string>
     <string name="journal_aaps_carbs_title">Carboidratos AAPS</string>
@@ -1635,7 +1638,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_food_save_to_library">Salvar na biblioteca</string>
     <string name="journal_food_protein_short">%1$s g proteína</string>
     <string name="journal_food_fat_short">%1$s g gordura</string>
-    <string name="journal_dose_calculator_desc">Sugerir insulina ou hidratos emparelhados pelo perfil do modelo e insulina ativa</string>
+    <string name="journal_dose_calculator_desc">Sugerir insulina ou carboidratos com base no seu modelo</string>
     <string name="journal_meal_shape">Curva da refeição</string>
     <string name="journal_meal_shape_fast">Rápida</string>
     <string name="journal_meal_shape_mixed">Mista</string>
@@ -1673,8 +1676,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_active_now_percent">%1$d%% ativo</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s U</string>
-    <string name="journal_eiob_display_title">Mostrar IOB efetivo (eIOB)</string>
-    <string name="journal_eiob_display_desc">Mostrar insulina ajustada à atividade junto ao IOB</string>
+    <string name="journal_eiob_display_title">IOB efetivo (eIOB)</string>
+    <string name="journal_eiob_display_desc">Mostrar insulina ajustada pela atividade ao lado do IOB</string>
     <string name="journal_iob_expanded">IoB restante: %1$s U</string>
     <string name="journal_eiob_expanded">eIoB ativo: %1$s U</string>
     <string name="journal_dashboard_quickadd_title">Adição rápida no painel</string>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -1588,9 +1588,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="state_dose_hint_desc">Sugerir carboidratos em quedas e correções em altas</string>
     <string name="state_dose_hint_in_range_title">Permitir correções dentro da faixa</string>
     <string name="state_dose_hint_in_range_desc">Permitir correções acima do alvo de dose enquanto o valor ainda está na faixa</string>
-    <string name="journal_model_suggestions_section">Sugestões</string>
-    <string name="journal_model_desc">Perfil, absorção e insulina ativa</string>
-    <string name="journal_model_title">Modelo</string>
+    <string name="journal_calculations_suggestions_section">Sugestões</string>
+    <string name="journal_calculations_desc">Perfil, absorção, insulina ativa e dicas de dose</string>
+    <string name="journal_calculations_title">Cálculos</string>
     <string name="state_dose_hint_horizon">Horizonte da sugestão</string>
     <string name="state_dose_hint_horizon_explanation">Até onde a sugestão de hidratos olha em frente enquanto o valor desce. Mais curto: mais tarde e menos vezes; mais longo: mais cedo e mais vezes.</string>
     <string name="state_dose_hint_profile_notice_title">Verifique o perfil do modelo</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1626,10 +1626,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Целевое значение для дозы</string>
     <string name="predictive_dose_target_explanation">Рекомендации по инсулину и углеводам корректируют до этого значения. Оно не связано с целевым диапазоном на графике.</string>
-    <string name="state_dose_hint_title">Подсказка по дозе</string>
-    <string name="state_dose_hint_desc">Предлагает углеводы, когда значение идёт ниже цели дозирования, и коррекцию, когда оно остаётся высоким и не снижается. Оставшийся инсулин вычитается; расчёт возможен и при нулевом IOB. Количества считаются из чувствительности и углеводного коэффициента профиля модели; задайте их сначала.</string>
-    <string name="state_dose_hint_in_range_title">Корректировать и в верхней части диапазона</string>
-    <string name="state_dose_hint_in_range_desc">Предлагает коррекцию и тогда, когда значение стоит заметно выше цели дозирования и держится там. Незанесённые углеводы могут делать график ровным, пока еда ещё усваивается, и коррекция тогда ляжет сверху. Число, это расчёт из профиля, а не рекомендация.</string>
+    <string name="state_dose_hint_title">Подсказки дозы</string>
+    <string name="state_dose_hint_desc">Предлагать углеводы при снижении и коррекцию при высоких значениях</string>
+    <string name="state_dose_hint_in_range_title">Разрешить коррекции в целевом диапазоне</string>
+    <string name="state_dose_hint_in_range_desc">Разрешать коррекции выше целевого значения дозы, пока показатель ещё в диапазоне</string>
+    <string name="journal_model_suggestions_section">Подсказки</string>
+    <string name="journal_model_desc">Профиль, усвоение и активный инсулин</string>
+    <string name="journal_model_title">Модель</string>
     <string name="state_dose_hint_horizon">Горизонт подсказки</string>
     <string name="state_dose_hint_horizon_explanation">Насколько далеко вперёд смотрит углеводное предложение при падении значения. Короче — позже и реже, длиннее — раньше и чаще.</string>
     <string name="state_dose_hint_profile_notice_title">Проверьте профиль модели</string>
@@ -1641,7 +1644,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_horizon_value">%1$d мин</string>
     <string name="journal_dose_math_title">Калькулятор дозы</string>
     <string name="journal_food_macros_title">Расширенное усвоение еды</string>
-    <string name="journal_food_macros_desc">Учитывать белки и жиры для поздней пищевой кривой и расчёта дозы</string>
+    <string name="journal_food_macros_desc">Учитывать белки и жиры для замедленного усвоения пищи</string>
     <string name="journal_aaps_import_title">Импорт терапии AAPS</string>
     <string name="journal_aaps_import_desc">Принимать трансляции терапии AAPS и добавлять инсулин и углеводы в журнал</string>
     <string name="journal_aaps_carbs_title">Углеводы AAPS</string>
@@ -1677,7 +1680,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_food_save_to_library">Сохранить в базу</string>
     <string name="journal_food_protein_short">%1$s г белка</string>
     <string name="journal_food_fat_short">%1$s г жира</string>
-    <string name="journal_dose_calculator_desc">Предлагать парный инсулин или углеводы по профилю модели и активному инсулину</string>
+    <string name="journal_dose_calculator_desc">Предлагать инсулин или углеводы по вашей модели</string>
     <string name="journal_meal_shape">Кривая еды</string>
     <string name="journal_meal_shape_fast">Быстро</string>
     <string name="journal_meal_shape_mixed">Смешанная</string>
@@ -1715,8 +1718,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_active_now_percent">Активно %1$d%%</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s ЕД</string>
-    <string name="journal_eiob_display_title">Показывать эффективный IOB (eIOB)</string>
-    <string name="journal_eiob_display_desc">Показывать инсулин с поправкой на активность рядом с IOB</string>
+    <string name="journal_eiob_display_title">Эффективный IOB (eIOB)</string>
+    <string name="journal_eiob_display_desc">Показывать инсулин с учётом активности рядом с IOB</string>
     <string name="journal_iob_expanded">Остаточный IoB: %1$s ЕД</string>
     <string name="journal_eiob_expanded">Действующий eIoB: %1$s ЕД</string>
     <string name="journal_dashboard_quickadd_title">Быстрое добавление на главной</string>

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -1630,9 +1630,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="state_dose_hint_desc">Предлагать углеводы при снижении и коррекцию при высоких значениях</string>
     <string name="state_dose_hint_in_range_title">Разрешить коррекции в целевом диапазоне</string>
     <string name="state_dose_hint_in_range_desc">Разрешать коррекции выше целевого значения дозы, пока показатель ещё в диапазоне</string>
-    <string name="journal_model_suggestions_section">Подсказки</string>
-    <string name="journal_model_desc">Профиль, усвоение и активный инсулин</string>
-    <string name="journal_model_title">Модель</string>
+    <string name="journal_calculations_suggestions_section">Подсказки</string>
+    <string name="journal_calculations_desc">Профиль, усвоение, активный инсулин и подсказки дозы</string>
+    <string name="journal_calculations_title">Расчёты</string>
     <string name="state_dose_hint_horizon">Горизонт подсказки</string>
     <string name="state_dose_hint_horizon_explanation">Насколько далеко вперёд смотрит углеводное предложение при падении значения. Короче — позже и реже, длиннее — раньше и чаще.</string>
     <string name="state_dose_hint_profile_notice_title">Проверьте профиль модели</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1863,9 +1863,9 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="state_dose_hint_desc">Ku soo jeedi karbohaydrayt marka hoos u dhacayo iyo sixid marka sarreeyo</string>
     <string name="state_dose_hint_in_range_title">Oggolow sixid gudaha inta la beegsanayo</string>
     <string name="state_dose_hint_in_range_desc">Oggolow sixid ka sarreysa bartilmaameedka qiyaasta inta qiimuhu weli gudaha yahay</string>
-    <string name="journal_model_suggestions_section">Talooyin</string>
-    <string name="journal_model_desc">Astaan, nuugis iyo insulin firfircoon</string>
-    <string name="journal_model_title">Qaab</string>
+    <string name="journal_calculations_suggestions_section">Talooyin</string>
+    <string name="journal_calculations_desc">Astaan, nuugis, insulin firfircoon iyo talooyinka qiyaasta</string>
+    <string name="journal_calculations_title">Xisaabinta</string>
     <string name="state_dose_hint_horizon">Muddada talada</string>
     <string name="state_dose_hint_horizon_explanation">Inta ay talada kaarbohaydraytku hore u fiiriso marka qiimuhu hoos u dhacayo. Gaaban: goor dambe oo yar; dheer: goor hore oo badan.</string>
     <string name="state_dose_hint_profile_notice_title">Hubi astaanta modelka</string>

--- a/Common/src/main/res/values-so/strings.xml
+++ b/Common/src/main/res/values-so/strings.xml
@@ -1859,10 +1859,13 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="predictive_absorption_value">%1$.0f g/saacaddii</string>
     <string name="predictive_dose_target">Bartilmaameedka qiyaasta</string>
     <string name="predictive_dose_target_explanation">Talooyinka insuliinta iyo kaarbohaydraytka waxay saxaan ilaa qiimahan. Wuu ka duwan yahay xadka bartilmaameedka ee garaafka lagu muujiyay.</string>
-    <string name="state_dose_hint_title">Talo qiyaas ah</string>
-    <string name="state_dose_hint_desc">Waxay soo jeedisaa kaarbohaydrayt marka qiimuhu ku sii socdo hoosta bartilmaameedka qiyaasta, iyo saxid marka uu sarreeyo oo aanu hoos u dhacayn. Insuliinta jirka ku hadhay waa laga jaraa; xisaabinta waa la samayn karaa xitaa marka IOB uu eber yahay. Tirooyinka waxaa laga xisaabiyaa dareenka iyo saamiga kaarbohaydraytka ee astaanta modelka; marka hore dejiso.</string>
-    <string name="state_dose_hint_in_range_title">Saxid xitaa qaybta sare ee xadka</string>
-    <string name="state_dose_hint_in_range_desc">Waxay sidoo kale soo jeedisaa saxid marka qiimuhu si cad uga sarreeyo bartilmaameedka qiyaasta oo uu halkaas ku sii jiro. Kaarbohaydrayt aan la diiwaangelin waxay ka dhigi kartaa xariiqda mid siman iyadoo cuntadu wali nuugmayso, saxiddana way ku soo kordhi lahayd. Tirada waa xisaab ka timid astaantaada, ma aha talo.</string>
+    <string name="state_dose_hint_title">Talooyinka qiyaasta</string>
+    <string name="state_dose_hint_desc">Ku soo jeedi karbohaydrayt marka hoos u dhacayo iyo sixid marka sarreeyo</string>
+    <string name="state_dose_hint_in_range_title">Oggolow sixid gudaha inta la beegsanayo</string>
+    <string name="state_dose_hint_in_range_desc">Oggolow sixid ka sarreysa bartilmaameedka qiyaasta inta qiimuhu weli gudaha yahay</string>
+    <string name="journal_model_suggestions_section">Talooyin</string>
+    <string name="journal_model_desc">Astaan, nuugis iyo insulin firfircoon</string>
+    <string name="journal_model_title">Qaab</string>
     <string name="state_dose_hint_horizon">Muddada talada</string>
     <string name="state_dose_hint_horizon_explanation">Inta ay talada kaarbohaydraytku hore u fiiriso marka qiimuhu hoos u dhacayo. Gaaban: goor dambe oo yar; dheer: goor hore oo badan.</string>
     <string name="state_dose_hint_profile_notice_title">Hubi astaanta modelka</string>
@@ -1874,7 +1877,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="predictive_horizon_value">%1$d daq</string>
     <string name="journal_dose_math_title">Xisaabiyaha qiyaasta</string>
     <string name="journal_food_macros_title">Nuugista cuntada horumarsan</string>
-    <string name="journal_food_macros_desc">U isticmaal borotiinka iyo dufanka ikhtiyaariga ah qalooca cuntada iyo xisaabta qiyaasta daahista</string>
+    <string name="journal_food_macros_desc">Isticmaal borotiinka iyo dufanka nuugista cuntada ee daahda</string>
     <string name="journal_aaps_import_title">Soo deji daawaynta AAPS</string>
     <string name="journal_aaps_import_desc">Hel baahinta daawaynta AAPS oo ku dar insulin iyo karbohaydraytyada joornaalka</string>
     <string name="journal_aaps_carbs_title">karbohaydraytyada AAPS</string>
@@ -1910,7 +1913,7 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="journal_food_save_to_library">Ku keydi maktabadda</string>
     <string name="journal_food_protein_short">%1$s g borotiinka</string>
     <string name="journal_food_fat_short">%1$s g dufan</string>
-    <string name="journal_dose_calculator_desc">Soo jeedi qaddarka insuliinta ama karbohaydraytka ku lammaan iyadoo lagu salaynayo astaanta moodelka iyo insuliinta firfircoon</string>
+    <string name="journal_dose_calculator_desc">Ku soo jeedi insulin ama karbohaydrayt qaabkaaga</string>
     <string name="journal_meal_shape">Qallooca cuntada</string>
     <string name="journal_meal_shape_fast">Degdeg ah</string>
     <string name="journal_meal_shape_mixed">Isku dhafan</string>
@@ -1947,8 +1950,8 @@ Marka la cadaadiyo OK waxay dhalin doontaa xidhiidh teleefankan oo waxa ay soo b
     <string name="journal_metric_activity_today">Hawsha maanta</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s U</string>
-    <string name="journal_eiob_display_title">Muuji IOB wax ku ool ah (eIOB)</string>
-    <string name="journal_eiob_display_desc">Sidoo kale muuji insuliinta ku salaysan dhaqdhaqaaqa ee jirka ku jirta, kana barbar dhig IOB-ga caadiga ah</string>
+    <string name="journal_eiob_display_title">IOB wax ku ool ah (eIOB)</string>
+    <string name="journal_eiob_display_desc">Muuji insulinta hawlaha lagu hagaajiyey ee IOB dhinaceeda</string>
     <string name="journal_dashboard_quickadd_title">Ku dar degdeg ah dashboard-ka</string>
     <string name="journal_dashboard_quickadd_desc">Muuji badhanka + ee joornaalka</string>
     <string name="journal_quickadd_always_now_title">Isticmaal wakhtiga hadda</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1584,9 +1584,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_dose_target">Målvärde för dos</string>
     <string name="predictive_dose_target_explanation">Insulin- och kolhydratförslag korrigerar mot det här värdet. Det är skilt från målområdet i diagrammet.</string>
     <string name="state_dose_hint_title">Dostips</string>
-    <string name="state_dose_hint_desc">Föreslår kolhydrater när värdet är på väg under dosmålet, och en korrigering när det förblir högt utan att sjunka. Kvarvarande insulin dras av; beräkningen är möjlig även med noll IOB. Mängderna räknas ur känsligheten och kolhydratkvoten i modellprofilen; ställ in dem först.</string>
-    <string name="state_dose_hint_in_range_title">Korrigera även i övre delen av målområdet</string>
-    <string name="state_dose_hint_in_range_desc">Föreslår en korrigering även när värdet ligger klart över dosmålet och blir kvar där. Kolhydrater som inte loggats kan få kurvan att se stillastående ut medan mat fortfarande tas upp, och korrigeringen skulle då läggas ovanpå. Siffran är en uträkning ur din profil, inte en rekommendation.</string>
+    <string name="state_dose_hint_desc">Föreslå kolhydrater vid lågt och korrigeringar vid högt</string>
+    <string name="state_dose_hint_in_range_title">Tillåt korrigeringar inom målområdet</string>
+    <string name="state_dose_hint_in_range_desc">Tillåt korrigeringar över dosmålet medan värdet fortfarande är inom målområdet</string>
+    <string name="journal_model_suggestions_section">Förslag</string>
+    <string name="journal_model_desc">Profil, upptag och aktivt insulin</string>
+    <string name="journal_model_title">Modell</string>
     <string name="state_dose_hint_horizon">Dostipsets horisont</string>
     <string name="state_dose_hint_horizon_explanation">Hur långt fram kolhydratförslaget tittar medan värdet faller. Kortare: senare och mer sällan; längre: tidigare och oftare.</string>
     <string name="state_dose_hint_profile_notice_title">Kontrollera din modellprofil</string>
@@ -1598,7 +1601,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_horizon_value">%1$d min</string>
     <string name="journal_dose_math_title">Dosräknare</string>
     <string name="journal_food_macros_title">Avancerat matupptag</string>
-    <string name="journal_food_macros_desc">Använd valfritt protein och fett för fördröjda matkurer och dosberäkning</string>
+    <string name="journal_food_macros_desc">Använd protein och fett för fördröjt matupptag</string>
     <string name="journal_aaps_import_title">Importera AAPS-behandlingar</string>
     <string name="journal_aaps_import_desc">Ta emot AAPS-behandlingsbroadcasts och lägg till insulin och kolhydrater i journalen</string>
     <string name="journal_aaps_carbs_title">AAPS-kolhydrater</string>
@@ -1634,7 +1637,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_food_save_to_library">Spara i bibliotek</string>
     <string name="journal_food_protein_short">%1$s g protein</string>
     <string name="journal_food_fat_short">%1$s g fett</string>
-    <string name="journal_dose_calculator_desc">Föreslå kopplat insulin eller kolhydrater från modellprofil och aktivt insulin</string>
+    <string name="journal_dose_calculator_desc">Föreslå insulin eller kolhydrater utifrån din modell</string>
     <string name="journal_meal_shape">Måltidskurva</string>
     <string name="journal_meal_shape_fast">Snabb</string>
     <string name="journal_meal_shape_mixed">Blandad</string>
@@ -1672,7 +1675,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_active_now_percent">%1$d%% aktivt</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s E</string>
-    <string name="journal_eiob_display_title">Visa effektivt IOB (eIOB)</string>
+    <string name="journal_eiob_display_title">Effektivt IOB (eIOB)</string>
     <string name="journal_eiob_display_desc">Visa aktivitetsjusterat insulin bredvid IOB</string>
     <string name="journal_iob_expanded">Återstående IoB: %1$s E</string>
     <string name="journal_eiob_expanded">Aktivt eIoB: %1$s E</string>

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -1587,9 +1587,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="state_dose_hint_desc">Föreslå kolhydrater vid lågt och korrigeringar vid högt</string>
     <string name="state_dose_hint_in_range_title">Tillåt korrigeringar inom målområdet</string>
     <string name="state_dose_hint_in_range_desc">Tillåt korrigeringar över dosmålet medan värdet fortfarande är inom målområdet</string>
-    <string name="journal_model_suggestions_section">Förslag</string>
-    <string name="journal_model_desc">Profil, upptag och aktivt insulin</string>
-    <string name="journal_model_title">Modell</string>
+    <string name="journal_calculations_suggestions_section">Förslag</string>
+    <string name="journal_calculations_desc">Profil, upptag, aktivt insulin och dostips</string>
+    <string name="journal_calculations_title">Beräkningar</string>
     <string name="state_dose_hint_horizon">Dostipsets horisont</string>
     <string name="state_dose_hint_horizon_explanation">Hur långt fram kolhydratförslaget tittar medan värdet faller. Kortare: senare och mer sällan; längre: tidigare och oftare.</string>
     <string name="state_dose_hint_profile_notice_title">Kontrollera din modellprofil</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1611,10 +1611,13 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Doz hedefi</string>
     <string name="predictive_dose_target_explanation">İnsülin ve karbonhidrat önerileri bu değere göre düzeltir. Grafikteki hedef aralıktan ayrıdır.</string>
-    <string name="state_dose_hint_title">Doz ipucu</string>
-    <string name="state_dose_hint_desc">Değer doz hedefinin altına doğru giderken karbonhidrat, düşmeden yüksek kalıyorsa düzeltme önerir. Vücuttaki kalan insülin çıkarılır; IOB sıfırken de hesaplama yapılabilir. Miktarlar model profilindeki duyarlılık ve karbonhidrat oranından hesaplanır; önce onları ayarlayın.</string>
-    <string name="state_dose_hint_in_range_title">Hedef aralığın üst kısmında da düzelt</string>
-    <string name="state_dose_hint_in_range_desc">Değer doz hedefinin belirgin şekilde üzerinde durup orada kaldığında da bir düzeltme önerir. Kaydedilmemiş karbonhidratlar, yemek hâlâ emilirken eğriyi durgun gösterebilir; düzeltme o zaman bunun üstüne biner. Sayı profilinizden yapılan bir hesaptır, öneri değildir.</string>
+    <string name="state_dose_hint_title">Doz ipuçları</string>
+    <string name="state_dose_hint_desc">Düşüşte karbonhidrat, yükseklerde düzeltme öner</string>
+    <string name="state_dose_hint_in_range_title">Aralık içinde düzeltmeye izin ver</string>
+    <string name="state_dose_hint_in_range_desc">Değer hâlâ aralıktayken doz hedefinin üzerinde düzeltmeye izin ver</string>
+    <string name="journal_model_suggestions_section">Öneriler</string>
+    <string name="journal_model_desc">Profil, emilim ve aktif insülin</string>
+    <string name="journal_model_title">Model</string>
     <string name="state_dose_hint_horizon">Doz ipucu ufku</string>
     <string name="state_dose_hint_horizon_explanation">Değer düşerken karbonhidrat önerisinin ne kadar ileriye baktığı. Kısa: daha geç ve daha seyrek; uzun: daha erken ve daha sık.</string>
     <string name="state_dose_hint_profile_notice_title">Model profilinizi kontrol edin</string>
@@ -1626,7 +1629,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="predictive_horizon_value">%1$d dk</string>
     <string name="journal_dose_math_title">Doz hesaplayıcı</string>
     <string name="journal_food_macros_title">Gelişmiş yiyecek emilimi</string>
-    <string name="journal_food_macros_desc">Gecikmeli yemek eğrileri ve doz hesabı için isteğe bağlı protein ve yağ kullan</string>
+    <string name="journal_food_macros_desc">Gecikmeli besin emilimi için protein ve yağı kullan</string>
     <string name="journal_aaps_import_title">AAPS tedavilerini içe aktar</string>
     <string name="journal_aaps_import_desc">AAPS tedavi yayınlarını alıp insülin ve karbonhidratı günlüğe ekle</string>
     <string name="journal_aaps_carbs_title">AAPS karbonhidratı</string>
@@ -1662,7 +1665,7 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="journal_food_save_to_library">Kitaplığa kaydet</string>
     <string name="journal_food_protein_short">%1$s g protein</string>
     <string name="journal_food_fat_short">%1$s g yağ</string>
-    <string name="journal_dose_calculator_desc">Model profili ve aktif insülinden eşleşen insülin veya karbonhidrat öner</string>
+    <string name="journal_dose_calculator_desc">Modelinize göre insülin veya karbonhidrat öner</string>
     <string name="journal_meal_shape">Öğün eğrisi</string>
     <string name="journal_meal_shape_fast">Hızlı</string>
     <string name="journal_meal_shape_mixed">Karışık</string>
@@ -1700,8 +1703,8 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="journal_active_now_percent">%1$d%% aktif</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s Ü</string>
-    <string name="journal_eiob_display_title">Etkin IOB’yi (eIOB) göster</string>
-    <string name="journal_eiob_display_desc">Etkinliğe göre ayarlanmış insülini IOB’nin yanında göster</string>
+    <string name="journal_eiob_display_title">Etkin IOB (eIOB)</string>
+    <string name="journal_eiob_display_desc">Aktiviteye göre ayarlanmış insülini IOB yanında göster</string>
     <string name="journal_iob_expanded">Kalan IoB: %1$s Ü</string>
     <string name="journal_eiob_expanded">Etkin eIoB: %1$s Ü</string>
     <string name="journal_dashboard_quickadd_title">Panoda hızlı ekleme</string>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -1615,9 +1615,9 @@ Tamam\'a basmak bağlantı için QR kod görüntüleyecektir. QR kodu diğer tel
     <string name="state_dose_hint_desc">Düşüşte karbonhidrat, yükseklerde düzeltme öner</string>
     <string name="state_dose_hint_in_range_title">Aralık içinde düzeltmeye izin ver</string>
     <string name="state_dose_hint_in_range_desc">Değer hâlâ aralıktayken doz hedefinin üzerinde düzeltmeye izin ver</string>
-    <string name="journal_model_suggestions_section">Öneriler</string>
-    <string name="journal_model_desc">Profil, emilim ve aktif insülin</string>
-    <string name="journal_model_title">Model</string>
+    <string name="journal_calculations_suggestions_section">Öneriler</string>
+    <string name="journal_calculations_desc">Profil, emilim, aktif insülin ve doz ipuçları</string>
+    <string name="journal_calculations_title">Hesaplamalar</string>
     <string name="state_dose_hint_horizon">Doz ipucu ufku</string>
     <string name="state_dose_hint_horizon_explanation">Değer düşerken karbonhidrat önerisinin ne kadar ileriye baktığı. Kısa: daha geç ve daha seyrek; uzun: daha erken ve daha sık.</string>
     <string name="state_dose_hint_profile_notice_title">Model profilinizi kontrol edin</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1658,10 +1658,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Цільове значення для дози</string>
     <string name="predictive_dose_target_explanation">Рекомендації щодо інсуліну та вуглеводів коригують до цього значення. Воно не пов\'язане з цільовим діапазоном на графіку.</string>
-    <string name="state_dose_hint_title">Підказка щодо дози</string>
-    <string name="state_dose_hint_desc">Пропонує вуглеводи, коли значення йде нижче цілі дозування, і корекцію, коли воно лишається високим і не знижується. Залишковий інсулін віднімається; розрахунок можливий і за нульового IOB. Кількості обчислюються з чутливості та вуглеводного коефіцієнта профілю моделі; спершу задайте їх.</string>
-    <string name="state_dose_hint_in_range_title">Коригувати й у верхній частині діапазону</string>
-    <string name="state_dose_hint_in_range_desc">Пропонує корекцію й тоді, коли значення стоїть помітно вище за ціль дозування й лишається там. Незанесені вуглеводи можуть робити криву рівною, поки їжа ще засвоюється, і корекція тоді ляже зверху. Число, це розрахунок із профілю, а не рекомендація.</string>
+    <string name="state_dose_hint_title">Підказки дози</string>
+    <string name="state_dose_hint_desc">Пропонувати вуглеводи при зниженні та корекцію при високих значеннях</string>
+    <string name="state_dose_hint_in_range_title">Дозволити корекції в цільовому діапазоні</string>
+    <string name="state_dose_hint_in_range_desc">Дозволяти корекції вище цільового значення дози, поки показник ще в діапазоні</string>
+    <string name="journal_model_suggestions_section">Підказки</string>
+    <string name="journal_model_desc">Профіль, засвоєння та активний інсулін</string>
+    <string name="journal_model_title">Модель</string>
     <string name="state_dose_hint_horizon">Горизонт підказки</string>
     <string name="state_dose_hint_horizon_explanation">Наскільки далеко вперед дивиться вуглеводна пропозиція, поки значення падає. Коротше — пізніше й рідше, довше — раніше й частіше.</string>
     <string name="state_dose_hint_profile_notice_title">Перевірте профіль моделі</string>
@@ -1673,7 +1676,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_horizon_value">%1$d хв</string>
     <string name="journal_dose_math_title">Калькулятор дози</string>
     <string name="journal_food_macros_title">Розширене засвоєння їжі</string>
-    <string name="journal_food_macros_desc">Ураховувати білки й жири для пізньої харчової кривої та розрахунку дози</string>
+    <string name="journal_food_macros_desc">Враховувати білки та жири для сповільненого засвоєння їжі</string>
     <string name="journal_aaps_import_title">Імпорт терапії AAPS</string>
     <string name="journal_aaps_import_desc">Приймати трансляції терапії AAPS і додавати інсулін та вуглеводи до журналу</string>
     <string name="journal_aaps_carbs_title">Вуглеводи AAPS</string>
@@ -1709,7 +1712,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_food_save_to_library">Зберегти в базу</string>
     <string name="journal_food_protein_short">%1$s г білка</string>
     <string name="journal_food_fat_short">%1$s г жиру</string>
-    <string name="journal_dose_calculator_desc">Пропонувати парний інсулін або вуглеводи з профілю моделі та активного інсуліну</string>
+    <string name="journal_dose_calculator_desc">Пропонувати інсулін або вуглеводи за вашою моделлю</string>
     <string name="journal_meal_shape">Крива їжі</string>
     <string name="journal_meal_shape_fast">Швидко</string>
     <string name="journal_meal_shape_mixed">Змішана</string>
@@ -1747,8 +1750,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_active_now_percent">Активно %1$d%%</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s ОД</string>
-    <string name="journal_eiob_display_title">Показувати ефективний IOB (eIOB)</string>
-    <string name="journal_eiob_display_desc">Показувати інсулін із поправкою на активність поруч з IOB</string>
+    <string name="journal_eiob_display_title">Ефективний IOB (eIOB)</string>
+    <string name="journal_eiob_display_desc">Показувати інсулін з урахуванням активності поруч з IOB</string>
     <string name="journal_iob_expanded">Залишковий IoB: %1$s ОД</string>
     <string name="journal_eiob_expanded">Діючий eIoB: %1$s ОД</string>
     <string name="journal_dashboard_quickadd_title">Швидке додавання на головній</string>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -1662,9 +1662,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="state_dose_hint_desc">Пропонувати вуглеводи при зниженні та корекцію при високих значеннях</string>
     <string name="state_dose_hint_in_range_title">Дозволити корекції в цільовому діапазоні</string>
     <string name="state_dose_hint_in_range_desc">Дозволяти корекції вище цільового значення дози, поки показник ще в діапазоні</string>
-    <string name="journal_model_suggestions_section">Підказки</string>
-    <string name="journal_model_desc">Профіль, засвоєння та активний інсулін</string>
-    <string name="journal_model_title">Модель</string>
+    <string name="journal_calculations_suggestions_section">Підказки</string>
+    <string name="journal_calculations_desc">Профіль, засвоєння, активний інсулін і підказки дози</string>
+    <string name="journal_calculations_title">Розрахунки</string>
     <string name="state_dose_hint_horizon">Горизонт підказки</string>
     <string name="state_dose_hint_horizon_explanation">Наскільки далеко вперед дивиться вуглеводна пропозиція, поки значення падає. Коротше — пізніше й рідше, довше — раніше й частіше.</string>
     <string name="state_dose_hint_profile_notice_title">Перевірте профіль моделі</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1603,9 +1603,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="state_dose_hint_desc">偏低时建议碳水，偏高时建议校正</string>
     <string name="state_dose_hint_in_range_title">允许范围内校正</string>
     <string name="state_dose_hint_in_range_desc">血糖仍在范围内但高于剂量目标时也允许校正</string>
-    <string name="journal_model_suggestions_section">建议</string>
-    <string name="journal_model_desc">配置、吸收与活性胰岛素</string>
-    <string name="journal_model_title">模型</string>
+    <string name="journal_calculations_suggestions_section">建议</string>
+    <string name="journal_calculations_desc">配置、吸收、活性胰岛素与剂量提示</string>
+    <string name="journal_calculations_title">计算</string>
     <string name="state_dose_hint_horizon">剂量提示前瞻时长</string>
     <string name="state_dose_hint_horizon_explanation">血糖下降时碳水建议向前看多远。越短越晚提示、提示越少；越长越早提示、提示越多。</string>
     <string name="state_dose_hint_profile_notice_title">检查模型配置</string>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -1600,9 +1600,12 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_dose_target">剂量目标</string>
     <string name="predictive_dose_target_explanation">胰岛素和碳水化合物建议以此数值为校正目标。它与图表上显示的目标范围无关。</string>
     <string name="state_dose_hint_title">剂量提示</string>
-    <string name="state_dose_hint_desc">当血糖正走向剂量目标以下时建议碳水，当血糖持续偏高且没有下降时建议校正。计算会减去体内剩余胰岛素，IOB 为零时也可计算。数值由模型配置中的敏感系数和碳水系数算出，请先设好它们。</string>
-    <string name="state_dose_hint_in_range_title">在目标区间上半段也校正</string>
-    <string name="state_dose_hint_in_range_desc">当血糖明显高于剂量目标并持续不降时，也给出校正建议。未记录的碳水可能让曲线看起来平稳，而食物其实仍在吸收，校正就会叠加上去。这个数字是按你的配置算出来的，不是医嘱。</string>
+    <string name="state_dose_hint_desc">偏低时建议碳水，偏高时建议校正</string>
+    <string name="state_dose_hint_in_range_title">允许范围内校正</string>
+    <string name="state_dose_hint_in_range_desc">血糖仍在范围内但高于剂量目标时也允许校正</string>
+    <string name="journal_model_suggestions_section">建议</string>
+    <string name="journal_model_desc">配置、吸收与活性胰岛素</string>
+    <string name="journal_model_title">模型</string>
     <string name="state_dose_hint_horizon">剂量提示前瞻时长</string>
     <string name="state_dose_hint_horizon_explanation">血糖下降时碳水建议向前看多远。越短越晚提示、提示越少；越长越早提示、提示越多。</string>
     <string name="state_dose_hint_profile_notice_title">检查模型配置</string>
@@ -1614,7 +1617,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_horizon_value">%1$d 分钟</string>
     <string name="journal_dose_math_title">剂量计算器</string>
     <string name="journal_food_macros_title">高级食物吸收</string>
-    <string name="journal_food_macros_desc">使用可选蛋白质和脂肪计算延迟食物曲线与剂量</string>
+    <string name="journal_food_macros_desc">使用蛋白质和脂肪计算延迟的食物吸收</string>
     <string name="journal_aaps_import_title">导入 AAPS 治疗</string>
     <string name="journal_aaps_import_desc">接收 AAPS 治疗广播，并将胰岛素和碳水添加到日志</string>
     <string name="journal_aaps_carbs_title">AAPS 碳水</string>
@@ -1650,7 +1653,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_food_save_to_library">保存到食物库</string>
     <string name="journal_food_protein_short">%1$s 克蛋白质</string>
     <string name="journal_food_fat_short">%1$s 克脂肪</string>
-    <string name="journal_dose_calculator_desc">根据模型配置和活性胰岛素建议配对的胰岛素或碳水</string>
+    <string name="journal_dose_calculator_desc">根据你的模型建议胰岛素或碳水</string>
     <string name="journal_meal_shape">餐食曲线</string>
     <string name="journal_meal_shape_fast">快速</string>
     <string name="journal_meal_shape_mixed">混合</string>
@@ -1688,8 +1691,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_active_now_percent">%1$d%% 活跃</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s U</string>
-    <string name="journal_eiob_display_title">显示有效 IOB (eIOB)</string>
-    <string name="journal_eiob_display_desc">在 IOB 旁显示活动校正后的胰岛素</string>
+    <string name="journal_eiob_display_title">有效 IOB（eIOB）</string>
+    <string name="journal_eiob_display_desc">在 IOB 旁显示按活动调整的胰岛素</string>
     <string name="journal_iob_expanded">剩余 IoB：%1$s U</string>
     <string name="journal_eiob_expanded">有效 eIoB：%1$s U</string>
     <string name="journal_dashboard_quickadd_title">在仪表板快速添加</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2078,10 +2078,13 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_absorption_value">%1$.0f g/h</string>
     <string name="predictive_dose_target">Dose target</string>
     <string name="predictive_dose_target_explanation">Insulin and carb suggestions correct toward this value. It is separate from the in-range band shown on the chart.</string>
-    <string name="state_dose_hint_title">Dose hint</string>
-    <string name="state_dose_hint_desc">Suggests carbs when the value is heading below the dose target, and a correction when it stays high without falling. Any insulin on board is subtracted; zero IOB is allowed. The amounts are computed from the sensitivity and carb ratio in the model profile, so set those first.</string>
-    <string name="state_dose_hint_in_range_title">Correct inside the target range</string>
-    <string name="state_dose_hint_in_range_desc">Also suggests a correction when the value sits well above the dose target and holds there. Carbs that were not logged can make a trace look settled while food is still being absorbed, and the correction would land on top of that. The figure is a calculation from your profile, not a recommendation.</string>
+    <string name="state_dose_hint_title">Dose hints</string>
+    <string name="state_dose_hint_desc">Suggest carbs for lows and corrections for highs</string>
+    <string name="state_dose_hint_in_range_title">Allow in-range corrections</string>
+    <string name="state_dose_hint_in_range_desc">Allow corrections above the dose target while still in range</string>
+    <string name="journal_model_suggestions_section">Suggestions</string>
+    <string name="journal_model_desc">Profile, absorption and active insulin</string>
+    <string name="journal_model_title">Model</string>
     <string name="state_dose_hint_horizon">Dose hint horizon</string>
     <string name="state_dose_hint_horizon_explanation">How far ahead the carb suggestion looks while the value is falling. Shorter reacts later and says less; longer reacts earlier and says more.</string>
     <string name="state_dose_hint_profile_notice_title">Check your model profile</string>
@@ -2093,7 +2096,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="predictive_horizon_value">%1$d min</string>
     <string name="journal_dose_math_title">Dose calculator</string>
     <string name="journal_food_macros_title">Advanced food absorption</string>
-    <string name="journal_food_macros_desc">Use optional protein and fat for delayed food curves and dose math</string>
+    <string name="journal_food_macros_desc">Use protein and fat for delayed food absorption</string>
     <string name="journal_aaps_import_title">Import AAPS treatments</string>
     <string name="journal_aaps_import_desc">Receive AAPS treatment broadcasts and add insulin and carbs to the journal</string>
     <string name="journal_aaps_carbs_title">AAPS carbs</string>
@@ -2129,7 +2132,7 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_food_save_to_library">Save to library</string>
     <string name="journal_food_protein_short">%1$s g protein</string>
     <string name="journal_food_fat_short">%1$s g fat</string>
-    <string name="journal_dose_calculator_desc">Suggest paired insulin or carbs from model profile and active insulin</string>
+    <string name="journal_dose_calculator_desc">Suggest insulin or carbs using your model</string>
     <string name="journal_meal_shape">Meal curve</string>
     <string name="journal_meal_shape_fast">Fast</string>
     <string name="journal_meal_shape_mixed">Mixed</string>
@@ -2168,8 +2171,8 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="journal_active_now_percent">%1$d%% active</string>
     <string name="journal_metric_iob">IOB</string>
     <string name="journal_metric_eiob">eIOB %1$s U</string>
-    <string name="journal_eiob_display_title">Show effective IOB (eIOB)</string>
-    <string name="journal_eiob_display_desc">Show activity-based insulin next to IOB</string>
+    <string name="journal_eiob_display_title">Effective IOB (eIOB)</string>
+    <string name="journal_eiob_display_desc">Show activity-adjusted insulin next to IOB</string>
     <string name="journal_dashboard_quickadd_title">Dashboard quick add</string>
     <string name="journal_dashboard_quickadd_desc">Show the Journal + button</string>
     <string name="journal_quickadd_always_now_title">Use the current time</string>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -2082,9 +2082,9 @@ Pressing OK will generate a connection on this phone and display a QR code that 
     <string name="state_dose_hint_desc">Suggest carbs for lows and corrections for highs</string>
     <string name="state_dose_hint_in_range_title">Allow in-range corrections</string>
     <string name="state_dose_hint_in_range_desc">Allow corrections above the dose target while still in range</string>
-    <string name="journal_model_suggestions_section">Suggestions</string>
-    <string name="journal_model_desc">Profile, absorption and active insulin</string>
-    <string name="journal_model_title">Model</string>
+    <string name="journal_calculations_suggestions_section">Suggestions</string>
+    <string name="journal_calculations_desc">Profile, absorption, active insulin and dose hints</string>
+    <string name="journal_calculations_title">Calculations</string>
     <string name="state_dose_hint_horizon">Dose hint horizon</string>
     <string name="state_dose_hint_horizon_explanation">How far ahead the carb suggestion looks while the value is falling. Shorter reacts later and says less; longer reacts earlier and says more.</string>
     <string name="state_dose_hint_profile_notice_title">Check your model profile</string>

--- a/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
@@ -79,7 +79,7 @@ import tk.glucodata.ui.journal.JournalDoseProfile
 import tk.glucodata.ui.journal.JournalEntrySheet
 import tk.glucodata.ui.journal.JournalFoodLibraryScreen
 import tk.glucodata.ui.journal.JournalInsulinLibraryScreen
-import tk.glucodata.ui.journal.JournalModelSettingsScreen
+import tk.glucodata.ui.journal.JournalCalculationsSettingsScreen
 import tk.glucodata.ui.journal.JournalScreen
 import tk.glucodata.ui.journal.JournalSettingsScreen
 import tk.glucodata.ui.viewmodel.DashboardViewModel
@@ -909,7 +909,7 @@ fun MainApp(themeMode: ThemeMode, onThemeChanged: (ThemeMode) -> Unit) {
                     composable("settings/alerts") { tk.glucodata.ui.alerts.AlertSettingsScreen(navController) }
                     composable("settings/alerts/talker") { tk.glucodata.ui.alerts.TalkerSettingsScreen(navController) }
                     composable("settings/journal") { JournalSettingsScreen(navController, dashboardViewModel) }
-                    composable("settings/journal/model") { JournalModelSettingsScreen(navController, dashboardViewModel) }
+                    composable("settings/journal/calculations") { JournalCalculationsSettingsScreen(navController, dashboardViewModel) }
                     composable("settings/journal/history") {
                         JournalSettingsHistoryRoute(
                             dashboardViewModel = dashboardViewModel,
@@ -1064,7 +1064,7 @@ fun MainApp(themeMode: ThemeMode, onThemeChanged: (ThemeMode) -> Unit) {
                 composable("settings/alerts") { tk.glucodata.ui.alerts.AlertSettingsScreen(navController) }
                 composable("settings/alerts/talker") { tk.glucodata.ui.alerts.TalkerSettingsScreen(navController) }
                 composable("settings/journal") { JournalSettingsScreen(navController, dashboardViewModel) }
-                composable("settings/journal/model") { JournalModelSettingsScreen(navController, dashboardViewModel) }
+                composable("settings/journal/calculations") { JournalCalculationsSettingsScreen(navController, dashboardViewModel) }
                 composable("settings/journal/history") {
                     JournalSettingsHistoryRoute(
                         dashboardViewModel = dashboardViewModel,

--- a/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/MainNavigation.kt
@@ -79,6 +79,7 @@ import tk.glucodata.ui.journal.JournalDoseProfile
 import tk.glucodata.ui.journal.JournalEntrySheet
 import tk.glucodata.ui.journal.JournalFoodLibraryScreen
 import tk.glucodata.ui.journal.JournalInsulinLibraryScreen
+import tk.glucodata.ui.journal.JournalModelSettingsScreen
 import tk.glucodata.ui.journal.JournalScreen
 import tk.glucodata.ui.journal.JournalSettingsScreen
 import tk.glucodata.ui.viewmodel.DashboardViewModel
@@ -908,6 +909,7 @@ fun MainApp(themeMode: ThemeMode, onThemeChanged: (ThemeMode) -> Unit) {
                     composable("settings/alerts") { tk.glucodata.ui.alerts.AlertSettingsScreen(navController) }
                     composable("settings/alerts/talker") { tk.glucodata.ui.alerts.TalkerSettingsScreen(navController) }
                     composable("settings/journal") { JournalSettingsScreen(navController, dashboardViewModel) }
+                    composable("settings/journal/model") { JournalModelSettingsScreen(navController, dashboardViewModel) }
                     composable("settings/journal/history") {
                         JournalSettingsHistoryRoute(
                             dashboardViewModel = dashboardViewModel,
@@ -1062,6 +1064,7 @@ fun MainApp(themeMode: ThemeMode, onThemeChanged: (ThemeMode) -> Unit) {
                 composable("settings/alerts") { tk.glucodata.ui.alerts.AlertSettingsScreen(navController) }
                 composable("settings/alerts/talker") { tk.glucodata.ui.alerts.TalkerSettingsScreen(navController) }
                 composable("settings/journal") { JournalSettingsScreen(navController, dashboardViewModel) }
+                composable("settings/journal/model") { JournalModelSettingsScreen(navController, dashboardViewModel) }
                 composable("settings/journal/history") {
                     JournalSettingsHistoryRoute(
                         dashboardViewModel = dashboardViewModel,

--- a/Common/src/mobile/java/tk/glucodata/ui/PredictionModelProfileScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/PredictionModelProfileScreen.kt
@@ -50,10 +50,8 @@ import tk.glucodata.R
 import tk.glucodata.data.prediction.DoseTarget
 import tk.glucodata.data.prediction.PredictionModelBlock
 import tk.glucodata.data.prediction.PredictionModelProfile
-import tk.glucodata.data.prediction.StateDoseHintCalculator
 import tk.glucodata.ui.util.GlucoseFormatter
 import tk.glucodata.ui.viewmodel.DashboardViewModel
-import kotlin.math.roundToInt
 
 private data class ProfileTimePickerRequest(
     val existingStartMinute: Int?,
@@ -68,8 +66,6 @@ fun PredictionModelProfileScreen(
     val profile by viewModel.predictionModelProfile.collectAsState()
     val unit by viewModel.unit.collectAsState()
     val doseTargetMgDl by viewModel.predictionDoseTargetMgDl.collectAsState()
-    val stateDoseHintEnabled by viewModel.stateDoseHintEnabled.collectAsState()
-    val stateDoseHintHorizonMinutes by viewModel.stateDoseHintHorizonMinutes.collectAsState()
     val isMmol = GlucoseFormatter.isMmol(unit)
     var timePickerRequest by remember { mutableStateOf<ProfileTimePickerRequest?>(null) }
     var pendingDeleteStart by remember { mutableStateOf<Int?>(null) }
@@ -108,17 +104,6 @@ fun PredictionModelProfileScreen(
                         )
                     }
                 )
-            }
-
-            // Only while the hint is on: with it off the number steers nothing, and the
-            // screen is long enough already.
-            if (stateDoseHintEnabled) {
-                item(key = "dose_hint_horizon") {
-                    DoseHintHorizonCard(
-                        horizonMinutes = stateDoseHintHorizonMinutes,
-                        onHorizonChange = { viewModel.setStateDoseHintHorizonMinutes(it.roundToInt()) }
-                    )
-                }
             }
 
             item(key = "explanation") {
@@ -279,40 +264,6 @@ private fun DoseTargetCard(
             )
             Text(
                 text = stringResource(R.string.predictive_dose_target_explanation),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(bottom = 8.dp)
-            )
-        }
-    }
-}
-
-/**
- * How far ahead the falling case looks. Its own card under the dose target: it belongs to
- * the same decision, but it is a duration rather than a glucose value.
- */
-@Composable
-private fun DoseHintHorizonCard(
-    horizonMinutes: Int,
-    onHorizonChange: (Float) -> Unit
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHigh
-    ) {
-        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)) {
-            PredictiveSimulationParameterRow(
-                title = stringResource(R.string.state_dose_hint_horizon),
-                valueLabel = stringResource(R.string.predictive_horizon_value, horizonMinutes),
-                value = horizonMinutes.toFloat(),
-                valueRange = StateDoseHintCalculator.HORIZON_MINUTES_MIN.toFloat()..
-                    StateDoseHintCalculator.HORIZON_MINUTES_MAX.toFloat(),
-                enabled = true,
-                onValueChange = onHorizonChange
-            )
-            Text(
-                text = stringResource(R.string.state_dose_hint_horizon_explanation),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(bottom = 8.dp)

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCalculationsSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalCalculationsSettingsScreen.kt
@@ -49,14 +49,14 @@ import tk.glucodata.ui.viewmodel.DashboardViewModel
 import kotlin.math.roundToInt
 
 /**
- * The metabolic model and the features that read it. The profile (carb ratio, sensitivity,
- * absorption, dose target) is the source of parameters; the dose calculator, dose hints,
- * IOB/eIOB and food absorption all consume it. Journal setup keeps only the journal-facing
- * switches and links here for everything model-shaped.
+ * Everything computed from the model profile: the profile itself (carb ratio, sensitivity,
+ * absorption, dose target) is the source of parameters, and food absorption, IOB/eIOB and
+ * the dose hints all read it. Journal setup keeps only the journal-facing switches and
+ * links here for the rest.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun JournalModelSettingsScreen(
+fun JournalCalculationsSettingsScreen(
     navController: NavController,
     viewModel: DashboardViewModel
 ) {
@@ -72,7 +72,7 @@ fun JournalModelSettingsScreen(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.journal_model_title)) },
+                title = { Text(stringResource(R.string.journal_calculations_title)) },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(
@@ -139,7 +139,7 @@ fun JournalModelSettingsScreen(
 
             item(key = "suggestions") {
                 Column {
-                    SectionLabel(text = stringResource(R.string.journal_model_suggestions_section), topPadding = 8.dp)
+                    SectionLabel(text = stringResource(R.string.journal_calculations_suggestions_section), topPadding = 8.dp)
                     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                         SettingsSwitchItem(
                             title = stringResource(R.string.state_dose_hint_title),

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalModelSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalModelSettingsScreen.kt
@@ -1,0 +1,216 @@
+package tk.glucodata.ui.journal
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CenterFocusStrong
+import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.TipsAndUpdates
+import androidx.compose.material.icons.filled.Vaccines
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import tk.glucodata.R
+import tk.glucodata.data.prediction.StateDoseHintCalculator
+import tk.glucodata.ui.PredictiveSimulationParameterRow
+import tk.glucodata.ui.components.CardPosition
+import tk.glucodata.ui.components.SectionLabel
+import tk.glucodata.ui.components.SettingsItem
+import tk.glucodata.ui.components.SettingsSwitchItem
+import tk.glucodata.ui.components.cardShape
+import tk.glucodata.ui.viewmodel.DashboardViewModel
+import kotlin.math.roundToInt
+
+/**
+ * The metabolic model and the features that read it. The profile (carb ratio, sensitivity,
+ * absorption, dose target) is the source of parameters; the dose calculator, dose hints,
+ * IOB/eIOB and food absorption all consume it. Journal setup keeps only the journal-facing
+ * switches and links here for everything model-shaped.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun JournalModelSettingsScreen(
+    navController: NavController,
+    viewModel: DashboardViewModel
+) {
+    val journalEnabled by viewModel.journalEnabled.collectAsState()
+    val predictionModelProfile by viewModel.predictionModelProfile.collectAsState()
+    val journalFoodMacrosEnabled by viewModel.journalFoodMacrosEnabled.collectAsState()
+    val journalEiobDisplayEnabled by viewModel.journalEiobDisplayEnabled.collectAsState()
+    val stateDoseHintEnabled by viewModel.stateDoseHintEnabled.collectAsState()
+    val stateDoseHintCorrectInRange by viewModel.stateDoseHintCorrectInRange.collectAsState()
+    val stateDoseHintHorizonMinutes by viewModel.stateDoseHintHorizonMinutes.collectAsState()
+
+    Scaffold(
+        contentWindowInsets = WindowInsets(0.dp),
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.journal_model_title)) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.navigate_back)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 28.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            item(key = "model") {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    SettingsItem(
+                        title = stringResource(R.string.predictive_model_tuning),
+                        subtitle = if (predictionModelProfile.blocks.size == 1) {
+                            stringResource(R.string.predictive_model_profile_summary_single)
+                        } else {
+                            stringResource(
+                                R.string.predictive_model_profile_summary_count,
+                                predictionModelProfile.blocks.size
+                            )
+                        },
+                        showArrow = true,
+                        onClick = if (journalEnabled) {
+                            { navController.navigate("settings/predictive-simulation/model-profile") }
+                        } else {
+                            null
+                        },
+                        icon = Icons.Default.Schedule,
+                        iconTint = MaterialTheme.colorScheme.primary,
+                        position = CardPosition.TOP
+                    )
+                    SettingsSwitchItem(
+                        title = stringResource(R.string.journal_food_macros_title),
+                        subtitle = stringResource(R.string.journal_food_macros_desc),
+                        checked = journalFoodMacrosEnabled,
+                        onCheckedChange = { viewModel.setJournalFoodMacrosEnabled(it) },
+                        icon = Icons.Default.Restaurant,
+                        iconTint = MaterialTheme.colorScheme.secondary,
+                        position = CardPosition.MIDDLE,
+                        enabled = journalEnabled
+                    )
+                    SettingsSwitchItem(
+                        title = stringResource(R.string.journal_eiob_display_title),
+                        subtitle = stringResource(R.string.journal_eiob_display_desc),
+                        checked = journalEiobDisplayEnabled,
+                        onCheckedChange = { viewModel.setJournalEiobDisplayEnabled(it) },
+                        icon = Icons.Default.Vaccines,
+                        iconTint = MaterialTheme.colorScheme.tertiary,
+                        position = CardPosition.BOTTOM,
+                        enabled = journalEnabled
+                    )
+                }
+            }
+
+            item(key = "suggestions") {
+                Column {
+                    SectionLabel(text = stringResource(R.string.journal_model_suggestions_section), topPadding = 8.dp)
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        SettingsSwitchItem(
+                            title = stringResource(R.string.state_dose_hint_title),
+                            subtitle = stringResource(R.string.state_dose_hint_desc),
+                            checked = stateDoseHintEnabled,
+                            onCheckedChange = { viewModel.setStateDoseHintEnabled(it) },
+                            icon = Icons.Default.TipsAndUpdates,
+                            iconTint = MaterialTheme.colorScheme.primary,
+                            position = CardPosition.TOP,
+                            enabled = journalEnabled
+                        )
+                        SettingsSwitchItem(
+                            title = stringResource(R.string.state_dose_hint_in_range_title),
+                            subtitle = stringResource(R.string.state_dose_hint_in_range_desc),
+                            checked = stateDoseHintCorrectInRange,
+                            onCheckedChange = { viewModel.setStateDoseHintCorrectInRange(it) },
+                            icon = Icons.Default.CenterFocusStrong,
+                            iconTint = MaterialTheme.colorScheme.secondary,
+                            position = if (stateDoseHintEnabled) CardPosition.MIDDLE else CardPosition.BOTTOM,
+                            enabled = journalEnabled && stateDoseHintEnabled
+                        )
+                        // The horizon only steers the falling case, so it hides with the hint.
+                        AnimatedVisibility(
+                            visible = stateDoseHintEnabled,
+                            enter = fadeIn() + expandVertically(),
+                            exit = fadeOut() + shrinkVertically()
+                        ) {
+                            DoseHintHorizonItem(
+                                horizonMinutes = stateDoseHintHorizonMinutes,
+                                enabled = journalEnabled,
+                                onHorizonChange = { viewModel.setStateDoseHintHorizonMinutes(it.roundToInt()) }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * How far ahead the carb hint looks while the value is falling. Sits as the last row of the
+ * suggestions group, same shape and colour as the switches above it.
+ */
+@Composable
+private fun DoseHintHorizonItem(
+    horizonMinutes: Int,
+    enabled: Boolean,
+    onHorizonChange: (Float) -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = cardShape(CardPosition.BOTTOM),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+            PredictiveSimulationParameterRow(
+                title = stringResource(R.string.state_dose_hint_horizon),
+                valueLabel = stringResource(R.string.predictive_horizon_value, horizonMinutes),
+                value = horizonMinutes.toFloat(),
+                valueRange = StateDoseHintCalculator.HORIZON_MINUTES_MIN.toFloat()..
+                    StateDoseHintCalculator.HORIZON_MINUTES_MAX.toFloat(),
+                enabled = enabled,
+                onValueChange = onHorizonChange
+            )
+            Text(
+                text = stringResource(R.string.state_dose_hint_horizon_explanation),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
@@ -276,13 +276,13 @@ fun JournalSettingsScreen(
                         enabled = journalEnabled
                     )
                     // The profile, absorption, eIOB and the dose hints all live behind one
-                    // row: they are the model and its readers, not journal tools.
+                    // row: they are calculations on the profile, not journal tools.
                     SettingsItem(
-                        title = stringResource(R.string.journal_model_title),
-                        subtitle = stringResource(R.string.journal_model_desc),
+                        title = stringResource(R.string.journal_calculations_title),
+                        subtitle = stringResource(R.string.journal_calculations_desc),
                         showArrow = true,
                         onClick = if (journalEnabled) {
-                            { navController.navigate("settings/journal/model") }
+                            { navController.navigate("settings/journal/calculations") }
                         } else {
                             null
                         },

--- a/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
+++ b/Common/src/mobile/java/tk/glucodata/ui/journal/JournalSettingsScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.material.icons.automirrored.filled.DirectionsRun
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Calculate
-import androidx.compose.material.icons.filled.CenterFocusStrong
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.EditNote
@@ -52,7 +51,6 @@ import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Schedule
-import androidx.compose.material.icons.filled.TipsAndUpdates
 import androidx.compose.material.icons.filled.Vaccines
 import androidx.compose.material.icons.filled.History
 
@@ -171,16 +169,11 @@ fun JournalSettingsScreen(
     val journalEnabled by viewModel.journalEnabled.collectAsState()
     val journalNavigationTabEnabled by viewModel.journalNavigationTabEnabled.collectAsState()
     val journalDoseCalculatorEnabled by viewModel.journalDoseCalculatorEnabled.collectAsState()
-    val stateDoseHintEnabled by viewModel.stateDoseHintEnabled.collectAsState()
-    val stateDoseHintCorrectInRange by viewModel.stateDoseHintCorrectInRange.collectAsState()
-    val journalFoodMacrosEnabled by viewModel.journalFoodMacrosEnabled.collectAsState()
     val journalFoodLibraryEnabled by viewModel.journalFoodLibraryEnabled.collectAsState()
-    val journalEiobDisplayEnabled by viewModel.journalEiobDisplayEnabled.collectAsState()
     val journalQuickAddAlwaysNow by viewModel.journalQuickAddAlwaysNow.collectAsState()
     val journalDashboardQuickAddButton by viewModel.journalDashboardQuickAddButton.collectAsState()
     val journalHealthConnectActivityEnabled by viewModel.journalHealthConnectActivityEnabled.collectAsState()
     val aapsJournalImportEnabled by viewModel.aapsJournalImportEnabled.collectAsState()
-    val predictionModelProfile by viewModel.predictionModelProfile.collectAsState()
     val allPresets by viewModel.journalInsulinPresets.collectAsState()
     val allFoods by viewModel.journalFoods.collectAsState()
     val activePresets = remember(allPresets) { allPresets.filter { !it.isArchived } }
@@ -282,65 +275,20 @@ fun JournalSettingsScreen(
                         position = CardPosition.TOP,
                         enabled = journalEnabled
                     )
-                    SettingsSwitchItem(
-                        title = stringResource(R.string.state_dose_hint_title),
-                        subtitle = stringResource(R.string.state_dose_hint_desc),
-                        checked = stateDoseHintEnabled,
-                        onCheckedChange = { viewModel.setStateDoseHintEnabled(it) },
-                        icon = Icons.Default.TipsAndUpdates,
-                        iconTint = MaterialTheme.colorScheme.primary,
-                        position = CardPosition.MIDDLE,
-                        enabled = journalEnabled
-                    )
-                    SettingsSwitchItem(
-                        title = stringResource(R.string.state_dose_hint_in_range_title),
-                        subtitle = stringResource(R.string.state_dose_hint_in_range_desc),
-                        checked = stateDoseHintCorrectInRange,
-                        onCheckedChange = { viewModel.setStateDoseHintCorrectInRange(it) },
-                        icon = Icons.Default.CenterFocusStrong,
-                        iconTint = MaterialTheme.colorScheme.secondary,
-                        position = CardPosition.MIDDLE,
-                        enabled = journalEnabled && stateDoseHintEnabled
-                    )
+                    // The profile, absorption, eIOB and the dose hints all live behind one
+                    // row: they are the model and its readers, not journal tools.
                     SettingsItem(
-                        title = stringResource(R.string.predictive_model_tuning),
-                        subtitle = if (predictionModelProfile.blocks.size == 1) {
-                            stringResource(R.string.predictive_model_profile_summary_single)
-                        } else {
-                            stringResource(
-                                R.string.predictive_model_profile_summary_count,
-                                predictionModelProfile.blocks.size
-                            )
-                        },
+                        title = stringResource(R.string.journal_model_title),
+                        subtitle = stringResource(R.string.journal_model_desc),
                         showArrow = true,
                         onClick = if (journalEnabled) {
-                            { navController.navigate("settings/predictive-simulation/model-profile") }
+                            { navController.navigate("settings/journal/model") }
                         } else {
                             null
                         },
                         icon = Icons.Default.Schedule,
                         iconTint = MaterialTheme.colorScheme.secondary,
                         position = CardPosition.MIDDLE
-                    )
-                    SettingsSwitchItem(
-                        title = stringResource(R.string.journal_food_macros_title),
-                        subtitle = stringResource(R.string.journal_food_macros_desc),
-                        checked = journalFoodMacrosEnabled,
-                        onCheckedChange = { viewModel.setJournalFoodMacrosEnabled(it) },
-                        icon = Icons.Default.Restaurant,
-                        iconTint = MaterialTheme.colorScheme.secondary,
-                        position = CardPosition.MIDDLE,
-                        enabled = journalEnabled
-                    )
-                    SettingsSwitchItem(
-                        title = stringResource(R.string.journal_eiob_display_title),
-                        subtitle = stringResource(R.string.journal_eiob_display_desc),
-                        checked = journalEiobDisplayEnabled,
-                        onCheckedChange = { viewModel.setJournalEiobDisplayEnabled(it) },
-                        icon = Icons.Default.Vaccines,
-                        iconTint = MaterialTheme.colorScheme.tertiary,
-                        position = CardPosition.MIDDLE,
-                        enabled = journalEnabled
                     )
                     SettingsItem(
                         title = stringResource(R.string.journal_import_health_activity),


### PR DESCRIPTION
Follow-up to #219. The journal intelligence group had become a metabolic model editor with feature switches interleaved: dose hints, in-range corrections, model profile, food absorption and eIOB all sat beside the dose calculator, and the two hint descriptions ran to five sentences each.

## What changes

**Journal setup** keeps the journal-facing switches — Dose calculator, Health Connect activity import, AAPS import — plus one navigation row:

> **Calculations ›**
> Profile, absorption, active insulin and dose hints

**Calculations** (new `JournalCalculationsSettingsScreen`, route `settings/journal/calculations`):

- Model profile › — period count as subtitle, opens the existing profile screen
- Advanced food absorption — "Use protein and fat for delayed food absorption"
- Effective IOB (eIOB) — "Show activity-adjusted insulin next to IOB"
- **Suggestions**
  - Dose hints — "Suggest carbs for lows and corrections for highs"
  - Allow in-range corrections — "Allow corrections above the dose target while still in range" (disabled with hints off)
  - Dose hint horizon slider (collapses with hints off)

The horizon slider moves here from the model profile screen, which now holds only model parameters (dose target stays there since both readers correct toward it).

The model profile is the source of parameters; the dose calculator, hints, IOB/eIOB and absorption are its readers. "Model" on its own reads as an internal term, so the parent is named for what it holds and "Model profile" keeps its name as the child, where the word has context.

## Strings

Rewritten descriptions are one line each. The eIOB switch is worded as the display toggle it is (`showEiob` only gates the pill). Three new keys and six rewritten ones across all 15 locales.

## Verification

- `:Common:compileMobileDebugKotlin` clean on this branch.
- `tk.glucodata.data.prediction.*` and `tk.glucodata.logic.*` unit tests: 73 passed, 0 failed (no logic changes; UI only).
- Not seen rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
