### PR TITLE
[CRITICAL] Prevent automatic alert acknowledgement and preserve triggering values

### DIFF
--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -2999,15 +2999,8 @@ public class Notify {
                 // Data Prep
                 int glucoseColor = NotificationChartDrawer.getGlucoseColor(Applic.app, glvalue, isMmol);
 
-                // Fetch Native Points for Consistent Text Formatting (Raw/Auto)
                 long endT = System.currentTimeMillis();
-                long recentStartT = endT - 10 * 60 * 1000L;
                 final String activeSensorSerial = NotificationHistorySource.resolveSensorSerial(resolvePrimarySensorName());
-                java.util.List<GlucosePoint> nativePoints = new java.util.ArrayList<>();
-                try {
-                    nativePoints = NotificationHistorySource.getDisplayHistory(recentStartT, isMmol, activeSensorSerial);
-                } catch (Exception e) {
-                }
 
                 // Determine ViewMode for formatting
                 int viewMode = 0;
@@ -3034,8 +3027,10 @@ public class Notify {
                         ? NotificationChartDrawer.drawArrow(Applic.app, displayRate, isMmol, glucoseColor, arrowSize)
                         : null;
 
-                CharSequence valueText = formatGlucoseText(glucose.value, glvalue, nativePoints, viewMode,
-                        glucose.time, activeSensorSerial);
+                // Keep the value supplied with this firing, as the full-screen alarm does.
+                // Resolving it again from history can replace a low trigger with a higher
+                // reading, or give a message-only alert a glucose value it never carried.
+                CharSequence valueText = alarmGlucoseValue;
 
                 // Construct RemoteViews using the same rich alert surface for every mode.
                 RemoteViews remoteViews = new RemoteViews(Applic.app.getPackageName(),

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -2943,11 +2943,9 @@ public class Notify {
                 ;
 
                 setIcon(GluNotBuilder, glvalue, glucose.sensorgen2);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    // final int timeout= Build.VERSION.SDK_INT >= 30? 60*1500:60*3000;
-                    final int timeout = 800 * 60;// Build.VERSION.SDK_INT >= 30? 60*1500:60*3000;
-                    GluNotBuilder.setTimeoutAfter(timeout);
-                }
+                // Do not expire an unacknowledged alert. Android also sends the delete
+                // intent on timeout, which would falsely dismiss/snooze the episode and
+                // cancel its retries. The sound/vibration timer is independent.
                 GluNotBuilder.setPriority(Notification.PRIORITY_HIGH);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     GluNotBuilder.setCategory(Notification.CATEGORY_ALARM);

--- a/Common/src/test/java/tk/glucodata/AlertNotificationLifetimeTests.kt
+++ b/Common/src/test/java/tk/glucodata/AlertNotificationLifetimeTests.kt
@@ -1,0 +1,226 @@
+package tk.glucodata
+
+import java.io.File
+import java.net.URLClassLoader
+import javax.tools.ToolProvider
+import org.junit.After
+import org.junit.AfterClass
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import tk.glucodata.alerts.AlertStateTracker
+import tk.glucodata.alerts.AlertType
+
+/**
+ * Compile Notify's actual notification configuration with recording Android surfaces.
+ * Loading Notify itself initializes native libraries. Rendering is excluded; timeout,
+ * delete intent, buttons and full-screen configuration execute unchanged.
+ * The deadline replay models AOSP NotificationManagerService: REASON_TIMEOUT also
+ * sends the delete intent. This is a JVM regression, not Android instrumentation.
+ */
+class AlertNotificationLifetimeTests {
+    private var logging = false
+
+    @Before fun setup() {
+        logging = Log.doLog
+        Log.doLog = false
+        AlertStateTracker.resetState(AlertType.LOW)
+    }
+
+    @After fun cleanup() {
+        AlertStateTracker.resetState(AlertType.LOW)
+        Log.doLog = logging
+    }
+
+    private fun dismissed(): Boolean {
+        val field = AlertStateTracker::class.java.getDeclaredField("dismissedAlerts")
+        field.isAccessible = true
+        return AlertType.LOW in field.get(AlertStateTracker) as Set<*>
+    }
+
+    @Test fun unattendedAlertDoesNotAcknowledgeAtTheOldNotificationDeadline() {
+        AlertStateTracker.onAlertTriggered(AlertType.LOW)
+        val notification = configure(36, false, "NOTIFICATION_ONLY", AlertType.LOW.id, null)
+        for (elapsedMs in listOf(45_000L, 48_000L, 60_000L, 600_000L)) {
+            // Android's notification timeout is independent of the sound duration.
+            if (timeout(notification) in 1..elapsedMs) {
+                assertEquals(4, compiled.getField("deleteRequest").getInt(notification))
+                assertEquals("tk.glucodata.ACTION_DISMISS", action(notification, 4))
+                AlertStateTracker.onAlertDismissed(AlertType.LOW)
+            }
+            assertFalse("Unattended alert acknowledged at ${elapsedMs}ms", dismissed())
+        }
+        assertEquals(4, compiled.getField("deleteRequest").getInt(notification))
+        assertEquals("tk.glucodata.ACTION_DISMISS", action(notification, 4))
+        AlertStateTracker.onAlertDismissed(AlertType.LOW)
+        assertTrue("Explicit acknowledgement must still work", dismissed())
+    }
+
+    @Test fun notificationAndAlarmFallbackSurfacesDoNotScheduleAutomaticRemoval() {
+        for (sdk in listOf(26, 30, 36)) {
+            for (mode in listOf("NOTIFICATION_ONLY", "BOTH", "SYSTEM_ALARM")) {
+                for (snooze in listOf(false, true)) {
+                    for (customId in listOf(null, "custom-low")) {
+                        val notification = configure(sdk, snooze, mode, AlertType.LOW.id, customId)
+                        assertEquals("sdk=$sdk mode=$mode snooze=$snooze custom=$customId", 0L, timeout(notification))
+                        assertEquals(mode != "NOTIFICATION_ONLY", compiled.getField("fullScreen").getBoolean(notification))
+                    }
+                }
+            }
+        }
+    }
+
+    @Test fun explicitButtonsAndConfiguredSwipeKeepTheirActionsAndAlertIdentity() {
+        for (snooze in listOf(false, true)) {
+            for (kind in listOf(AlertType.LOW.id, AlertType.VERY_LOW.id, AlertType.HIGH.id)) {
+                for (customId in listOf(null, "custom-low")) {
+                    val notification = configure(36, snooze, "BOTH", kind, customId)
+                    assertEquals(4, compiled.getField("deleteRequest").getInt(notification))
+                    assertEquals("tk.glucodata.ACTION_SNOOZE", action(notification, 1))
+                    assertEquals("tk.glucodata.ACTION_DISMISS", action(notification, 2))
+                    assertEquals(if (snooze) action(notification, 1) else action(notification, 2), action(notification, 4))
+                    for (request in listOf(1, 2, 4)) {
+                        assertEquals(kind, compiled.getMethod("extra", Int::class.javaPrimitiveType, String::class.java)
+                            .invoke(notification, request, "alert_type_id"))
+                        assertEquals(customId, compiled.getMethod("extra", Int::class.javaPrimitiveType, String::class.java)
+                            .invoke(notification, request, "custom_alert_id"))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun configure(sdk: Int, snooze: Boolean, mode: String, kind: Int, customId: String?): Any =
+        compiled.getConstructor().newInstance().also {
+            compiled.getMethod("configure", Int::class.javaPrimitiveType, Boolean::class.javaPrimitiveType,
+                String::class.java, Int::class.javaPrimitiveType, String::class.java)
+                .invoke(it, sdk, snooze, mode, kind, customId)
+        }
+
+    private fun timeout(notification: Any) = compiled.getField("timeoutMs").getLong(notification)
+    private fun action(notification: Any, request: Int) =
+        compiled.getMethod("action", Int::class.javaPrimitiveType).invoke(notification, request)
+
+    companion object {
+        private var scratch: File? = null
+        private var loader: URLClassLoader? = null
+
+        @JvmStatic @AfterClass fun removeHarness() {
+            loader?.close()
+            scratch?.deleteRecursively()
+        }
+
+        private val compiled: Class<*> by lazy {
+            val root = generateSequence(File(System.getProperty("user.dir"))) { it.parentFile }
+                .first { File(it, "Common/src/main/java/tk/glucodata/Notify.java").exists() }
+            val source = File(root, "Common/src/main/java/tk/glucodata/Notify.java").readText()
+            val start = source.indexOf("                var GluNotBuilder = mkbuilderintent(type, intent, false);")
+            check(start >= 0)
+            val end = source.indexOf("                // --- RICH UI START", start)
+            check(end > start)
+            val configuration = source.substring(start, end)
+            val dir = java.nio.file.Files.createTempDirectory("alert-notification-lifetime").toFile()
+            scratch = dir
+            val receiver = File(dir, "AlarmActionReceiver.java").apply {
+                writeText("""
+                    package tk.glucodata.receivers;
+                    public class AlarmActionReceiver {
+                        public static final String ACTION_SNOOZE = "tk.glucodata.ACTION_SNOOZE";
+                        public static final String ACTION_DISMISS = "tk.glucodata.ACTION_DISMISS";
+                    }
+                """.trimIndent())
+            }
+            val javaFile = File(dir, "AlertNotificationHarness.java").apply {
+                writeText("""
+                    package tk.glucodata;
+                    import java.util.*;
+                    public class AlertNotificationHarness {
+                        public long timeoutMs;
+                        public boolean fullScreen;
+                        public int deleteRequest = -1;
+                        Map<Integer, Intent> broadcasts = new HashMap<>();
+                        static boolean snooze;
+                        boolean doLog = false;
+                        String LOG_ID = "test", EXTRA_CUSTOM_ALERT_ID = "custom_alert_id";
+                        int penmutable = 0;
+                        static class Build {
+                            static class VERSION { static int SDK_INT; }
+                            static class VERSION_CODES { static final int O = 26, LOLLIPOP = 21; }
+                        }
+                        static class Applic { static Object app = new Object(); }
+                        static class Log { static void i(String a, String b) {} static void e(String a, String b) {} }
+                        // Upstream uses the global swipe preference; local integration
+                        // uses the per-alert default. Both supply the same two actions.
+                        enum AlertNotificationDismissAction { SNOOZE, DISMISS }
+                        enum AlertDefaultAction { SNOOZE, DISMISS }
+                        static class AlertRepository {
+                            static AlertRepository INSTANCE = new AlertRepository();
+                            AlertNotificationDismissAction loadNotificationDismissAction() {
+                                return snooze ? AlertNotificationDismissAction.SNOOZE : AlertNotificationDismissAction.DISMISS;
+                            }
+                            AlertDefaultAction resolveDefaultAction(int kind, String customId) {
+                                return snooze ? AlertDefaultAction.SNOOZE : AlertDefaultAction.DISMISS;
+                            }
+                        }
+                        static class Intent {
+                            String action;
+                            Map<String, Object> extras = new HashMap<>();
+                            Intent(Object context, Class<?> receiver) {}
+                            void setAction(String value) { action = value; }
+                            void putExtra(String key, Object value) { extras.put(key, value); }
+                        }
+                        static class PendingIntent {
+                            static final int FLAG_UPDATE_CURRENT = 1;
+                            static AlertNotificationHarness owner;
+                            int request = -1;
+                            static PendingIntent getBroadcast(Object app, int request, Intent intent, int flags) {
+                                owner.broadcasts.put(request, intent);
+                                PendingIntent pending = new PendingIntent();
+                                pending.request = request;
+                                return pending;
+                            }
+                        }
+                        class Notification {
+                            static final int PRIORITY_HIGH = 1;
+                            static final String CATEGORY_ALARM = "alarm";
+                            class Builder {
+                                void setDeleteIntent(PendingIntent value) { deleteRequest = value.request; }
+                                void setTimeoutAfter(long value) { timeoutMs = value; }
+                                void setPriority(int value) {}
+                                void setCategory(String value) {}
+                                void setFullScreenIntent(PendingIntent value, boolean high) { fullScreen = true; }
+                            }
+                        }
+                        static class notGlucose { float rate; int sensorgen2; }
+                        Notification.Builder mkbuilderintent(String type, PendingIntent intent, boolean grouped) {
+                            return new Notification().new Builder();
+                        }
+                        void setIcon(Notification.Builder builder, float value, int gen) {}
+                        PendingIntent mkAlarmPendingIntent(String value, String message, float rate, int kind,
+                                String custom, String mode) { return new PendingIntent(); }
+                        public String action(int request) { return broadcasts.get(request).action; }
+                        public Object extra(int request, String key) { return broadcasts.get(request).extras.get(key); }
+                        public void configure(int sdk, boolean swipeSnoozes, String currentDeliveryMode,
+                                int alertTypeId, String customAlertId) {
+                            Build.VERSION.SDK_INT = sdk;
+                            snooze = swipeSnoozes;
+                            PendingIntent.owner = this;
+                            String type = "LOW", message = "Low", alarmGlucoseValue = "63";
+                            PendingIntent intent = new PendingIntent();
+                            float glvalue = 63;
+                            notGlucose glucose = new notGlucose();
+                            $configuration
+                        }
+                    }
+                """.trimIndent())
+            }
+            val paths = File(AlertDeliveryPolicy::class.java.protectionDomain.codeSource.location.toURI()).path
+            val output = java.io.ByteArrayOutputStream()
+            val result = checkNotNull(ToolProvider.getSystemJavaCompiler()).run(null, output, output,
+                "-classpath", paths, "-d", dir.path, receiver.path, javaFile.path)
+            check(result == 0) { output.toString() }
+            URLClassLoader(arrayOf(dir.toURI().toURL()), AlertNotificationLifetimeTests::class.java.classLoader)
+                .also { loader = it }.loadClass("tk.glucodata.AlertNotificationHarness")
+        }
+    }
+}

--- a/Common/src/test/java/tk/glucodata/AlertNotificationValueTests.kt
+++ b/Common/src/test/java/tk/glucodata/AlertNotificationValueTests.kt
@@ -1,0 +1,110 @@
+package tk.glucodata
+
+import java.io.File
+import java.net.URLClassLoader
+import javax.tools.ToolProvider
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import tk.glucodata.alerts.AlertDisplayText
+
+/**
+ * Execute the production banner's value assignment and alarm formatter without loading
+ * Notify's native-backed singleton. The old history lookup uses the real display resolver;
+ * only Android text styling is omitted. This catches re-resolving a frozen alert value.
+ */
+class AlertNotificationValueTests {
+    @Test fun lowBannerKeepsTriggeringValueWhenHistoryIsHigher() {
+        assertEquals("69", render(69f, "69", 75f, false))
+    }
+
+    @Test fun highBannerKeepsTriggeringValueWhenHistoryIsLower() {
+        assertEquals("181", render(181f, "181", 160f, false))
+    }
+
+    @Test fun mmolBannerKeepsTriggeringValue() {
+        assertEquals("3.8", render(3.8f, "3.8", 4.2f, true))
+    }
+
+    @Test fun messageOnlyBannerDoesNotBorrowAReadingFromHistory() {
+        assertEquals("", render(Float.NaN, "", 75f, false))
+    }
+
+    private fun render(value: Float, snapshot: String, history: Float, mmol: Boolean): String =
+        compiled.getMethod("render", Float::class.javaPrimitiveType, String::class.java,
+            Float::class.javaPrimitiveType, Boolean::class.javaPrimitiveType)
+            .invoke(null, value, snapshot, history, mmol) as String
+
+    companion object {
+        private var scratch: File? = null
+        private var loader: URLClassLoader? = null
+
+        @JvmStatic @AfterClass fun cleanup() {
+            loader?.close()
+            scratch?.deleteRecursively()
+        }
+
+        private val compiled: Class<*> by lazy {
+            val root = generateSequence(File(checkNotNull(System.getProperty("user.dir")))) { it.parentFile }
+                .first { File(it, "Common/src/main/java/tk/glucodata/Notify.java").exists() }
+            val source = File(root, "Common/src/main/java/tk/glucodata/Notify.java").readText()
+            val bannerStart = source.indexOf("    private void makeseparatenotification(")
+            val valueStart = source.indexOf("                CharSequence valueText =", bannerStart)
+            check(bannerStart >= 0 && valueStart > bannerStart)
+            val valueAssignment = source.substring(valueStart, source.indexOf(';', valueStart) + 1)
+            val helperStart = source.indexOf("    private static String alarmDisplayGlucoseValue(")
+            check(helperStart >= 0)
+            val helper = source.substring(helperStart, source.indexOf("\n    }", helperStart) + 6)
+            val dir = java.nio.file.Files.createTempDirectory("alert-notification-value").toFile()
+            scratch = dir
+            val sourceFile = File(dir, "AlertValueHarness.java").apply {
+                writeText("""
+                    package tk.glucodata;
+                    import java.util.*;
+                    import tk.glucodata.alerts.AlertDisplayText;
+                    public class AlertValueHarness {
+                        static Locale usedlocale = Locale.US;
+                        static String pureglucoseformat;
+                        static boolean isMmol;
+                        static class notGlucose {
+                            String value; long time;
+                            notGlucose(String value, long time) { this.value = value; this.time = time; }
+                        }
+                        static String format(Locale locale, String pattern, Object... values) {
+                            return String.format(locale, pattern, values);
+                        }
+                        $helper
+                        static CharSequence formatGlucoseText(String value, float glvalue, List<GlucosePoint> points,
+                                int viewMode, long targetTime, String sensorId) {
+                            CurrentDisplaySource.Snapshot resolved = CurrentDisplaySource.resolveFromLive(
+                                value, glvalue, Float.NaN, targetTime, sensorId, 0, 0, "notification",
+                                points, viewMode, isMmol);
+                            return resolved != null ? resolved.getPrimaryStr() : "";
+                        }
+                        public static String render(float glvalue, String snapshotValue, float historyValue, boolean mmol) {
+                            isMmol = mmol;
+                            pureglucoseformat = mmol ? "%.1f" : "%.0f";
+                            notGlucose glucose = new notGlucose(snapshotValue, 1700000000000L);
+                            String activeSensorSerial = "alert-value-test";
+                            int viewMode = 0;
+                            List<GlucosePoint> nativePoints = List.of(new GlucosePoint(glucose.time, historyValue, historyValue));
+                            String alarmGlucoseValue = alarmDisplayGlucoseValue(glvalue, glucose);
+                            $valueAssignment
+                            return valueText.toString();
+                        }
+                    }
+                """.trimIndent())
+            }
+            val paths = listOf(CurrentDisplaySource::class.java, GlucosePoint::class.java,
+                AlertDisplayText::class.java, kotlin.Unit::class.java).map {
+                File(checkNotNull(it.protectionDomain).codeSource.location.toURI()).path
+            }.distinct().joinToString(File.pathSeparator)
+            val output = java.io.ByteArrayOutputStream()
+            val result = checkNotNull(ToolProvider.getSystemJavaCompiler()).run(null, output, output,
+                "-classpath", paths, "-d", dir.path, sourceFile.path)
+            check(result == 0) { output.toString() }
+            URLClassLoader(arrayOf(dir.toURI().toURL()), AlertNotificationValueTests::class.java.classLoader)
+                .also { loader = it }.loadClass("tk.glucodata.AlertValueHarness")
+        }
+    }
+}


### PR DESCRIPTION
Alert notifications can acknowledge an unattended alert and display a glucose value that was never supplied with its firing. Both behaviors need correcting: the automatic acknowledgement can cancel retries without a user response, while the substituted value can make the alert contradict its threshold and erase useful evidence from notification history.

The first defect is a 48,000 ms notification timeout. [Android sends the delete intent on timeout](https://android.googlesource.com/platform/frameworks/base/+/android-13.0.0_r83/services/core/java/com/android/server/notification/NotificationManagerService.java), and the app maps that intent to the configured dismiss or snooze action. Remove that explicit timeout so the notification remains available after its sound and vibration stop. This covers a separate path missed by #281, which prevented silent glucose refreshes from clearing alert state.

The second defect is a fresh history lookup when formatting the alert banner. It can replace the supplied triggering value with another reading: the regression reproduces a trigger value of 69 mg/dL displayed as 75 mg/dL. Use the same supplied value as the full-screen alarm, preserving the value in collapsed, expanded, heads-up and public notification text. Message-only alerts retain an empty glucose field. The redundant history fetch is removed.

The configured sound duration, retry timing, thresholds and action handlers are unchanged. This corrects notification behavior; it does not establish the cause of the originally reported above-threshold LOW firing. No device trace was available to reconstruct that event.

Verification:

- Expiry regression: before the fix, two of three tests failed, including `Unattended alert acknowledged at 48000ms`; the explicit-action check passed. All three pass after the fix.
- Value regression: all four tests failed before the change, showing substitutions of 69 to 75, 181 to 160, 3.8 to 4.2 mmol/L, and an empty message-only value to 75. The unchanged tests pass afterward.
- All 24 focused tests pass on this branch: four value tests, three expiry tests, three earlier silent-refresh tests and fourteen alert-text tests. Expiry coverage includes all delivery modes, both swipe actions, standard/custom alert identifiers, and API levels 26, 30 and 36.
- The JVM harnesses compile the production notification assignments and configuration. Value tests use the real history display resolver with Android styling omitted; the expiry test models Android's timeout callback against the real alert tracker. These are not phone instrumentation tests.

Both fixes are integrated into local-build. All 2,791 release unit tests passed with zero failures, errors or skips, and the ARM64 release assemble succeeded. Physical-phone confirmation remains pending.
