### PR TITLE
Fix Dexcom forecasts appearing as measured glucose

### DIFF
--- a/Common/src/main/cpp/g.cpp
+++ b/Common/src/main/cpp/g.cpp
@@ -1879,6 +1879,12 @@ using HistorySamples = std::map<jlong, std::pair<jlong, jlong>>;
 // dashboard instead of only reaching native followers/LibreView.
 static void appendStoredHistory(const SensorGlucoseData *hist, jlong starttime,
                                 HistorySamples &samples) {
+  // Dexcom historydata contains saveDexFuture forecasts, including forecasts
+  // whose timestamps are now in the past. Actual readings/backfill live in polls.
+  // Keep this independent of the graph's prediction visibility setting.
+  if (hist->isDexcom())
+    return;
+
   const int start = std::max(0, hist->getstarthistory());
   const int end = std::min(hist->getAllendhistory(), hist->maxpos());
   for (int pos = start; pos < end; ++pos) {

--- a/Common/src/test/java/tk/glucodata/data/NativeMeasuredHistoryTests.kt
+++ b/Common/src/test/java/tk/glucodata/data/NativeMeasuredHistoryTests.kt
@@ -1,0 +1,50 @@
+package tk.glucodata.data
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Executes the production C++ exporter with an in-memory sensor (requires a host C++ compiler). */
+class NativeMeasuredHistoryTests {
+    private fun repositoryFile(path: String): File {
+        var directory: File? = File(System.getProperty("user.dir")).absoluteFile
+        while (directory != null) {
+            val file = File(directory, path)
+            if (file.isFile) return file
+            directory = directory.parentFile
+        }
+        error("Cannot find $path")
+    }
+
+    @Test
+    fun measuredHistoryExcludesDexcomForecastsButPreservesLibreHistoryAndPolls() {
+        val nativeSource = repositoryFile("Common/src/main/cpp/g.cpp").readText()
+        val start = nativeSource.indexOf("static void appendStoredHistory(")
+        val end = nativeSource.indexOf("static void appendScanHistory(", start)
+        assertTrue("Locate the production stored-history exporter", start >= 0 && end > start)
+        val exporter = nativeSource.substring(start, end)
+        val fixture = repositoryFile("Common/src/test/resources/native/measured_history.cpp").readText()
+        val directory = Files.createTempDirectory("measured-history-test").toFile()
+        try {
+            val source = File(directory, "test.cpp")
+            source.writeText(fixture.replace("// PRODUCTION_EXPORTER", exporter))
+            val binary = File(directory, "test")
+            run(directory, listOf(System.getenv("CXX") ?: "c++", "-std=c++17", source.path, "-o", binary.path))
+            run(directory, listOf(binary.path))
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    private fun run(directory: File, command: List<String>) {
+        val log = File(directory, "output.log")
+        val process = ProcessBuilder(command).redirectErrorStream(true).redirectOutput(log).start()
+        val completed = process.waitFor(60, TimeUnit.SECONDS)
+        if (!completed) process.destroyForcibly()
+        assertTrue("Timed out: $command", completed)
+        assertEquals(log.readText(), 0, process.exitValue())
+    }
+}

--- a/Common/src/test/resources/native/measured_history.cpp
+++ b/Common/src/test/resources/native/measured_history.cpp
@@ -1,0 +1,71 @@
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include <utility>
+#include <vector>
+
+using jlong = int64_t;
+using HistorySamples = std::map<jlong, std::pair<jlong, jlong>>;
+
+struct Glucose {
+    uint32_t time;
+    uint16_t mgdlTimes10;
+    bool valid() const { return mgdlTimes10 > 380 && mgdlTimes10 < 5020; }
+    uint32_t gettime() const { return time; }
+    uint16_t getsputnik() const { return mgdlTimes10; }
+};
+
+struct SensorGlucoseData {
+    bool dexcom;
+    std::vector<Glucose> history;
+    int first = 0;
+    bool isDexcom() const { return dexcom; }
+    int getstarthistory() const { return first; }
+    int getAllendhistory() const { return history.size(); }
+    int maxpos() const { return history.size(); }
+    const Glucose* getglucose(int pos) const { return &history.at(pos); }
+};
+
+// PRODUCTION_EXPORTER
+
+int main() {
+    // Issue #250 trace: measured 136 mg/dL at 16:04:33, forecast 125 at 16:14:33.
+    constexpr uint32_t measuredTime = 1787925873;
+    constexpr uint32_t forecastTime = measuredTime + 600;
+    const SensorGlucoseData dexcom{true, {{measuredTime - 300, 1400},
+                                        {forecastTime, 1250}}};
+    HistorySamples samples;
+    appendStoredHistory(&dexcom, measuredTime - 120, samples);
+    assert(samples.empty()); // Live queries must not return the future forecast.
+
+    appendStoredHistory(&dexcom, 0, samples);
+    assert(samples.empty()); // Full sync must also exclude old, now-past forecasts.
+
+    // A forecast colliding with an actual poll must never overwrite the measurement.
+    samples[forecastTime] = {1360, 0};
+    appendStoredHistory(&dexcom, 0, samples);
+    assert(samples.size() == 1);
+    assert(samples.at(forecastTime).first == 1360);
+
+    // Libre NFC history must still export in JNI units (mg/dL * 10), with no raw lane.
+    const SensorGlucoseData libre{false, {{measuredTime - 900, 770},
+                                        {measuredTime, 1360},
+                                        {forecastTime, 0}}};
+    samples.clear();
+    appendStoredHistory(&libre, 0, samples);
+    assert(samples.size() == 2);
+    assert(samples.at(measuredTime - 900).first == 770);
+    assert(samples.at(measuredTime).first == 1360);
+    assert(samples.at(measuredTime).second == 0);
+
+    samples.clear();
+    appendStoredHistory(&libre, measuredTime - 900, samples);
+    assert(samples.size() == 1); // starttime is exclusive.
+    assert(samples.begin()->first == measuredTime);
+
+    const SensorGlucoseData empty{false, {}};
+    samples.clear();
+    appendStoredHistory(&empty, 0, samples);
+    assert(samples.empty());
+}


### PR DESCRIPTION
Dexcom G7 forecasts were being exported as measured glucose. In the issue trace, a real 136 mg/dL reading at 16:04:33 is followed by a separate 125 mg/dL forecast for 16:14:33. `saveDexFuture` stores that forecast in `historydata`, and the shared JNI exporter was merging it into the readings consumed by Room, the dashboard list, and the current-reading path.

Exclude Dexcom's forecast history from both JNI measured-history APIs through their shared `appendStoredHistory` collector. This also excludes forecasts whose timestamps have already passed and works independently of prediction visibility. Actual Dexcom readings and backfill still come from polls; Libre NFC history and graph prediction storage remain available. No packet decoding, native storage layout, or glucose unit conversion changes.

Validation:
- A host C++ regression fixture executes the production exporter: it fails against the original code and passes with this fix. Covers future and past Dexcom forecasts, protection of an existing measured sample, Libre NFC values in mg/dL × 10, an exclusive start time, invalid records, and empty history.
- The regression is included in the standard JVM suite under `NativeMeasuredHistoryTests` and requires a host C++ compiler (`CXX`, default `c++`).
- Full `:Common:testMobileDebugUnitTest --no-daemon --offline -PjugglucoAbi=arm64-v8a` passed: 2363 tests, zero failures/errors.
- `git diff --check` passed.
- `:Common:assembleMobileDebug :Common:assembleWearDebug :Common:assembleMobileRelease -PjugglucoAbi=arm64-v8a --no-daemon --offline` passed, including native compilation for all three configurations and release/R8. This validates arm64 only.
- Live Dexcom hardware behavior has not been retested.

Existing Room rows have no forecast provenance. This change prevents further forecast imports, including full native resyncs, but deliberately does not perform a blanket deletion of previously imported historical rows. Normal sync can replace a forecast when an actual reading arrives in the same minute bucket.

Based directly on `origin/main` at `a495d041b`; the PR contains only commit `866668ac0`, with no `test/3sep` commits.

Fixes #250.
